### PR TITLE
Make default buffer pool size in Java API same as others

### DIFF
--- a/tools/java_api/src/jni/kuzu_java.cpp
+++ b/tools/java_api/src/jni/kuzu_java.cpp
@@ -253,8 +253,8 @@ JNIEXPORT jlong JNICALL Java_com_kuzudb_Native_kuzu_1database_1init(JNIEnv* env,
 
     const char* path = env->GetStringUTFChars(database_path, JNI_FALSE);
     uint64_t buffer = static_cast<uint64_t>(buffer_pool_size);
-    SystemConfig systemConfig;
-    systemConfig.bufferPoolSize = buffer == 0 ? -1u : buffer;
+    SystemConfig systemConfig{};
+    systemConfig.bufferPoolSize = buffer == 0 ? systemConfig.bufferPoolSize : buffer;
     systemConfig.enableCompression = enable_compression;
     systemConfig.readOnly = read_only;
     systemConfig.maxDBSize = max_db_size == 0 ? systemConfig.maxDBSize : max_db_size;


### PR DESCRIPTION
# Description

The default buffer pool size in Java API was being set to 4GB (-1u bytes) instead of the default values for other APIs (80% of system memory) which caused the fintech benchmark to run out of memory. This updates it to use the same default buffer pool size as others.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).