### PR TITLE
Add edge direction to gds

### DIFF
--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -194,8 +194,8 @@ public:
     }
 
     std::unique_ptr<RJOutputWriter> copy() override {
-        return std::make_unique<VarLenPathsOutputWriter>(context, rjOutputs, lowerBound,
-            upperBound, writeEdgeDirection);
+        return std::make_unique<VarLenPathsOutputWriter>(context, rjOutputs, lowerBound, upperBound,
+            writeEdgeDirection);
     }
 };
 
@@ -205,7 +205,7 @@ public:
         PathMultiplicities* multiplicities)
         : frontierPair{frontierPair}, multiplicities{multiplicities} {};
 
-    bool edgeCompute(nodeID_t boundNodeID, nodeID_t nbrID, relID_t, bool ) override {
+    bool edgeCompute(nodeID_t boundNodeID, nodeID_t nbrID, relID_t, bool) override {
         auto nbrVal =
             frontierPair->pathLengths->getMaskValueFromNextFrontierFixedMask(nbrID.offset);
         // We should update the nbrID's multiplicity in 2 cases: 1) if nbrID is being visited for
@@ -239,7 +239,8 @@ public:
         parentListBlock = bfsGraph->addNewBlock();
     }
 
-    bool edgeCompute(nodeID_t boundNodeID, nodeID_t nbrNodeID, relID_t edgeID, bool fwdEdge) override {
+    bool edgeCompute(nodeID_t boundNodeID, nodeID_t nbrNodeID, relID_t edgeID,
+        bool fwdEdge) override {
         auto nbrLen =
             frontiersPair->pathLengths->getMaskValueFromNextFrontierFixedMask(nbrNodeID.offset);
         // We should update the nbrID's multiplicity in 2 cases: 1) if nbrID is being visited for
@@ -279,7 +280,9 @@ public:
     AllSPDestinationsAlgorithm() = default;
     AllSPDestinationsAlgorithm(const AllSPDestinationsAlgorithm& other) : SPAlgorithm{other} {}
 
-    expression_vector getResultColumns(Binder* binder) const override { return getBaseResultColumns(binder); }
+    expression_vector getResultColumns(Binder* binder) const override {
+        return getBaseResultColumns(binder);
+    }
 
     std::unique_ptr<GDSAlgorithm> copy() const override {
         return std::make_unique<AllSPDestinationsAlgorithm>(*this);
@@ -379,7 +382,8 @@ struct VarLenJoinsEdgeCompute : public EdgeCompute {
         parentPtrsBlock = bfsGraph->addNewBlock();
     };
 
-    bool edgeCompute(nodeID_t boundNodeID, nodeID_t nbrNodeID, relID_t edgeID, bool isFwd) override {
+    bool edgeCompute(nodeID_t boundNodeID, nodeID_t nbrNodeID, relID_t edgeID,
+        bool isFwd) override {
         // We should always update the nbrID in variable length joins
         if (!parentPtrsBlock->hasSpace()) {
             parentPtrsBlock = bfsGraph->addNewBlock();

--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -7,13 +7,13 @@ namespace function {
 
 static uint64_t computeScanResult(nodeID_t sourceNodeID,
     const std::span<const nodeID_t>& nbrNodeIDs, const std::span<const relID_t>& edgeIDs,
-    EdgeCompute& ec, FrontierPair& frontierPair) {
+    EdgeCompute& ec, FrontierPair& frontierPair, bool isFwd) {
     KU_ASSERT(nbrNodeIDs.size() == edgeIDs.size());
     uint64_t numComputedResult = 0;
     for (size_t i = 0; i < nbrNodeIDs.size(); i++) {
         const auto& nbrNodeID = nbrNodeIDs[i];
         const auto& edgeID = edgeIDs[i];
-        if (ec.edgeCompute(sourceNodeID, nbrNodeID, edgeID)) {
+        if (ec.edgeCompute(sourceNodeID, nbrNodeID, edgeID, isFwd)) {
             frontierPair.getNextFrontierUnsafe().setActive(nbrNodeID);
             numComputedResult++;
         }
@@ -35,23 +35,23 @@ void FrontierTask::run() {
                 case ExtendDirection::FWD: {
                     for (const auto [nodes, edges] : graph->scanFwd(nodeID, *scanState)) {
                         numApproxActiveNodesForNextIter += computeScanResult(nodeID, nodes, edges,
-                            *localEc, sharedState->frontierPair);
+                            *localEc, sharedState->frontierPair, true);
                     }
                 } break;
                 case ExtendDirection::BWD: {
                     for (const auto [nodes, edges] : graph->scanBwd(nodeID, *scanState)) {
                         numApproxActiveNodesForNextIter += computeScanResult(nodeID, nodes, edges,
-                            *localEc, sharedState->frontierPair);
+                            *localEc, sharedState->frontierPair, false);
                     }
                 } break;
                 case ExtendDirection::BOTH: {
                     for (const auto [nodes, edges] : graph->scanFwd(nodeID, *scanState)) {
                         numApproxActiveNodesForNextIter += computeScanResult(nodeID, nodes, edges,
-                            *localEc, sharedState->frontierPair);
+                            *localEc, sharedState->frontierPair, true);
                     }
                     for (const auto [nodes, edges] : graph->scanBwd(nodeID, *scanState)) {
                         numApproxActiveNodesForNextIter += computeScanResult(nodeID, nodes, edges,
-                            *localEc, sharedState->frontierPair);
+                            *localEc, sharedState->frontierPair, false);
                     }
                 } break;
                 default:

--- a/src/function/gds/output_writer.cpp
+++ b/src/function/gds/output_writer.cpp
@@ -19,7 +19,8 @@ void PathsOutputs::beginWritingOutputsForDstNodesInTable(common::table_id_t tabl
     bfsGraph.pinNodeTable(tableID);
 }
 
-static std::unique_ptr<ValueVector> createVector(const LogicalType& type, storage::MemoryManager* mm, std::vector<ValueVector*>& vectors) {
+static std::unique_ptr<ValueVector> createVector(const LogicalType& type,
+    storage::MemoryManager* mm, std::vector<ValueVector*>& vectors) {
     auto vector = std::make_unique<ValueVector>(type.copy(), mm);
     vector->state = DataChunkState::getSingleValueDataChunkState();
     vectors.push_back(vector.get());
@@ -36,7 +37,8 @@ RJOutputWriter::RJOutputWriter(main::ClientContext* context, RJOutputs* rjOutput
 
 PathsOutputWriter::PathsOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs,
     uint16_t lowerBound, uint16_t upperBound, bool writeEdgeDirection)
-    : RJOutputWriter(context, rjOutputs), lowerBound{lowerBound}, upperBound{upperBound}, writeEdgeDirection{writeEdgeDirection} {
+    : RJOutputWriter(context, rjOutputs), lowerBound{lowerBound}, upperBound{upperBound},
+      writeEdgeDirection{writeEdgeDirection} {
     auto mm = context->getMemoryManager();
     if (writeEdgeDirection) {
         directionVector = createVector(LogicalType::LIST(LogicalType::BOOL()), mm, vectors);
@@ -82,7 +84,7 @@ void PathsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNo
             // order of the nodes/edges that should be placed into the ListVector.
             for (auto i = 1u; i < curPath.size(); i++) {
                 auto p = curPath[curPath.size() - 1 - i];
-                addNodeEdge(p->getNodeID(), p->getEdgeID(), p->isFwdEdge(),  i);
+                addNodeEdge(p->getNodeID(), p->getEdgeID(), p->isFwdEdge(), i);
             }
             auto lastPathElement = curPath[curPath.size() - 1];
             addEdge(lastPathElement->getEdgeID(), lastPathElement->isFwdEdge(), 0);
@@ -141,7 +143,8 @@ void PathsOutputWriter::addEdge(relID_t edgeID, bool fwdEdge, sel_t pos) const {
     }
 }
 
-void PathsOutputWriter::addNodeEdge(nodeID_t nodeID, relID_t edgeID, bool fwdEdge, sel_t pos) const {
+void PathsOutputWriter::addNodeEdge(nodeID_t nodeID, relID_t edgeID, bool fwdEdge,
+    sel_t pos) const {
     KU_ASSERT(pos > 0);
     ListVector::getDataVector(pathNodeIDsVector.get())->setValue(pos - 1, nodeID);
     ListVector::getDataVector(pathEdgeIDsVector.get())->setValue(pos, edgeID);

--- a/src/function/gds/rec_joins.cpp
+++ b/src/function/gds/rec_joins.cpp
@@ -50,7 +50,8 @@ expression_vector RJAlgorithm::getBaseResultColumns(Binder* binder) const {
     auto& outputNode = bindData->getNodeOutput()->constCast<NodeExpression>();
     columns.push_back(outputNode.getInternalID());
     if (bindData->ptrCast<RJBindData>()->extendDirection == ExtendDirection::BOTH) {
-        columns.push_back(binder->createVariable(DIRECTION_COLUMN_NAME, LogicalType::LIST(LogicalType::BOOL())));
+        columns.push_back(
+            binder->createVariable(DIRECTION_COLUMN_NAME, LogicalType::LIST(LogicalType::BOOL())));
     }
     return columns;
 }

--- a/src/function/gds/rec_joins.cpp
+++ b/src/function/gds/rec_joins.cpp
@@ -43,12 +43,15 @@ void RJAlgorithm::validateLowerUpperBound(int64_t lowerBound, int64_t upperBound
     }
 }
 
-expression_vector RJAlgorithm::getNodeIDResultColumns() const {
+expression_vector RJAlgorithm::getBaseResultColumns(Binder* binder) const {
     expression_vector columns;
     auto& inputNode = bindData->getNodeInput()->constCast<NodeExpression>();
     columns.push_back(inputNode.getInternalID());
     auto& outputNode = bindData->getNodeOutput()->constCast<NodeExpression>();
     columns.push_back(outputNode.getInternalID());
+    if (bindData->ptrCast<RJBindData>()->extendDirection == ExtendDirection::BOTH) {
+        columns.push_back(binder->createVariable(DIRECTION_COLUMN_NAME, LogicalType::LIST(LogicalType::BOOL())));
+    }
     return columns;
 }
 

--- a/src/function/gds/single_shortest_paths.cpp
+++ b/src/function/gds/single_shortest_paths.cpp
@@ -81,7 +81,8 @@ public:
         parentListBlock = bfsGraph->addNewBlock();
     }
 
-    bool edgeCompute(nodeID_t boundNodeID, nodeID_t nbrNodeID, relID_t edgeID, bool fwdEdge) override {
+    bool edgeCompute(nodeID_t boundNodeID, nodeID_t nbrNodeID, relID_t edgeID,
+        bool fwdEdge) override {
         auto shouldUpdate = frontierPair->pathLengths->getMaskValueFromNextFrontierFixedMask(
                                 nbrNodeID.offset) == PathLengths::UNVISITED;
         if (shouldUpdate) {
@@ -116,7 +117,9 @@ public:
     SingleSPDestinationsAlgorithm(const SingleSPDestinationsAlgorithm& other)
         : SPAlgorithm{other} {}
 
-    expression_vector getResultColumns(Binder* binder) const override { return getBaseResultColumns(binder); }
+    expression_vector getResultColumns(Binder* binder) const override {
+        return getBaseResultColumns(binder);
+    }
 
     std::unique_ptr<GDSAlgorithm> copy() const override {
         return std::make_unique<SingleSPDestinationsAlgorithm>(*this);

--- a/src/function/gds/single_shortest_paths.cpp
+++ b/src/function/gds/single_shortest_paths.cpp
@@ -61,7 +61,7 @@ public:
     explicit SingleSPLengthsEdgeCompute(SinglePathLengthsFrontierPair* frontierPair)
         : frontierPair{frontierPair} {};
 
-    bool edgeCompute(common::nodeID_t, common::nodeID_t nbrID, relID_t) override {
+    bool edgeCompute(nodeID_t, nodeID_t nbrID, relID_t, bool) override {
         return frontierPair->pathLengths->getMaskValueFromNextFrontierFixedMask(nbrID.offset) ==
                PathLengths::UNVISITED;
     }
@@ -81,7 +81,7 @@ public:
         parentListBlock = bfsGraph->addNewBlock();
     }
 
-    bool edgeCompute(nodeID_t boundNodeID, nodeID_t nbrNodeID, relID_t edgeID) override {
+    bool edgeCompute(nodeID_t boundNodeID, nodeID_t nbrNodeID, relID_t edgeID, bool fwdEdge) override {
         auto shouldUpdate = frontierPair->pathLengths->getMaskValueFromNextFrontierFixedMask(
                                 nbrNodeID.offset) == PathLengths::UNVISITED;
         if (shouldUpdate) {
@@ -89,7 +89,7 @@ public:
                 parentListBlock = bfsGraph->addNewBlock();
             }
             bfsGraph->tryAddSingleParent(frontierPair->curIter.load(std::memory_order_relaxed),
-                parentListBlock, nbrNodeID /* child */, boundNodeID /* parent */, edgeID);
+                parentListBlock, nbrNodeID /* child */, boundNodeID /* parent */, edgeID, fwdEdge);
         }
         return shouldUpdate;
     }
@@ -116,7 +116,7 @@ public:
     SingleSPDestinationsAlgorithm(const SingleSPDestinationsAlgorithm& other)
         : SPAlgorithm{other} {}
 
-    expression_vector getResultColumns(Binder*) const override { return getNodeIDResultColumns(); }
+    expression_vector getResultColumns(Binder* binder) const override { return getBaseResultColumns(binder); }
 
     std::unique_ptr<GDSAlgorithm> copy() const override {
         return std::make_unique<SingleSPDestinationsAlgorithm>(*this);
@@ -143,7 +143,7 @@ public:
     SingleSPLengthsAlgorithm(const SingleSPLengthsAlgorithm& other) : SPAlgorithm{other} {}
 
     expression_vector getResultColumns(Binder* binder) const override {
-        auto columns = getNodeIDResultColumns();
+        auto columns = getBaseResultColumns(binder);
         columns.push_back(getLengthColumn(binder));
         return columns;
     }
@@ -174,7 +174,7 @@ public:
     SingleSPPathsAlgorithm(const SingleSPPathsAlgorithm& other) : SPAlgorithm{other} {}
 
     expression_vector getResultColumns(Binder* binder) const override {
-        auto columns = getNodeIDResultColumns();
+        auto columns = getBaseResultColumns(binder);
         columns.push_back(getLengthColumn(binder));
         columns.push_back(getPathNodeIDsColumn(binder));
         columns.push_back(getPathEdgeIDsColumn(binder));
@@ -192,8 +192,9 @@ private:
             std::make_unique<PathsOutputs>(sharedState->graph->getNodeTableIDAndNumNodes(),
                 sourceNodeID, clientContext->getMemoryManager());
         auto rjBindData = bindData->ptrCast<RJBindData>();
+        bool writeDirection = rjBindData->extendDirection == ExtendDirection::BOTH;
         auto outputWriter = std::make_unique<SPPathsOutputWriter>(clientContext, output.get(),
-            rjBindData->upperBound);
+            rjBindData->upperBound, writeDirection);
         auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,
             clientContext->getMaxNumThreadForExec());
         auto edgeCompute =

--- a/src/include/function/gds/bfs_graph.h
+++ b/src/include/function/gds/bfs_graph.h
@@ -9,16 +9,15 @@ namespace function {
 // TODO(Xiyang): optimize if edgeID is not needed.
 class ParentList {
 public:
-    ParentList(uint16_t iter_, common::nodeID_t nodeID, common::relID_t edgeID) {
-        store(iter_, nodeID, edgeID);
-    }
+    ParentList() = default;
 
-    void store(uint16_t iter_, common::nodeID_t nodeID, common::relID_t edgeID) {
+    void store(uint16_t iter_, common::nodeID_t nodeID, common::relID_t edgeID, bool isFwd) {
         iter.store(iter_, std::memory_order_relaxed);
         nodeOffset.store(nodeID.offset, std::memory_order_relaxed);
         nodeTableID.store(nodeID.tableID, std::memory_order_relaxed);
         edgeOffset.store(edgeID.offset, std::memory_order_relaxed);
         edgeTableID.store(edgeID.tableID, std::memory_order_relaxed);
+        fwd_.store(isFwd, std::memory_order_relaxed);
     }
 
     void setNextPtr(ParentList* ptr) { next.store(ptr, std::memory_order_relaxed); }
@@ -35,6 +34,9 @@ public:
         return {edgeOffset.load(std::memory_order_relaxed),
             edgeTableID.load(std::memory_order_relaxed)};
     }
+    bool isFwdEdge() {
+        return fwd_.load(std::memory_order_relaxed);
+    }
 
 private:
     // Iteration level
@@ -45,6 +47,8 @@ private:
     // Edge information
     std::atomic<common::offset_t> edgeOffset;
     std::atomic<common::table_id_t> edgeTableID;
+    // Edge direction
+    std::atomic<bool> fwd_;
     // Next pointer
     std::atomic<ParentList*> next;
 };
@@ -87,9 +91,9 @@ public:
     // Warning: Make sure hasSpace has returned true on parentPtrBlock already before calling this
     // function.
     void addParent(uint16_t iter, ObjectBlock<ParentList>* parentListBlock,
-        common::nodeID_t childNodeID, common::nodeID_t parentNodeID, common::relID_t edgeID) {
+        common::nodeID_t childNodeID, common::nodeID_t parentNodeID, common::relID_t edgeID, bool isFwd) {
         auto parentEdgePtr = parentListBlock->reserveNext();
-        parentEdgePtr->store(iter, parentNodeID, edgeID);
+        parentEdgePtr->store(iter, parentNodeID, edgeID, isFwd);
         auto curPtr = currParentPtrs.load(std::memory_order_relaxed);
         KU_ASSERT(curPtr != nullptr);
         // Since by default the parentPtr of each node is nullptr, that's what we start with.
@@ -101,9 +105,9 @@ public:
 
     // For single shortest path, we do NOT add parent if a parent has already existed.
     void tryAddSingleParent(uint16_t iter, ObjectBlock<ParentList>* parentListBlock,
-        common::nodeID_t childNodeID, common::nodeID_t parentNodeID, common::relID_t edgeID) {
+        common::nodeID_t childNodeID, common::nodeID_t parentNodeID, common::relID_t edgeID, bool isFwd) {
         auto parentEdgePtr = parentListBlock->reserveNext();
-        parentEdgePtr->store(iter, parentNodeID, edgeID);
+        parentEdgePtr->store(iter, parentNodeID, edgeID, isFwd);
         auto curPtr = currParentPtrs.load(std::memory_order_relaxed);
         ParentList* expected = nullptr;
         if (curPtr[childNodeID.offset].compare_exchange_strong(expected, parentEdgePtr)) {

--- a/src/include/function/gds/bfs_graph.h
+++ b/src/include/function/gds/bfs_graph.h
@@ -34,9 +34,7 @@ public:
         return {edgeOffset.load(std::memory_order_relaxed),
             edgeTableID.load(std::memory_order_relaxed)};
     }
-    bool isFwdEdge() {
-        return fwd_.load(std::memory_order_relaxed);
-    }
+    bool isFwdEdge() { return fwd_.load(std::memory_order_relaxed); }
 
 private:
     // Iteration level
@@ -91,7 +89,8 @@ public:
     // Warning: Make sure hasSpace has returned true on parentPtrBlock already before calling this
     // function.
     void addParent(uint16_t iter, ObjectBlock<ParentList>* parentListBlock,
-        common::nodeID_t childNodeID, common::nodeID_t parentNodeID, common::relID_t edgeID, bool isFwd) {
+        common::nodeID_t childNodeID, common::nodeID_t parentNodeID, common::relID_t edgeID,
+        bool isFwd) {
         auto parentEdgePtr = parentListBlock->reserveNext();
         parentEdgePtr->store(iter, parentNodeID, edgeID, isFwd);
         auto curPtr = currParentPtrs.load(std::memory_order_relaxed);
@@ -105,7 +104,8 @@ public:
 
     // For single shortest path, we do NOT add parent if a parent has already existed.
     void tryAddSingleParent(uint16_t iter, ObjectBlock<ParentList>* parentListBlock,
-        common::nodeID_t childNodeID, common::nodeID_t parentNodeID, common::relID_t edgeID, bool isFwd) {
+        common::nodeID_t childNodeID, common::nodeID_t parentNodeID, common::relID_t edgeID,
+        bool isFwd) {
         auto parentEdgePtr = parentListBlock->reserveNext();
         parentEdgePtr->store(iter, parentNodeID, edgeID, isFwd);
         auto curPtr = currParentPtrs.load(std::memory_order_relaxed);

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -24,7 +24,7 @@ public:
     // So if the implementing class has access to the next frontier as a field,
     // **do not** call setActive. Helper functions in GDSUtils will do that work.
     virtual bool edgeCompute(common::nodeID_t boundNodeID, common::nodeID_t nbrNodeID,
-        common::relID_t edgeID) = 0;
+        common::relID_t edgeID, bool fwdEdge) = 0;
 
     virtual std::unique_ptr<EdgeCompute> copy() = 0;
 };

--- a/src/include/function/gds/output_writer.h
+++ b/src/include/function/gds/output_writer.h
@@ -101,13 +101,20 @@ protected:
 class PathsOutputWriter : public RJOutputWriter {
 public:
     PathsOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs, uint16_t lowerBound,
-        uint16_t upperBound);
+        uint16_t upperBound, bool writeEdgeDirection);
 
     void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID) const override;
+
+private:
+    void beginWritingNewPath(uint64_t length) const;
+    void addEdge(common::relID_t edgeID, bool fwdEdge, common::sel_t pos) const;
+    void addNodeEdge(common::nodeID_t nodeID, common::relID_t edgeID, bool fwdEdge, common::sel_t pos) const;
 
 protected:
     uint16_t lowerBound;
     uint16_t upperBound;
+    bool writeEdgeDirection;
+    std::unique_ptr<common::ValueVector> directionVector;
     std::unique_ptr<common::ValueVector> lengthVector;
     std::unique_ptr<common::ValueVector> pathNodeIDsVector;
     std::unique_ptr<common::ValueVector> pathEdgeIDsVector;
@@ -115,8 +122,8 @@ protected:
 
 class SPPathsOutputWriter : public PathsOutputWriter {
 public:
-    SPPathsOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs, uint16_t upperBound)
-        : PathsOutputWriter(context, rjOutputs, 1 /* lower bound */, upperBound) {}
+    SPPathsOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs, uint16_t upperBound, bool writeEdgeDirection)
+        : PathsOutputWriter(context, rjOutputs, 1 /* lower bound */, upperBound, writeEdgeDirection) {}
 
     bool skipWriting(common::nodeID_t dstNodeID) const override {
         auto pathsOutputs = rjOutputs->ptrCast<PathsOutputs>();
@@ -128,7 +135,7 @@ public:
     }
 
     std::unique_ptr<RJOutputWriter> copy() override {
-        return std::make_unique<SPPathsOutputWriter>(context, rjOutputs, upperBound);
+        return std::make_unique<SPPathsOutputWriter>(context, rjOutputs, upperBound, writeEdgeDirection);
     }
 };
 

--- a/src/include/function/gds/output_writer.h
+++ b/src/include/function/gds/output_writer.h
@@ -108,7 +108,8 @@ public:
 private:
     void beginWritingNewPath(uint64_t length) const;
     void addEdge(common::relID_t edgeID, bool fwdEdge, common::sel_t pos) const;
-    void addNodeEdge(common::nodeID_t nodeID, common::relID_t edgeID, bool fwdEdge, common::sel_t pos) const;
+    void addNodeEdge(common::nodeID_t nodeID, common::relID_t edgeID, bool fwdEdge,
+        common::sel_t pos) const;
 
 protected:
     uint16_t lowerBound;
@@ -122,8 +123,10 @@ protected:
 
 class SPPathsOutputWriter : public PathsOutputWriter {
 public:
-    SPPathsOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs, uint16_t upperBound, bool writeEdgeDirection)
-        : PathsOutputWriter(context, rjOutputs, 1 /* lower bound */, upperBound, writeEdgeDirection) {}
+    SPPathsOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs, uint16_t upperBound,
+        bool writeEdgeDirection)
+        : PathsOutputWriter(context, rjOutputs, 1 /* lower bound */, upperBound,
+              writeEdgeDirection) {}
 
     bool skipWriting(common::nodeID_t dstNodeID) const override {
         auto pathsOutputs = rjOutputs->ptrCast<PathsOutputs>();
@@ -135,7 +138,8 @@ public:
     }
 
     std::unique_ptr<RJOutputWriter> copy() override {
-        return std::make_unique<SPPathsOutputWriter>(context, rjOutputs, upperBound, writeEdgeDirection);
+        return std::make_unique<SPPathsOutputWriter>(context, rjOutputs, upperBound,
+            writeEdgeDirection);
     }
 };
 

--- a/src/include/function/gds/rec_joins.h
+++ b/src/include/function/gds/rec_joins.h
@@ -79,7 +79,7 @@ struct RJCompState {
 };
 
 class RJAlgorithm : public GDSAlgorithm {
-protected:
+    static constexpr char DIRECTION_COLUMN_NAME[] = "direction";
     static constexpr char LENGTH_COLUMN_NAME[] = "length";
     static constexpr char PATH_NODE_IDS_COLUMN_NAME[] = "pathNodeIDs";
     static constexpr char PATH_EDGE_IDS_COLUMN_NAME[] = "pathEdgeIDs";
@@ -95,7 +95,7 @@ public:
 protected:
     void validateLowerUpperBound(int64_t lowerBound, int64_t upperBound);
 
-    binder::expression_vector getNodeIDResultColumns() const;
+    binder::expression_vector getBaseResultColumns(binder::Binder* binder) const;
     std::shared_ptr<binder::Expression> getLengthColumn(binder::Binder* binder) const;
     std::shared_ptr<binder::Expression> getPathNodeIDsColumn(binder::Binder* binder) const;
     std::shared_ptr<binder::Expression> getPathEdgeIDsColumn(binder::Binder* binder) const;

--- a/test/test_files/function/gds/rec_joins_small.test
+++ b/test/test_files/function/gds/rec_joins_small.test
@@ -81,15 +81,15 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 1
            CALL var_len_joins(PK, a, 1, 2, "BOTH")
-           RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs;
+           RETURN a.ID, _node.ID, length, pathNodeIDs, pathEdgeIDs, direction;
 ---- 7
-1|0|1|[]|[2:0]
-1|1|2|[0:0]|[2:0,2:0]
-1|1|2|[0:2]|[2:1,2:1]
-1|2|1|[]|[2:1]
-1|3|2|[0:2]|[2:1,2:2]
-1|4|2|[0:2]|[2:1,2:4]
-1|4|2|[0:2]|[2:1,2:5]
+1|0|1|[]|[2:0]|[False]
+1|1|2|[0:0]|[2:0,2:0]|[False,True]
+1|1|2|[0:2]|[2:1,2:1]|[True,False]
+1|2|1|[]|[2:1]|[True]
+1|3|2|[0:2]|[2:1,2:2]|[True,True]
+1|4|2|[0:2]|[2:1,2:4]|[True,True]
+1|4|2|[0:2]|[2:1,2:5]|[True,True]
 
 -LOG VarLenJoinsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
@@ -301,7 +301,6 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 0|3|3|[0:1,0:2]|[2:0,2:1,2:2]
 0|4|3|[0:1,0:2]|[2:0,2:1,2:4]
 0|4|3|[0:1,0:2]|[2:0,2:1,2:5]
--LOG AllSPPaths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 4
            CALL all_sp_paths(PK, a, 5, "BOTH")


### PR DESCRIPTION
# Description

Track edge direction when we extend both fwd and bwd adjacency list. This is not the most performant implementation since we will always store a boolean field in `ParentList` which could be optimized. We can try to figure this out eventually. This is not yet my priority.

Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).