### PR TITLE
Use an iterator instead of collecting Graph scan results into an std::vector

### DIFF
--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -10,19 +10,19 @@ void FrontierTask::run() {
     auto numApproxActiveNodesForNextIter = 0u;
     std::unique_ptr<graph::Graph> graph = sharedState->graph->copy();
     auto state = graph->prepareScan(sharedState->relTableIDToScan);
-    auto scanResult = graph::GraphScanResult();
     auto localEc = sharedState->ec.copy();
     while (sharedState->frontierPair.getNextRangeMorsel(frontierMorsel)) {
         while (frontierMorsel.hasNextOffset()) {
             common::nodeID_t nodeID = frontierMorsel.getNextNodeID();
             if (sharedState->frontierPair.curFrontier->isActive(nodeID)) {
-                graph->scanFwd(nodeID, *state, scanResult);
-                for (auto i = 0u; i < scanResult.size(); ++i) {
-                    auto nbrNodeID = scanResult.nbrNodeIDs[i];
-                    auto edgeID = scanResult.edgeIDs[i];
-                    if (localEc->edgeCompute(nodeID, nbrNodeID, edgeID)) {
-                        sharedState->frontierPair.nextFrontier->setActive(nbrNodeID);
-                        numApproxActiveNodesForNextIter++;
+                for (const auto [nodes, edges] : graph->scanFwd(nodeID, *state)) {
+                    for (size_t i = 0; i < nodes.size(); i++) {
+                        const auto& nbrNodeID = nodes[i];
+                        const auto& edgeID = edges[i];
+                        if (localEc->edgeCompute(nodeID, nbrNodeID, edgeID)) {
+                            sharedState->frontierPair.nextFrontier->setActive(nbrNodeID);
+                            numApproxActiveNodesForNextIter++;
+                        }
                     }
                 }
             }

--- a/src/function/gds/weakly_connected_components.cpp
+++ b/src/function/gds/weakly_connected_components.cpp
@@ -1,5 +1,6 @@
 #include "binder/binder.h"
 #include "common/types/internal_id_util.h"
+#include "common/types/types.h"
 #include "function/gds/gds_function_collection.h"
 #include "function/gds_function.h"
 #include "graph/graph.h"
@@ -113,14 +114,11 @@ private:
         GraphScanState& scanState) {
         KU_ASSERT(!visitedMap.contains(nodeID));
         visitedMap.insert({nodeID, groupID});
-        auto scanResult = GraphScanResult();
-        sharedState->graph->scanFwd(nodeID, scanState, scanResult);
-        for (auto i = 0u; i < scanResult.size(); ++i) {
-            auto nbr = scanResult.nbrNodeIDs[i];
-            if (visitedMap.contains(nbr)) {
-                continue;
+        // Collect the nodes so that the recursive scan doesn't begin until this scan is done
+        for (auto& nbr : sharedState->graph->scanFwd(nodeID, scanState).collectNbrNodes()) {
+            if (!visitedMap.contains(nbr)) {
+                findConnectedComponent(nbr, groupID, scanState);
             }
-            findConnectedComponent(nbr, groupID, scanState);
         }
     }
 

--- a/src/include/common/mask.h
+++ b/src/include/common/mask.h
@@ -92,8 +92,6 @@ public:
     common::table_id_t getTableID() const { return tableID; }
     common::offset_t getMaxOffset() const { return maxOffset; }
 
-    virtual void init() = 0;
-
     virtual void incrementMaskValue(common::offset_t nodeOffset, uint8_t currentMaskValue) = 0;
     virtual bool isMasked(common::offset_t startNodeOffset, common::offset_t endNodeOffset) = 0;
 
@@ -110,13 +108,11 @@ protected:
 class NodeOffsetLevelSemiMask final : public NodeSemiMask {
 public:
     explicit NodeOffsetLevelSemiMask(common::table_id_t tableID, common::offset_t maxOffset)
-        : NodeSemiMask{tableID, maxOffset} {}
+        : NodeSemiMask{tableID, maxOffset} {
 
-    void init() override {
-        if (maxOffset == common::INVALID_OFFSET) {
-            return;
+        if (maxOffset != common::INVALID_OFFSET) {
+            maskCollection.init(maxOffset + 1);
         }
-        maskCollection.init(maxOffset + 1);
     }
 
     void incrementMaskValue(common::offset_t nodeOffset, uint8_t currentMaskValue) override {
@@ -131,13 +127,10 @@ public:
 class NodeVectorLevelSemiMask final : public NodeSemiMask {
 public:
     explicit NodeVectorLevelSemiMask(common::table_id_t tableID, common::offset_t maxOffset)
-        : NodeSemiMask{tableID, maxOffset} {}
-
-    void init() override {
-        if (maxOffset == common::INVALID_OFFSET) {
-            return;
+        : NodeSemiMask{tableID, maxOffset} {
+        if (maxOffset != common::INVALID_OFFSET) {
+            maskCollection.init(MaskUtil::getVectorIdx(maxOffset) + 1);
         }
-        maskCollection.init(MaskUtil::getVectorIdx(maxOffset) + 1);
     }
 
     void incrementMaskValue(uint64_t nodeOffset, uint8_t currentMaskValue) override {

--- a/src/processor/operator/semi_masker.cpp
+++ b/src/processor/operator/semi_masker.cpp
@@ -30,11 +30,6 @@ void BaseSemiMasker::initGlobalStateInternal(ExecutionContext* /*context*/) {
 
 void BaseSemiMasker::initLocalStateInternal(ResultSet* resultSet, ExecutionContext*) {
     keyVector = resultSet->getValueVector(info->keyPos).get();
-    for (auto& [tableID, masks] : info->masksPerTable) {
-        for (auto& [mask, _] : masks) {
-            mask->init();
-        }
-    }
 }
 
 bool SingleTableSemiMasker::getNextTuplesInternal(ExecutionContext* context) {


### PR DESCRIPTION
This has a smaller benefit than it did initially (now roughly a 5-6% improvement in the comparison I'd done; I'll try some more benchmarks and add them in a later comment). I think this is because adding the edge IDs (in #4310) increased the time spent scanning but didn't increase the cost of the overhead for the results as much.

The iterator is actually producing chunks of values as I found that eliminating that had performance tradeoffs that seemed to outweigh the benefits of avoiding the extra copy (I don't think there's an efficient way of turning a nested loop into an iterator; it might be worth looking at [std::ranges::join_view](https://en.cppreference.com/w/cpp/ranges/join_view), though we've had issues with std::ranges and apple clang in the past).
The iterator is not polymorphic, but passes off the task of fetching the next chunk of results to the scan state. `Graph::Iterator` is just providing an easy to use interface to work with the scan state.

It's important to note that you cannot begin another scan using the same scan state and then continue the original scan. All of the iterator's state is stored in the scan state, not in the iterator. For page rank I added a second scan state to work around this, and in weakly connected components I made it collect the results into a vector so that the scan always can finish before the function gets called recursively (the alternative would be one scan state per function call, which would probably be slower), so it doesn't benefit from this at all.