### PR TITLE
Remove outputProperty from gds function parameter list

### DIFF
--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -409,11 +409,9 @@ public:
      * srcNode::NODE
      * lowerBound::INT64
      * upperBound::INT64
-     * outputProperty::BOOL
      */
     std::vector<LogicalTypeID> getParameterTypeIDs() const override {
-        return {LogicalTypeID::ANY, LogicalTypeID::NODE, LogicalTypeID::INT64, LogicalTypeID::INT64,
-            LogicalTypeID::BOOL};
+        return {LogicalTypeID::ANY, LogicalTypeID::NODE, LogicalTypeID::INT64, LogicalTypeID::INT64};
     }
 
     void bind(const expression_vector& params, Binder* binder,
@@ -423,8 +421,7 @@ public:
         auto lowerBound = ExpressionUtil::getLiteralValue<int64_t>(*params[2]);
         auto upperBound = ExpressionUtil::getLiteralValue<int64_t>(*params[3]);
         validateLowerUpperBound(lowerBound, upperBound);
-        auto outputProperty = ExpressionUtil::getLiteralValue<bool>(*params[4]);
-        bindData = std::make_unique<RJBindData>(nodeInput, nodeOutput, outputProperty, lowerBound,
+        bindData = std::make_unique<RJBindData>(nodeInput, nodeOutput, lowerBound,
             upperBound);
     }
 

--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -411,7 +411,8 @@ public:
      * upperBound::INT64
      */
     std::vector<LogicalTypeID> getParameterTypeIDs() const override {
-        return {LogicalTypeID::ANY, LogicalTypeID::NODE, LogicalTypeID::INT64, LogicalTypeID::INT64};
+        return {LogicalTypeID::ANY, LogicalTypeID::NODE, LogicalTypeID::INT64,
+            LogicalTypeID::INT64};
     }
 
     void bind(const expression_vector& params, Binder* binder,
@@ -421,8 +422,7 @@ public:
         auto lowerBound = ExpressionUtil::getLiteralValue<int64_t>(*params[2]);
         auto upperBound = ExpressionUtil::getLiteralValue<int64_t>(*params[3]);
         validateLowerUpperBound(lowerBound, upperBound);
-        bindData = std::make_unique<RJBindData>(nodeInput, nodeOutput, lowerBound,
-            upperBound);
+        bindData = std::make_unique<RJBindData>(nodeInput, nodeOutput, lowerBound, upperBound);
     }
 
     binder::expression_vector getResultColumns(binder::Binder* binder) const override {

--- a/src/function/gds/page_rank.cpp
+++ b/src/function/gds/page_rank.cpp
@@ -1,5 +1,4 @@
 #include "binder/binder.h"
-#include "binder/expression/expression_util.h"
 #include "common/types/internal_id_util.h"
 #include "function/gds/gds.h"
 #include "function/gds/gds_function_collection.h"
@@ -23,8 +22,8 @@ struct PageRankBindData final : public GDSBindData {
     int64_t maxIteration = 10;
     double delta = 0.0001; // detect convergence
 
-    PageRankBindData(std::shared_ptr<binder::Expression> nodeOutput, bool outputAsNode)
-        : GDSBindData{std::move(nodeOutput), outputAsNode} {};
+    explicit PageRankBindData(std::shared_ptr<binder::Expression> nodeOutput)
+        : GDSBindData{std::move(nodeOutput)} {};
     PageRankBindData(const PageRankBindData& other)
         : GDSBindData{other}, dampingFactor{other.dampingFactor}, maxIteration{other.maxIteration},
           delta{other.delta} {}
@@ -75,10 +74,9 @@ public:
      * Inputs are
      *
      * graph::ANY
-     * outputProperty::BOOL
      */
     std::vector<common::LogicalTypeID> getParameterTypeIDs() const override {
-        return {LogicalTypeID::ANY, LogicalTypeID::BOOL};
+        return {LogicalTypeID::ANY};
     }
 
     /*
@@ -95,10 +93,9 @@ public:
         return columns;
     }
 
-    void bind(const expression_vector& params, Binder* binder, GraphEntry& graphEntry) override {
+    void bind(const expression_vector&, Binder* binder, GraphEntry& graphEntry) override {
         auto nodeOutput = bindNodeOutput(binder, graphEntry);
-        auto outputProperty = ExpressionUtil::getLiteralValue<bool>(*params[1]);
-        bindData = std::make_unique<PageRankBindData>(nodeOutput, outputProperty);
+        bindData = std::make_unique<PageRankBindData>(nodeOutput);
     }
 
     void initLocalState(main::ClientContext* context) override {

--- a/src/function/gds/rec_joins.cpp
+++ b/src/function/gds/rec_joins.cpp
@@ -76,16 +76,14 @@ static void validateSPUpperBound(int64_t upperBound) {
 
 void SPAlgorithm::bind(const expression_vector& params, Binder* binder,
     graph::GraphEntry& graphEntry) {
-    KU_ASSERT(params.size() == 4);
+    KU_ASSERT(params.size() == 3);
     auto nodeInput = params[1];
     auto nodeOutput = bindNodeOutput(binder, graphEntry);
     auto lowerBound = 1;
     auto upperBound = ExpressionUtil::getLiteralValue<int64_t>(*params[2]);
     validateSPUpperBound(upperBound);
     validateLowerUpperBound(lowerBound, upperBound);
-    auto outputProperty = ExpressionUtil::getLiteralValue<bool>(*params[3]);
-    bindData =
-        std::make_unique<RJBindData>(nodeInput, nodeOutput, outputProperty, lowerBound, upperBound);
+    bindData = std::make_unique<RJBindData>(nodeInput, nodeOutput, lowerBound, upperBound);
 }
 
 class RJOutputWriterVCSharedState {

--- a/src/function/gds/weakly_connected_components.cpp
+++ b/src/function/gds/weakly_connected_components.cpp
@@ -1,5 +1,4 @@
 #include "binder/binder.h"
-#include "binder/expression/expression_util.h"
 #include "common/types/internal_id_util.h"
 #include "function/gds/gds_function_collection.h"
 #include "function/gds_function.h"
@@ -58,10 +57,9 @@ public:
      * Inputs are
      *
      * graph::ANY
-     * outputProperty::BOOL
      */
     std::vector<common::LogicalTypeID> getParameterTypeIDs() const override {
-        return std::vector<LogicalTypeID>{LogicalTypeID::ANY, LogicalTypeID::BOOL};
+        return std::vector<LogicalTypeID>{LogicalTypeID::ANY};
     }
 
     /*
@@ -78,10 +76,9 @@ public:
         return columns;
     }
 
-    void bind(const expression_vector& params, Binder* binder, GraphEntry& graphEntry) override {
+    void bind(const expression_vector&, Binder* binder, GraphEntry& graphEntry) override {
         auto nodeOutput = bindNodeOutput(binder, graphEntry);
-        auto outputProperty = ExpressionUtil::getLiteralValue<bool>(*params[1]);
-        bindData = std::make_unique<GDSBindData>(nodeOutput, outputProperty);
+        bindData = std::make_unique<GDSBindData>(nodeOutput);
     }
 
     void initLocalState(main::ClientContext* context) override {

--- a/src/include/function/gds/gds.h
+++ b/src/include/function/gds/gds.h
@@ -21,14 +21,11 @@ namespace function {
 // Struct maintaining GDS specific information that needs to be obtained at compile time.
 struct GDSBindData {
     std::shared_ptr<binder::Expression> nodeOutput;
-    // If outputAsNode is true, we will scan all properties of the node.
-    // Otherwise, we return node ID only.
-    bool outputAsNode;
-    explicit GDSBindData(std::shared_ptr<binder::Expression> nodeOutput, bool outputAsNode)
-        : nodeOutput{std::move(nodeOutput)}, outputAsNode{outputAsNode} {}
 
+    explicit GDSBindData(std::shared_ptr<binder::Expression> nodeOutput)
+        : nodeOutput{std::move(nodeOutput)}{}
     GDSBindData(const GDSBindData& other)
-        : nodeOutput{other.nodeOutput}, outputAsNode{other.outputAsNode} {}
+        : nodeOutput{other.nodeOutput} {}
 
     virtual ~GDSBindData() = default;
 
@@ -36,9 +33,10 @@ struct GDSBindData {
 
     virtual std::shared_ptr<binder::Expression> getNodeInput() const { return nullptr; }
 
-    virtual bool hasNodeOutput() const { return outputAsNode; }
-
-    virtual std::shared_ptr<binder::Expression> getNodeOutput() const { return nodeOutput; }
+    virtual std::shared_ptr<binder::Expression> getNodeOutput() const {
+        KU_ASSERT(nodeOutput != nullptr);
+        return nodeOutput;
+    }
 
     virtual std::unique_ptr<GDSBindData> copy() const {
         return std::make_unique<GDSBindData>(*this);

--- a/src/include/function/gds/gds.h
+++ b/src/include/function/gds/gds.h
@@ -23,9 +23,8 @@ struct GDSBindData {
     std::shared_ptr<binder::Expression> nodeOutput;
 
     explicit GDSBindData(std::shared_ptr<binder::Expression> nodeOutput)
-        : nodeOutput{std::move(nodeOutput)}{}
-    GDSBindData(const GDSBindData& other)
-        : nodeOutput{other.nodeOutput} {}
+        : nodeOutput{std::move(nodeOutput)} {}
+    GDSBindData(const GDSBindData& other) : nodeOutput{other.nodeOutput} {}
 
     virtual ~GDSBindData() = default;
 

--- a/src/include/function/gds/rec_joins.h
+++ b/src/include/function/gds/rec_joins.h
@@ -24,8 +24,7 @@ struct RJBindData final : public GDSBindData {
     uint16_t upperBound;
 
     RJBindData(std::shared_ptr<binder::Expression> nodeInput,
-        std::shared_ptr<binder::Expression> nodeOutput, uint16_t lowerBound,
-        uint16_t upperBound)
+        std::shared_ptr<binder::Expression> nodeOutput, uint16_t lowerBound, uint16_t upperBound)
         : GDSBindData{std::move(nodeOutput)}, nodeInput{std::move(nodeInput)},
           lowerBound{lowerBound}, upperBound{upperBound} {
         KU_ASSERT(upperBound < DEFAULT_MAXIMUM_ALLOWED_UPPER_BOUND);

--- a/src/include/function/gds/rec_joins.h
+++ b/src/include/function/gds/rec_joins.h
@@ -7,7 +7,7 @@
 namespace kuzu {
 namespace function {
 
-struct RJBindData final : public function::GDSBindData {
+struct RJBindData final : public GDSBindData {
     static constexpr uint16_t DEFAULT_MAXIMUM_ALLOWED_UPPER_BOUND = (uint16_t)255;
 
     std::shared_ptr<binder::Expression> nodeInput;
@@ -24,9 +24,9 @@ struct RJBindData final : public function::GDSBindData {
     uint16_t upperBound;
 
     RJBindData(std::shared_ptr<binder::Expression> nodeInput,
-        std::shared_ptr<binder::Expression> nodeOutput, bool outputAsNode, uint16_t lowerBound,
+        std::shared_ptr<binder::Expression> nodeOutput, uint16_t lowerBound,
         uint16_t upperBound)
-        : GDSBindData{std::move(nodeOutput), outputAsNode}, nodeInput{std::move(nodeInput)},
+        : GDSBindData{std::move(nodeOutput)}, nodeInput{std::move(nodeInput)},
           lowerBound{lowerBound}, upperBound{upperBound} {
         KU_ASSERT(upperBound < DEFAULT_MAXIMUM_ALLOWED_UPPER_BOUND);
     }
@@ -109,11 +109,10 @@ public:
      * graph::ANY
      * srcNode::NODE
      * upperBound::INT64
-     * outputProperty::BOOL
      */
     std::vector<common::LogicalTypeID> getParameterTypeIDs() const override {
         return {common::LogicalTypeID::ANY, common::LogicalTypeID::NODE,
-            common::LogicalTypeID::INT64, common::LogicalTypeID::BOOL};
+            common::LogicalTypeID::INT64};
     }
 
     void bind(const binder::expression_vector& params, binder::Binder* binder,

--- a/src/planner/plan/plan_read.cpp
+++ b/src/planner/plan/plan_read.cpp
@@ -150,11 +150,14 @@ void Planner::planGDSCall(const BoundReadingClause& readingClause,
             planReadOp(getGDSCall(readingClause), predicatesToPush, *plan);
         }
     }
-    if (bindData->hasNodeOutput()) {
+
+    auto nodeOutput = bindData->getNodeOutput();
+    KU_ASSERT(nodeOutput != nullptr);
+    auto properties = getProperties(*nodeOutput);
+    if (!properties.empty()) {
         auto& node = bindData->getNodeOutput()->constCast<NodeExpression>();
         auto scanPlan = LogicalPlan();
         cardinalityEstimator.addNodeIDDom(*node.getInternalID(), node.getTableIDs());
-        auto properties = node.getPropertyExprs();
         appendScanNodeTable(node.getInternalID(), node.getTableIDs(), properties, scanPlan);
         expression_vector joinConditions;
         joinConditions.push_back(node.getInternalID());

--- a/test/test_files/function/gds/basic.test
+++ b/test/test_files/function/gds/basic.test
@@ -6,7 +6,7 @@
 
 -STATEMENT PROJECT GRAPH PK (person, knows)
            MATCH (a:person) WHERE a.ID < 6
-           CALL VAR_LEN_JOINS(PK, a, 1, 2, true)
+           CALL VAR_LEN_JOINS(PK, a, 1, 2)
            RETURN a.fName, COUNT(*);
 ---- 4
 Alice|12
@@ -19,13 +19,13 @@ Dan|12
 Parser exception: Filtering or projecting properties in graph projection is not supported.
 -STATEMENT PROJECT GRAPH PK (person, knows)
            MATCH (a:person) WHERE a.ID = 0
-           CALL SINGLE_SP_LENGTHS(PK, a, 2, true)
+           CALL SINGLE_SP_LENGTHS(PK, a, 2)
            RETURN a.fName, _node.name, length;
 ---- error
 Binder exception: Cannot find property name for _node.
 -STATEMENT PROJECT GRAPH PK (person, knows)
            MATCH (a:person) WHERE a.ID = 0
-           CALL SINGLE_SP_LENGTHS(PK, a, 2, true)
+           CALL SINGLE_SP_LENGTHS(PK, a, 2)
            RETURN a.fName, _node.fName, length;
 ---- 3
 Alice|Bob|1
@@ -33,7 +33,7 @@ Alice|Carol|1
 Alice|Dan|1
 -STATEMENT PROJECT GRAPH PK (person, organisation, workAt, knows)
            MATCH (a:person) WHERE a.ID = 0
-           CALL SINGLE_SP_LENGTHS(PK, a, 2, true)
+           CALL SINGLE_SP_LENGTHS(PK, a, 2)
            RETURN a.fName, _node.fName, _node.name, length;
 ---- 5
 Alice|Bob||1
@@ -41,7 +41,7 @@ Alice|Carol||1
 Alice|Dan||1
 Alice||CsWork|2
 Alice||DEsWork|2
--STATEMENT PROJECT GRAPH PK (person, knows) CALL weakly_connected_component(PK, true) RETURN _node.fName, group_id;
+-STATEMENT PROJECT GRAPH PK (person, knows) CALL weakly_connected_component(PK) RETURN _node.fName, group_id;
 ---- 8
 Alice|0
 Bob|0
@@ -51,7 +51,7 @@ Elizabeth|1
 Farooq|1
 Greg|1
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|2
--STATEMENT PROJECT GRAPH PK (person, organisation, knows, workAt) CALL weakly_connected_component(PK, true) RETURN _node.fName, _node.name, group_id;
+-STATEMENT PROJECT GRAPH PK (person, organisation, knows, workAt) CALL weakly_connected_component(PK) RETURN _node.fName, _node.name, group_id;
 ---- 11
 Alice||0
 Bob||0
@@ -64,7 +64,7 @@ Hubert Blaine Wolfeschlegelsteinhausenbergerdorff||2
 |ABFsUni|3
 |CsWork|0
 |DEsWork|0
--STATEMENT PROJECT GRAPH PK (person, knows) CALL page_rank(PK, true) RETURN _node.fName, rank;
+-STATEMENT PROJECT GRAPH PK (person, knows) CALL page_rank(PK) RETURN _node.fName, rank;
 ---- 8
 Alice|0.125000
 Bob|0.125000

--- a/test/test_files/function/gds/rec_joins_large.test
+++ b/test/test_files/function/gds/rec_joins_large.test
@@ -17,7 +17,7 @@
 -LOG VarLenJoins
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 1, 30, true)
+           CALL var_len_joins(PK, a, 1, 30)
            RETURN length, count(*);
 ---- 4
 1|10
@@ -29,7 +29,7 @@
 -LOG VarLenJoinsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 1, 30, true)
+           CALL var_len_joins(PK, a, 1, 30)
            RETURN length, count(*);
 ---- 4
 1|10
@@ -41,7 +41,7 @@
 -LOG VarLenJoinsMultilabel1CountDistinct
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 1, 30, true)
+           CALL var_len_joins(PK, a, 1, 30)
            RETURN count(distinct _node);
 ---- 1
 50
@@ -51,7 +51,7 @@
 -LOG VarLenJoinsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 1, 30, true)
