### PR TITLE
Add bwd/both direction scan to gds

### DIFF
--- a/src/binder/expression/expression_util.cpp
+++ b/src/binder/expression/expression_util.cpp
@@ -230,6 +230,12 @@ bool ExpressionUtil::getLiteralValue(const Expression& expr) {
     validateDataType(expr, LogicalType::BOOL());
     return expr.constCast<LiteralExpression>().getValue().getValue<bool>();
 }
+template<>
+std::string ExpressionUtil::getLiteralValue(const Expression& expr) {
+    validateExpressionType(expr, ExpressionType::LITERAL);
+    validateDataType(expr, LogicalType::STRING());
+    return expr.constCast<LiteralExpression>().getValue().getValue<std::string>();
+}
 
 // For primitive types, two types are compatible if they have the same id.
 // For nested types, two types are compatible if they have the same id and their children are also

--- a/src/common/enums/CMakeLists.txt
+++ b/src/common/enums/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(kuzu_common_enums
         table_type.cpp
         transaction_action.cpp
         drop_type.cpp
+        extend_direction.cpp
         conflict_action.cpp)
         
 set(ALL_OBJECT_FILES

--- a/src/common/enums/extend_direction.cpp
+++ b/src/common/enums/extend_direction.cpp
@@ -1,7 +1,7 @@
 #include "common/enums/extend_direction.h"
 
-#include "common/string_utils.h"
 #include "common/exception/runtime.h"
+#include "common/string_utils.h"
 
 namespace kuzu {
 namespace common {
@@ -19,5 +19,5 @@ ExtendDirection ExtendDirectionUtil::fromString(const std::string& str) {
     }
 }
 
-}
-}
+} // namespace common
+} // namespace kuzu

--- a/src/common/enums/extend_direction.cpp
+++ b/src/common/enums/extend_direction.cpp
@@ -1,0 +1,23 @@
+#include "common/enums/extend_direction.h"
+
+#include "common/string_utils.h"
+#include "common/exception/runtime.h"
+
+namespace kuzu {
+namespace common {
+
+ExtendDirection ExtendDirectionUtil::fromString(const std::string& str) {
+    auto normalizedString = StringUtils::getUpper(str);
+    if (normalizedString == "FWD") {
+        return ExtendDirection::FWD;
+    } else if (normalizedString == "BWD") {
+        return ExtendDirection::BWD;
+    } else if (normalizedString == "BOTH") {
+        return ExtendDirection::BOTH;
+    } else {
+        throw RuntimeException(stringFormat("Cannot parse {} as ExtendDirection.", str));
+    }
+}
+
+}
+}

--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -412,8 +412,8 @@ public:
      * direction::STRING
      */
     std::vector<LogicalTypeID> getParameterTypeIDs() const override {
-        return {LogicalTypeID::ANY, LogicalTypeID::NODE, LogicalTypeID::INT64,
-            LogicalTypeID::INT64, LogicalTypeID::STRING};
+        return {LogicalTypeID::ANY, LogicalTypeID::NODE, LogicalTypeID::INT64, LogicalTypeID::INT64,
+            LogicalTypeID::STRING};
     }
 
     void bind(const expression_vector& params, Binder* binder,
@@ -423,8 +423,10 @@ public:
         auto lowerBound = ExpressionUtil::getLiteralValue<int64_t>(*params[2]);
         auto upperBound = ExpressionUtil::getLiteralValue<int64_t>(*params[3]);
         validateLowerUpperBound(lowerBound, upperBound);
-        auto extendDirection = ExtendDirectionUtil::fromString(ExpressionUtil::getLiteralValue<std::string>(*params[4]));
-        bindData = std::make_unique<RJBindData>(nodeInput, nodeOutput, lowerBound, upperBound, extendDirection);
+        auto extendDirection = ExtendDirectionUtil::fromString(
+            ExpressionUtil::getLiteralValue<std::string>(*params[4]));
+        bindData = std::make_unique<RJBindData>(nodeInput, nodeOutput, lowerBound, upperBound,
+            extendDirection);
     }
 
     binder::expression_vector getResultColumns(binder::Binder* binder) const override {
@@ -460,7 +462,8 @@ private:
 function_set VarLenJoinsFunction::getFunctionSet() {
     function_set result;
     auto algo = std::make_unique<VarLenJoinsAlgorithm>();
-    result.push_back(std::make_unique<GDSFunction>(name,algo->getParameterTypeIDs(), std::move(algo)));
+    result.push_back(
+        std::make_unique<GDSFunction>(name, algo->getParameterTypeIDs(), std::move(algo)));
     return result;
 }
 
@@ -483,7 +486,8 @@ function_set AllSPLengthsFunction::getFunctionSet() {
 function_set AllSPPathsFunction::getFunctionSet() {
     function_set result;
     auto algo = std::make_unique<AllSPPathsAlgorithm>();
-    result.push_back(std::make_unique<GDSFunction>(name, algo->getParameterTypeIDs(), std::move(algo)));
+    result.push_back(
+        std::make_unique<GDSFunction>(name, algo->getParameterTypeIDs(), std::move(algo)));
     return result;
 }
 

--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -409,10 +409,11 @@ public:
      * srcNode::NODE
      * lowerBound::INT64
      * upperBound::INT64
+     * direction::STRING
      */
     std::vector<LogicalTypeID> getParameterTypeIDs() const override {
         return {LogicalTypeID::ANY, LogicalTypeID::NODE, LogicalTypeID::INT64,
-            LogicalTypeID::INT64};
+            LogicalTypeID::INT64, LogicalTypeID::STRING};
     }
 
     void bind(const expression_vector& params, Binder* binder,
@@ -422,7 +423,8 @@ public:
         auto lowerBound = ExpressionUtil::getLiteralValue<int64_t>(*params[2]);
         auto upperBound = ExpressionUtil::getLiteralValue<int64_t>(*params[3]);
         validateLowerUpperBound(lowerBound, upperBound);
-        bindData = std::make_unique<RJBindData>(nodeInput, nodeOutput, lowerBound, upperBound);
+        auto extendDirection = ExtendDirectionUtil::fromString(ExpressionUtil::getLiteralValue<std::string>(*params[4]));
+        bindData = std::make_unique<RJBindData>(nodeInput, nodeOutput, lowerBound, upperBound, extendDirection);
     }
 
     binder::expression_vector getResultColumns(binder::Binder* binder) const override {
@@ -457,27 +459,31 @@ private:
 
 function_set VarLenJoinsFunction::getFunctionSet() {
     function_set result;
-    result.push_back(std::make_unique<GDSFunction>(name, std::make_unique<VarLenJoinsAlgorithm>()));
+    auto algo = std::make_unique<VarLenJoinsAlgorithm>();
+    result.push_back(std::make_unique<GDSFunction>(name,algo->getParameterTypeIDs(), std::move(algo)));
     return result;
 }
 
 function_set AllSPDestinationsFunction::getFunctionSet() {
     function_set result;
+    auto algo = std::make_unique<AllSPDestinationsAlgorithm>();
     result.push_back(
-        std::make_unique<GDSFunction>(name, std::make_unique<AllSPDestinationsAlgorithm>()));
+        std::make_unique<GDSFunction>(name, algo->getParameterTypeIDs(), std::move(algo)));
     return result;
 }
 
 function_set AllSPLengthsFunction::getFunctionSet() {
     function_set result;
+    auto algo = std::make_unique<AllSPLengthsAlgorithm>();
     result.push_back(
-        std::make_unique<GDSFunction>(name, std::make_unique<AllSPLengthsAlgorithm>()));
+        std::make_unique<GDSFunction>(name, algo->getParameterTypeIDs(), std::move(algo)));
     return result;
 }
 
 function_set AllSPPathsFunction::getFunctionSet() {
     function_set result;
-    result.push_back(std::make_unique<GDSFunction>(name, std::make_unique<AllSPPathsAlgorithm>()));
+    auto algo = std::make_unique<AllSPPathsAlgorithm>();
+    result.push_back(std::make_unique<GDSFunction>(name, algo->getParameterTypeIDs(), std::move(algo)));
     return result;
 }
 

