### PR TITLE
Swap order of type arguments to ku_dynamic_cast

### DIFF
--- a/extension/duckdb/src/duckdb_catalog.cpp
+++ b/extension/duckdb/src/duckdb_catalog.cpp
@@ -65,8 +65,8 @@ void DuckDBCatalog::createForeignTable(const std::string& tableName) {
     if (info == nullptr) {
         return;
     }
-    auto extraInfo = common::ku_dynamic_cast<binder::BoundExtraCreateCatalogEntryInfo*,
-        BoundExtraCreateDuckDBTableInfo*>(info->extraInfo.get());
+    auto extraInfo =
+        common::ku_dynamic_cast<BoundExtraCreateDuckDBTableInfo*>(info->extraInfo.get());
     std::vector<common::LogicalType> columnTypes;
     std::vector<std::string> columnNames;
     for (auto& definition : extraInfo->propertyDefinitions) {

--- a/extension/httpfs/src/httpfs.cpp
+++ b/extension/httpfs/src/httpfs.cpp
@@ -366,7 +366,7 @@ std::unique_ptr<HTTPResponse> HTTPFileSystem::runRequestWithRetry(
 
 std::unique_ptr<HTTPResponse> HTTPFileSystem::headRequest(FileInfo* fileInfo,
     const std::string& url, HeaderMap headerMap) const {
-    auto httpFileInfo = ku_dynamic_cast<FileInfo*, HTTPFileInfo*>(fileInfo);
+    auto httpFileInfo = ku_dynamic_cast<HTTPFileInfo*>(fileInfo);
     auto parsedURL = parseUrl(url);
     auto host = parsedURL.first;
     auto hostPath = parsedURL.second;
@@ -383,7 +383,7 @@ std::unique_ptr<HTTPResponse> HTTPFileSystem::headRequest(FileInfo* fileInfo,
 std::unique_ptr<HTTPResponse> HTTPFileSystem::getRangeRequest(FileInfo* fileInfo,
     const std::string& url, HeaderMap headerMap, uint64_t fileOffset, char* buffer,
     uint64_t bufferLen) const {
-    auto httpFileInfo = ku_dynamic_cast<FileInfo*, HTTPFileInfo*>(fileInfo);
+    auto httpFileInfo = ku_dynamic_cast<HTTPFileInfo*>(fileInfo);
     auto parsedURL = parseUrl(url);
     auto host = parsedURL.first;
     auto hostPath = parsedURL.second;
@@ -447,7 +447,7 @@ std::unique_ptr<HTTPResponse> HTTPFileSystem::postRequest(common::FileInfo* file
     const std::string& url, HeaderMap headerMap, std::unique_ptr<uint8_t[]>& outputBuffer,
     uint64_t& outputBufferLen, const uint8_t* inputBuffer, uint64_t inputBufferLen,
     std::string /*params*/) const {
-    auto httpFileInfo = ku_dynamic_cast<FileInfo*, HTTPFileInfo*>(fileInfo);
+    auto httpFileInfo = ku_dynamic_cast<HTTPFileInfo*>(fileInfo);
     auto hostPath = parseUrl(url).second;
     auto headers = getHTTPHeaders(headerMap);
     uint64_t outputBufferPos = 0;
@@ -482,7 +482,7 @@ std::unique_ptr<HTTPResponse> HTTPFileSystem::postRequest(common::FileInfo* file
 std::unique_ptr<HTTPResponse> HTTPFileSystem::putRequest(common::FileInfo* fileInfo,
     const std::string& url, HeaderMap headerMap, const uint8_t* inputBuffer,
     uint64_t inputBufferLen, std::string /*params*/) const {
-    auto httpFileInfo = ku_dynamic_cast<FileInfo*, HTTPFileInfo*>(fileInfo);
+    auto httpFileInfo = ku_dynamic_cast<HTTPFileInfo*>(fileInfo);
     auto hostPath = parseUrl(url).second;
     auto headers = getHTTPHeaders(headerMap);
     std::function<httplib::Result(void)> request([&]() {

--- a/src/binder/bind/bind_create_macro.cpp
+++ b/src/binder/bind/bind_create_macro.cpp
@@ -14,7 +14,7 @@ namespace kuzu {
 namespace binder {
 
 std::unique_ptr<BoundStatement> Binder::bindCreateMacro(const Statement& statement) {
-    auto& createMacro = ku_dynamic_cast<const Statement&, const CreateMacro&>(statement);
+    auto& createMacro = ku_dynamic_cast<const CreateMacro&>(statement);
     auto macroName = createMacro.getMacroName();
     StringUtils::toUpper(macroName);
     if (clientContext->getCatalog()->containsMacro(clientContext->getTx(), macroName)) {

--- a/src/binder/bind/bind_ddl.cpp
+++ b/src/binder/bind/bind_ddl.cpp
@@ -426,7 +426,7 @@ std::unique_ptr<BoundStatement> Binder::bindAlter(const Statement& statement) {
 std::unique_ptr<BoundStatement> Binder::bindRenameTable(const Statement& statement) {
     auto& alter = statement.constCast<Alter>();
     auto info = alter.getInfo();
-    auto extraInfo = ku_dynamic_cast<ExtraAlterInfo*, ExtraRenameTableInfo*>(info->extraInfo.get());
+    auto extraInfo = ku_dynamic_cast<ExtraRenameTableInfo*>(info->extraInfo.get());
     auto tableName = info->tableName;
     auto newName = extraInfo->newName;
     validateTableExist(tableName);

--- a/src/binder/bind/bind_file_scan.cpp
+++ b/src/binder/bind/bind_file_scan.cpp
@@ -63,7 +63,7 @@ std::unordered_map<std::string, Value> Binder::bindParsingOptions(
         common::StringUtils::toUpper(name);
         auto expr = expressionBinder.bindExpression(*option.second);
         KU_ASSERT(expr->expressionType == ExpressionType::LITERAL);
-        auto literalExpr = ku_dynamic_cast<Expression*, LiteralExpression*>(expr.get());
+        auto literalExpr = ku_dynamic_cast<LiteralExpression*>(expr.get());
         options.insert({name, literalExpr->getValue()});
     }
     return options;

--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -96,15 +96,15 @@ std::shared_ptr<Expression> Binder::createPath(const std::string& pathName,
     std::vector<LogicalType> relFieldTypes;
     for (auto& child : children) {
         if (ExpressionUtil::isNodePattern(*child)) {
-            auto node = ku_dynamic_cast<Expression*, NodeExpression*>(child.get());
+            auto node = ku_dynamic_cast<NodeExpression*>(child.get());
             extraFieldFromStructType(node->getDataType(), nodeFieldNameSet, nodeFieldNames,
                 nodeFieldTypes);
         } else if (ExpressionUtil::isRelPattern(*child)) {
-            auto rel = ku_dynamic_cast<Expression*, RelExpression*>(child.get());
+            auto rel = ku_dynamic_cast<RelExpression*>(child.get());
             extraFieldFromStructType(rel->getDataType(), relFieldNameSet, relFieldNames,
                 relFieldTypes);
         } else if (ExpressionUtil::isRecursiveRelPattern(*child)) {
-            auto recursiveRel = ku_dynamic_cast<Expression*, RelExpression*>(child.get());
+            auto recursiveRel = ku_dynamic_cast<RelExpression*>(child.get());
             auto recursiveInfo = recursiveRel->getRecursiveInfo();
             extraFieldFromStructType(recursiveInfo->node->getDataType(), nodeFieldNameSet,
                 nodeFieldNames, nodeFieldTypes);
@@ -329,7 +329,7 @@ static void bindRecursiveRelProjectionList(const expression_vector& projectionLi
             throw BinderException(stringFormat("Unsupported projection item {} on recursive rel.",
                 expression->toString()));
         }
-        auto property = ku_dynamic_cast<Expression*, PropertyExpression*>(expression.get());
+        auto property = ku_dynamic_cast<PropertyExpression*>(expression.get());
         fields.emplace_back(property->getPropertyName(), property->getDataType().copy());
     }
 }
@@ -586,7 +586,7 @@ std::shared_ptr<NodeExpression> Binder::createQueryNode(const std::string& parse
     // Bind properties.
     bindQueryNodeProperties(*queryNode);
     for (auto& expression : queryNode->getPropertyExprsRef()) {
-        auto property = ku_dynamic_cast<Expression*, PropertyExpression*>(expression.get());
+        auto property = ku_dynamic_cast<PropertyExpression*>(expression.get());
         fieldNames.emplace_back(property->getPropertyName());
         fieldTypes.emplace_back(property->dataType.copy());
     }

--- a/src/binder/bind/bind_standalone_call.cpp
+++ b/src/binder/bind/bind_standalone_call.cpp
@@ -15,8 +15,7 @@ namespace kuzu {
 namespace binder {
 
 std::unique_ptr<BoundStatement> Binder::bindStandaloneCall(const parser::Statement& statement) {
-    auto& callStatement =
-        ku_dynamic_cast<const parser::Statement&, const parser::StandaloneCall&>(statement);
+    auto& callStatement = ku_dynamic_cast<const parser::StandaloneCall&>(statement);
     main::Option* option = main::DBConfig::getOptionByName(callStatement.getOptionName());
     if (option == nullptr) {
         option =

--- a/src/binder/bind/bind_updating_clause.cpp
+++ b/src/binder/bind/bind_updating_clause.cpp
@@ -209,8 +209,7 @@ void Binder::bindInsertRel(std::shared_ptr<RelExpression> rel,
     }
     if (parentTableEntry != nullptr) {
         KU_ASSERT(parentTableEntry->getTableType() == TableType::RDF);
-        auto rdfGraphEntry = ku_dynamic_cast<const TableCatalogEntry*, const RDFGraphCatalogEntry*>(
-            parentTableEntry);
+        auto rdfGraphEntry = ku_dynamic_cast<const RDFGraphCatalogEntry*>(parentTableEntry);
         if (!rel->hasPropertyDataExpr(std::string(rdf::IRI))) {
             throw BinderException(stringFormat(
                 "Insert relationship {} expects {} property as input.", rel->toString(), rdf::IRI));
@@ -326,7 +325,7 @@ expression_pair Binder::bindSetItem(parser::ParsedExpression* column,
 }
 
 static void validateRdfResourceDeletion(Expression* pattern, main::ClientContext* context) {
-    auto node = ku_dynamic_cast<Expression*, NodeExpression*>(pattern);
+    auto node = ku_dynamic_cast<NodeExpression*>(pattern);
     for (auto& entry : node->getEntries()) {
         for (auto& rdfGraphEntry : context->getCatalog()->getRdfGraphEntries(context->getTx())) {
             if (rdfGraphEntry->isParent(entry->getTableID()) &&

--- a/src/binder/bind/copy/bind_copy_from.cpp
+++ b/src/binder/bind/copy/bind_copy_from.cpp
@@ -20,7 +20,7 @@ namespace kuzu {
 namespace binder {
 
 std::unique_ptr<BoundStatement> Binder::bindCopyFromClause(const Statement& statement) {
-    auto& copyStatement = ku_dynamic_cast<const Statement&, const CopyFrom&>(statement);
+    auto& copyStatement = ku_dynamic_cast<const CopyFrom&>(statement);
     auto tableName = copyStatement.getTableName();
     validateTableExist(tableName);
     // Bind to table schema.
@@ -79,7 +79,7 @@ static std::pair<ColumnEvaluateType, std::shared_ptr<Expression>> matchColumnExp
 
 std::unique_ptr<BoundStatement> Binder::bindCopyNodeFrom(const Statement& statement,
     NodeTableCatalogEntry* nodeTableEntry) {
-    auto& copyStatement = ku_dynamic_cast<const Statement&, const CopyFrom&>(statement);
+    auto& copyStatement = ku_dynamic_cast<const CopyFrom&>(statement);
     // Bind expected columns based on catalog information.
     std::vector<std::string> expectedColumnNames;
     std::vector<LogicalType> expectedColumnTypes;

--- a/src/binder/bind_expression/bind_property_expression.cpp
+++ b/src/binder/bind_expression/bind_property_expression.cpp
@@ -107,7 +107,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindNodeOrRelPropertyExpression(
     // & rel expression.
     if (propertyName == InternalKeyword::ID &&
         child.dataType.getLogicalTypeID() == common::LogicalTypeID::NODE) {
-        auto& node = ku_dynamic_cast<const Expression&, const NodeExpression&>(child);
+        auto& node = ku_dynamic_cast<const NodeExpression&>(child);
         return node.getInternalID();
     }
     if (!nodeOrRel.hasPropertyExpression(propertyName)) {

--- a/src/binder/bind_expression/bind_subquery_expression.cpp
+++ b/src/binder/bind_expression/bind_subquery_expression.cpp
@@ -18,8 +18,7 @@ namespace binder {
 
 std::shared_ptr<Expression> ExpressionBinder::bindSubqueryExpression(
     const ParsedExpression& parsedExpr) {
-    auto& subqueryExpr =
-        ku_dynamic_cast<const ParsedExpression&, const ParsedSubqueryExpression&>(parsedExpr);
+    auto& subqueryExpr = ku_dynamic_cast<const ParsedSubqueryExpression&>(parsedExpr);
     auto prevScope = binder->saveScope();
     auto boundGraphPattern = binder->bindGraphPattern(subqueryExpr.getPatternElements());
     if (subqueryExpr.hasWhereClause()) {

--- a/src/binder/bind_expression/bind_variable_expression.cpp
+++ b/src/binder/bind_expression/bind_variable_expression.cpp
@@ -14,8 +14,7 @@ namespace binder {
 
 std::shared_ptr<Expression> ExpressionBinder::bindVariableExpression(
     const ParsedExpression& parsedExpression) {
-    auto& variableExpression =
-        ku_dynamic_cast<const ParsedExpression&, const ParsedVariableExpression&>(parsedExpression);
+    auto& variableExpression = ku_dynamic_cast<const ParsedVariableExpression&>(parsedExpression);
     auto variableName = variableExpression.getVariableName();
     return bindVariableExpression(variableName);
 }

--- a/src/binder/bound_statement_visitor.cpp
+++ b/src/binder/bound_statement_visitor.cpp
@@ -83,22 +83,20 @@ void BoundStatementVisitor::visitUnsafe(BoundStatement& statement) {
 }
 
 void BoundStatementVisitor::visitCopyFrom(const BoundStatement& statement) {
-    auto& copyFrom = ku_dynamic_cast<const BoundStatement&, const BoundCopyFrom&>(statement);
+    auto& copyFrom = ku_dynamic_cast<const BoundCopyFrom&>(statement);
     if (copyFrom.getInfo()->source->type == ScanSourceType::QUERY) {
-        auto querySource = ku_dynamic_cast<BoundBaseScanSource*, BoundQueryScanSource*>(
-            copyFrom.getInfo()->source.get());
+        auto querySource = ku_dynamic_cast<BoundQueryScanSource*>(copyFrom.getInfo()->source.get());
         visit(*querySource->statement);
     }
 }
 
 void BoundStatementVisitor::visitCopyTo(const BoundStatement& statement) {
-    auto& copyTo = ku_dynamic_cast<const BoundStatement&, const BoundCopyTo&>(statement);
+    auto& copyTo = ku_dynamic_cast<const BoundCopyTo&>(statement);
     visitRegularQuery(*copyTo.getRegularQuery());
 }
 
 void BoundStatementVisitor::visitRegularQuery(const BoundStatement& statement) {
-    auto& regularQuery =
-        ku_dynamic_cast<const BoundStatement&, const BoundRegularQuery&>(statement);
+    auto& regularQuery = ku_dynamic_cast<const BoundRegularQuery&>(statement);
     for (auto i = 0u; i < regularQuery.getNumSingleQueries(); ++i) {
         visitSingleQuery(*regularQuery.getSingleQuery(i));
     }

--- a/src/catalog/catalog_entry/rdf_graph_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rdf_graph_catalog_entry.cpp
@@ -96,7 +96,7 @@ static std::optional<binder::BoundCreateTableInfo> getBoundCreateTableInfoForTab
     transaction::Transaction* transaction, const CatalogEntrySet& entries,
     common::table_id_t tableID) {
     for (auto& [name, entry] : entries) {
-        auto current = common::ku_dynamic_cast<CatalogEntry*, TableCatalogEntry*>(entry);
+        auto current = common::ku_dynamic_cast<TableCatalogEntry*>(entry);
         if (current->getTableID() == tableID) {
             auto boundInfo = current->getBoundCreateTableInfo(transaction);
             return boundInfo;

--- a/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
@@ -53,7 +53,7 @@ std::unique_ptr<TableCatalogEntry> RelGroupCatalogEntry::copy() const {
 static std::optional<binder::BoundCreateTableInfo> getBoundCreateTableInfoForTable(
     transaction::Transaction* transaction, const CatalogEntrySet& entries, table_id_t tableID) {
     for (auto& [name, entry] : entries) {
-        auto current = ku_dynamic_cast<CatalogEntry*, TableCatalogEntry*>(entry);
+        auto current = ku_dynamic_cast<TableCatalogEntry*>(entry);
         if (current->getTableID() == tableID) {
             auto boundInfo = current->getBoundCreateTableInfo(transaction);
             return boundInfo;

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -129,7 +129,7 @@ std::unique_ptr<TableCatalogEntry> TableCatalogEntry::deserialize(Deserializer& 
 
 void TableCatalogEntry::copyFrom(const CatalogEntry& other) {
     CatalogEntry::copyFrom(other);
-    auto& otherTable = ku_dynamic_cast<const CatalogEntry&, const TableCatalogEntry&>(other);
+    auto& otherTable = ku_dynamic_cast<const TableCatalogEntry&>(other);
     set = otherTable.set;
     comment = otherTable.comment;
     propertyCollection = otherTable.propertyCollection.copy();

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -284,8 +284,7 @@ uint32_t PhysicalTypeUtils::getFixedTypeSize(PhysicalTypeID physicalType) {
 }
 
 bool DecimalTypeInfo::operator==(const ExtraTypeInfo& other) const {
-    auto otherDecimalTypeInfo =
-        ku_dynamic_cast<const ExtraTypeInfo*, const DecimalTypeInfo*>(&other);
+    auto otherDecimalTypeInfo = ku_dynamic_cast<const DecimalTypeInfo*>(&other);
     if (otherDecimalTypeInfo) {
         return precision == otherDecimalTypeInfo->precision && scale == otherDecimalTypeInfo->scale;
     }
@@ -313,7 +312,7 @@ bool ListTypeInfo::containsAny() const {
 }
 
 bool ListTypeInfo::operator==(const ExtraTypeInfo& other) const {
-    auto otherListTypeInfo = ku_dynamic_cast<const ExtraTypeInfo*, const ListTypeInfo*>(&other);
+    auto otherListTypeInfo = ku_dynamic_cast<const ListTypeInfo*>(&other);
     if (otherListTypeInfo) {
         return childType == otherListTypeInfo->childType;
     }
@@ -333,7 +332,7 @@ void ListTypeInfo::serializeInternal(Serializer& serializer) const {
 }
 
 bool ArrayTypeInfo::operator==(const ExtraTypeInfo& other) const {
-    auto otherArrayTypeInfo = ku_dynamic_cast<const ExtraTypeInfo*, const ArrayTypeInfo*>(&other);
+    auto otherArrayTypeInfo = ku_dynamic_cast<const ArrayTypeInfo*>(&other);
     if (otherArrayTypeInfo) {
         return childType == otherArrayTypeInfo->childType &&
                numElements == otherArrayTypeInfo->numElements;
@@ -460,7 +459,7 @@ bool StructTypeInfo::containsAny() const {
 }
 
 bool StructTypeInfo::operator==(const ExtraTypeInfo& other) const {
-    auto otherStructTypeInfo = ku_dynamic_cast<const ExtraTypeInfo*, const StructTypeInfo*>(&other);
+    auto otherStructTypeInfo = ku_dynamic_cast<const StructTypeInfo*>(&other);
     if (otherStructTypeInfo) {
         if (fields.size() != otherStructTypeInfo->fields.size()) {
             return false;
@@ -553,22 +552,21 @@ bool LogicalType::operator!=(const LogicalType& other) const {
 std::string LogicalType::toString() const {
     switch (typeID) {
     case LogicalTypeID::MAP: {
-        auto structType =
-            ku_dynamic_cast<ExtraTypeInfo*, ListTypeInfo*>(extraTypeInfo.get())->getChildType();
+        auto structType = ku_dynamic_cast<ListTypeInfo*>(extraTypeInfo.get())->getChildType();
         auto fieldTypes = StructType::getFieldTypes(structType);
         return "MAP(" + fieldTypes[0]->toString() + ", " + fieldTypes[1]->toString() + ")";
     }
     case LogicalTypeID::LIST: {
-        auto listTypeInfo = ku_dynamic_cast<ExtraTypeInfo*, ListTypeInfo*>(extraTypeInfo.get());
+        auto listTypeInfo = ku_dynamic_cast<ListTypeInfo*>(extraTypeInfo.get());
         return listTypeInfo->getChildType().toString() + "[]";
     }
     case LogicalTypeID::ARRAY: {
-        auto arrayTypeInfo = ku_dynamic_cast<ExtraTypeInfo*, ArrayTypeInfo*>(extraTypeInfo.get());
+        auto arrayTypeInfo = ku_dynamic_cast<ArrayTypeInfo*>(extraTypeInfo.get());
         return arrayTypeInfo->getChildType().toString() + "[" +
                std::to_string(arrayTypeInfo->getNumElements()) + "]";
     }
     case LogicalTypeID::UNION: {
-        auto unionTypeInfo = ku_dynamic_cast<ExtraTypeInfo*, StructTypeInfo*>(extraTypeInfo.get());
+        auto unionTypeInfo = ku_dynamic_cast<StructTypeInfo*>(extraTypeInfo.get());
         std::string dataTypeStr = LogicalTypeUtils::toString(typeID) + "(";
         auto numFields = unionTypeInfo->getChildrenTypes().size();
         auto fieldNames = unionTypeInfo->getChildrenNames();
@@ -580,7 +578,7 @@ std::string LogicalType::toString() const {
         return dataTypeStr;
     }
     case LogicalTypeID::STRUCT: {
-        auto structTypeInfo = ku_dynamic_cast<ExtraTypeInfo*, StructTypeInfo*>(extraTypeInfo.get());
+        auto structTypeInfo = ku_dynamic_cast<StructTypeInfo*>(extraTypeInfo.get());
         std::string dataTypeStr = LogicalTypeUtils::toString(typeID) + "(";
         auto numFields = structTypeInfo->getChildrenTypes().size();
         auto fieldNames = structTypeInfo->getChildrenNames();
@@ -594,8 +592,7 @@ std::string LogicalType::toString() const {
         return dataTypeStr + ")";
     }
     case LogicalTypeID::DECIMAL: {
-        auto decimalTypeInfo =
-            ku_dynamic_cast<ExtraTypeInfo*, DecimalTypeInfo*>(extraTypeInfo.get());
+        auto decimalTypeInfo = ku_dynamic_cast<DecimalTypeInfo*>(extraTypeInfo.get());
         return "DECIMAL(" + std::to_string(decimalTypeInfo->getPrecision()) + ", " +
                std::to_string(decimalTypeInfo->getScale()) + ")";
     }

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -303,21 +303,18 @@ std::unique_ptr<Value> ValueVector::getAsValue(uint64_t pos) const {
 void ValueVector::resetAuxiliaryBuffer() {
     switch (dataType.getPhysicalType()) {
     case PhysicalTypeID::STRING: {
-        ku_dynamic_cast<AuxiliaryBuffer*, StringAuxiliaryBuffer*>(auxiliaryBuffer.get())
-            ->resetOverflowBuffer();
+        ku_dynamic_cast<StringAuxiliaryBuffer*>(auxiliaryBuffer.get())->resetOverflowBuffer();
         return;
     }
     case PhysicalTypeID::ARRAY:
     case PhysicalTypeID::LIST: {
-        auto listAuxiliaryBuffer =
-            ku_dynamic_cast<AuxiliaryBuffer*, ListAuxiliaryBuffer*>(auxiliaryBuffer.get());
+        auto listAuxiliaryBuffer = ku_dynamic_cast<ListAuxiliaryBuffer*>(auxiliaryBuffer.get());
         listAuxiliaryBuffer->resetSize();
         listAuxiliaryBuffer->getDataVector()->resetAuxiliaryBuffer();
         return;
     }
     case PhysicalTypeID::STRUCT: {
-        auto structAuxiliaryBuffer =
-            ku_dynamic_cast<AuxiliaryBuffer*, StructAuxiliaryBuffer*>(auxiliaryBuffer.get());
+        auto structAuxiliaryBuffer = ku_dynamic_cast<StructAuxiliaryBuffer*>(auxiliaryBuffer.get());
         for (auto& vector : structAuxiliaryBuffer->getFieldVectors()) {
             vector->resetAuxiliaryBuffer();
         }
@@ -439,8 +436,7 @@ void ValueVector::setNull(uint32_t pos, bool isNull) {
 
 void StringVector::addString(ValueVector* vector, uint32_t vectorPos, ku_string_t& srcStr) {
     KU_ASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
-    auto stringBuffer =
-        ku_dynamic_cast<AuxiliaryBuffer*, StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get());
+    auto stringBuffer = ku_dynamic_cast<StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get());
     auto& dstStr = vector->getValue<ku_string_t>(vectorPos);
     if (ku_string_t::isShortString(srcStr.len)) {
         dstStr.setShortString(srcStr);
@@ -453,8 +449,7 @@ void StringVector::addString(ValueVector* vector, uint32_t vectorPos, ku_string_
 void StringVector::addString(ValueVector* vector, uint32_t vectorPos, const char* srcStr,
     uint64_t length) {
     KU_ASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
-    auto stringBuffer =
-        ku_dynamic_cast<AuxiliaryBuffer*, StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get());
+    auto stringBuffer = ku_dynamic_cast<StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get());
     auto& dstStr = vector->getValue<ku_string_t>(vectorPos);
     if (ku_string_t::isShortString(length)) {
         dstStr.setShortString(srcStr, length);
@@ -470,8 +465,7 @@ void StringVector::addString(ValueVector* vector, uint32_t vectorPos, const std:
 
 ku_string_t& StringVector::reserveString(ValueVector* vector, uint32_t vectorPos, uint64_t length) {
     KU_ASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
-    auto stringBuffer =
-        ku_dynamic_cast<AuxiliaryBuffer*, StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get());
+    auto stringBuffer = ku_dynamic_cast<StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get());
     auto& dstStr = vector->getValue<ku_string_t>(vectorPos);
     dstStr.len = length;
     if (!ku_string_t::isShortString(length)) {
@@ -482,8 +476,7 @@ ku_string_t& StringVector::reserveString(ValueVector* vector, uint32_t vectorPos
 
 void StringVector::reserveString(ValueVector* vector, ku_string_t& dstStr, uint64_t length) {
     KU_ASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
-    auto stringBuffer =
-        ku_dynamic_cast<AuxiliaryBuffer*, StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get());
+    auto stringBuffer = ku_dynamic_cast<StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get());
     dstStr.len = length;
     if (!ku_string_t::isShortString(length)) {
         dstStr.overflowPtr = reinterpret_cast<uint64_t>(stringBuffer->allocateOverflow(length));
@@ -492,8 +485,7 @@ void StringVector::reserveString(ValueVector* vector, ku_string_t& dstStr, uint6
 
 void StringVector::addString(ValueVector* vector, ku_string_t& dstStr, ku_string_t& srcStr) {
     KU_ASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
-    auto stringBuffer =
-        ku_dynamic_cast<AuxiliaryBuffer*, StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get());
+    auto stringBuffer = ku_dynamic_cast<StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get());
     if (ku_string_t::isShortString(srcStr.len)) {
         dstStr.setShortString(srcStr);
     } else {
@@ -505,8 +497,7 @@ void StringVector::addString(ValueVector* vector, ku_string_t& dstStr, ku_string
 void StringVector::addString(ValueVector* vector, ku_string_t& dstStr, const char* srcStr,
     uint64_t length) {
     KU_ASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
-    auto stringBuffer =
-        ku_dynamic_cast<AuxiliaryBuffer*, StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get());
+    auto stringBuffer = ku_dynamic_cast<StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get());
     if (ku_string_t::isShortString(length)) {
         dstStr.setShortString(srcStr, length);
     } else {

--- a/src/function/list/list_any_value_function.cpp
+++ b/src/function/list/list_any_value_function.cpp
@@ -27,7 +27,7 @@ struct ListAnyValue {
 };
 
 static std::unique_ptr<FunctionBindData> bindFunc(ScalarBindFuncInput input) {
-    auto scalarFunction = ku_dynamic_cast<Function*, ScalarFunction*>(input.definition);
+    auto scalarFunction = ku_dynamic_cast<ScalarFunction*>(input.definition);
     const auto& resultType = ListType::getChildType(input.arguments[0]->dataType);
     TypeUtils::visit(resultType.getPhysicalType(), [&scalarFunction]<typename T>(T) {
         scalarFunction->execFunc =

--- a/src/function/list/list_reverse_function.cpp
+++ b/src/function/list/list_reverse_function.cpp
@@ -21,7 +21,7 @@ struct ListReverse {
 };
 
 static std::unique_ptr<FunctionBindData> bindFunc(ScalarBindFuncInput input) {
-    auto scalarFunction = ku_dynamic_cast<Function*, ScalarFunction*>(input.definition);
+    auto scalarFunction = ku_dynamic_cast<ScalarFunction*>(input.definition);
     const auto& resultType = input.arguments[0]->dataType;
     scalarFunction->execFunc =
         ScalarFunction::UnaryExecNestedTypeFunction<list_entry_t, list_entry_t, ListReverse>;

--- a/src/function/map/map_extract_function.cpp
+++ b/src/function/map/map_extract_function.cpp
@@ -20,7 +20,7 @@ static void validateKeyType(const std::shared_ptr<binder::Expression>& mapExpres
 
 static std::unique_ptr<FunctionBindData> bindFunc(ScalarBindFuncInput input) {
     validateKeyType(input.arguments[0], input.arguments[1]);
-    auto scalarFunction = ku_dynamic_cast<Function*, ScalarFunction*>(input.definition);
+    auto scalarFunction = ku_dynamic_cast<ScalarFunction*>(input.definition);
     TypeUtils::visit(input.arguments[1]->getDataType().getPhysicalType(), [&]<typename T>(T) {
         scalarFunction->execFunc =
             ScalarFunction::BinaryExecListStructFunction<list_entry_t, T, list_entry_t, MapExtract>;

--- a/src/function/struct/struct_extract_function.cpp
+++ b/src/function/struct/struct_extract_function.cpp
@@ -33,7 +33,7 @@ void StructExtractFunctions::compileFunc(FunctionBindData* bindData,
     const std::vector<std::shared_ptr<ValueVector>>& parameters,
     std::shared_ptr<ValueVector>& result) {
     KU_ASSERT(parameters[0]->dataType.getPhysicalType() == PhysicalTypeID::STRUCT);
-    auto structBindData = ku_dynamic_cast<FunctionBindData*, StructExtractBindData*>(bindData);
+    auto structBindData = ku_dynamic_cast<StructExtractBindData*>(bindData);
     result = StructVector::getFieldVector(parameters[0].get(), structBindData->childIdx);
     result->state = parameters[0]->state;
 }

--- a/src/function/table/call/show_connection.cpp
+++ b/src/function/table/call/show_connection.cpp
@@ -33,7 +33,7 @@ static void outputRelTableConnection(DataChunk& outputDataChunk, uint64_t output
     ClientContext* context, table_id_t tableID) {
     auto catalog = context->getCatalog();
     auto tableEntry = catalog->getTableCatalogEntry(context->getTx(), tableID);
-    auto relTableEntry = ku_dynamic_cast<TableCatalogEntry*, RelTableCatalogEntry*>(tableEntry);
+    auto relTableEntry = ku_dynamic_cast<RelTableCatalogEntry*>(tableEntry);
     KU_ASSERT(tableEntry->getTableType() == TableType::REL);
     // Get src and dst name
     auto srcTableID = relTableEntry->getSrcTableID();
@@ -68,7 +68,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
         vectorPos++;
     } break;
     case TableType::REL_GROUP: {
-        auto relGroupEntry = ku_dynamic_cast<TableCatalogEntry*, RelGroupCatalogEntry*>(tableEntry);
+        auto relGroupEntry = ku_dynamic_cast<RelGroupCatalogEntry*>(tableEntry);
         auto relTableIDs = relGroupEntry->getRelTableIDs();
         for (; vectorPos < numRelationsToOutput; vectorPos++) {
             outputRelTableConnection(dataChunk, vectorPos, bindData->context,
@@ -105,7 +105,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
     columnTypes.emplace_back(LogicalType::STRING());
     common::offset_t maxOffset = 1;
     if (tableEntry->getTableType() == common::TableType::REL_GROUP) {
-        auto relGroupEntry = ku_dynamic_cast<TableCatalogEntry*, RelGroupCatalogEntry*>(tableEntry);
+        auto relGroupEntry = ku_dynamic_cast<RelGroupCatalogEntry*>(tableEntry);
         maxOffset = relGroupEntry->getRelTableIDs().size();
     }
     return std::make_unique<ShowConnectionBindData>(context, tableEntry, std::move(columnTypes),

--- a/src/function/table/call/storage_info.cpp
+++ b/src/function/table/call/storage_info.cpp
@@ -41,7 +41,7 @@ static void collectColumns(Column* column, std::vector<Column*>& result) {
     }
     switch (column->getDataType().getPhysicalType()) {
     case PhysicalTypeID::STRUCT: {
-        auto structColumn = ku_dynamic_cast<Column*, StructColumn*>(column);
+        auto structColumn = ku_dynamic_cast<StructColumn*>(column);
         auto numChildren = StructType::getNumFields(structColumn->getDataType());
         for (auto i = 0u; i < numChildren; i++) {
             auto childColumn = structColumn->getChild(i);
@@ -49,14 +49,14 @@ static void collectColumns(Column* column, std::vector<Column*>& result) {
         }
     } break;
     case PhysicalTypeID::STRING: {
-        auto stringColumn = ku_dynamic_cast<Column*, StringColumn*>(column);
+        auto stringColumn = ku_dynamic_cast<StringColumn*>(column);
         auto& dictionary = stringColumn->getDictionary();
         collectColumns(dictionary.getDataColumn(), result);
         collectColumns(dictionary.getOffsetColumn(), result);
     } break;
     case PhysicalTypeID::ARRAY:
     case PhysicalTypeID::LIST: {
-        auto listColumn = ku_dynamic_cast<Column*, ListColumn*>(column);
+        auto listColumn = ku_dynamic_cast<ListColumn*>(column);
         collectColumns(listColumn->getOffsetColumn(), result);
         collectColumns(listColumn->getSizeColumn(), result);
         collectColumns(listColumn->getDataColumn(), result);
@@ -243,8 +243,7 @@ static void appendStorageInfoForNodeGroup(StorageInfoLocalState* localState, Dat
 
 static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output) {
     auto& dataChunk = output.dataChunk;
-    auto localState =
-        ku_dynamic_cast<TableFuncLocalState*, StorageInfoLocalState*>(input.localState);
+    auto localState = ku_dynamic_cast<StorageInfoLocalState*>(input.localState);
     KU_ASSERT(dataChunk.state->getSelVector().isUnfiltered());
     while (true) {
         if (localState->currChunkIdx < localState->dataChunkCollection->getNumChunks()) {

--- a/src/function/table/call_functions.cpp
+++ b/src/function/table/call_functions.cpp
@@ -18,8 +18,7 @@ CallFuncMorsel CallFuncSharedState::getMorsel() {
 }
 
 std::unique_ptr<TableFuncSharedState> CallFunction::initSharedState(TableFunctionInitInput& input) {
-    auto callTableFuncBindData =
-        ku_dynamic_cast<TableFuncBindData*, CallTableFuncBindData*>(input.bindData);
+    auto callTableFuncBindData = ku_dynamic_cast<CallTableFuncBindData*>(input.bindData);
     return std::make_unique<CallFuncSharedState>(callTableFuncBindData->maxOffset);
 }
 

--- a/src/function/vector_arithmetic_functions.cpp
+++ b/src/function/vector_arithmetic_functions.cpp
@@ -779,7 +779,7 @@ static void getBinaryExecutionHelperA(const LogicalType& typeB, const LogicalTyp
 template<typename FUNC>
 static std::unique_ptr<FunctionBindData> genericBinaryArithmeticFunc(
     const binder::expression_vector& arguments, Function* func) {
-    auto asScalar = ku_dynamic_cast<Function*, ScalarFunction*>(func);
+    auto asScalar = ku_dynamic_cast<ScalarFunction*>(func);
     KU_ASSERT(asScalar != nullptr);
     auto argADataType = arguments[0]->getDataType().copy();
     auto argBDataType = arguments[1]->getDataType().copy();
@@ -872,7 +872,7 @@ static void getUnaryExecutionHelper(const LogicalType& resultType, scalar_func_e
 template<typename FUNC>
 static std::unique_ptr<FunctionBindData> genericUnaryArithmeticFunc(
     const binder::expression_vector& arguments, Function* func) {
-    auto asScalar = ku_dynamic_cast<Function*, ScalarFunction*>(func);
+    auto asScalar = ku_dynamic_cast<ScalarFunction*>(func);
     KU_ASSERT(asScalar != nullptr);
     auto argPrecision = DecimalType::getPrecision(arguments[0]->getDataType());
     auto argScale = DecimalType::getScale(arguments[0]->getDataType());

--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -166,7 +166,7 @@ std::unique_ptr<GraphScanState> OnDiskGraph::prepareMultiTableScanBwd(
 }
 
 std::vector<nodeID_t> OnDiskGraph::scanFwd(nodeID_t nodeID, GraphScanState& state) {
-    auto& onDiskScanState = ku_dynamic_cast<GraphScanState&, OnDiskGraphScanStates&>(state);
+    auto& onDiskScanState = ku_dynamic_cast<OnDiskGraphScanStates&>(state);
     KU_ASSERT(nodeTableIDToFwdRelTables.contains(nodeID.tableID));
     auto& relTables = nodeTableIDToFwdRelTables.at(nodeID.tableID);
     std::vector<nodeID_t> result;
@@ -180,12 +180,12 @@ std::vector<nodeID_t> OnDiskGraph::scanFwd(nodeID_t nodeID, GraphScanState& stat
 }
 
 std::vector<nodeID_t> OnDiskGraph::scanFwdRandom(nodeID_t, GraphScanState&) {
-    // auto& onDiskScanState = ku_dynamic_cast<GraphScanState&, OnDiskGraphScanStates&>(state);
+    // auto& onDiskScanState = ku_dynamic_cast<OnDiskGraphScanStates&>(state);
     // KU_ASSERT(nodeTableIDToFwdRelTables.contains(nodeID.tableID));
     // auto& relTables = nodeTableIDToFwdRelTables.at(nodeID.tableID);
     std::vector<nodeID_t> result;
     // for (auto& [tableID, scanState] : onDiskScanState.scanStates) {
-    //     ku_dynamic_cast<TableDataScanState*, RelDataReadState*>(
+    //     ku_dynamic_cast<RelDataReadState*>(
     //         scanState.fwdScanState->dataScanState.get())
     //         ->randomAccess = true;
     //     auto relTablePair = relTables.find(tableID);
@@ -197,7 +197,7 @@ std::vector<nodeID_t> OnDiskGraph::scanFwdRandom(nodeID_t, GraphScanState&) {
 }
 
 std::vector<nodeID_t> OnDiskGraph::scanBwd(nodeID_t nodeID, GraphScanState& state) {
-    auto& onDiskScanState = ku_dynamic_cast<GraphScanState&, OnDiskGraphScanStates&>(state);
+    auto& onDiskScanState = ku_dynamic_cast<OnDiskGraphScanStates&>(state);
     KU_ASSERT(nodeTableIDToBwdRelTables.contains(nodeID.tableID));
     auto& relTables = nodeTableIDToBwdRelTables.at(nodeID.tableID);
     std::vector<nodeID_t> result;
@@ -211,12 +211,12 @@ std::vector<nodeID_t> OnDiskGraph::scanBwd(nodeID_t nodeID, GraphScanState& stat
 }
 
 std::vector<nodeID_t> OnDiskGraph::scanBwdRandom(nodeID_t, GraphScanState&) {
-    // auto& onDiskScanState = ku_dynamic_cast<GraphScanState&, OnDiskGraphScanStates&>(state);
+    // auto& onDiskScanState = ku_dynamic_cast<OnDiskGraphScanStates&>(state);
     // KU_ASSERT(nodeTableIDToBwdRelTables.contains(nodeID.tableID));
     // auto& relTables = nodeTableIDToBwdRelTables.at(nodeID.tableID);
     std::vector<nodeID_t> result;
     // for (auto& [tableID, scanState] : onDiskScanState.scanStates) {
-    //     ku_dynamic_cast<TableDataScanState*, RelDataReadState*>(
+    //     ku_dynamic_cast<RelDataReadState*>(
     //         scanState.bwdScanState->dataScanState.get())
     //         ->randomAccess = true;
     //     auto relTablePair = relTables.find(tableID);

--- a/src/include/binder/bound_scan_source.h
+++ b/src/include/binder/bound_scan_source.h
@@ -24,7 +24,7 @@ struct BoundBaseScanSource {
 
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const BoundBaseScanSource&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
 
 protected:

--- a/src/include/binder/bound_statement.h
+++ b/src/include/binder/bound_statement.h
@@ -23,11 +23,11 @@ public:
 
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const BoundStatement&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<BoundStatement&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
 
 private:

--- a/src/include/binder/copy/bound_copy_from.h
+++ b/src/include/binder/copy/bound_copy_from.h
@@ -15,7 +15,7 @@ struct ExtraBoundCopyFromInfo {
 
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const ExtraBoundCopyFromInfo&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
 };
 

--- a/src/include/binder/ddl/bound_alter_info.h
+++ b/src/include/binder/ddl/bound_alter_info.h
@@ -12,11 +12,11 @@ struct BoundExtraAlterInfo {
 
     template<class TARGET>
     const TARGET* constPtrCast() const {
-        return common::ku_dynamic_cast<const BoundExtraAlterInfo*, const TARGET*>(this);
+        return common::ku_dynamic_cast<const TARGET*>(this);
     }
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const BoundExtraAlterInfo&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
 
     virtual std::unique_ptr<BoundExtraAlterInfo> copy() const = 0;

--- a/src/include/binder/ddl/bound_create_table_info.h
+++ b/src/include/binder/ddl/bound_create_table_info.h
@@ -17,13 +17,12 @@ struct BoundExtraCreateCatalogEntryInfo {
 
     template<class TARGET>
     const TARGET* constPtrCast() const {
-        return common::ku_dynamic_cast<const BoundExtraCreateCatalogEntryInfo*, const TARGET*>(
-            this);
+        return common::ku_dynamic_cast<const TARGET*>(this);
     }
 
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<BoundExtraCreateCatalogEntryInfo*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
 
     virtual void serialize(common::Serializer& serializer) const = 0;

--- a/src/include/binder/expression/expression.h
+++ b/src/include/binder/expression/expression.h
@@ -90,19 +90,19 @@ public:
 
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<Expression&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<Expression*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const Expression&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
     template<class TARGET>
     const TARGET* constPtrCast() const {
-        return common::ku_dynamic_cast<const Expression*, const TARGET*>(this);
+        return common::ku_dynamic_cast<const TARGET*>(this);
     }
 
 protected:

--- a/src/include/binder/query/reading_clause/bound_reading_clause.h
+++ b/src/include/binder/query/reading_clause/bound_reading_clause.h
@@ -23,15 +23,15 @@ public:
 
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<BoundReadingClause&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const BoundReadingClause&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
     template<class TARGET>
     const TARGET* constPtrCast() const {
-        return common::ku_dynamic_cast<const BoundReadingClause*, const TARGET*>(this);
+        return common::ku_dynamic_cast<const TARGET*>(this);
     }
 
 private:

--- a/src/include/binder/query/updating_clause/bound_updating_clause.h
+++ b/src/include/binder/query/updating_clause/bound_updating_clause.h
@@ -15,7 +15,7 @@ public:
 
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const BoundUpdatingClause&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
 
 private:

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -146,7 +146,7 @@ public:
 
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<Catalog*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
 
 private:
@@ -166,9 +166,8 @@ private:
     std::vector<T*> getTableCatalogEntries(transaction::Transaction* transaction,
         CatalogEntryType catalogType) const {
         std::vector<T*> result;
-        tables->iterateEntriesOfType(transaction, catalogType, [&](CatalogEntry* entry) {
-            result.push_back(common::ku_dynamic_cast<CatalogEntry*, T*>(entry));
-        });
+        tables->iterateEntriesOfType(transaction, catalogType,
+            [&](CatalogEntry* entry) { result.push_back(common::ku_dynamic_cast<T*>(entry)); });
         return result;
     }
 

--- a/src/include/catalog/catalog_entry/catalog_entry.h
+++ b/src/include/catalog/catalog_entry/catalog_entry.h
@@ -70,15 +70,15 @@ public:
 
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const CatalogEntry&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
     template<class TARGET>
     const TARGET* constPtrCast() const {
-        return common::ku_dynamic_cast<const CatalogEntry*, const TARGET*>(this);
+        return common::ku_dynamic_cast<const TARGET*>(this);
     }
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<CatalogEntry*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
 
 protected:

--- a/src/include/common/cast.h
+++ b/src/include/common/cast.h
@@ -7,14 +7,24 @@
 namespace kuzu {
 namespace common {
 
-template<typename FROM, typename TO>
-TO ku_dynamic_cast(FROM old) {
+template<typename TO, typename FROM>
+TO ku_dynamic_cast(FROM* old) {
 #if defined(KUZU_RUNTIME_CHECKS) || !defined(NDEBUG)
+    static_assert(std::is_pointer<TO>());
+    TO newVal = dynamic_cast<TO>(old);
+    KU_ASSERT(newVal != nullptr);
+    return newVal;
+#else
+    return reinterpret_cast<TO>(old);
+#endif
+}
+
+template<typename TO, typename FROM>
+TO ku_dynamic_cast(FROM& old) {
+#if defined(KUZU_RUNTIME_CHECKS) || !defined(NDEBUG)
+    static_assert(std::is_reference<TO>());
     try {
         TO newVal = dynamic_cast<TO>(old);
-        if constexpr (std::is_pointer<FROM>()) {
-            KU_ASSERT(newVal != nullptr);
-        }
         return newVal;
     } catch (std::bad_cast& e) {
         KU_ASSERT(false);

--- a/src/include/common/file_system/file_info.h
+++ b/src/include/common/file_system/file_info.h
@@ -33,22 +33,22 @@ struct KUZU_API FileInfo {
 
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<FileInfo*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
 
     template<class TARGET>
     const TARGET* constPtrCast() const {
-        return common::ku_dynamic_cast<const FileInfo*, const TARGET*>(this);
+        return common::ku_dynamic_cast<const TARGET*>(this);
     }
 
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const FileInfo&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
 
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<FileInfo&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
 
     const std::string path;

--- a/src/include/common/file_system/file_system.h
+++ b/src/include/common/file_system/file_system.h
@@ -68,12 +68,12 @@ public:
 
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<FileSystem*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
 
     template<class TARGET>
     const TARGET* constPtrCast() const {
-        return common::ku_dynamic_cast<const FileSystem*, const TARGET*>(this);
+        return common::ku_dynamic_cast<const TARGET*>(this);
     }
 
     virtual void cleanUP(main::ClientContext* context) = 0;

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -372,7 +372,7 @@ public:
 
     template<class TARGET>
     const TARGET* constPtrCast() const {
-        return common::ku_dynamic_cast<const ExtraTypeInfo*, const TARGET*>(this);
+        return common::ku_dynamic_cast<const TARGET*>(this);
     }
 
 protected:

--- a/src/include/common/vector/auxiliary_buffer.h
+++ b/src/include/common/vector/auxiliary_buffer.h
@@ -20,12 +20,12 @@ public:
 
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<AuxiliaryBuffer&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
 
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const AuxiliaryBuffer&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
 };
 

--- a/src/include/common/vector/value_vector.h
+++ b/src/include/common/vector/value_vector.h
@@ -115,8 +115,7 @@ class KUZU_API StringVector {
 public:
     static inline InMemOverflowBuffer* getInMemOverflowBuffer(ValueVector* vector) {
         KU_ASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
-        return ku_dynamic_cast<AuxiliaryBuffer*, StringAuxiliaryBuffer*>(
-            vector->auxiliaryBuffer.get())
+        return ku_dynamic_cast<StringAuxiliaryBuffer*>(vector->auxiliaryBuffer.get())
             ->getOverflowBuffer();
     }
 
@@ -221,21 +220,19 @@ class StructVector {
 public:
     static inline const std::vector<std::shared_ptr<ValueVector>>& getFieldVectors(
         const ValueVector* vector) {
-        return ku_dynamic_cast<AuxiliaryBuffer*, StructAuxiliaryBuffer*>(
-            vector->auxiliaryBuffer.get())
+        return ku_dynamic_cast<StructAuxiliaryBuffer*>(vector->auxiliaryBuffer.get())
             ->getFieldVectors();
     }
 
     static inline std::shared_ptr<ValueVector> getFieldVector(const ValueVector* vector,
         struct_field_idx_t idx) {
-        return ku_dynamic_cast<AuxiliaryBuffer*, StructAuxiliaryBuffer*>(
-            vector->auxiliaryBuffer.get())
+        return ku_dynamic_cast<StructAuxiliaryBuffer*>(vector->auxiliaryBuffer.get())
             ->getFieldVectors()[idx];
     }
 
     static inline void referenceVector(ValueVector* vector, struct_field_idx_t idx,
         std::shared_ptr<ValueVector> vectorToReference) {
-        ku_dynamic_cast<AuxiliaryBuffer*, StructAuxiliaryBuffer*>(vector->auxiliaryBuffer.get())
+        ku_dynamic_cast<StructAuxiliaryBuffer*>(vector->auxiliaryBuffer.get())
             ->referenceChildVector(idx, std::move(vectorToReference));
     }
 

--- a/src/include/expression_evaluator/expression_evaluator.h
+++ b/src/include/expression_evaluator/expression_evaluator.h
@@ -59,15 +59,15 @@ public:
 
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const ExpressionEvaluator&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<ExpressionEvaluator&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<ExpressionEvaluator*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
 
 protected:

--- a/src/include/function/export/export_function.h
+++ b/src/include/function/export/export_function.h
@@ -11,7 +11,7 @@ struct ExportFuncLocalState {
 
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<ExportFuncLocalState&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
 };
 
@@ -22,7 +22,7 @@ struct ExportFuncSharedState {
 
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<ExportFuncSharedState&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
 
     virtual void init(main::ClientContext& context, const ExportFuncBindData& bindData) = 0;
@@ -42,7 +42,7 @@ struct ExportFuncBindData {
 
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const ExportFuncBindData&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
 
     virtual std::unique_ptr<ExportFuncBindData> copy() const = 0;

--- a/src/include/function/function.h
+++ b/src/include/function/function.h
@@ -30,7 +30,7 @@ struct KUZU_API FunctionBindData {
 
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<FunctionBindData&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
 
     virtual std::unique_ptr<FunctionBindData> copy() const {
@@ -77,11 +77,11 @@ struct Function {
 
     template<class TARGET>
     const TARGET* constPtrCast() const {
-        return common::ku_dynamic_cast<const Function*, const TARGET*>(this);
+        return common::ku_dynamic_cast<const TARGET*>(this);
     }
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<Function*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
 };
 

--- a/src/include/function/gds/gds.h
+++ b/src/include/function/gds/gds.h
@@ -46,7 +46,7 @@ struct GDSBindData {
 
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<GDSBindData*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
 };
 

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -122,7 +122,7 @@ public:
     virtual void setActive(nodeID_t nodeID) = 0;
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<GDSFrontier*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
 };
 

--- a/src/include/function/gds/rec_joins.h
+++ b/src/include/function/gds/rec_joins.h
@@ -208,7 +208,7 @@ public:
     virtual void beginWritingOutputsForDstNodesInTable(table_id_t tableID) = 0;
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<RJOutputs*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
 
 public:

--- a/src/include/function/table/bind_data.h
+++ b/src/include/function/table/bind_data.h
@@ -45,7 +45,7 @@ struct TableFuncBindData {
 
     template<class TARGET>
     const TARGET* constPtrCast() const {
-        return common::ku_dynamic_cast<const TableFuncBindData*, const TARGET*>(this);
+        return common::ku_dynamic_cast<const TARGET*>(this);
     }
 
 private:

--- a/src/include/function/table_functions.h
+++ b/src/include/function/table_functions.h
@@ -24,7 +24,7 @@ struct TableFuncSharedState {
 
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<TableFuncSharedState*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
 };
 
@@ -33,7 +33,7 @@ struct TableFuncLocalState {
 
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<TableFuncLocalState*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
 };
 

--- a/src/include/parser/ddl/alter_info.h
+++ b/src/include/parser/ddl/alter_info.h
@@ -14,11 +14,11 @@ struct ExtraAlterInfo {
 
     template<class TARGET>
     const TARGET* constPtrCast() const {
-        return common::ku_dynamic_cast<const ExtraAlterInfo*, const TARGET*>(this);
+        return common::ku_dynamic_cast<const TARGET*>(this);
     }
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<ExtraAlterInfo*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
 };
 

--- a/src/include/parser/ddl/create_table_info.h
+++ b/src/include/parser/ddl/create_table_info.h
@@ -17,7 +17,7 @@ struct ExtraCreateTableInfo {
 
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const ExtraCreateTableInfo&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
 };
 

--- a/src/include/parser/expression/parsed_expression.h
+++ b/src/include/parser/expression/parsed_expression.h
@@ -70,15 +70,15 @@ public:
 
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<ParsedExpression&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const ParsedExpression&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
     template<class TARGET>
     const TARGET* constPtrCast() const {
-        return common::ku_dynamic_cast<const ParsedExpression*, const TARGET*>(this);
+        return common::ku_dynamic_cast<const TARGET*>(this);
     }
 
 private:

--- a/src/include/parser/query/reading_clause/reading_clause.h
+++ b/src/include/parser/query/reading_clause/reading_clause.h
@@ -22,7 +22,7 @@ public:
 
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const ReadingClause&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
 
 private:

--- a/src/include/parser/query/updating_clause/updating_clause.h
+++ b/src/include/parser/query/updating_clause/updating_clause.h
@@ -15,7 +15,7 @@ public:
 
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const UpdatingClause&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
 
 private:

--- a/src/include/parser/scan_source.h
+++ b/src/include/parser/scan_source.h
@@ -20,11 +20,11 @@ struct BaseScanSource {
 
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<BaseScanSource*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
     template<class TARGET>
     const TARGET* constPtrCast() const {
-        return common::ku_dynamic_cast<const BaseScanSource*, const TARGET*>(this);
+        return common::ku_dynamic_cast<const TARGET*>(this);
     }
 };
 

--- a/src/include/parser/statement.h
+++ b/src/include/parser/statement.h
@@ -25,15 +25,15 @@ public:
 
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<Statement&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const Statement&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
     template<class TARGET>
     const TARGET* constPtrCast() const {
-        return common::ku_dynamic_cast<const Statement*, const TARGET*>(this);
+        return common::ku_dynamic_cast<const TARGET*>(this);
     }
 
 private:

--- a/src/include/planner/join_order/join_tree.h
+++ b/src/include/planner/join_order/join_tree.h
@@ -23,11 +23,11 @@ struct ExtraTreeNodeInfo {
 
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const ExtraTreeNodeInfo&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<ExtraTreeNodeInfo&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
 };
 

--- a/src/include/planner/operator/logical_operator.h
+++ b/src/include/planner/operator/logical_operator.h
@@ -105,19 +105,19 @@ public:
 
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const LogicalOperator&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<LogicalOperator&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
     template<class TARGET>
     const TARGET* constPtrCast() const {
-        return common::ku_dynamic_cast<const LogicalOperator*, const TARGET*>(this);
+        return common::ku_dynamic_cast<const TARGET*>(this);
     }
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<LogicalOperator*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
 
 protected:

--- a/src/include/planner/operator/scan/logical_scan_node_table.h
+++ b/src/include/planner/operator/scan/logical_scan_node_table.h
@@ -19,7 +19,7 @@ struct ExtraScanNodeTableInfo {
 
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const ExtraScanNodeTableInfo&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
 };
 

--- a/src/include/processor/operator/persistent/batch_insert.h
+++ b/src/include/processor/operator/persistent/batch_insert.h
@@ -32,7 +32,7 @@ struct BatchInsertInfo {
 
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<BatchInsertInfo*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
 };
 
@@ -81,7 +81,7 @@ struct BatchInsertLocalState {
 
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<BatchInsertLocalState*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
 };
 

--- a/src/include/processor/operator/persistent/reader/rdf/rdf_scan.h
+++ b/src/include/processor/operator/persistent/reader/rdf/rdf_scan.h
@@ -141,11 +141,11 @@ struct RdfInMemScanSharedState : public function::BaseScanSharedStateWithNumRows
         : function::BaseScanSharedStateWithNumRows{0 /* numRows */}, store{std::move(store)} {}
 
     std::pair<uint64_t, uint64_t> getResourceTripleRange() {
-        auto& store_ = common::ku_dynamic_cast<RdfStore&, TripleStore&>(*store);
+        auto& store_ = common::ku_dynamic_cast<TripleStore&>(*store);
         return getRange(store_.rtStore, rtCursor);
     }
     std::pair<uint64_t, uint64_t> getLiteralTripleRange() {
-        auto& store_ = common::ku_dynamic_cast<RdfStore&, TripleStore&>(*store);
+        auto& store_ = common::ku_dynamic_cast<TripleStore&>(*store);
         return getRange(store_.ltStore, ltCursor);
     }
 

--- a/src/include/processor/operator/persistent/reader/rdf/triple_store.h
+++ b/src/include/processor/operator/persistent/reader/rdf/triple_store.h
@@ -18,7 +18,7 @@ struct RdfStore {
 
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<RdfStore&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
 };
 

--- a/src/include/processor/operator/physical_operator.h
+++ b/src/include/processor/operator/physical_operator.h
@@ -150,11 +150,11 @@ public:
 
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<PhysicalOperator*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
     template<class TARGET>
     const TARGET& constCast() {
-        return common::ku_dynamic_cast<const PhysicalOperator&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
 
 protected:

--- a/src/include/storage/compression/compression.h
+++ b/src/include/storage/compression/compression.h
@@ -178,11 +178,10 @@ struct CompressionMetadata {
         return extraMetadata.value().get();
     }
     inline const ALPMetadata* floatMetadata() const {
-        return common::ku_dynamic_cast<const ExtraMetadata*, const ALPMetadata*>(
-            getExtraMetadata());
+        return common::ku_dynamic_cast<const ALPMetadata*>(getExtraMetadata());
     }
     inline ALPMetadata* floatMetadata() {
-        return common::ku_dynamic_cast<ExtraMetadata*, ALPMetadata*>(getExtraMetadata());
+        return common::ku_dynamic_cast<ALPMetadata*>(getExtraMetadata());
     }
 
     void serialize(common::Serializer& serializer) const;

--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -311,13 +311,12 @@ public:
 
     template<typename T>
     inline HashIndex<HashIndexType<T>>* getTypedHashIndex(T key) {
-        return common::ku_dynamic_cast<OnDiskHashIndex*, HashIndex<HashIndexType<T>>*>(
+        return common::ku_dynamic_cast<HashIndex<HashIndexType<T>>*>(
             hashIndices[HashIndexUtils::getHashIndexPosition(key)].get());
     }
     template<common::IndexHashable T>
     inline HashIndex<T>* getTypedHashIndexByPos(uint64_t indexPos) {
-        return common::ku_dynamic_cast<OnDiskHashIndex*, HashIndex<HashIndexType<T>>*>(
-            hashIndices[indexPos].get());
+        return common::ku_dynamic_cast<HashIndex<HashIndexType<T>>*>(hashIndices[indexPos].get());
     }
 
     inline bool lookup(const transaction::Transaction* trx, common::ku_string_t key,

--- a/src/include/storage/local_storage/local_hash_index.h
+++ b/src/include/storage/local_storage/local_hash_index.h
@@ -137,8 +137,7 @@ public:
     template<common::IndexHashable T>
     common::offset_t lookup(T key, visible_func isVisible) {
         common::offset_t result = common::INVALID_OFFSET;
-        common::ku_dynamic_cast<BaseHashIndexLocalStorage*,
-            HashIndexLocalStorage<HashIndexType<T>>*>(localIndex.get())
+        common::ku_dynamic_cast<HashIndexLocalStorage<HashIndexType<T>>*>(localIndex.get())
             ->lookup(key, result, isVisible);
         return result;
     }
@@ -165,8 +164,7 @@ public:
     template<common::IndexHashable T>
     bool insert(T key, common::offset_t value, visible_func isVisible) {
         KU_ASSERT(keyDataTypeID == common::TypeUtils::getPhysicalTypeIDForType<T>());
-        return common::ku_dynamic_cast<BaseHashIndexLocalStorage*,
-            HashIndexLocalStorage<HashIndexType<T>>*>(localIndex.get())
+        return common::ku_dynamic_cast<HashIndexLocalStorage<HashIndexType<T>>*>(localIndex.get())
             ->insert(key, value, isVisible);
     }
 
@@ -186,8 +184,7 @@ public:
     template<common::IndexHashable T>
     void delete_(T key) {
         KU_ASSERT(keyDataTypeID == common::TypeUtils::getPhysicalTypeIDForType<T>());
-        common::ku_dynamic_cast<BaseHashIndexLocalStorage*,
-            HashIndexLocalStorage<HashIndexType<T>>*>(localIndex.get())
+        common::ku_dynamic_cast<HashIndexLocalStorage<HashIndexType<T>>*>(localIndex.get())
             ->deleteKey(key);
     }
 

--- a/src/include/storage/local_storage/local_table.h
+++ b/src/include/storage/local_storage/local_table.h
@@ -37,19 +37,19 @@ public:
 
     template<class TARGET>
     const TARGET& constCast() {
-        return common::ku_dynamic_cast<const LocalTable&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<LocalTable&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<LocalTable*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
     template<class TARGET>
     const TARGET* ptrCast() const {
-        return common::ku_dynamic_cast<LocalTable*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
 
 protected:

--- a/src/include/storage/predicate/column_predicate.h
+++ b/src/include/storage/predicate/column_predicate.h
@@ -46,7 +46,7 @@ public:
 
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const ColumnPredicate&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
 
 protected:

--- a/src/include/storage/store/chunked_node_group.h
+++ b/src/include/storage/store/chunked_node_group.h
@@ -151,11 +151,11 @@ public:
 
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<ChunkedNodeGroup&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
     template<class TARGETT>
     const TARGETT& cast() const {
-        return common::ku_dynamic_cast<const ChunkedNodeGroup&, const TARGETT&>(*this);
+        return common::ku_dynamic_cast<const TARGETT&>(*this);
     }
 
 protected:

--- a/src/include/storage/store/column.h
+++ b/src/include/storage/store/column.h
@@ -87,11 +87,11 @@ public:
 
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<Column&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
     template<class TARGET>
     const TARGET& cast() const {
-        return common::ku_dynamic_cast<Column&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
 
 protected:

--- a/src/include/storage/store/column_chunk_data.h
+++ b/src/include/storage/store/column_chunk_data.h
@@ -220,11 +220,11 @@ public:
 
     template<typename TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<ColumnChunkData&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
     template<typename TARGET>
     const TARGET& cast() const {
-        return common::ku_dynamic_cast<const ColumnChunkData&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
 
     MemoryManager& getMemoryManager() const { return *buffer->mm; }

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -36,11 +36,11 @@ struct NodeGroupScanState {
 
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<NodeGroupScanState&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
     template<class TARGETT>
     const TARGETT& constCast() {
-        return common::ku_dynamic_cast<const NodeGroupScanState&, const TARGETT&>(*this);
+        return common::ku_dynamic_cast<const TARGETT&>(*this);
     }
 };
 
@@ -58,11 +58,11 @@ struct NodeGroupCheckpointState {
 
     template<typename T>
     const T& cast() const {
-        return common::ku_dynamic_cast<const NodeGroupCheckpointState&, const T&>(*this);
+        return common::ku_dynamic_cast<const T&>(*this);
     }
     template<typename T>
     T& cast() {
-        return common::ku_dynamic_cast<NodeGroupCheckpointState&, T&>(*this);
+        return common::ku_dynamic_cast<T&>(*this);
     }
 };
 
@@ -170,11 +170,11 @@ public:
 
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<NodeGroup&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
     template<class TARGETT>
     const TARGETT& cast() const {
-        return common::ku_dynamic_cast<const NodeGroup&, const TARGETT&>(*this);
+        return common::ku_dynamic_cast<const TARGETT&>(*this);
     }
 
     bool isVisible(const transaction::Transaction* transaction, common::row_idx_t rowIdxInGroup);

--- a/src/include/storage/store/table.h
+++ b/src/include/storage/store/table.h
@@ -71,11 +71,11 @@ struct TableScanState {
 
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<TableScanState&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
     template<class TARGETT>
     const TARGETT& cast() const {
-        return common::ku_dynamic_cast<const TableScanState&, const TARGETT&>(*this);
+        return common::ku_dynamic_cast<const TARGETT&>(*this);
     }
 };
 
@@ -88,11 +88,11 @@ struct TableInsertState {
 
     template<typename T>
     const T& constCast() const {
-        return common::ku_dynamic_cast<const TableInsertState&, const T&>(*this);
+        return common::ku_dynamic_cast<const T&>(*this);
     }
     template<typename T>
     T& cast() {
-        return common::ku_dynamic_cast<TableInsertState&, T&>(*this);
+        return common::ku_dynamic_cast<T&>(*this);
     }
 };
 
@@ -106,11 +106,11 @@ struct TableUpdateState {
 
     template<typename T>
     const T& constCast() const {
-        return common::ku_dynamic_cast<const TableUpdateState&, const T&>(*this);
+        return common::ku_dynamic_cast<const T&>(*this);
     }
     template<typename T>
     T& cast() {
-        return common::ku_dynamic_cast<TableUpdateState&, T&>(*this);
+        return common::ku_dynamic_cast<T&>(*this);
     }
 };
 
@@ -119,11 +119,11 @@ struct TableDeleteState {
 
     template<typename T>
     const T& constCast() const {
-        return common::ku_dynamic_cast<const TableDeleteState&, const T&>(*this);
+        return common::ku_dynamic_cast<const T&>(*this);
     }
     template<typename T>
     T& cast() {
-        return common::ku_dynamic_cast<TableDeleteState&, T&>(*this);
+        return common::ku_dynamic_cast<T&>(*this);
     }
 };
 
@@ -175,15 +175,15 @@ public:
 
     template<class TARGET>
     TARGET& cast() {
-        return common::ku_dynamic_cast<Table&, TARGET&>(*this);
+        return common::ku_dynamic_cast<TARGET&>(*this);
     }
     template<class TARGET>
     const TARGET& cast() const {
-        return common::ku_dynamic_cast<const Table&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
     template<class TARGET>
     TARGET* ptrCast() {
-        return common::ku_dynamic_cast<Table*, TARGET*>(this);
+        return common::ku_dynamic_cast<TARGET*>(this);
     }
 
     MemoryManager& getMemoryManager() const { return *memoryManager; }

--- a/src/include/storage/wal/wal_record.h
+++ b/src/include/storage/wal/wal_record.h
@@ -53,7 +53,7 @@ struct WALRecord {
 
     template<class TARGET>
     const TARGET& constCast() const {
-        return common::ku_dynamic_cast<const WALRecord&, const TARGET&>(*this);
+        return common::ku_dynamic_cast<const TARGET&>(*this);
     }
 };
 

--- a/src/optimizer/remove_unnecessary_join_optimizer.cpp
+++ b/src/optimizer/remove_unnecessary_join_optimizer.cpp
@@ -38,16 +38,14 @@ std::shared_ptr<LogicalOperator> RemoveUnnecessaryJoinOptimizer::visitHashJoinRe
     }
     // TODO(Xiyang): Double check on these changes here.
     if (op->getChild(1)->getOperatorType() == LogicalOperatorType::SCAN_NODE_TABLE) {
-        const auto scanNode =
-            ku_dynamic_cast<LogicalOperator*, LogicalScanNodeTable*>(op->getChild(1).get());
+        const auto scanNode = ku_dynamic_cast<LogicalScanNodeTable*>(op->getChild(1).get());
         if (scanNode->getProperties().empty()) {
             // Build side is trivial. Prune build side.
             return op->getChild(0);
         }
     }
     if (op->getChild(0)->getOperatorType() == LogicalOperatorType::SCAN_NODE_TABLE) {
-        const auto scanNode =
-            ku_dynamic_cast<LogicalOperator*, LogicalScanNodeTable*>(op->getChild(0).get());
+        const auto scanNode = ku_dynamic_cast<LogicalScanNodeTable*>(op->getChild(0).get());
         if (scanNode->getProperties().empty()) {
             // Probe side is trivial. Prune probe side.
             return op->getChild(1);

--- a/src/parser/parsed_expression_visitor.cpp
+++ b/src/parser/parsed_expression_visitor.cpp
@@ -40,8 +40,7 @@ void ParsedExpressionChildrenVisitor::setChild(kuzu::parser::ParsedExpression& e
 std::vector<ParsedExpression*> ParsedExpressionChildrenVisitor::collectCaseChildren(
     const ParsedExpression& expression) {
     std::vector<ParsedExpression*> children;
-    auto& parsedCaseExpr =
-        ku_dynamic_cast<const ParsedExpression&, const ParsedCaseExpression&>(expression);
+    auto& parsedCaseExpr = ku_dynamic_cast<const ParsedCaseExpression&>(expression);
     if (parsedCaseExpr.getCaseExpression() != nullptr) {
         children.push_back(parsedCaseExpr.getCaseExpression());
     }
@@ -58,7 +57,7 @@ std::vector<ParsedExpression*> ParsedExpressionChildrenVisitor::collectCaseChild
 
 void ParsedExpressionChildrenVisitor::setCaseChild(kuzu::parser::ParsedExpression& expression,
     uint64_t idx, std::unique_ptr<ParsedExpression> expressionToSet) {
-    auto& parsedCaseExpr = ku_dynamic_cast<ParsedExpression&, ParsedCaseExpression&>(expression);
+    auto& parsedCaseExpr = ku_dynamic_cast<ParsedCaseExpression&>(expression);
     if (idx == 0) {
         parsedCaseExpr.caseExpression = std::move(expressionToSet);
     } else if (idx < 1 + parsedCaseExpr.getNumCaseAlternative() * 2) {

--- a/src/parser/parsed_statement_visitor.cpp
+++ b/src/parser/parsed_statement_visitor.cpp
@@ -71,12 +71,12 @@ void StatementVisitor::visit(const Statement& statement) {
 }
 
 void StatementVisitor::visitExplain(const Statement& statement) {
-    auto& explainStatement = ku_dynamic_cast<const Statement&, const ExplainStatement&>(statement);
+    auto& explainStatement = ku_dynamic_cast<const ExplainStatement&>(statement);
     visit(*explainStatement.getStatementToExplain());
 }
 
 void StatementVisitor::visitQuery(const Statement& statement) {
-    auto& regularQuery = ku_dynamic_cast<const Statement&, const RegularQuery&>(statement);
+    auto& regularQuery = ku_dynamic_cast<const RegularQuery&>(statement);
     for (auto i = 0u; i < regularQuery.getNumSingleQueries(); ++i) {
         visitSingleQuery(regularQuery.getSingleQuery(i));
     }

--- a/src/planner/operator/logical_hash_join.cpp
+++ b/src/planner/operator/logical_hash_join.cpp
@@ -198,7 +198,7 @@ bool LogicalHashJoin::isJoinKeyUniqueOnBuildSide(const binder::Expression& joinN
     if (op->getOperatorType() != LogicalOperatorType::SCAN_NODE_TABLE) {
         return false;
     }
-    auto scan = ku_dynamic_cast<LogicalOperator*, LogicalScanNodeTable*>(op);
+    auto scan = ku_dynamic_cast<LogicalScanNodeTable*>(op);
     if (scan->getNodeID()->getUniqueName() != joinNodeID.getUniqueName()) {
         return false;
     }

--- a/src/planner/operator/persistent/logical_insert.cpp
+++ b/src/planner/operator/persistent/logical_insert.cpp
@@ -21,7 +21,7 @@ void LogicalInsert::computeFactorizedSchema() {
             }
         }
         if (info.tableType == TableType::NODE) {
-            auto node = ku_dynamic_cast<Expression*, NodeExpression*>(info.pattern.get());
+            auto node = ku_dynamic_cast<NodeExpression*>(info.pattern.get());
             schema->insertToGroupAndScopeMayRepeat(node->getInternalID(), groupPos);
         }
     }
@@ -36,7 +36,7 @@ void LogicalInsert::computeFlatSchema() {
             }
         }
         if (info.tableType == TableType::NODE) {
-            auto node = ku_dynamic_cast<Expression*, NodeExpression*>(info.pattern.get());
+            auto node = ku_dynamic_cast<NodeExpression*>(info.pattern.get());
             schema->insertToGroupAndScopeMayRepeat(node->getInternalID(), 0);
         }
     }

--- a/src/planner/operator/persistent/logical_merge.cpp
+++ b/src/planner/operator/persistent/logical_merge.cpp
@@ -14,7 +14,7 @@ void LogicalMerge::computeFactorizedSchema() {
     copyChildSchema(0);
     for (auto& info : insertNodeInfos) {
         // Predicate iri is not matched but needs to be inserted.
-        auto node = ku_dynamic_cast<Expression*, NodeExpression*>(info.pattern.get());
+        auto node = ku_dynamic_cast<NodeExpression*>(info.pattern.get());
         if (!schema->isExpressionInScope(*node->getInternalID())) {
             auto groupPos = schema->createGroup();
             schema->setGroupAsSingleState(groupPos);
@@ -26,7 +26,7 @@ void LogicalMerge::computeFactorizedSchema() {
 void LogicalMerge::computeFlatSchema() {
     copyChildSchema(0);
     for (auto& info : insertNodeInfos) {
-        auto node = ku_dynamic_cast<Expression*, NodeExpression*>(info.pattern.get());
+        auto node = ku_dynamic_cast<NodeExpression*>(info.pattern.get());
         schema->insertToGroupAndScopeMayRepeat(node->getInternalID(), 0);
     }
 }

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -69,7 +69,7 @@ static std::unordered_set<table_id_t> getNbrNodeTableIDSet(const RelExpression& 
 
 static std::shared_ptr<Expression> getIRIProperty(const expression_vector& properties) {
     for (auto& property : properties) {
-        auto propertyExpr = ku_dynamic_cast<Expression*, PropertyExpression*>(property.get());
+        auto propertyExpr = ku_dynamic_cast<PropertyExpression*>(property.get());
         if (propertyExpr->isIRI()) {
             return property;
         }

--- a/src/planner/plan/append_unwind.cpp
+++ b/src/planner/plan/append_unwind.cpp
@@ -9,8 +9,7 @@ namespace kuzu {
 namespace planner {
 
 void Planner::appendUnwind(const BoundReadingClause& readingClause, LogicalPlan& plan) {
-    auto& unwindClause =
-        ku_dynamic_cast<const BoundReadingClause&, const BoundUnwindClause&>(readingClause);
+    auto& unwindClause = ku_dynamic_cast<const BoundUnwindClause&>(readingClause);
     auto unwind = make_shared<LogicalUnwind>(unwindClause.getInExpr(), unwindClause.getOutExpr(),
         unwindClause.getIDExpr(), plan.getLastOperator());
     appendFlattens(unwind->getGroupsPosToFlatten(), plan);

--- a/src/planner/plan/plan_join_order.cpp
+++ b/src/planner/plan/plan_join_order.cpp
@@ -386,7 +386,7 @@ static bool isNodeSequentialOnPlan(const LogicalPlan& plan, const NodeExpression
     if (seqScan == nullptr) {
         return false;
     }
-    const auto sequentialScan = ku_dynamic_cast<LogicalOperator*, LogicalScanNodeTable*>(seqScan);
+    const auto sequentialScan = ku_dynamic_cast<LogicalScanNodeTable*>(seqScan);
     return sequentialScan->getNodeID()->getUniqueName() == node.getInternalID()->getUniqueName();
 }
 

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -126,7 +126,7 @@ std::vector<std::unique_ptr<LogicalPlan>> Planner::getAllPlans(const BoundStatem
         }
     } break;
     case StatementType::EXPLAIN: {
-        auto& explain = ku_dynamic_cast<const BoundStatement&, const BoundExplain&>(statement);
+        auto& explain = ku_dynamic_cast<const BoundExplain&>(statement);
         plans = getAllPlans(*explain.getStatementToExplain());
         for (auto& plan : plans) {
             appendExplain(explain, *plan);

--- a/src/processor/map/create_factorized_table_scan.cpp
+++ b/src/processor/map/create_factorized_table_scan.cpp
@@ -27,7 +27,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createFTableScan(const expression_
     auto function = function::BuiltInFunctionsUtils::matchFunction(clientContext->getTx(),
         FTableScan::name, clientContext->getCatalog()->getFunctions(clientContext->getTx()));
     auto info = TableFunctionCallInfo();
-    info.function = *ku_dynamic_cast<Function*, TableFunction*>(function);
+    info.function = *ku_dynamic_cast<TableFunction*>(function);
     info.bindData = std::move(bindData);
     info.outPosV = std::move(outPosV);
     if (offset != nullptr) {

--- a/src/processor/map/map_copy_from.cpp
+++ b/src/processor/map/map_copy_from.cpp
@@ -205,7 +205,7 @@ physical_op_vector_t PlanMapper::mapCopyRelFrom(LogicalOperator* logicalOperator
 }
 
 std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyRdfFrom(LogicalOperator* logicalOperator) {
-    const auto copyFrom = ku_dynamic_cast<LogicalOperator*, LogicalCopyFrom*>(logicalOperator);
+    const auto copyFrom = ku_dynamic_cast<LogicalCopyFrom*>(logicalOperator);
     const auto logicalRRLChild = logicalOperator->getChild(0).get();
     const auto logicalRRRChild = logicalOperator->getChild(1).get();
     const auto logicalLChild = logicalOperator->getChild(2).get();
@@ -220,31 +220,27 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyRdfFrom(LogicalOperator* lo
 
     auto rChild = mapCopyNodeFrom(logicalRChild);
     KU_ASSERT(rChild->getOperatorType() == PhysicalOperatorType::BATCH_INSERT);
-    const auto rCopy = ku_dynamic_cast<PhysicalOperator*, NodeBatchInsert*>(rChild.get());
+    const auto rCopy = ku_dynamic_cast<NodeBatchInsert*>(rChild.get());
     auto lChild = mapCopyNodeFrom(logicalLChild);
-    const auto lCopy = ku_dynamic_cast<PhysicalOperator*, NodeBatchInsert*>(lChild.get());
+    const auto lCopy = ku_dynamic_cast<NodeBatchInsert*>(lChild.get());
     auto rrrChildren = mapCopyRelFrom(logicalRRRChild);
     KU_ASSERT(rrrChildren[2]->getOperatorType() == PhysicalOperatorType::PARTITIONER);
-    const auto rrrPartitioner =
-        ku_dynamic_cast<PhysicalOperator*, Partitioner*>(rrrChildren[2].get());
+    const auto rrrPartitioner = ku_dynamic_cast<Partitioner*>(rrrChildren[2].get());
     rrrPartitioner->getSharedState()->nodeBatchInsertSharedStates.push_back(
         rCopy->getSharedState());
     rrrPartitioner->getSharedState()->nodeBatchInsertSharedStates.push_back(
         rCopy->getSharedState());
     KU_ASSERT(rrrChildren[2]->getChild(0)->getOperatorType() == PhysicalOperatorType::INDEX_LOOKUP);
-    const auto rrrLookup =
-        ku_dynamic_cast<PhysicalOperator*, IndexLookup*>(rrrChildren[2]->getChild(0));
+    const auto rrrLookup = ku_dynamic_cast<IndexLookup*>(rrrChildren[2]->getChild(0));
     rrrLookup->setBatchInsertSharedState(rCopy->getSharedState());
     auto rrlChildren = mapCopyRelFrom(logicalRRLChild);
-    const auto rrLPartitioner =
-        ku_dynamic_cast<PhysicalOperator*, Partitioner*>(rrlChildren[2].get());
+    const auto rrLPartitioner = ku_dynamic_cast<Partitioner*>(rrlChildren[2].get());
     rrLPartitioner->getSharedState()->nodeBatchInsertSharedStates.push_back(
         rCopy->getSharedState());
     rrLPartitioner->getSharedState()->nodeBatchInsertSharedStates.push_back(
         lCopy->getSharedState());
     KU_ASSERT(rrlChildren[2]->getChild(0)->getOperatorType() == PhysicalOperatorType::INDEX_LOOKUP);
-    const auto rrlLookup =
-        ku_dynamic_cast<PhysicalOperator*, IndexLookup*>(rrlChildren[2]->getChild(0));
+    const auto rrlLookup = ku_dynamic_cast<IndexLookup*>(rrlChildren[2]->getChild(0));
     rrlLookup->setBatchInsertSharedState(rCopy->getSharedState());
     auto sharedState = std::make_shared<CopyRdfSharedState>();
     const auto fTable =

--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -10,7 +10,7 @@ namespace processor {
 
 static void setPhysicalPlanIfProfile(const LogicalPlan* logicalPlan, PhysicalPlan* physicalPlan) {
     if (logicalPlan->isProfile()) {
-        ku_dynamic_cast<PhysicalOperator*, Profile*>(physicalPlan->lastOperator->getChild(0))
+        ku_dynamic_cast<Profile*>(physicalPlan->lastOperator->getChild(0))
             ->setPhysicalPlan(physicalPlan);
     }
 }

--- a/src/processor/operator/persistent/index_builder.cpp
+++ b/src/processor/operator/persistent/index_builder.cpp
@@ -156,8 +156,7 @@ void IndexBuilder::insert(const ColumnChunkData& chunk,
             }
         },
         [&](ku_string_t) {
-            auto& stringColumnChunk =
-                ku_dynamic_cast<const ColumnChunkData&, const StringChunkData&>(chunk);
+            auto& stringColumnChunk = ku_dynamic_cast<const StringChunkData&>(chunk);
             for (auto i = 0u; i < numNodes; i++) {
                 if (checkNonNullConstraint(chunk, warningData, nodeOffset, i, errorHandler)) {
                     auto value = stringColumnChunk.getValue<std::string>(i);

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -35,29 +35,27 @@ void NodeBatchInsertSharedState::initPKIndex(const ExecutionContext* context) {
         KU_ASSERT(distinctSharedState);
         numRows = distinctSharedState->getFactorizedTable()->getNumTuples();
     }
-    auto* nodeTable = ku_dynamic_cast<Table*, NodeTable*>(table);
+    auto* nodeTable = ku_dynamic_cast<NodeTable*>(table);
     nodeTable->getPKIndex()->bulkReserve(numRows);
     globalIndexBuilder = IndexBuilder(
         std::make_shared<IndexBuilderSharedState>(context->clientContext->getTx(), nodeTable));
 }
 
 void NodeBatchInsert::initGlobalStateInternal(ExecutionContext* context) {
-    const auto nodeSharedState =
-        ku_dynamic_cast<BatchInsertSharedState*, NodeBatchInsertSharedState*>(sharedState.get());
+    const auto nodeSharedState = ku_dynamic_cast<NodeBatchInsertSharedState*>(sharedState.get());
     nodeSharedState->initPKIndex(context);
 }
 
 void NodeBatchInsert::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     auto nodeInfo = info->ptrCast<NodeBatchInsertInfo>();
 
-    const auto nodeSharedState =
-        ku_dynamic_cast<BatchInsertSharedState*, NodeBatchInsertSharedState*>(sharedState.get());
+    const auto nodeSharedState = ku_dynamic_cast<NodeBatchInsertSharedState*>(sharedState.get());
     localState = std::make_unique<NodeBatchInsertLocalState>();
     const auto nodeLocalState = localState->ptrCast<NodeBatchInsertLocalState>();
     KU_ASSERT(nodeSharedState->globalIndexBuilder);
     nodeLocalState->localIndexBuilder = nodeSharedState->globalIndexBuilder->clone();
 
-    auto* nodeTable = ku_dynamic_cast<Table*, NodeTable*>(sharedState->table);
+    auto* nodeTable = ku_dynamic_cast<NodeTable*>(sharedState->table);
     nodeLocalState->errorHandler =
         NodeBatchInsertErrorHandler{context, nodeSharedState->pkType.getLogicalTypeID(), nodeTable,
             context->clientContext->getWarningContext().getIgnoreErrorsOption(),
@@ -126,8 +124,7 @@ void NodeBatchInsert::executeInternal(ExecutionContext* context) {
 void NodeBatchInsert::copyToNodeGroup(transaction::Transaction* transaction,
     MemoryManager* mm) const {
     auto numAppendedTuples = 0ul;
-    const auto nodeLocalState =
-        ku_dynamic_cast<BatchInsertLocalState*, NodeBatchInsertLocalState*>(localState.get());
+    const auto nodeLocalState = ku_dynamic_cast<NodeBatchInsertLocalState*>(localState.get());
     const auto numTuplesToAppend = nodeLocalState->columnState->getSelVector().getSelSize();
     while (numAppendedTuples < numTuplesToAppend) {
         const auto numAppendedTuplesInNodeGroup = nodeLocalState->chunkedGroup->append(
@@ -157,10 +154,9 @@ void NodeBatchInsert::clearToIndex(MemoryManager* mm, std::unique_ptr<ChunkedNod
 void NodeBatchInsert::writeAndResetNodeGroup(transaction::Transaction* transaction,
     std::unique_ptr<ChunkedNodeGroup>& nodeGroup, std::optional<IndexBuilder>& indexBuilder,
     MemoryManager* mm) const {
-    const auto nodeSharedState =
-        ku_dynamic_cast<BatchInsertSharedState*, NodeBatchInsertSharedState*>(sharedState.get());
+    const auto nodeSharedState = ku_dynamic_cast<NodeBatchInsertSharedState*>(sharedState.get());
     const auto nodeLocalState = localState->ptrCast<NodeBatchInsertLocalState>();
-    const auto nodeTable = ku_dynamic_cast<Table*, NodeTable*>(sharedState->table);
+    const auto nodeTable = ku_dynamic_cast<NodeTable*>(sharedState->table);
     auto nodeInfo = info->ptrCast<NodeBatchInsertInfo>();
 
     // we only need to write the main data in the chunked node group, the extra data is only used
@@ -190,8 +186,7 @@ void NodeBatchInsert::appendIncompleteNodeGroup(transaction::Transaction* transa
     std::unique_ptr<ChunkedNodeGroup> localNodeGroup, std::optional<IndexBuilder>& indexBuilder,
     MemoryManager* mm) const {
     std::unique_lock xLck{sharedState->mtx};
-    const auto nodeSharedState =
-        ku_dynamic_cast<BatchInsertSharedState*, NodeBatchInsertSharedState*>(sharedState.get());
+    const auto nodeSharedState = ku_dynamic_cast<NodeBatchInsertSharedState*>(sharedState.get());
     if (!nodeSharedState->sharedNodeGroup) {
         nodeSharedState->sharedNodeGroup = std::move(localNodeGroup);
         return;
@@ -211,8 +206,7 @@ void NodeBatchInsert::appendIncompleteNodeGroup(transaction::Transaction* transa
 }
 
 void NodeBatchInsert::finalize(ExecutionContext* context) {
-    const auto nodeSharedState =
-        ku_dynamic_cast<BatchInsertSharedState*, NodeBatchInsertSharedState*>(sharedState.get());
+    const auto nodeSharedState = ku_dynamic_cast<NodeBatchInsertSharedState*>(sharedState.get());
     if (nodeSharedState->sharedNodeGroup) {
         while (nodeSharedState->sharedNodeGroup->getNumRows() > 0) {
             writeAndResetNodeGroup(context->clientContext->getTx(),
@@ -221,8 +215,7 @@ void NodeBatchInsert::finalize(ExecutionContext* context) {
         }
     }
     if (nodeSharedState->globalIndexBuilder) {
-        auto* localNodeState =
-            ku_dynamic_cast<BatchInsertLocalState*, NodeBatchInsertLocalState*>(localState.get());
+        auto* localNodeState = ku_dynamic_cast<NodeBatchInsertLocalState*>(localState.get());
         KU_ASSERT(localNodeState->errorHandler.has_value());
         nodeSharedState->globalIndexBuilder->finalize(context,
             localNodeState->errorHandler.value());

--- a/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
@@ -258,7 +258,7 @@ static double progressFunc(TableFuncSharedState* sharedState) {
 
 static void finalizeFunc(ExecutionContext* ctx, TableFuncSharedState* sharedState,
     TableFuncLocalState* /*localState*/) {
-    auto state = ku_dynamic_cast<TableFuncSharedState*, ParallelCSVScanSharedState*>(sharedState);
+    auto state = ku_dynamic_cast<ParallelCSVScanSharedState*>(sharedState);
     for (idx_t i = 0; i < state->readerConfig.getNumFiles(); ++i) {
         // If we run into errors while reconstructing lines they should be unrecoverable
         LocalCSVFileErrorHandler localErrorHandler{&state->errorHandlers[i], false, state->context};

--- a/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
@@ -100,8 +100,7 @@ void SerialCSVScanSharedState::initReader(main::ClientContext* context) {
 }
 
 static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output) {
-    auto serialCSVScanSharedState =
-        ku_dynamic_cast<TableFuncSharedState*, SerialCSVScanSharedState*>(input.sharedState);
+    auto serialCSVScanSharedState = ku_dynamic_cast<SerialCSVScanSharedState*>(input.sharedState);
     serialCSVScanSharedState->read(output.dataChunk);
     return output.dataChunk.state->getSelVector().getSelSize();
 }
@@ -184,7 +183,7 @@ static std::unique_ptr<TableFuncLocalState> initLocalState(TableFunctionInitInpu
 
 static void finalizeFunc(ExecutionContext* ctx, TableFuncSharedState* sharedState,
     TableFuncLocalState*) {
-    auto state = ku_dynamic_cast<TableFuncSharedState*, SerialCSVScanSharedState*>(sharedState);
+    auto state = ku_dynamic_cast<SerialCSVScanSharedState*>(sharedState);
     for (idx_t i = 0; i < state->readerConfig.getNumFiles(); ++i) {
         state->localErrorHandlers[i].finalize();
 
@@ -197,7 +196,7 @@ static void finalizeFunc(ExecutionContext* ctx, TableFuncSharedState* sharedStat
 }
 
 static double progressFunc(TableFuncSharedState* sharedState) {
-    auto state = ku_dynamic_cast<TableFuncSharedState*, SerialCSVScanSharedState*>(sharedState);
+    auto state = ku_dynamic_cast<SerialCSVScanSharedState*>(sharedState);
     if (state->totalSize == 0) {
         return 0.0;
     } else if (state->fileIdx >= state->readerConfig.getNumFiles()) {

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -52,9 +52,7 @@ bool ParquetReader::scanInternal(ParquetReaderScanState& state, DataChunk& resul
         state.currentGroup++;
         state.groupOffset = 0;
 
-        auto& trans =
-            ku_dynamic_cast<kuzu_apache::thrift::transport::TTransport&, ThriftFileTransport&>(
-                *state.thriftFileProto->getTransport());
+        auto& trans = ku_dynamic_cast<ThriftFileTransport&>(*state.thriftFileProto->getTransport());
         trans.ClearPrefetch();
         state.currentGroupPrefetched = false;
 
@@ -69,8 +67,7 @@ bool ParquetReader::scanInternal(ParquetReaderScanState& state, DataChunk& resul
 
             auto fileColIdx = colIdx;
 
-            auto rootReader =
-                ku_dynamic_cast<ColumnReader*, StructColumnReader*>(state.rootReader.get());
+            auto rootReader = ku_dynamic_cast<StructColumnReader*>(state.rootReader.get());
             toScanCompressedBytes +=
                 rootReader->getChildReader(fileColIdx)->getTotalCompressedSize();
         }
@@ -102,8 +99,7 @@ bool ParquetReader::scanInternal(ParquetReaderScanState& state, DataChunk& resul
                 // Prefetch column-wise.
                 for (auto colIdx = 0u; colIdx < result.getNumValueVectors(); colIdx++) {
                     auto fileColIdx = colIdx;
-                    auto rootReader =
-                        ku_dynamic_cast<ColumnReader*, StructColumnReader*>(state.rootReader.get());
+                    auto rootReader = ku_dynamic_cast<StructColumnReader*>(state.rootReader.get());
 
                     rootReader->getChildReader(fileColIdx)
                         ->registerPrefetch(trans, true /* lazy fetch */);
@@ -140,7 +136,7 @@ bool ParquetReader::scanInternal(ParquetReaderScanState& state, DataChunk& resul
     auto definePtr = (uint8_t*)state.defineBuf.ptr;
     auto repeatPtr = (uint8_t*)state.repeatBuf.ptr;
 
-    auto rootReader = ku_dynamic_cast<ColumnReader*, StructColumnReader*>(state.rootReader.get());
+    auto rootReader = ku_dynamic_cast<StructColumnReader*>(state.rootReader.get());
     for (auto colIdx = 0u; colIdx < result.getNumValueVectors(); colIdx++) {
         if (!columnSkips.empty() && columnSkips[colIdx]) {
             continue;
@@ -174,9 +170,7 @@ void ParquetReader::scan(processor::ParquetReaderScanState& state, DataChunk& re
 void ParquetReader::initMetadata() {
     auto fileInfo = context->getVFSUnsafe()->openFile(filePath, FileFlags::READ_ONLY, context);
     auto proto = createThriftProtocol(fileInfo.get(), false);
-    auto& transport =
-        ku_dynamic_cast<kuzu_apache::thrift::transport::TTransport&, ThriftFileTransport&>(
-            *proto->getTransport());
+    auto& transport = ku_dynamic_cast<ThriftFileTransport&>(*proto->getTransport());
     auto fileSize = transport.GetSize();
     // LCOV_EXCL_START
     if (fileSize < 12) {
@@ -627,10 +621,8 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
     if (input.localState == nullptr) {
         return 0;
     }
-    auto parquetScanLocalState =
-        ku_dynamic_cast<TableFuncLocalState*, ParquetScanLocalState*>(input.localState);
-    auto parquetScanSharedState =
-        ku_dynamic_cast<TableFuncSharedState*, ParquetScanSharedState*>(input.sharedState);
+    auto parquetScanLocalState = ku_dynamic_cast<ParquetScanLocalState*>(input.localState);
+    auto parquetScanSharedState = ku_dynamic_cast<ParquetScanSharedState*>(input.sharedState);
     do {
         parquetScanLocalState->reader->scan(*parquetScanLocalState->state, outputChunk);
         if (outputChunk.state->getSelVector().getSelSize() > 0) {

--- a/src/processor/operator/persistent/reader/rdf/rdf_reader.cpp
+++ b/src/processor/operator/persistent/reader/rdf/rdf_reader.cpp
@@ -186,7 +186,7 @@ SerdStatus RdfResourceReader::handle(void* handle, SerdStatementFlags, const Ser
 
 uint64_t RdfResourceReader::readToVector(DataChunk* dataChunk) {
     auto rVector = dataChunk->getValueVector(0).get();
-    auto& store = ku_dynamic_cast<RdfStore&, ResourceStore&>(*store_);
+    auto& store = ku_dynamic_cast<ResourceStore&>(*store_);
     auto numTuplesToScan = std::min(store.size() - cursor, DEFAULT_VECTOR_CAPACITY);
     for (auto i = 0u; i < numTuplesToScan; ++i) {
         StringVector::addString(rVector, i, store.resources[cursor + i]);

--- a/src/processor/operator/persistent/reader/rdf/rdf_scan.cpp
+++ b/src/processor/operator/persistent/reader/rdf/rdf_scan.cpp
@@ -66,7 +66,7 @@ static common::offset_t scanTableFunc(TableFuncInput& input, TableFuncOutput& ou
 
 static std::unique_ptr<TableFuncSharedState> inMemScanInitSharedState(
     TableFunctionInitInput& input) {
-    auto bindData = ku_dynamic_cast<TableFuncBindData*, RdfScanBindData*>(input.bindData);
+    auto bindData = ku_dynamic_cast<RdfScanBindData*>(input.bindData);
     return std::make_unique<RdfInMemScanSharedState>(bindData->store);
 }
 
@@ -89,12 +89,11 @@ static std::unique_ptr<function::TableFuncBindData> RdfAllTripleScanBindFunc(mai
 }
 
 static offset_t RdfResourceInMemScanTableFunc(TableFuncInput& input, TableFuncOutput& output) {
-    auto sharedState =
-        ku_dynamic_cast<TableFuncSharedState*, RdfInMemScanSharedState*>(input.sharedState);
+    auto sharedState = ku_dynamic_cast<RdfInMemScanSharedState*>(input.sharedState);
     auto sVector = output.dataChunk.getValueVector(0).get();
     auto vectorPos = 0u;
     // Scan resource triples
-    auto& store = ku_dynamic_cast<RdfStore&, TripleStore&>(*sharedState->store);
+    auto& store = ku_dynamic_cast<TripleStore&>(*sharedState->store);
     auto [rStartIdx, rNumTuplesToScan] = sharedState->getResourceTripleRange();
     if (rNumTuplesToScan == 0) {
         // scan literal triples
@@ -114,11 +113,10 @@ static offset_t RdfResourceInMemScanTableFunc(TableFuncInput& input, TableFuncOu
 }
 
 static offset_t RdfLiteralInMemScanTableFunc(TableFuncInput& input, TableFuncOutput& output) {
-    auto sharedState =
-        ku_dynamic_cast<TableFuncSharedState*, RdfInMemScanSharedState*>(input.sharedState);
+    auto sharedState = ku_dynamic_cast<RdfInMemScanSharedState*>(input.sharedState);
     auto oVector = output.dataChunk.getValueVector(0).get();
     auto langVector = output.dataChunk.getValueVector(1).get();
-    auto& store = ku_dynamic_cast<RdfStore&, TripleStore&>(*sharedState->store);
+    auto& store = ku_dynamic_cast<TripleStore&>(*sharedState->store);
     auto [startIdx, numTuplesToScan] = sharedState->getLiteralTripleRange();
     for (auto i = 0u; i < numTuplesToScan; ++i) {
         auto& object = store.ltStore.objects[startIdx + i];
@@ -132,13 +130,12 @@ static offset_t RdfLiteralInMemScanTableFunc(TableFuncInput& input, TableFuncOut
 
 static offset_t RdfResourceTripleInMemScanTableFunc(TableFuncInput& input,
     TableFuncOutput& output) {
-    auto sharedState =
-        ku_dynamic_cast<TableFuncSharedState*, RdfInMemScanSharedState*>(input.sharedState);
+    auto sharedState = ku_dynamic_cast<RdfInMemScanSharedState*>(input.sharedState);
     auto [startIdx, numTuplesToScan] = sharedState->getResourceTripleRange();
     auto sVector = output.dataChunk.getValueVector(0).get();
     auto pVector = output.dataChunk.getValueVector(1).get();
     auto oVector = output.dataChunk.getValueVector(2).get();
-    auto& store = ku_dynamic_cast<RdfStore&, TripleStore&>(*sharedState->store);
+    auto& store = ku_dynamic_cast<TripleStore&>(*sharedState->store);
     for (auto i = 0u; i < numTuplesToScan; ++i) {
         StringVector::addString(sVector, i, store.rtStore.subjects[startIdx + i]);
         StringVector::addString(pVector, i, store.rtStore.predicates[startIdx + i]);
@@ -148,13 +145,12 @@ static offset_t RdfResourceTripleInMemScanTableFunc(TableFuncInput& input,
 }
 
 static offset_t RdfLiteralTripleInMemScanTableFunc(TableFuncInput& input, TableFuncOutput& output) {
-    auto sharedState =
-        ku_dynamic_cast<TableFuncSharedState*, RdfInMemScanSharedState*>(input.sharedState);
+    auto sharedState = ku_dynamic_cast<RdfInMemScanSharedState*>(input.sharedState);
     auto [startIdx, numTuplesToScan] = sharedState->getLiteralTripleRange();
     auto sVector = output.dataChunk.getValueVector(0).get();
     auto pVector = output.dataChunk.getValueVector(1).get();
     auto oVector = output.dataChunk.getValueVector(2).get();
-    auto& store = ku_dynamic_cast<RdfStore&, TripleStore&>(*sharedState->store);
+    auto& store = ku_dynamic_cast<TripleStore&>(*sharedState->store);
     for (auto i = 0u; i < numTuplesToScan; ++i) {
         StringVector::addString(sVector, i, store.ltStore.subjects[startIdx + i]);
         StringVector::addString(pVector, i, store.ltStore.predicates[startIdx + i]);
@@ -197,17 +193,15 @@ static std::unique_ptr<TableFuncSharedState> RdfLiteralTripleScanInitSharedState
 
 static std::unique_ptr<TableFuncSharedState> RdfAllTripleScanInitSharedState(
     TableFunctionInitInput& input) {
-    auto bindData = ku_dynamic_cast<TableFuncBindData*, RdfScanBindData*>(input.bindData);
+    auto bindData = ku_dynamic_cast<RdfScanBindData*>(input.bindData);
     auto rdfConfig = RdfReaderConfig::construct(bindData->config.options);
     return std::make_unique<RdfTripleScanSharedState>(bindData->config.copy(), std::move(rdfConfig),
         bindData->store);
 }
 
 static double RdfResourceInMemScanProgressFunc(TableFuncSharedState* sharedState) {
-    auto rdfSharedState =
-        ku_dynamic_cast<TableFuncSharedState*, RdfInMemScanSharedState*>(sharedState);
-    uint64_t rtSize =
-        ku_dynamic_cast<RdfStore*, TripleStore*>(rdfSharedState->store.get())->rtStore.size();
+    auto rdfSharedState = ku_dynamic_cast<RdfInMemScanSharedState*>(sharedState);
+    uint64_t rtSize = ku_dynamic_cast<TripleStore*>(rdfSharedState->store.get())->rtStore.size();
     if (rtSize == 0) {
         return 0.0;
     }
@@ -215,10 +209,8 @@ static double RdfResourceInMemScanProgressFunc(TableFuncSharedState* sharedState
 }
 
 static double RdfLiteralInMemScanProgressFunc(TableFuncSharedState* sharedState) {
-    auto rdfSharedState =
-        ku_dynamic_cast<TableFuncSharedState*, RdfInMemScanSharedState*>(sharedState);
-    uint64_t ltSize =
-        ku_dynamic_cast<RdfStore*, TripleStore*>(rdfSharedState->store.get())->ltStore.size();
+    auto rdfSharedState = ku_dynamic_cast<RdfInMemScanSharedState*>(sharedState);
+    uint64_t ltSize = ku_dynamic_cast<TripleStore*>(rdfSharedState->store.get())->ltStore.size();
     if (ltSize == 0) {
         return 0.0;
     }
@@ -226,9 +218,8 @@ static double RdfLiteralInMemScanProgressFunc(TableFuncSharedState* sharedState)
 }
 
 static double RdfResourceTripleInMemScanProgressFunc(TableFuncSharedState* sharedState) {
-    auto rdfSharedState =
-        ku_dynamic_cast<TableFuncSharedState*, RdfInMemScanSharedState*>(sharedState);
-    TripleStore* store = ku_dynamic_cast<RdfStore*, TripleStore*>(rdfSharedState->store.get());
+    auto rdfSharedState = ku_dynamic_cast<RdfInMemScanSharedState*>(sharedState);
+    TripleStore* store = ku_dynamic_cast<TripleStore*>(rdfSharedState->store.get());
     uint64_t size = store->rtStore.size() + store->ltStore.size();
     if (size == 0) {
         return 0.0;
@@ -238,7 +229,7 @@ static double RdfResourceTripleInMemScanProgressFunc(TableFuncSharedState* share
 
 static void finalizeFunc(ExecutionContext* ctx, TableFuncSharedState* sharedState,
     TableFuncLocalState*) {
-    auto state = ku_dynamic_cast<TableFuncSharedState*, RdfScanSharedState*>(sharedState);
+    auto state = ku_dynamic_cast<RdfScanSharedState*>(sharedState);
     for (idx_t i = 0; i < state->readerConfig.getNumFiles(); ++i) {
         ctx->clientContext->getWarningContextUnsafe().populateWarnings(i, ctx->queryID);
     }

--- a/src/processor/operator/standalone_call.cpp
+++ b/src/processor/operator/standalone_call.cpp
@@ -19,8 +19,7 @@ bool StandaloneCall::getNextTuplesInternal(kuzu::processor::ExecutionContext* co
     switch (standaloneCallInfo->option->optionType) {
     case main::OptionType::CONFIGURATION: {
         auto configurationOption =
-            common::ku_dynamic_cast<main::Option*, main::ConfigurationOption*>(
-                standaloneCallInfo->option);
+            common::ku_dynamic_cast<main::ConfigurationOption*>(standaloneCallInfo->option);
         configurationOption->setContext(context->clientContext, standaloneCallInfo->optionValue);
         break;
     }

--- a/src/processor/operator/table_scan/ftable_scan_function.cpp
+++ b/src/processor/operator/table_scan/ftable_scan_function.cpp
@@ -41,9 +41,8 @@ struct FTableScanSharedState final : public function::BaseScanSharedState {
 };
 
 static offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output) {
-    auto sharedState =
-        ku_dynamic_cast<TableFuncSharedState*, FTableScanSharedState*>(input.sharedState);
-    auto bindData = ku_dynamic_cast<TableFuncBindData*, FTableScanBindData*>(input.bindData);
+    auto sharedState = ku_dynamic_cast<FTableScanSharedState*>(input.sharedState);
+    auto bindData = ku_dynamic_cast<FTableScanBindData*>(input.bindData);
     auto morsel = sharedState->getMorsel();
     if (morsel.numTuples == 0) {
         return 0;
@@ -54,7 +53,7 @@ static offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output) {
 }
 
 static std::unique_ptr<TableFuncSharedState> initSharedState(TableFunctionInitInput& input) {
-    auto bindData = ku_dynamic_cast<TableFuncBindData*, FTableScanBindData*>(input.bindData);
+    auto bindData = ku_dynamic_cast<FTableScanBindData*>(input.bindData);
     return std::make_unique<FTableScanSharedState>(bindData->table, bindData->morselSize);
 }
 

--- a/src/processor/processor.cpp
+++ b/src/processor/processor.cpp
@@ -17,7 +17,7 @@ QueryProcessor::QueryProcessor(uint64_t numThreads) {
 std::shared_ptr<FactorizedTable> QueryProcessor::execute(PhysicalPlan* physicalPlan,
     ExecutionContext* context) {
     auto lastOperator = physicalPlan->lastOperator.get();
-    auto resultCollector = ku_dynamic_cast<PhysicalOperator*, ResultCollector*>(lastOperator);
+    auto resultCollector = ku_dynamic_cast<ResultCollector*>(lastOperator);
     // The root pipeline(task) consists of operators and its prevOperator only, because we
     // expect to have linear plans. For binary operators, e.g., HashJoin, we  keep probe and its
     // prevOperator in the same pipeline, and decompose build and its prevOperator into another
@@ -37,8 +37,7 @@ void QueryProcessor::decomposePlanIntoTask(PhysicalOperator* op, Task* task,
         context->clientContext->getProgressBar()->addPipeline();
     }
     if (op->isSink()) {
-        auto childTask =
-            std::make_unique<ProcessorTask>(ku_dynamic_cast<PhysicalOperator*, Sink*>(op), context);
+        auto childTask = std::make_unique<ProcessorTask>(ku_dynamic_cast<Sink*>(op), context);
         for (auto i = (int64_t)op->getNumChildren() - 1; i >= 0; --i) {
             decomposePlanIntoTask(op->getChild(i), childTask.get(), context);
         }
@@ -52,7 +51,7 @@ void QueryProcessor::decomposePlanIntoTask(PhysicalOperator* op, Task* task,
 }
 
 void QueryProcessor::initTask(Task* task) {
-    auto processorTask = ku_dynamic_cast<Task*, ProcessorTask*>(task);
+    auto processorTask = ku_dynamic_cast<ProcessorTask*>(task);
     PhysicalOperator* op = processorTask->sink;
     while (!op->isSource()) {
         if (!op->isParallel()) {

--- a/src/storage/local_storage/local_node_table.cpp
+++ b/src/storage/local_storage/local_node_table.cpp
@@ -21,7 +21,7 @@ LocalNodeTable::LocalNodeTable(Table& table)
 }
 
 void LocalNodeTable::initLocalHashIndex() {
-    auto& nodeTable = ku_dynamic_cast<const Table&, const NodeTable&>(table);
+    auto& nodeTable = ku_dynamic_cast<const NodeTable&>(table);
     DBFileIDAndName dbFileIDAndName{DBFileID{}, "in-mem-overflow"};
     overflowFile = std::make_unique<InMemOverflowFile>(dbFileIDAndName);
     overflowFileHandle = std::make_unique<OverflowFileHandle>(*overflowFile, overflowCursor);
@@ -107,7 +107,7 @@ uint64_t LocalNodeTable::getEstimatedMemUsage() {
 }
 
 void LocalNodeTable::clear() {
-    auto& nodeTable = ku_dynamic_cast<const Table&, const NodeTable&>(table);
+    auto& nodeTable = ku_dynamic_cast<const NodeTable&>(table);
     hashIndex = std::make_unique<LocalHashIndex>(
         nodeTable.getColumn(nodeTable.getPKColumnID()).getDataType().getPhysicalType(),
         overflowFileHandle.get());

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -57,7 +57,7 @@ static void setCommonTableIDToRdfRelTable(const RelTable* relTable,
             columns.push_back(relTable->getDirectedTableData(RelDataDirection::FWD)->getColumn(2));
             columns.push_back(relTable->getDirectedTableData(RelDataDirection::BWD)->getColumn(2));
             for (const auto& column : columns) {
-                ku_dynamic_cast<Column*, InternalIDColumn*>(column)->setCommonTableID(
+                ku_dynamic_cast<InternalIDColumn*>(column)->setCommonTableID(
                     rdfEntry->getResourceTableID());
             }
         }
@@ -134,7 +134,7 @@ void StorageManager::createRelTableGroup(table_id_t, const RelGroupCatalogEntry*
     const Catalog* catalog, Transaction* transaction) {
     for (const auto relTableID : tableSchema->getRelTableIDs()) {
         createRelTable(relTableID,
-            ku_dynamic_cast<TableCatalogEntry*, RelTableCatalogEntry*>(
+            ku_dynamic_cast<RelTableCatalogEntry*>(
                 catalog->getTableCatalogEntry(transaction, relTableID)),
             catalog, transaction);
     }
@@ -143,10 +143,9 @@ void StorageManager::createRelTableGroup(table_id_t, const RelGroupCatalogEntry*
 void StorageManager::createRdfGraph(table_id_t, RDFGraphCatalogEntry* tableSchema,
     const Catalog* catalog, main::ClientContext* context) {
     KU_ASSERT(context != nullptr);
-    const auto rdfGraphSchema =
-        ku_dynamic_cast<TableCatalogEntry*, RDFGraphCatalogEntry*>(tableSchema);
+    const auto rdfGraphSchema = ku_dynamic_cast<RDFGraphCatalogEntry*>(tableSchema);
     const auto resourceTableID = rdfGraphSchema->getResourceTableID();
-    const auto resourceTableEntry = ku_dynamic_cast<TableCatalogEntry*, NodeTableCatalogEntry*>(
+    const auto resourceTableEntry = ku_dynamic_cast<NodeTableCatalogEntry*>(
         catalog->getTableCatalogEntry(context->getTx(), resourceTableID));
     createNodeTable(resourceTableID, resourceTableEntry, context);
     const auto literalTableID = rdfGraphSchema->getLiteralTableID();
@@ -194,7 +193,7 @@ PrimaryKeyIndex* StorageManager::getPKIndex(table_id_t tableID) {
     std::lock_guard lck{mtx};
     KU_ASSERT(tables.contains(tableID));
     KU_ASSERT(tables.at(tableID)->getTableType() == TableType::NODE);
-    const auto table = ku_dynamic_cast<Table*, NodeTable*>(tables.at(tableID).get());
+    const auto table = ku_dynamic_cast<NodeTable*>(tables.at(tableID).get());
     return table->getPKIndex();
 }
 

--- a/src/storage/store/compression_flush_buffer.cpp
+++ b/src/storage/store/compression_flush_buffer.cpp
@@ -56,7 +56,7 @@ template<std::floating_point T>
 std::pair<std::unique_ptr<uint8_t[]>, uint64_t> flushCompressedFloats(const CompressionAlg& alg,
     PhysicalTypeID dataType, std::span<const uint8_t> buffer, FileHandle* dataFH,
     page_idx_t startPageIdx, const ColumnChunkMetadata& metadata) {
-    const auto& castedAlg = ku_dynamic_cast<const CompressionAlg&, const FloatCompression<T>&>(alg);
+    const auto& castedAlg = ku_dynamic_cast<const FloatCompression<T>&>(alg);
 
     const auto* floatMetadata = metadata.compMeta.floatMetadata();
     KU_ASSERT(floatMetadata->exceptionCapacity >= floatMetadata->exceptionCount);

--- a/src/storage/store/list_chunk_data.cpp
+++ b/src/storage/store/list_chunk_data.cpp
@@ -221,7 +221,7 @@ void ListChunkData::lookup(offset_t offsetInChunk, ValueVector& output,
 void ListChunkData::initializeScanState(ChunkState& state, Column* column) const {
     ColumnChunkData::initializeScanState(state, column);
 
-    auto* listColumn = ku_dynamic_cast<Column*, ListColumn*>(column);
+    auto* listColumn = ku_dynamic_cast<ListColumn*>(column);
     state.childrenStates.resize(CHILD_COLUMN_COUNT);
     sizeColumnChunk->initializeScanState(state.childrenStates[SIZE_COLUMN_CHILD_READ_STATE_IDX],
         listColumn->getSizeColumn());

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -232,8 +232,7 @@ void NodeTable::update(Transaction* transaction, TableUpdateState& updateState) 
 }
 
 bool NodeTable::delete_(Transaction* transaction, TableDeleteState& deleteState) {
-    const auto& nodeDeleteState =
-        ku_dynamic_cast<TableDeleteState&, NodeTableDeleteState&>(deleteState);
+    const auto& nodeDeleteState = ku_dynamic_cast<NodeTableDeleteState&>(deleteState);
     KU_ASSERT(nodeDeleteState.nodeIDVector.state->getSelVector().getSelSize() == 1);
     const auto pos = nodeDeleteState.nodeIDVector.state->getSelVector()[0];
     if (nodeDeleteState.nodeIDVector.isNull(pos)) {

--- a/src/storage/store/string_chunk_data.cpp
+++ b/src/storage/store/string_chunk_data.cpp
@@ -132,7 +132,7 @@ void StringChunkData::lookup(offset_t offsetInChunk, ValueVector& output,
 void StringChunkData::initializeScanState(ChunkState& state, Column* column) const {
     ColumnChunkData::initializeScanState(state, column);
 
-    auto* stringColumn = ku_dynamic_cast<Column*, StringColumn*>(column);
+    auto* stringColumn = ku_dynamic_cast<StringColumn*>(column);
     state.childrenStates.resize(CHILD_COLUMN_COUNT);
     indexColumnChunk->initializeScanState(state.childrenStates[INDEX_COLUMN_CHILD_READ_STATE_IDX],
         stringColumn->getIndexColumn());

--- a/src/storage/store/struct_chunk_data.cpp
+++ b/src/storage/store/struct_chunk_data.cpp
@@ -138,7 +138,7 @@ void StructChunkData::lookup(offset_t offsetInChunk, ValueVector& output,
 void StructChunkData::initializeScanState(ChunkState& state, Column* column) const {
     ColumnChunkData::initializeScanState(state, column);
 
-    auto* structColumn = ku_dynamic_cast<Column*, StructColumn*>(column);
+    auto* structColumn = ku_dynamic_cast<StructColumn*>(column);
     state.childrenStates.resize(childChunks.size());
     for (auto i = 0u; i < childChunks.size(); i++) {
         childChunks[i]->initializeScanState(state.childrenStates[i], structColumn->getChild(i));

--- a/tools/nodejs_api/src_cpp/include/node_connection.h
+++ b/tools/nodejs_api/src_cpp/include/node_connection.h
@@ -85,8 +85,7 @@ public:
         auto progressBar = connection->getClientContext()->getProgressBar();
         auto trackProgress = progressBar->getProgressBarPrinting();
         auto display = progressBar->getDisplay().get();
-        NodeProgressBarDisplay* nodeDisplay =
-            ku_dynamic_cast<ProgressBarDisplay*, NodeProgressBarDisplay*>(display);
+        NodeProgressBarDisplay* nodeDisplay = ku_dynamic_cast<NodeProgressBarDisplay*>(display);
         if (progressCallback) {
             nodeDisplay->setCallbackFunction(queryID, *progressCallback);
             progressBar->toggleProgressBarPrinting(true);
@@ -142,8 +141,7 @@ public:
         auto progressBar = connection->getClientContext()->getProgressBar();
         auto trackProgress = progressBar->getProgressBarPrinting();
         auto display = progressBar->getDisplay().get();
-        NodeProgressBarDisplay* nodeDisplay =
-            ku_dynamic_cast<ProgressBarDisplay*, NodeProgressBarDisplay*>(display);
+        NodeProgressBarDisplay* nodeDisplay = ku_dynamic_cast<NodeProgressBarDisplay*>(display);
         if (progressCallback) {
             nodeDisplay->setCallbackFunction(queryID, *progressCallback);
             progressBar->toggleProgressBarPrinting(true);

--- a/tools/python_api/src_cpp/pandas/pandas_scan.cpp
+++ b/tools/python_api/src_cpp/pandas/pandas_scan.cpp
@@ -63,8 +63,7 @@ std::unique_ptr<function::TableFuncSharedState> initSharedState(
         throw RuntimeException("PandasScan called but GIL was already held!");
     }
     // LCOV_EXCL_STOP
-    auto scanBindData =
-        ku_dynamic_cast<TableFuncBindData*, PandasScanFunctionData*>(input.bindData);
+    auto scanBindData = ku_dynamic_cast<PandasScanFunctionData*>(input.bindData);
     return std::make_unique<PandasScanSharedState>(scanBindData->numRows);
 }
 

--- a/tools/python_api/src_cpp/pyarrow/pyarrow_scan.cpp
+++ b/tools/python_api/src_cpp/pyarrow/pyarrow_scan.cpp
@@ -124,8 +124,7 @@ static common::offset_t tableFunc(function::TableFuncInput& input,
 }
 
 static double progressFunc(function::TableFuncSharedState* sharedState) {
-    PyArrowTableScanSharedState* state =
-        ku_dynamic_cast<TableFuncSharedState*, PyArrowTableScanSharedState*>(sharedState);
+    PyArrowTableScanSharedState* state = ku_dynamic_cast<PyArrowTableScanSharedState*>(sharedState);
     if (state->chunks.size() == 0) {
         return 0.0;
     }

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -605,8 +605,7 @@ std::string escapeJsonString(const std::string& str) {
 std::string EmbeddedShell::printJsonExecutionResult(QueryResult& queryResult) const {
     auto colNames = queryResult.getColumnNames();
     auto jsonDrawingCharacters =
-        common::ku_dynamic_cast<DrawingCharacters*, JSONDrawingCharacters*>(
-            drawingCharacters.get());
+        common::ku_dynamic_cast<JSONDrawingCharacters*>(drawingCharacters.get());
     bool jsonLines = jsonDrawingCharacters->printType == PrintType::JSONLINES;
     std::string printString = "";
     if (!jsonLines) {
@@ -671,8 +670,7 @@ std::string escapeHtmlString(const std::string& str) {
 std::string EmbeddedShell::printHtmlExecutionResult(QueryResult& queryResult) const {
     auto colNames = queryResult.getColumnNames();
     auto htmlDrawingCharacters =
-        common::ku_dynamic_cast<DrawingCharacters*, HTMLDrawingCharacters*>(
-            drawingCharacters.get());
+        common::ku_dynamic_cast<HTMLDrawingCharacters*>(drawingCharacters.get());
     std::string printString = htmlDrawingCharacters->TableOpen;
     printString += "\n";
     printString += htmlDrawingCharacters->RowOpen;
@@ -752,8 +750,7 @@ std::string escapeLatexString(const std::string& str) {
 std::string EmbeddedShell::printLatexExecutionResult(QueryResult& queryResult) const {
     auto colNames = queryResult.getColumnNames();
     auto latexDrawingCharacters =
-        common::ku_dynamic_cast<DrawingCharacters*, LatexDrawingCharacters*>(
-            drawingCharacters.get());
+        common::ku_dynamic_cast<LatexDrawingCharacters*>(drawingCharacters.get());
     std::string printString = latexDrawingCharacters->TableOpen;
     printString += latexDrawingCharacters->AlignOpen;
     for (auto i = 0u; i < queryResult.getNumColumns(); i++) {
@@ -887,8 +884,7 @@ void EmbeddedShell::printExecutionResult(QueryResult& queryResult) const {
 
 void EmbeddedShell::printTruncatedExecutionResult(QueryResult& queryResult) const {
     auto tableDrawingCharacters =
-        common::ku_dynamic_cast<DrawingCharacters*, BaseTableDrawingCharacters*>(
-            drawingCharacters.get());
+        common::ku_dynamic_cast<BaseTableDrawingCharacters*>(drawingCharacters.get());
     auto querySummary = queryResult.getQuerySummary();
     constexpr uint32_t SMALL_TABLE_SEPERATOR_LENGTH = 3;
     const uint32_t minTruncatedWidth = 20;


### PR DESCRIPTION
Leaving FROM until last lets it be inferred.

As part of the operator overloading necessary to handle the type inference (otherwise the FROM type may be inferred as passing by value instead of by reference) this does leave FROM having the pointer/reference inferred even if the type is passed explicitly, while the pointer/reference needs to be declared as part of the TO type (e.g. `ku_dynamic_cast<Child*, Parent>`). It's less odd when FROM is inferred though.
We could also have it so that TO just needs the type and uses the type inference on the FROM type to determine if it should be a pointer or reference, but I'd prefer leaving it more explicit.