+           CALL var_len_joins(PK, a, 1, 30)
            RETURN length, count(*)
 ---- 4
 1|20
@@ -62,7 +62,7 @@
 -LOG VarLenJoinsLowerBound1
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 2, 3, true)
+           CALL var_len_joins(PK, a, 2, 3)
            RETURN length, count(*);
 ---- 2
 2|100
@@ -71,7 +71,7 @@
 -LOG VarLenJoinsLowerBound2
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 4, 30, true)
+           CALL var_len_joins(PK, a, 4, 30)
            RETURN length, count(*);
 ---- 1
 4|10000
@@ -79,7 +79,7 @@
 -LOG VarLenJoinsEmptyPaths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 4
-           CALL var_len_joins(PK, a, 1, 4, true)
+           CALL var_len_joins(PK, a, 1, 4)
            RETURN length, count(*);
 ---- 0
 
@@ -88,7 +88,7 @@
 -LOG AllSPDestinations
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_destinations(PK, a, 30, true)
+           CALL all_sp_destinations(PK, a, 30)
            RETURN count(*)
 ---- 1
 3110
@@ -97,7 +97,7 @@
 -LOG AllSPDestinationsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_destinations(PK, a, 30, true)
+           CALL all_sp_destinations(PK, a, 30)
            RETURN count(*)
 ---- 1
 13110