--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -5,8 +5,9 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace function {
 
-static uint64_t computeScanResult(nodeID_t sourceNodeID, const std::span<const nodeID_t>& nbrNodeIDs,
-    const std::span<const relID_t>& edgeIDs, EdgeCompute& ec, FrontierPair& frontierPair) {
+static uint64_t computeScanResult(nodeID_t sourceNodeID,
+    const std::span<const nodeID_t>& nbrNodeIDs, const std::span<const relID_t>& edgeIDs,
+    EdgeCompute& ec, FrontierPair& frontierPair) {
     KU_ASSERT(nbrNodeIDs.size() == edgeIDs.size());
     uint64_t numComputedResult = 0;
     for (size_t i = 0; i < nbrNodeIDs.size(); i++) {
@@ -33,20 +34,24 @@ void FrontierTask::run() {
                 switch (info.direction) {
                 case ExtendDirection::FWD: {
                     for (const auto [nodes, edges] : graph->scanFwd(nodeID, *scanState)) {
-                        numApproxActiveNodesForNextIter += computeScanResult(nodeID, nodes, edges, *localEc, sharedState->frontierPair);
+                        numApproxActiveNodesForNextIter += computeScanResult(nodeID, nodes, edges,
+                            *localEc, sharedState->frontierPair);
                     }
                 } break;
                 case ExtendDirection::BWD: {
                     for (const auto [nodes, edges] : graph->scanBwd(nodeID, *scanState)) {
-                        numApproxActiveNodesForNextIter += computeScanResult(nodeID, nodes, edges, *localEc, sharedState->frontierPair);
+                        numApproxActiveNodesForNextIter += computeScanResult(nodeID, nodes, edges,
+                            *localEc, sharedState->frontierPair);
                     }
                 } break;
                 case ExtendDirection::BOTH: {
                     for (const auto [nodes, edges] : graph->scanFwd(nodeID, *scanState)) {
-                        numApproxActiveNodesForNextIter += computeScanResult(nodeID, nodes, edges, *localEc, sharedState->frontierPair);
+                        numApproxActiveNodesForNextIter += computeScanResult(nodeID, nodes, edges,
+                            *localEc, sharedState->frontierPair);
                     }
                     for (const auto [nodes, edges] : graph->scanBwd(nodeID, *scanState)) {
-                        numApproxActiveNodesForNextIter += computeScanResult(nodeID, nodes, edges, *localEc, sharedState->frontierPair);
+                        numApproxActiveNodesForNextIter += computeScanResult(nodeID, nodes, edges,
+                            *localEc, sharedState->frontierPair);
                     }
                 } break;
                 default:

--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -1,29 +1,56 @@
 #include "function/gds/gds_task.h"
 
-#include "graph/graph.h"
+using namespace kuzu::common;
 
 namespace kuzu {
 namespace function {
 
+static uint64_t computeScanResult(nodeID_t sourceNodeID, const std::span<const nodeID_t>& nbrNodeIDs,
+    const std::span<const relID_t>& edgeIDs, EdgeCompute& ec, FrontierPair& frontierPair) {
+    KU_ASSERT(nbrNodeIDs.size() == edgeIDs.size());
+    uint64_t numComputedResult = 0;
+    for (size_t i = 0; i < nbrNodeIDs.size(); i++) {
+        const auto& nbrNodeID = nbrNodeIDs[i];
+        const auto& edgeID = edgeIDs[i];
+        if (ec.edgeCompute(sourceNodeID, nbrNodeID, edgeID)) {
+            frontierPair.getNextFrontierUnsafe().setActive(nbrNodeID);
+            numComputedResult++;
+        }
+    }
+    return numComputedResult;
+}
+
 void FrontierTask::run() {
     FrontierMorsel frontierMorsel;
     auto numApproxActiveNodesForNextIter = 0u;
-    std::unique_ptr<graph::Graph> graph = sharedState->graph->copy();
-    auto state = graph->prepareScan(sharedState->relTableIDToScan);
-    auto localEc = sharedState->ec.copy();
+    auto graph = info.graph;
+    auto scanState = graph->prepareScan(info.relTableIDToScan);
+    auto localEc = info.edgeCompute.copy();
     while (sharedState->frontierPair.getNextRangeMorsel(frontierMorsel)) {
         while (frontierMorsel.hasNextOffset()) {
             common::nodeID_t nodeID = frontierMorsel.getNextNodeID();
             if (sharedState->frontierPair.curFrontier->isActive(nodeID)) {
-                for (const auto [nodes, edges] : graph->scanFwd(nodeID, *state)) {
-                    for (size_t i = 0; i < nodes.size(); i++) {
-                        const auto& nbrNodeID = nodes[i];
-                        const auto& edgeID = edges[i];
-                        if (localEc->edgeCompute(nodeID, nbrNodeID, edgeID)) {
-                            sharedState->frontierPair.nextFrontier->setActive(nbrNodeID);
-                            numApproxActiveNodesForNextIter++;
-                        }
+                switch (info.direction) {
+                case ExtendDirection::FWD: {
+                    for (const auto [nodes, edges] : graph->scanFwd(nodeID, *scanState)) {
+                        numApproxActiveNodesForNextIter += computeScanResult(nodeID, nodes, edges, *localEc, sharedState->frontierPair);
                     }
+                } break;
+                case ExtendDirection::BWD: {
+                    for (const auto [nodes, edges] : graph->scanBwd(nodeID, *scanState)) {
+                        numApproxActiveNodesForNextIter += computeScanResult(nodeID, nodes, edges, *localEc, sharedState->frontierPair);
+                    }
+                } break;
+                case ExtendDirection::BOTH: {
+                    for (const auto [nodes, edges] : graph->scanFwd(nodeID, *scanState)) {
+                        numApproxActiveNodesForNextIter += computeScanResult(nodeID, nodes, edges, *localEc, sharedState->frontierPair);
+                    }
+                    for (const auto [nodes, edges] : graph->scanBwd(nodeID, *scanState)) {
+                        numApproxActiveNodesForNextIter += computeScanResult(nodeID, nodes, edges, *localEc, sharedState->frontierPair);
+                    }
+                } break;
+                default:
+                    KU_UNREACHABLE;
                 }
             }
         }

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -13,35 +13,29 @@ using namespace kuzu::function;
 namespace kuzu {
 namespace function {
 
-void GDSUtils::parallelizeFrontierCompute(processor::ExecutionContext* executionContext,
-    std::shared_ptr<FrontierTaskSharedState> sharedState) {
-    auto task = std::make_shared<FrontierTask>(
-        executionContext->clientContext->getCurrentSetting(main::ThreadsSetting::name)
-            .getValue<uint64_t>(),
-        sharedState);
-    // GDSUtils::parallelizeFrontierCompute is called from a GDSCall operator, which is already
-    // executed by a worker thread Tm of the task scheduler. So this function is executed by Tm.
-    // Because this function will monitor the task and wait for it to complete, running GDS
-    // algorithms effectively "loses" Tm. This can even lead to the query processor to halt, e.g.,
-    // if there is a single worker thread in the system, and more generally decrease the number of
-    // worker threads by 1. Therefore, we instruct scheduleTaskAndWaitOrError to start a new thread
-    // by passing true as the last argument.
-    executionContext->clientContext->getTaskScheduler()->scheduleTaskAndWaitOrError(task,
-        executionContext, true /* launchNewWorkerThread */);
-}
-
-void GDSUtils::runFrontiersUntilConvergence(processor::ExecutionContext* executionContext,
-    RJCompState& rjCompState, graph::Graph* graph, uint64_t maxIters) {
+void GDSUtils::runFrontiersUntilConvergence(processor::ExecutionContext* context,
+    RJCompState& rjCompState, graph::Graph* graph, ExtendDirection extendDirection, uint64_t maxIters) {
+    auto clientContext = context->clientContext;
     auto frontierPair = rjCompState.frontierPair.get();
-    auto fc = rjCompState.edgeCompute.get();
     while (frontierPair->hasActiveNodesForNextLevel() && frontierPair->getNextIter() <= maxIters) {
         frontierPair->beginNewIteration();
         for (auto& relTableIDInfo : graph->getRelTableIDInfos()) {
             rjCompState.beginFrontierComputeBetweenTables(relTableIDInfo.fromNodeTableID,
                 relTableIDInfo.toNodeTableID);
-            auto sharedState = std::make_shared<FrontierTaskSharedState>(*frontierPair, graph, *fc,
-                relTableIDInfo.relTableID);
-            GDSUtils::parallelizeFrontierCompute(executionContext, sharedState);
+            auto info = FrontierTaskInfo(relTableIDInfo.relTableID, graph, extendDirection, *rjCompState.edgeCompute);
+            auto sharedState = std::make_shared<FrontierTaskSharedState>(*frontierPair);
+            auto maxThreads = clientContext->getCurrentSetting(main::ThreadsSetting::name)
+                                  .getValue<uint64_t>();
+            auto task = std::make_shared<FrontierTask>( maxThreads, info, sharedState);
+            // GDSUtils::runFrontiersUntilConvergence is called from a GDSCall operator, which is already
+            // executed by a worker thread Tm of the task scheduler. So this function is executed by Tm.
+            // Because this function will monitor the task and wait for it to complete, running GDS
+            // algorithms effectively "loses" Tm. This can even lead to the query processor to halt, e.g.,
+            // if there is a single worker thread in the system, and more generally decrease the number of
+            // worker threads by 1. Therefore, we instruct scheduleTaskAndWaitOrError to start a new thread
+            // by passing true as the last argument.
+            clientContext->getTaskScheduler()->scheduleTaskAndWaitOrError(task,
+                context, true /* launchNewWorkerThread */);
         }
     }
 }

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -14,7 +14,8 @@ namespace kuzu {
 namespace function {
 
 void GDSUtils::runFrontiersUntilConvergence(processor::ExecutionContext* context,
-    RJCompState& rjCompState, graph::Graph* graph, ExtendDirection extendDirection, uint64_t maxIters) {
+    RJCompState& rjCompState, graph::Graph* graph, ExtendDirection extendDirection,
+    uint64_t maxIters) {
     auto clientContext = context->clientContext;
     auto frontierPair = rjCompState.frontierPair.get();
     while (frontierPair->hasActiveNodesForNextLevel() && frontierPair->getNextIter() <= maxIters) {
@@ -22,20 +23,22 @@ void GDSUtils::runFrontiersUntilConvergence(processor::ExecutionContext* context
         for (auto& relTableIDInfo : graph->getRelTableIDInfos()) {
             rjCompState.beginFrontierComputeBetweenTables(relTableIDInfo.fromNodeTableID,
                 relTableIDInfo.toNodeTableID);
-            auto info = FrontierTaskInfo(relTableIDInfo.relTableID, graph, extendDirection, *rjCompState.edgeCompute);
+            auto info = FrontierTaskInfo(relTableIDInfo.relTableID, graph, extendDirection,
+                *rjCompState.edgeCompute);
             auto sharedState = std::make_shared<FrontierTaskSharedState>(*frontierPair);
-            auto maxThreads = clientContext->getCurrentSetting(main::ThreadsSetting::name)
-                                  .getValue<uint64_t>();
-            auto task = std::make_shared<FrontierTask>( maxThreads, info, sharedState);
-            // GDSUtils::runFrontiersUntilConvergence is called from a GDSCall operator, which is already
-            // executed by a worker thread Tm of the task scheduler. So this function is executed by Tm.
-            // Because this function will monitor the task and wait for it to complete, running GDS
-            // algorithms effectively "loses" Tm. This can even lead to the query processor to halt, e.g.,
-            // if there is a single worker thread in the system, and more generally decrease the number of
-            // worker threads by 1. Therefore, we instruct scheduleTaskAndWaitOrError to start a new thread
-            // by passing true as the last argument.
-            clientContext->getTaskScheduler()->scheduleTaskAndWaitOrError(task,
-                context, true /* launchNewWorkerThread */);
+            auto maxThreads =
+                clientContext->getCurrentSetting(main::ThreadsSetting::name).getValue<uint64_t>();
+            auto task = std::make_shared<FrontierTask>(maxThreads, info, sharedState);
+            // GDSUtils::runFrontiersUntilConvergence is called from a GDSCall operator, which is
+            // already executed by a worker thread Tm of the task scheduler. So this function is
+            // executed by Tm. Because this function will monitor the task and wait for it to
+            // complete, running GDS algorithms effectively "loses" Tm. This can even lead to the
+            // query processor to halt, e.g., if there is a single worker thread in the system, and
+            // more generally decrease the number of worker threads by 1. Therefore, we instruct
+            // scheduleTaskAndWaitOrError to start a new thread by passing true as the last
+            // argument.
+            clientContext->getTaskScheduler()->scheduleTaskAndWaitOrError(task, context,
+                true /* launchNewWorkerThread */);
         }
     }
 }

--- a/src/function/gds/page_rank.cpp
+++ b/src/function/gds/page_rank.cpp
@@ -162,7 +162,8 @@ private:
 
 function_set PageRankFunction::getFunctionSet() {
     function_set result;
-    auto function = std::make_unique<GDSFunction>(name, std::make_unique<PageRank>());
+    auto algo = std::make_unique<PageRank>();
+    auto function = std::make_unique<GDSFunction>(name, algo->getParameterTypeIDs(), std::move(algo));
     result.push_back(std::move(function));
     return result;
 }

--- a/src/function/gds/page_rank.cpp
+++ b/src/function/gds/page_rank.cpp
@@ -163,7 +163,8 @@ private:
 function_set PageRankFunction::getFunctionSet() {
     function_set result;
     auto algo = std::make_unique<PageRank>();
-    auto function = std::make_unique<GDSFunction>(name, algo->getParameterTypeIDs(), std::move(algo));
+    auto function =
+        std::make_unique<GDSFunction>(name, algo->getParameterTypeIDs(), std::move(algo));
     result.push_back(std::move(function));
     return result;
 }

--- a/src/function/gds/rec_joins.cpp
+++ b/src/function/gds/rec_joins.cpp
@@ -76,14 +76,15 @@ static void validateSPUpperBound(int64_t upperBound) {
 
 void SPAlgorithm::bind(const expression_vector& params, Binder* binder,
     graph::GraphEntry& graphEntry) {
-    KU_ASSERT(params.size() == 3);
+    KU_ASSERT(params.size() == 4);
     auto nodeInput = params[1];
     auto nodeOutput = bindNodeOutput(binder, graphEntry);
     auto lowerBound = 1;
     auto upperBound = ExpressionUtil::getLiteralValue<int64_t>(*params[2]);
     validateSPUpperBound(upperBound);
     validateLowerUpperBound(lowerBound, upperBound);
-    bindData = std::make_unique<RJBindData>(nodeInput, nodeOutput, lowerBound, upperBound);
+    auto extendDirection = ExtendDirectionUtil::fromString(ExpressionUtil::getLiteralValue<std::string>(*params[3]));
+    bindData = std::make_unique<RJBindData>(nodeInput, nodeOutput, lowerBound, upperBound, extendDirection);
 }
 
 class RJOutputWriterVCSharedState {
@@ -144,9 +145,10 @@ void RJAlgorithm::exec(processor::ExecutionContext* executionContext) {
             }
             auto sourceNodeID = nodeID_t{offset, tableID};
             RJCompState rjCompState = getRJCompState(executionContext, sourceNodeID);
-            rjCompState.initRJFromSource(sourceNodeID);
+            rjCompState.initSource(sourceNodeID);
+            auto rjBindData = bindData->ptrCast<RJBindData>();
             GDSUtils::runFrontiersUntilConvergence(executionContext, rjCompState,
-                sharedState->graph.get(), bindData->ptrCast<RJBindData>()->upperBound);
+                sharedState->graph.get(), rjBindData->extendDirection, rjBindData->upperBound);
             auto writerVCSharedState = std::make_unique<RJOutputWriterVCSharedState>(
                 executionContext->clientContext->getMemoryManager(), sharedState->fTable.get(),
                 rjCompState.outputWriter.get());

--- a/src/function/gds/rec_joins.cpp
+++ b/src/function/gds/rec_joins.cpp
@@ -83,8 +83,10 @@ void SPAlgorithm::bind(const expression_vector& params, Binder* binder,
     auto upperBound = ExpressionUtil::getLiteralValue<int64_t>(*params[2]);
     validateSPUpperBound(upperBound);
     validateLowerUpperBound(lowerBound, upperBound);
-    auto extendDirection = ExtendDirectionUtil::fromString(ExpressionUtil::getLiteralValue<std::string>(*params[3]));
-    bindData = std::make_unique<RJBindData>(nodeInput, nodeOutput, lowerBound, upperBound, extendDirection);
+    auto extendDirection =
+        ExtendDirectionUtil::fromString(ExpressionUtil::getLiteralValue<std::string>(*params[3]));
+    bindData = std::make_unique<RJBindData>(nodeInput, nodeOutput, lowerBound, upperBound,
+        extendDirection);
 }
 
 class RJOutputWriterVCSharedState {

--- a/src/function/gds/single_shortest_paths.cpp
+++ b/src/function/gds/single_shortest_paths.cpp
@@ -205,22 +205,25 @@ private:
 
 function_set SingleSPDestinationsFunction::getFunctionSet() {
     function_set result;
+    auto algo = std::make_unique<SingleSPDestinationsAlgorithm>();
     result.push_back(
-        std::make_unique<GDSFunction>(name, std::make_unique<SingleSPDestinationsAlgorithm>()));
+        std::make_unique<GDSFunction>(name, algo->getParameterTypeIDs(), std::move(algo)));
     return result;
 }
 
 function_set SingleSPLengthsFunction::getFunctionSet() {
     function_set result;
+    auto algo = std::make_unique<SingleSPLengthsAlgorithm>();
     result.push_back(
-        std::make_unique<GDSFunction>(name, std::make_unique<SingleSPLengthsAlgorithm>()));
+        std::make_unique<GDSFunction>(name, algo->getParameterTypeIDs(), std::move(algo)));
     return result;
 }
 
 function_set SingleSPPathsFunction::getFunctionSet() {
     function_set result;
+    auto algo = std::make_unique<SingleSPPathsAlgorithm>();
     result.push_back(
-        std::make_unique<GDSFunction>(name, std::make_unique<SingleSPPathsAlgorithm>()));
+        std::make_unique<GDSFunction>(name, algo->getParameterTypeIDs(), std::move(algo)));
     return result;
 }
 

--- a/src/function/gds/weakly_connected_components.cpp
+++ b/src/function/gds/weakly_connected_components.cpp
@@ -129,8 +129,9 @@ private:
 
 function_set WeaklyConnectedComponentsFunction::getFunctionSet() {
     function_set result;
+    auto algo = std::make_unique<WeaklyConnectedComponent>();
     auto function =
-        std::make_unique<GDSFunction>(name, std::make_unique<WeaklyConnectedComponent>());
+        std::make_unique<GDSFunction>(name, algo->getParameterTypeIDs(), std::move(algo));
     result.push_back(std::move(function));
     return result;
 }

--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -96,12 +96,6 @@ OnDiskGraph::OnDiskGraph(ClientContext* context, const GraphEntry& entry)
     }
 }
 
-OnDiskGraph::OnDiskGraph(const OnDiskGraph& other)
-    : context{other.context}, graphEntry{other.graphEntry.copy()},
-      nodeIDToNodeTable{other.nodeIDToNodeTable},
-      nodeTableIDToFwdRelTables{other.nodeTableIDToFwdRelTables},
-      nodeTableIDToBwdRelTables{other.nodeTableIDToBwdRelTables} {}
-
 std::vector<table_id_t> OnDiskGraph::getNodeTableIDs() {
     return graphEntry.nodeTableIDs;
 }

--- a/src/include/common/enums/extend_direction.h
+++ b/src/include/common/enums/extend_direction.h
@@ -15,6 +15,8 @@ struct ExtendDirectionUtil {
         KU_ASSERT(direction != ExtendDirection::BOTH);
         return direction == ExtendDirection::FWD ? RelDataDirection::FWD : RelDataDirection::BWD;
     }
+
+    static ExtendDirection fromString(const std::string& str);
 };
 
 } // namespace common

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -221,7 +221,7 @@ class FrontierPair {
     friend class FrontierTask;
 
 public:
-     FrontierPair(std::shared_ptr<GDSFrontier> curFrontier,
+    FrontierPair(std::shared_ptr<GDSFrontier> curFrontier,
         std::shared_ptr<GDSFrontier> nextFrontier, uint64_t initialActiveNodes,
         uint64_t maxThreadsForExec);
 

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -221,7 +221,7 @@ class FrontierPair {
     friend class FrontierTask;
 
 public:
-    explicit FrontierPair(std::shared_ptr<GDSFrontier> curFrontier,
+     FrontierPair(std::shared_ptr<GDSFrontier> curFrontier,
         std::shared_ptr<GDSFrontier> nextFrontier, uint64_t initialActiveNodes,
         uint64_t maxThreadsForExec);
 
@@ -241,6 +241,8 @@ public:
 
     uint16_t getCurrentIter() { return curIter.load(std::memory_order_relaxed); }
     uint16_t getNextIter() { return curIter.load() + 1u; }
+
+    GDSFrontier& getNextFrontierUnsafe() { return *nextFrontier; }
 
     bool hasActiveNodesForNextLevel() { return numApproxActiveNodesForNextIter.load() > 0; }
 

--- a/src/include/function/gds/gds_task.h
+++ b/src/include/function/gds/gds_task.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "common/enums/extend_direction.h"
 #include "common/task_system/task.h"
 #include "function/gds/gds_frontier.h"
 #include "graph/graph.h"
-#include "common/enums/extend_direction.h"
 
 namespace kuzu {
 namespace function {
@@ -14,17 +14,18 @@ struct FrontierTaskInfo {
     common::ExtendDirection direction;
     EdgeCompute& edgeCompute;
 
-    FrontierTaskInfo(common::table_id_t tableID, graph::Graph* graph, common::ExtendDirection direction, EdgeCompute& edgeCompute)
+    FrontierTaskInfo(common::table_id_t tableID, graph::Graph* graph,
+        common::ExtendDirection direction, EdgeCompute& edgeCompute)
         : relTableIDToScan{tableID}, graph{graph}, direction{direction}, edgeCompute{edgeCompute} {}
     FrontierTaskInfo(const FrontierTaskInfo& other)
-        : relTableIDToScan{other.relTableIDToScan}, graph{other.graph}, direction{other.direction}, edgeCompute{other.edgeCompute} {}
+        : relTableIDToScan{other.relTableIDToScan}, graph{other.graph}, direction{other.direction},
+          edgeCompute{other.edgeCompute} {}
 };
 
 struct FrontierTaskSharedState {
     FrontierPair& frontierPair;
 
-    explicit FrontierTaskSharedState(FrontierPair& frontierPair)
-        : frontierPair{frontierPair} {}
+    explicit FrontierTaskSharedState(FrontierPair& frontierPair) : frontierPair{frontierPair} {}
     DELETE_COPY_AND_MOVE(FrontierTaskSharedState);
 };
 
@@ -32,8 +33,7 @@ class FrontierTask : public common::Task {
 public:
     FrontierTask(uint64_t maxNumThreads, const FrontierTaskInfo& info,
         std::shared_ptr<FrontierTaskSharedState> sharedState)
-        : common::Task{maxNumThreads}, info{info},
-          sharedState{std::move(sharedState)} {}
+        : common::Task{maxNumThreads}, info{info}, sharedState{std::move(sharedState)} {}
 
     void run() override;
 

--- a/src/include/function/gds/gds_task.h
+++ b/src/include/function/gds/gds_task.h
@@ -3,31 +3,42 @@
 #include "common/task_system/task.h"
 #include "function/gds/gds_frontier.h"
 #include "graph/graph.h"
+#include "common/enums/extend_direction.h"
 
 namespace kuzu {
 namespace function {
 
-class FrontierTaskSharedState {
-public:
-    FrontierTaskSharedState(FrontierPair& frontierPair, graph::Graph* graph, EdgeCompute& ec,
-        common::table_id_t relTableIDToScan)
-        : frontierPair{frontierPair}, graph{graph}, ec{ec}, relTableIDToScan{relTableIDToScan} {};
-
-public:
-    FrontierPair& frontierPair;
-    graph::Graph* graph;
-    EdgeCompute& ec;
+struct FrontierTaskInfo {
     common::table_id_t relTableIDToScan;
+    graph::Graph* graph;
+    common::ExtendDirection direction;
+    EdgeCompute& edgeCompute;
+
+    FrontierTaskInfo(common::table_id_t tableID, graph::Graph* graph, common::ExtendDirection direction, EdgeCompute& edgeCompute)
+        : relTableIDToScan{tableID}, graph{graph}, direction{direction}, edgeCompute{edgeCompute} {}
+    FrontierTaskInfo(const FrontierTaskInfo& other)
+        : relTableIDToScan{other.relTableIDToScan}, graph{other.graph}, direction{other.direction}, edgeCompute{other.edgeCompute} {}
+};
+
+struct FrontierTaskSharedState {
+    FrontierPair& frontierPair;
+
+    explicit FrontierTaskSharedState(FrontierPair& frontierPair)
+        : frontierPair{frontierPair} {}
+    DELETE_COPY_AND_MOVE(FrontierTaskSharedState);
 };
 
 class FrontierTask : public common::Task {
 public:
-    FrontierTask(uint64_t maxNumThreads, std::shared_ptr<FrontierTaskSharedState> sharedState)
-        : common::Task{maxNumThreads}, sharedState{std::move(sharedState)} {}
+    FrontierTask(uint64_t maxNumThreads, const FrontierTaskInfo& info,
+        std::shared_ptr<FrontierTaskSharedState> sharedState)
+        : common::Task{maxNumThreads}, info{info},
+          sharedState{std::move(sharedState)} {}
 
     void run() override;
 
 private:
+    FrontierTaskInfo info;
     std::shared_ptr<FrontierTaskSharedState> sharedState;
 };
 

--- a/src/include/function/gds/gds_utils.h
+++ b/src/include/function/gds/gds_utils.h
@@ -18,7 +18,8 @@ class VertexCompute;
 class GDSUtils {
 public:
     static void runFrontiersUntilConvergence(processor::ExecutionContext* executionContext,
-        RJCompState& rjCompState, graph::Graph* graph, common::ExtendDirection extendDirection, uint64_t maxIters);
+        RJCompState& rjCompState, graph::Graph* graph, common::ExtendDirection extendDirection,
+        uint64_t maxIters);
     static void runVertexComputeIteration(processor::ExecutionContext* executionContext,
         graph::Graph* graph, VertexCompute& vc);
 };

--- a/src/include/function/gds/gds_utils.h
+++ b/src/include/function/gds/gds_utils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <memory>
+#include "common/enums/extend_direction.h"
 
 namespace kuzu {
 namespace processor {
@@ -12,20 +12,13 @@ class Graph;
 }
 
 namespace function {
-class FrontierPair;
-class EdgeCompute;
-class FrontierTaskSharedState;
+struct FrontierTaskSharedState;
 struct RJCompState;
 class VertexCompute;
 class GDSUtils {
 public:
-public:
-    explicit GDSUtils();
-
-    static void parallelizeFrontierCompute(processor::ExecutionContext* executionContext,
-        std::shared_ptr<FrontierTaskSharedState> sharedState);
     static void runFrontiersUntilConvergence(processor::ExecutionContext* executionContext,
-        RJCompState& rjCompState, graph::Graph* graph, uint64_t maxIters);
+        RJCompState& rjCompState, graph::Graph* graph, common::ExtendDirection extendDirection, uint64_t maxIters);
     static void runVertexComputeIteration(processor::ExecutionContext* executionContext,
         graph::Graph* graph, VertexCompute& vc);
 };

--- a/src/include/function/gds/rec_joins.h
+++ b/src/include/function/gds/rec_joins.h
@@ -3,6 +3,7 @@
 #include "function/gds/gds.h"
 #include "function/gds/gds_frontier.h"
 #include "output_writer.h"
+#include "common/enums/extend_direction.h"
 
 namespace kuzu {
 namespace function {
@@ -23,15 +24,17 @@ struct RJBindData final : public GDSBindData {
     uint16_t lowerBound;
     uint16_t upperBound;
 
+    common::ExtendDirection extendDirection = common::ExtendDirection::FWD;
+
     RJBindData(std::shared_ptr<binder::Expression> nodeInput,
-        std::shared_ptr<binder::Expression> nodeOutput, uint16_t lowerBound, uint16_t upperBound)
+        std::shared_ptr<binder::Expression> nodeOutput, uint16_t lowerBound, uint16_t upperBound, common::ExtendDirection extendDirection)
         : GDSBindData{std::move(nodeOutput)}, nodeInput{std::move(nodeInput)},
-          lowerBound{lowerBound}, upperBound{upperBound} {
+          lowerBound{lowerBound}, upperBound{upperBound}, extendDirection{extendDirection} {
         KU_ASSERT(upperBound < DEFAULT_MAXIMUM_ALLOWED_UPPER_BOUND);
     }
     RJBindData(const RJBindData& other)
         : GDSBindData{other}, nodeInput{other.nodeInput}, lowerBound{other.lowerBound},
-          upperBound{other.upperBound} {}
+          upperBound{other.upperBound}, extendDirection{other.extendDirection} {}
 
     bool hasNodeInput() const override { return true; }
     std::shared_ptr<binder::Expression> getNodeInput() const override { return nodeInput; }
@@ -49,11 +52,11 @@ struct RJCompState {
     std::unique_ptr<RJOutputs> outputs;
     std::unique_ptr<RJOutputWriter> outputWriter;
 
-    explicit RJCompState(std::unique_ptr<function::FrontierPair> frontierPair3,
+    RJCompState(std::unique_ptr<function::FrontierPair> frontierPair,
         std::unique_ptr<function::EdgeCompute> edgeCompute, std::unique_ptr<RJOutputs> outputs,
         std::unique_ptr<RJOutputWriter> outputWriter);
 
-    void initRJFromSource(common::nodeID_t sourceNodeID) const {
+    void initSource(common::nodeID_t sourceNodeID) const {
         frontierPair->initRJFromSource(sourceNodeID);
         outputs->initRJFromSource(sourceNodeID);
     }
@@ -108,10 +111,11 @@ public:
      * graph::ANY
      * srcNode::NODE
      * upperBound::INT64
+     * direction::STRING
      */
     std::vector<common::LogicalTypeID> getParameterTypeIDs() const override {
         return {common::LogicalTypeID::ANY, common::LogicalTypeID::NODE,
-            common::LogicalTypeID::INT64};
+            common::LogicalTypeID::INT64, common::LogicalTypeID::STRING};
     }
 
     void bind(const binder::expression_vector& params, binder::Binder* binder,

--- a/src/include/function/gds/rec_joins.h
+++ b/src/include/function/gds/rec_joins.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "common/enums/extend_direction.h"
 #include "function/gds/gds.h"
 #include "function/gds/gds_frontier.h"
 #include "output_writer.h"
-#include "common/enums/extend_direction.h"
 
 namespace kuzu {
 namespace function {
@@ -27,7 +27,8 @@ struct RJBindData final : public GDSBindData {
     common::ExtendDirection extendDirection = common::ExtendDirection::FWD;
 
     RJBindData(std::shared_ptr<binder::Expression> nodeInput,
-        std::shared_ptr<binder::Expression> nodeOutput, uint16_t lowerBound, uint16_t upperBound, common::ExtendDirection extendDirection)
+        std::shared_ptr<binder::Expression> nodeOutput, uint16_t lowerBound, uint16_t upperBound,
+        common::ExtendDirection extendDirection)
         : GDSBindData{std::move(nodeOutput)}, nodeInput{std::move(nodeInput)},
           lowerBound{lowerBound}, upperBound{upperBound}, extendDirection{extendDirection} {
         KU_ASSERT(upperBound < DEFAULT_MAXIMUM_ALLOWED_UPPER_BOUND);

--- a/src/include/function/gds_function.h
+++ b/src/include/function/gds_function.h
@@ -9,8 +9,9 @@ namespace function {
 struct GDSFunction : public Function {
     std::unique_ptr<GDSAlgorithm> gds;
 
-    GDSFunction(std::string name, std::unique_ptr<GDSAlgorithm> gds)
-        : Function{std::move(name), gds->getParameterTypeIDs()}, gds{std::move(gds)} {}
+    GDSFunction(std::string name, std::vector<common::LogicalTypeID> parameterTypeIDs,
+        std::unique_ptr<GDSAlgorithm> gds)
+        : Function{std::move(name), std::move(parameterTypeIDs)}, gds{std::move(gds)} {}
     EXPLICIT_COPY_DEFAULT_MOVE(GDSFunction);
 
 private:

--- a/src/include/graph/graph.h
+++ b/src/include/graph/graph.h
@@ -98,7 +98,6 @@ public:
     Graph() = default;
     virtual ~Graph() = default;
 
-    virtual std::unique_ptr<Graph> copy() = 0;
     // Get id for all node tables.
     virtual std::vector<common::table_id_t> getNodeTableIDs() = 0;
     // Get id for all relationship tables.

--- a/src/include/graph/on_disk_graph.h
+++ b/src/include/graph/on_disk_graph.h
@@ -125,9 +125,7 @@ private:
 class OnDiskGraph final : public Graph {
 public:
     OnDiskGraph(main::ClientContext* context, const GraphEntry& entry);
-    OnDiskGraph(const OnDiskGraph& other);
 
-    std::unique_ptr<Graph> copy() override { return std::make_unique<OnDiskGraph>(*this); }
     std::vector<common::table_id_t> getNodeTableIDs() override;
     std::vector<common::table_id_t> getRelTableIDs() override;
 

--- a/test/test_files/function/gds/basic.test
+++ b/test/test_files/function/gds/basic.test
@@ -6,26 +6,49 @@
 
 -STATEMENT PROJECT GRAPH PK (person, knows)
            MATCH (a:person) WHERE a.ID < 6
-           CALL VAR_LEN_JOINS(PK, a, 1, 2)
+           CALL VAR_LEN_JOINS(PK, a, 1, 2, "FWD")
            RETURN a.fName, COUNT(*);
 ---- 4
 Alice|12
 Bob|12
 Carol|12
 Dan|12
-
+-STATEMENT PROJECT GRAPH PK (person, knows)
+           MATCH (a:person) WHERE a.ID < 6
+           CALL VAR_LEN_JOINS(PK, a, 1, 2, "BWD")
+           RETURN a.fName, COUNT(*);
+---- 4
+Alice|12
+Bob|12
+Carol|12
+Dan|12
+-STATEMENT PROJECT GRAPH PK (person, knows)
+           MATCH (a:person) WHERE a.ID < 6
+           CALL VAR_LEN_JOINS(PK, a, 1, 2, "BOTH")
+           RETURN a.fName, COUNT(*);
+---- 4
+Alice|42
+Bob|42
+Carol|42
+Dan|42
 -STATEMENT PROJECT GRAPH PK (person {age}, knows) CALL variable_length_path(PK, 1, 1) RETURN *;
 ---- error
 Parser exception: Filtering or projecting properties in graph projection is not supported.
 -STATEMENT PROJECT GRAPH PK (person, knows)
            MATCH (a:person) WHERE a.ID = 0
-           CALL SINGLE_SP_LENGTHS(PK, a, 2)
+           CALL SINGLE_SP_LENGTHS(PK, a, 2, "FWD")
            RETURN a.fName, _node.name, length;
 ---- error
 Binder exception: Cannot find property name for _node.
 -STATEMENT PROJECT GRAPH PK (person, knows)
            MATCH (a:person) WHERE a.ID = 0
-           CALL SINGLE_SP_LENGTHS(PK, a, 2)
+           CALL SINGLE_SP_LENGTHS(PK, a, 2, "X")
+           RETURN a.fName, _node.name, length;
+---- error
+Runtime exception: Cannot parse X as ExtendDirection.
+-STATEMENT PROJECT GRAPH PK (person, knows)
+           MATCH (a:person) WHERE a.ID = 0
+           CALL SINGLE_SP_LENGTHS(PK, a, 2, "FWD")
            RETURN a.fName, _node.fName, length;
 ---- 3
 Alice|Bob|1
@@ -33,7 +56,7 @@ Alice|Carol|1
 Alice|Dan|1
 -STATEMENT PROJECT GRAPH PK (person, organisation, workAt, knows)
            MATCH (a:person) WHERE a.ID = 0
-           CALL SINGLE_SP_LENGTHS(PK, a, 2)
+           CALL SINGLE_SP_LENGTHS(PK, a, 2, "FWD")
            RETURN a.fName, _node.fName, _node.name, length;
 ---- 5
 Alice|Bob||1

--- a/test/test_files/function/gds/rec_joins_large.test
+++ b/test/test_files/function/gds/rec_joins_large.test
@@ -17,7 +17,7 @@
 -LOG VarLenJoins
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 1, 30)
+           CALL var_len_joins(PK, a, 1, 30, "FWD")
            RETURN length, count(*);
 ---- 4
 1|10
@@ -29,7 +29,7 @@
 -LOG VarLenJoinsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 1, 30)
+           CALL var_len_joins(PK, a, 1, 30, "FWD")
            RETURN length, count(*);
 ---- 4
 1|10
@@ -41,7 +41,7 @@
 -LOG VarLenJoinsMultilabel1CountDistinct
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 1, 30)
+           CALL var_len_joins(PK, a, 1, 30, "FWD")
            RETURN count(distinct _node);
 ---- 1
 50
@@ -51,7 +51,7 @@
 -LOG VarLenJoinsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 1, 30)
+           CALL var_len_joins(PK, a, 1, 30, "FWD")
            RETURN length, count(*)
 ---- 4
 1|20
@@ -62,7 +62,7 @@
 -LOG VarLenJoinsLowerBound1
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 2, 3)
+           CALL var_len_joins(PK, a, 2, 3, "FWD")
            RETURN length, count(*);
 ---- 2
 2|100
@@ -71,7 +71,7 @@
 -LOG VarLenJoinsLowerBound2
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 4, 30)
+           CALL var_len_joins(PK, a, 4, 30, "FWD")
            RETURN length, count(*);
 ---- 1
 4|10000
@@ -79,7 +79,7 @@
 -LOG VarLenJoinsEmptyPaths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 4
-           CALL var_len_joins(PK, a, 1, 4)
+           CALL var_len_joins(PK, a, 1, 4, "FWD")
            RETURN length, count(*);
 ---- 0
 
@@ -88,7 +88,7 @@
 -LOG AllSPDestinations
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_destinations(PK, a, 30)
+           CALL all_sp_destinations(PK, a, 30, "FWD")
            RETURN count(*)
 ---- 1
 3110
@@ -97,7 +97,7 @@
 -LOG AllSPDestinationsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_destinations(PK, a, 30)
+           CALL all_sp_destinations(PK, a, 30, "FWD")
            RETURN count(*)
 ---- 1
 13110
@@ -107,7 +107,7 @@
 -LOG AllSPDestinationsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_destinations(PK, a, 30)
+           CALL all_sp_destinations(PK, a, 30, "FWD")
            RETURN count(*)
 ---- 1
 24420
@@ -116,7 +116,7 @@
 -LOG AllSPLengths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_lengths(PK, a, 30)
+           CALL all_sp_lengths(PK, a, 30, "FWD")
            RETURN length, count(*);
 ---- 3
 1|10
@@ -127,7 +127,7 @@
 -LOG AllSPLengthsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_lengths(PK, a, 30)
+           CALL all_sp_lengths(PK, a, 30, "FWD")
            RETURN length, count(*);
 ---- 4
 1|10
@@ -139,7 +139,7 @@
 -LOG AllSPLengthsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_lengths(PK, a, 30)
+           CALL all_sp_lengths(PK, a, 30, "FWD")
            RETURN length, count(*);
 ---- 3
 1|20
@@ -150,7 +150,7 @@
 -LOG AllSPPaths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_paths(PK, a, 5)
+           CALL all_sp_paths(PK, a, 5, "FWD")
            RETURN size(pathNodeIDs), count(*);
 ---- 3
 0|10
@@ -161,7 +161,7 @@
 -LOG AllSPPathsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_paths(PK, a, 30)
+           CALL all_sp_paths(PK, a, 30, "FWD")
            RETURN size(pathNodeIDs), count(*);
 ---- 4
 0|10
@@ -173,7 +173,7 @@
 -LOG AllSPPathsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_paths(PK, a, 30)
+           CALL all_sp_paths(PK, a, 30, "FWD")
            RETURN size(pathNodeIDs), count(*);
 ---- 3
 0|20
@@ -185,7 +185,7 @@
 -LOG SingleSPDestinations
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_destinations(PK, a, 30)
+           CALL single_sp_destinations(PK, a, 30, "FWD")
            RETURN count(*);
 ---- 1
 40
@@ -194,7 +194,7 @@
 -LOG SingleSPDestinationsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_destinations(PK, a, 30)
+           CALL single_sp_destinations(PK, a, 30, "FWD")
            RETURN count(*);
 ---- 1
 50
@@ -203,7 +203,7 @@
 -LOG SingleSPDestinationsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_destinations(PK, a, 30)
+           CALL single_sp_destinations(PK, a, 30, "FWD")
            RETURN count(*);
 ---- 1
 80
@@ -212,7 +212,7 @@
 -LOG SingleSPLengths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_lengths(PK, a, 30)
+           CALL single_sp_lengths(PK, a, 30, "FWD")
            RETURN length, count(*);
 ---- 3
 1|10
@@ -223,7 +223,7 @@
 -LOG SingleSPLengthsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_lengths(PK, a, 30)
+           CALL single_sp_lengths(PK, a, 30, "FWD")
            RETURN length, count(*);
 ---- 4
 1|10
@@ -235,7 +235,7 @@
 -LOG SingleSPLengthsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_lengths(PK, a, 30)
+           CALL single_sp_lengths(PK, a, 30, "FWD")
            RETURN length, count(*);
 ---- 3
 1|20
@@ -246,7 +246,7 @@
 -LOG SingleSPPaths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_paths(PK, a, 5)
+           CALL single_sp_paths(PK, a, 5, "FWD")
            RETURN size(pathNodeIDs), count(*);
 ---- 3
 0|10
@@ -257,7 +257,7 @@
 -LOG SingleSPPathsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_paths(PK, a, 30)
+           CALL single_sp_paths(PK, a, 30, "FWD")
            RETURN size(pathNodeIDs), count(*);
 ---- 4
 0|10
@@ -269,7 +269,7 @@
 -LOG SingleSPPathsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_paths(PK, a, 30)
+           CALL single_sp_paths(PK, a, 30, "FWD")
            RETURN size(pathNodeIDs), count(*)
 ---- 3
 0|20

--- a/test/test_files/function/gds/rec_joins_small.test
+++ b/test/test_files/function/gds/rec_joins_small.test
@@ -14,7 +14,7 @@
 -LOG VarLenJoinsUBLessThanLBError
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1)
-           CALL var_len_joins(PK, a, 2, 1)
+           CALL var_len_joins(PK, a, 2, 1, "FWD")
            RETURN *;
 ---- error
 Runtime exception: Lower bound length of recursive join operations need to be less than or equal to upper bound. Given lower bound is: 2 and upper bound is: 1.
@@ -22,7 +22,7 @@ Runtime exception: Lower bound length of recursive join operations need to be le
 -LOG VarLenJoinsUBTooHighError
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1)
-           CALL var_len_joins(PK, a, 1, 10000)
+           CALL var_len_joins(PK, a, 1, 10000,"FWD")
            RETURN *;
 ---- error
 Runtime exception: Recursive join operations only works for non-positive upper bound iterations that are up to 255. Given upper bound is: 10000.
@@ -30,7 +30,7 @@ Runtime exception: Recursive join operations only works for non-positive upper b
 -LOG VarLenJoinsLBNonPositiveError
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1)
-           CALL var_len_joins(PK, a, -1, 3)
+           CALL var_len_joins(PK, a, -1, 3, "FWD")
            RETURN *;
 ---- error
 Runtime exception: Lower and upper bound lengths of recursive join operations need to be non-negative. Given lower bound is: -1 and upper bound is: 3.
@@ -38,7 +38,7 @@ Runtime exception: Lower and upper bound lengths of recursive join operations ne
 -LOG ShortestPathsJoinsUBNonPositiveError
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1)
-           CALL all_sp_paths(PK, a, -5)
+           CALL all_sp_paths(PK, a, -5, "FWD")
            RETURN *;
 ---- error
 Runtime exception: Lower and upper bound lengths of recursive join operations need to be non-negative. Given lower bound is: 1 and upper bound is: -5.
@@ -46,7 +46,7 @@ Runtime exception: Lower and upper bound lengths of recursive join operations ne
 -LOG ShortestPathsJoinsUBNonPositiveError
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1)
-           CALL all_sp_paths(PK, a, 0)
+           CALL all_sp_paths(PK, a, 0, "FWD")
            RETURN *;
 ---- error
 Runtime exception: Shortest path operations only works for positive upper bound iterations. Given upper bound is: 0.
@@ -54,7 +54,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG VarLenJoins
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 1, 30)
+           CALL var_len_joins(PK, a, 1, 30, "FWD")
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 6
 0|1|1|[]|[2:0]
@@ -63,11 +63,38 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 0|4|3|[0:1,0:2]|[2:0,2:1,2:4]
 0|4|3|[0:1,0:2]|[2:0,2:1,2:5]
 0|4|4|[0:1,0:2,0:3]|[2:0,2:1,2:2,2:3]
+-STATEMENT PROJECT GRAPH PK (person1, knows11)
+           MATCH (a:person1) WHERE a.ID = 4
+           CALL var_len_joins(PK, a, 1, 30, "BWD")
+           RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
+---- 10
+4|0|3|[0:2,0:1]|[2:4,2:1,2:0]
+4|0|3|[0:2,0:1]|[2:5,2:1,2:0]
+4|0|4|[0:3,0:2,0:1]|[2:3,2:2,2:1,2:0]
+4|1|2|[0:2]|[2:4,2:1]
+4|1|2|[0:2]|[2:5,2:1]
+4|1|3|[0:3,0:2]|[2:3,2:2,2:1]
+4|2|1|[]|[2:4]
+4|2|1|[]|[2:5]
+4|2|2|[0:3]|[2:3,2:2]
+4|3|1|[]|[2:3]
+-STATEMENT PROJECT GRAPH PK (person1, knows11)
+           MATCH (a:person1) WHERE a.ID = 1
+           CALL var_len_joins(PK, a, 1, 2, "BOTH")
+           RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
+---- 7
+1|0|1|[]|[2:0]
+1|1|2|[0:0]|[2:0,2:0]
+1|1|2|[0:2]|[2:1,2:1]
+1|2|1|[]|[2:1]
+1|3|2|[0:2]|[2:1,2:2]
+1|4|2|[0:2]|[2:1,2:4]
+1|4|2|[0:2]|[2:1,2:5]
 
 -LOG VarLenJoinsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 1, 30)
+           CALL var_len_joins(PK, a, 1, 30, "FWD")
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 6
 0|1|1|[]|[3:0]
@@ -80,7 +107,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG VarLenJoinsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 1, 30)
+           CALL var_len_joins(PK, a, 1, 30, "FWD")
            RETURN length, count(*)
 ---- 4
 1|2
@@ -91,7 +118,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG VarLenJoinsLowerBoundZeroUpperBoundOne
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 0, 2)
+           CALL var_len_joins(PK, a, 0, 2, "FWD")
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 5
 0|0|0|[]|[]
@@ -103,7 +130,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG VarLenJoinsLowerBoundZeroUpperBoundZero
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 0, 0)
+           CALL var_len_joins(PK, a, 0, 0, "FWD")
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 5
 0|0|0|[]|[]
@@ -115,7 +142,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG VarLenJoinsLowerBound1
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 2, 3)
+           CALL var_len_joins(PK, a, 2, 3, "FWD")
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 4
 0|2|2|[0:1]|[2:0,2:1]
@@ -126,7 +153,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG VarLenJoinsLowerBound2
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL var_len_joins(PK, a, 4, 30)
+           CALL var_len_joins(PK, a, 4, 30, "FWD")
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 1
 0|4|4|[0:1,0:2,0:3]|[2:0,2:1,2:2,2:3]
@@ -134,7 +161,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG VarLenJoinsEmptyPaths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 4
-           CALL var_len_joins(PK, a, 1, 4)
+           CALL var_len_joins(PK, a, 1, 4, "FWD")
            RETURN a.ID, _node.ID, length, pathNodeIDs;
 ---- 0
 
@@ -142,7 +169,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPDestinations
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_destinations(PK, a, 30)
+           CALL all_sp_destinations(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID;
 ---- 5
 0|1
@@ -154,7 +181,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPDestinationsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_destinations(PK, a, 30)
+           CALL all_sp_destinations(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID;
 ---- 6
 0|1
@@ -167,7 +194,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPDestinationsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_destinations(PK, a, 30)
+           CALL all_sp_destinations(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID;
 ---- 30
 0|1
@@ -204,7 +231,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPLengths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_lengths(PK, a, 30)
+           CALL all_sp_lengths(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID, length;
 ---- 5
 0|1|1
@@ -216,7 +243,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPLengthsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_lengths(PK, a, 30)
+           CALL all_sp_lengths(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID, length;
 ---- 6
 0|1|1
@@ -229,7 +256,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPLengthsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_lengths(PK, a, 30)
+           CALL all_sp_lengths(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID, length;
 ---- 30
 0|1|1
@@ -266,7 +293,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPPaths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_paths(PK, a, 5)
+           CALL all_sp_paths(PK, a, 5, "FWD")
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 5
 0|1|1|[]|[2:0]
@@ -274,11 +301,24 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 0|3|3|[0:1,0:2]|[2:0,2:1,2:2]
 0|4|3|[0:1,0:2]|[2:0,2:1,2:4]
 0|4|3|[0:1,0:2]|[2:0,2:1,2:5]
+-LOG AllSPPaths
+-STATEMENT PROJECT GRAPH PK (person1, knows11)
+           MATCH (a:person1) WHERE a.ID = 4
+           CALL all_sp_paths(PK, a, 5, "BOTH")
+           RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
+---- 7
+4|0|3|[0:2,0:1]|[2:4,2:1,2:0]
+4|0|3|[0:2,0:1]|[2:5,2:1,2:0]
+4|1|2|[0:2]|[2:4,2:1]
+4|1|2|[0:2]|[2:5,2:1]
+4|2|1|[]|[2:4]
+4|2|1|[]|[2:5]
+4|3|1|[]|[2:3]
 
 -LOG AllSPPathsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_paths(PK, a, 30)
+           CALL all_sp_paths(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 6
 0|1|1|[]|[3:0]
@@ -291,7 +331,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPPathsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_paths(PK, a, 30)
+           CALL all_sp_paths(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 30
 0|1|1|[]|[2:0]
@@ -328,7 +368,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPDestinations
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_destinations(PK, a, 30)
+           CALL single_sp_destinations(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID;
 ---- 4
 0|1
@@ -339,7 +379,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPDestinationsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_destinations(PK, a, 30)
+           CALL single_sp_destinations(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID;
 ---- 5
 0|1
@@ -351,7 +391,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPDestinationsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_destinations(PK, a, 30)
+           CALL single_sp_destinations(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID
 ---- 8
 0|1
@@ -366,7 +406,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPLengths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_lengths(PK, a, 30)
+           CALL single_sp_lengths(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID, length;
 ---- 4
 0|1|1
@@ -377,7 +417,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPLengthsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_lengths(PK, a, 30)
+           CALL single_sp_lengths(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID, length;
 ---- 5
 0|1|1
@@ -389,7 +429,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPLengthsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_lengths(PK, a, 30)
+           CALL single_sp_lengths(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID, length
 ---- 8
 0|1|1
@@ -404,18 +444,27 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPPaths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_paths(PK, a, 5)
+           CALL single_sp_paths(PK, a, 5, "FWD")
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 4
 0|1|1|[]|[2:0]
 0|2|2|[0:1]|[2:0,2:1]
 0|3|3|[0:1,0:2]|[2:0,2:1,2:2]
 0|4|3|[0:1,0:2]|[2:0,2:1,2:4]
+-STATEMENT PROJECT GRAPH PK (person1, knows11)
+           MATCH (a:person1) WHERE a.ID = 2
+           CALL single_sp_paths(PK, a, 5, "BOTH")
+           RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
+---- 4
+2|0|2|[0:1]|[2:1,2:0]
+2|1|1|[]|[2:1]
+2|3|1|[]|[2:2]
+2|4|1|[]|[2:4]
 
 -LOG SingleSPPathsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_paths(PK, a, 30)
+           CALL single_sp_paths(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
 ---- 5
 0|1|1|[]|[3:0]
@@ -427,7 +476,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPPathsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_paths(PK, a, 30)
+           CALL single_sp_paths(PK, a, 30, "FWD")
            RETURN length, count(*)
 ---- 3
 1|2


### PR DESCRIPTION
# Description

This PR adds additional parameter to GDS functions to allow it scanning using BWD or FWD&BWD adjacency list. This lays the foundation for us to migrate current recursive join to GDS framework.

Note, I add some basic tests because checking internal ID is such a pain. We will have good coverage once we migrate recursive join to GDS.

Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).