@@ -107,7 +107,7 @@
 -LOG AllSPDestinationsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_destinations(PK, a, 30, true)
+           CALL all_sp_destinations(PK, a, 30)
            RETURN count(*)
 ---- 1
 24420
@@ -116,7 +116,7 @@
 -LOG AllSPLengths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_lengths(PK, a, 30, true)
+           CALL all_sp_lengths(PK, a, 30)
            RETURN length, count(*);
 ---- 3
 1|10
@@ -127,7 +127,7 @@
 -LOG AllSPLengthsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_lengths(PK, a, 30, true)
+           CALL all_sp_lengths(PK, a, 30)
            RETURN length, count(*);
 ---- 4
 1|10
@@ -139,7 +139,7 @@
 -LOG AllSPLengthsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_lengths(PK, a, 30, true)
+           CALL all_sp_lengths(PK, a, 30)
            RETURN length, count(*);
 ---- 3
 1|20
@@ -150,7 +150,7 @@
 -LOG AllSPPaths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_paths(PK, a, 5, true)
+           CALL all_sp_paths(PK, a, 5)
            RETURN size(pathNodeIDs), count(*);
 ---- 3
 0|10
@@ -161,7 +161,7 @@
 -LOG AllSPPathsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_paths(PK, a, 30, true)
+           CALL all_sp_paths(PK, a, 30)
            RETURN size(pathNodeIDs), count(*);
 ---- 4
 0|10
@@ -173,7 +173,7 @@
 -LOG AllSPPathsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_paths(PK, a, 30, true)
+           CALL all_sp_paths(PK, a, 30)
            RETURN size(pathNodeIDs), count(*);
 ---- 3
 0|20
@@ -185,7 +185,7 @@
 -LOG SingleSPDestinations
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_destinations(PK, a, 30, true)
+           CALL single_sp_destinations(PK, a, 30)
            RETURN count(*);
 ---- 1
 40
@@ -194,7 +194,7 @@
 -LOG SingleSPDestinationsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_destinations(PK, a, 30, true)
+           CALL single_sp_destinations(PK, a, 30)
            RETURN count(*);
 ---- 1
 50
@@ -203,7 +203,7 @@
 -LOG SingleSPDestinationsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_destinations(PK, a, 30, true)
+           CALL single_sp_destinations(PK, a, 30)
            RETURN count(*);
 ---- 1
 80
@@ -212,7 +212,7 @@
 -LOG SingleSPLengths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_lengths(PK, a, 30, true)
+           CALL single_sp_lengths(PK, a, 30)
            RETURN length, count(*);
 ---- 3
 1|10
@@ -223,7 +223,7 @@
 -LOG SingleSPLengthsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_lengths(PK, a, 30, true)
+           CALL single_sp_lengths(PK, a, 30)
            RETURN length, count(*);
 ---- 4
 1|10
@@ -235,7 +235,7 @@
 -LOG SingleSPLengthsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_lengths(PK, a, 30, true)
+           CALL single_sp_lengths(PK, a, 30)
            RETURN length, count(*);
 ---- 3
 1|20
@@ -246,7 +246,7 @@
 -LOG SingleSPPaths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_paths(PK, a, 5, true)
+           CALL single_sp_paths(PK, a, 5)
            RETURN size(pathNodeIDs), count(*);
 ---- 3
 0|10
@@ -257,7 +257,7 @@
 -LOG SingleSPPathsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_paths(PK, a, 30, true)
+           CALL single_sp_paths(PK, a, 30)
            RETURN size(pathNodeIDs), count(*);
 ---- 4
 0|10
@@ -269,7 +269,7 @@
 -LOG SingleSPPathsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_paths(PK, a, 30, true)
+           CALL single_sp_paths(PK, a, 30)
            RETURN size(pathNodeIDs), count(*)
 ---- 3
 0|20

--- a/test/test_files/function/gds/rec_joins_small.test
+++ b/test/test_files/function/gds/rec_joins_small.test
@@ -14,7 +14,7 @@
 -LOG VarLenJoinsUBLessThanLBError
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1)
-           CALL var_len_joins(PK, a, 2, 1, true)
+           CALL var_len_joins(PK, a, 2, 1)
            RETURN *;
 ---- error
 Runtime exception: Lower bound length of recursive join operations need to be less than or equal to upper bound. Given lower bound is: 2 and upper bound is: 1.
@@ -22,7 +22,7 @@ Runtime exception: Lower bound length of recursive join operations need to be le
 -LOG VarLenJoinsUBTooHighError
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1)
-           CALL var_len_joins(PK, a, 1, 10000, true)
+           CALL var_len_joins(PK, a, 1, 10000)
            RETURN *;
 ---- error
 Runtime exception: Recursive join operations only works for non-positive upper bound iterations that are up to 255. Given upper bound is: 10000.
@@ -30,7 +30,7 @@ Runtime exception: Recursive join operations only works for non-positive upper b
 -LOG VarLenJoinsLBNonPositiveError
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1)
-           CALL var_len_joins(PK, a, -1, 3, true)
+           CALL var_len_joins(PK, a, -1, 3)
            RETURN *;
 ---- error
 Runtime exception: Lower and upper bound lengths of recursive join operations need to be non-negative. Given lower bound is: -1 and upper bound is: 3.
@@ -38,7 +38,7 @@ Runtime exception: Lower and upper bound lengths of recursive join operations ne
 -LOG ShortestPathsJoinsUBNonPositiveError
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1)
-           CALL all_sp_paths(PK, a, -5, true)
+           CALL all_sp_paths(PK, a, -5)
            RETURN *;
 ---- error
 Runtime exception: Lower and upper bound lengths of recursive join operations need to be non-negative. Given lower bound is: 1 and upper bound is: -5.
@@ -46,7 +46,7 @@ Runtime exception: Lower and upper bound lengths of recursive join operations ne
 -LOG ShortestPathsJoinsUBNonPositiveError
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1)
-           CALL all_sp_paths(PK, a, 0, true)
+           CALL all_sp_paths(PK, a, 0)
            RETURN *;
 ---- error
 Runtime exception: Shortest path operations only works for positive upper bound iterations. Given upper bound is: 0.
@@ -54,7 +54,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG VarLenJoins
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 1, 30, true)
+           CALL var_len_joins(PK, a, 1, 30)
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 6
 0|1|1|[]|[2:0]
@@ -67,7 +67,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG VarLenJoinsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 1, 30, true)
+           CALL var_len_joins(PK, a, 1, 30)
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 6
 0|1|1|[]|[3:0]
@@ -80,7 +80,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG VarLenJoinsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 1, 30, true)
+           CALL var_len_joins(PK, a, 1, 30)
            RETURN length, count(*)
 ---- 4
 1|2
@@ -91,7 +91,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG VarLenJoinsLowerBoundZeroUpperBoundOne
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 0, 2, true)
+           CALL var_len_joins(PK, a, 0, 2)
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 5
 0|0|0|[]|[]
@@ -103,7 +103,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG VarLenJoinsLowerBoundZeroUpperBoundZero
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 0, 0, true)
+           CALL var_len_joins(PK, a, 0, 0)
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 5
 0|0|0|[]|[]
@@ -115,7 +115,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG VarLenJoinsLowerBound1
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 2, 3, true)
+           CALL var_len_joins(PK, a, 2, 3)
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 4
 0|2|2|[0:1]|[2:0,2:1]
@@ -126,7 +126,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG VarLenJoinsLowerBound2
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 4, 30, true)
+           CALL var_len_joins(PK, a, 4, 30)
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 1
 0|4|4|[0:1,0:2,0:3]|[2:0,2:1,2:2,2:3]
@@ -134,7 +134,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG VarLenJoinsEmptyPaths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 4
-           CALL var_len_joins(PK, a, 1, 4, true)
+           CALL var_len_joins(PK, a, 1, 4)
            RETURN a.ID, _node.ID, length, pathNodeIDs;
 ---- 0
 
@@ -142,7 +142,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPDestinations
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_destinations(PK, a, 30, true)
+           CALL all_sp_destinations(PK, a, 30)
            RETURN a.ID, _node.ID;
 ---- 5
 0|1
@@ -154,7 +154,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPDestinationsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_destinations(PK, a, 30, true)
+           CALL all_sp_destinations(PK, a, 30)
            RETURN a.ID, _node.ID;
 ---- 6
 0|1
@@ -167,7 +167,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPDestinationsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_destinations(PK, a, 30, true)
+           CALL all_sp_destinations(PK, a, 30)
            RETURN a.ID, _node.ID;
 ---- 30
 0|1
@@ -204,7 +204,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPLengths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_lengths(PK, a, 30, true)
+           CALL all_sp_lengths(PK, a, 30)
            RETURN a.ID, _node.ID, length;
 ---- 5
 0|1|1
@@ -216,7 +216,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPLengthsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_lengths(PK, a, 30, true)
+           CALL all_sp_lengths(PK, a, 30)
            RETURN a.ID, _node.ID, length;
 ---- 6
 0|1|1
@@ -229,7 +229,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPLengthsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_lengths(PK, a, 30, true)
+           CALL all_sp_lengths(PK, a, 30)
            RETURN a.ID, _node.ID, length;
 ---- 30
 0|1|1
@@ -266,7 +266,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPPaths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_paths(PK, a, 5, true)
+           CALL all_sp_paths(PK, a, 5)
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 5
 0|1|1|[]|[2:0]
@@ -278,7 +278,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPPathsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_paths(PK, a, 30, true)
+           CALL all_sp_paths(PK, a, 30)
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 6
 0|1|1|[]|[3:0]
@@ -291,7 +291,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPPathsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_paths(PK, a, 30, true)
+           CALL all_sp_paths(PK, a, 30)
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 30
 0|1|1|[]|[2:0]
@@ -328,7 +328,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPDestinations
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_destinations(PK, a, 30, true)
+           CALL single_sp_destinations(PK, a, 30)
            RETURN a.ID, _node.ID;
 ---- 4
 0|1
@@ -339,7 +339,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPDestinationsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_destinations(PK, a, 30, true)
+           CALL single_sp_destinations(PK, a, 30)
            RETURN a.ID, _node.ID;
 ---- 5
 0|1
@@ -351,7 +351,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPDestinationsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_destinations(PK, a, 30, true)
+           CALL single_sp_destinations(PK, a, 30)
            RETURN a.ID, _node.ID
 ---- 8
 0|1
@@ -366,7 +366,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPLengths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_lengths(PK, a, 30, true)
+           CALL single_sp_lengths(PK, a, 30)
            RETURN a.ID, _node.ID, length;
 ---- 4
 0|1|1
@@ -377,7 +377,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPLengthsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_lengths(PK, a, 30, true)
+           CALL single_sp_lengths(PK, a, 30)
            RETURN a.ID, _node.ID, length;
 ---- 5
 0|1|1
@@ -389,7 +389,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPLengthsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_lengths(PK, a, 30, true)
+           CALL single_sp_lengths(PK, a, 30)
            RETURN a.ID, _node.ID, length
 ---- 8
 0|1|1
@@ -404,7 +404,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPPaths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_paths(PK, a, 5, true)
+           CALL single_sp_paths(PK, a, 5)
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 4
 0|1|1|[]|[2:0]
@@ -415,7 +415,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPPathsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_paths(PK, a, 30, true)
+           CALL single_sp_paths(PK, a, 30)
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 5
 0|1|1|[]|[3:0]
@@ -427,7 +427,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPPathsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_paths(PK, a, 30, true)
+           CALL single_sp_paths(PK, a, 30)
            RETURN length, count(*)
 ---- 3
 1|2


### PR DESCRIPTION
# Description

Remove outputProperty from gds function parameter list.

I forgot why we did this back in the day but apparently this can be detected from whether use is trying to return property or not.

Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).