### PR TITLE
Vectorize EdgeCompute

### DIFF
--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -1,4 +1,5 @@
 #include "binder/expression/expression_util.h"
+#include "common/data_chunk/sel_vector.h"
 #include "function/gds/bfs_graph.h"
 #include "function/gds/gds_frontier.h"
 #include "function/gds/gds_function_collection.h"
@@ -206,22 +207,29 @@ public:
         PathMultiplicities* multiplicities)
         : frontierPair{frontierPair}, multiplicities{multiplicities} {};
 
-    bool edgeCompute(nodeID_t boundNodeID, nodeID_t nbrID, relID_t, bool) override {
-        auto nbrVal =
-            frontierPair->pathLengths->getMaskValueFromNextFrontierFixedMask(nbrID.offset);
-        // We should update the nbrID's multiplicity in 2 cases: 1) if nbrID is being visited for
-        // the first time, i.e., when its value in the pathLengths frontier is
-        // PathLengths::UNVISITED. Or 2) if nbrID has already been visited but in this iteration,
-        // so it's value is curIter + 1.
-        auto shouldUpdate =
-            nbrVal == PathLengths::UNVISITED || nbrVal == frontierPair->pathLengths->getCurIter();
-        if (shouldUpdate) {
-            // Note: This is safe because curNodeID is in the current frontier, so its
-            // shortest paths multiplicity is guaranteed to not change in the current iteration.
-            multiplicities->incrementTargetMultiplicity(nbrID.offset,
-                multiplicities->getBoundMultiplicity(boundNodeID.offset));
-        }
-        return nbrVal == PathLengths::UNVISITED;
+    void edgeCompute(nodeID_t boundNodeID, std::span<const nodeID_t> nbrIDs,
+        std::span<const relID_t>, SelectionVector& mask, bool) override {
+        size_t activeCount = 0;
+        mask.forEach([&](auto i) {
+            auto nbrVal =
+                frontierPair->pathLengths->getMaskValueFromNextFrontierFixedMask(nbrIDs[i].offset);
+            // We should update the nbrID's multiplicity in 2 cases: 1) if nbrID is being visited
+            // for the first time, i.e., when its value in the pathLengths frontier is
+            // PathLengths::UNVISITED. Or 2) if nbrID has already been visited but in this
+            // iteration, so it's value is curIter + 1.
+            auto shouldUpdate = nbrVal == PathLengths::UNVISITED ||
+                                nbrVal == frontierPair->pathLengths->getCurIter();
+            if (shouldUpdate) {
+                // Note: This is safe because curNodeID is in the current frontier, so its
+                // shortest paths multiplicity is guaranteed to not change in the current iteration.
+                multiplicities->incrementTargetMultiplicity(nbrIDs[i].offset,
+                    multiplicities->getBoundMultiplicity(boundNodeID.offset));
+            }
+            if (nbrVal == PathLengths::UNVISITED) {
+                mask.getMutableBuffer()[activeCount++] = i;
+            }
+        });
+        mask.setToFiltered(activeCount);
     }
 
     std::unique_ptr<EdgeCompute> copy() override {
@@ -240,24 +248,31 @@ public:
         parentListBlock = bfsGraph->addNewBlock();
     }
 
-    bool edgeCompute(nodeID_t boundNodeID, nodeID_t nbrNodeID, relID_t edgeID,
-        bool fwdEdge) override {
-        auto nbrLen =
-            frontiersPair->pathLengths->getMaskValueFromNextFrontierFixedMask(nbrNodeID.offset);
-        // We should update the nbrID's multiplicity in 2 cases: 1) if nbrID is being visited for
-        // the first time, i.e., when its value in the pathLengths frontier is
-        // PathLengths::UNVISITED. Or 2) if nbrID has already been visited but in this iteration,
-        // so it's value is curIter + 1.
-        auto shouldUpdate =
-            nbrLen == PathLengths::UNVISITED || nbrLen == frontiersPair->pathLengths->getCurIter();
-        if (shouldUpdate) {
-            if (!parentListBlock->hasSpace()) {
-                parentListBlock = bfsGraph->addNewBlock();
+    void edgeCompute(nodeID_t boundNodeID, std::span<const nodeID_t> nbrNodeIDs,
+        std::span<const relID_t> edgeIDs, SelectionVector& mask, bool fwdEdge) override {
+        size_t activeCount = 0;
+        mask.forEach([&](auto i) {
+            auto nbrLen = frontiersPair->pathLengths->getMaskValueFromNextFrontierFixedMask(
+                nbrNodeIDs[i].offset);
+            // We should update the nbrID's multiplicity in 2 cases: 1) if nbrID is being visited
+            // for the first time, i.e., when its value in the pathLengths frontier is
+            // PathLengths::UNVISITED. Or 2) if nbrID has already been visited but in this
+            // iteration, so it's value is curIter + 1.
+            auto shouldUpdate = nbrLen == PathLengths::UNVISITED ||
+                                nbrLen == frontiersPair->pathLengths->getCurIter();
+            if (shouldUpdate) {
+                if (!parentListBlock->hasSpace()) {
+                    parentListBlock = bfsGraph->addNewBlock();
+                }
+                bfsGraph->addParent(frontiersPair->curIter.load(std::memory_order_relaxed),
+                    parentListBlock, nbrNodeIDs[i] /* child */, boundNodeID /* parent */,
+                    edgeIDs[i], fwdEdge);
             }
-            bfsGraph->addParent(frontiersPair->curIter.load(std::memory_order_relaxed),
-                parentListBlock, nbrNodeID /* child */, boundNodeID /* parent */, edgeID, fwdEdge);
-        }
-        return nbrLen == PathLengths::UNVISITED;
+            if (nbrLen == PathLengths::UNVISITED) {
+                mask.getMutableBuffer()[activeCount++] = i;
+            }
+        });
+        mask.setToFiltered(activeCount);
     }
 
     std::unique_ptr<EdgeCompute> copy() override {
@@ -272,8 +287,8 @@ private:
 
 /**
  * Algorithm for parallel all shortest paths computation, so all shortest paths from a source to
- * is returned for each destination. If paths are not returned, multiplicities indicate the number
- * of paths to each destination.
+ * is returned for each destination. If paths are not returned, multiplicities indicate the
+ * number of paths to each destination.
  */
 
 class AllSPDestinationsAlgorithm final : public SPAlgorithm {
@@ -383,15 +398,17 @@ struct VarLenJoinsEdgeCompute : public EdgeCompute {
         parentPtrsBlock = bfsGraph->addNewBlock();
     };
 
-    bool edgeCompute(nodeID_t boundNodeID, nodeID_t nbrNodeID, relID_t edgeID,
-        bool isFwd) override {
-        // We should always update the nbrID in variable length joins
-        if (!parentPtrsBlock->hasSpace()) {
-            parentPtrsBlock = bfsGraph->addNewBlock();
-        }
-        bfsGraph->addParent(frontierPair->getCurrentIter(), parentPtrsBlock, nbrNodeID /* child */,
-            boundNodeID /* parent */, edgeID, isFwd);
-        return true;
+    void edgeCompute(nodeID_t boundNodeID, std::span<const nodeID_t> nbrNodeIDs,
+        std::span<const relID_t> edgeIDs, SelectionVector& mask, bool isFwd) override {
+        mask.forEach([&](auto i) {
+            // We should always update the nbrID in variable length joins
+            if (!parentPtrsBlock->hasSpace()) {
+                parentPtrsBlock = bfsGraph->addNewBlock();
+            }
+            bfsGraph->addParent(frontierPair->getCurrentIter(), parentPtrsBlock,
+                nbrNodeIDs[i] /* child */, boundNodeID /* parent */, edgeIDs[i], isFwd);
+            // all nodes visited are active, so the mask is left unmodified
+        });
     }
 
     std::unique_ptr<EdgeCompute> copy() override {
@@ -401,8 +418,8 @@ struct VarLenJoinsEdgeCompute : public EdgeCompute {
 
 /**
  * Algorithm for parallel all shortest paths computation, so all shortest paths from a source to
- * is returned for each destination. If paths are not returned, multiplicities indicate the number
- * of paths to each destination.
+ * is returned for each destination. If paths are not returned, multiplicities indicate the
+ * number of paths to each destination.
  */
 class VarLenJoinsAlgorithm final : public RJAlgorithm {
 public:

--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -244,7 +244,7 @@ std::vector<nodeID_t> OnDiskGraph::scanBwdRandom(nodeID_t, GraphScanState&) {
 
 bool OnDiskGraphScanState::InnerIterator::next() {
     return tableScanState->source != TableScanSource::NONE &&
-           relTable->scan(context->getTx(), *tableScanState) && dstSelVector().getSelSize() > 0;
+           relTable->scan(context->getTx(), *tableScanState) && getSelVector().getSelSize() > 0;
 }
 
 OnDiskGraphScanState::InnerIterator::InnerIterator(const main::ClientContext* context,

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <mutex>
 
+#include "common/data_chunk/sel_vector.h"
 #include "common/types/types.h"
 #include "storage/buffer_manager/memory_manager.h"
 
@@ -20,11 +21,12 @@ public:
 
     // Does any work that is needed while extending the (boundNodeID, nbrNodeID, edgeID) edge.
     // boundNodeID is the nodeID that is in the current frontier and currently executing.
-    // Returns true if the neighbor should be put in the next frontier.
+    // Updates the mask to indicate the neighbors which should be put in the next frontier.
     // So if the implementing class has access to the next frontier as a field,
     // **do not** call setActive. Helper functions in GDSUtils will do that work.
-    virtual bool edgeCompute(common::nodeID_t boundNodeID, common::nodeID_t nbrNodeID,
-        common::relID_t edgeID, bool fwdEdge) = 0;
+    virtual void edgeCompute(common::nodeID_t boundNodeID,
+        std::span<const common::nodeID_t> nbrNodeID, std::span<const common::relID_t> edgeID,
+        common::SelectionVector& mask, bool fwdEdge) = 0;
 
     virtual std::unique_ptr<EdgeCompute> copy() = 0;
 };
@@ -114,6 +116,8 @@ class GDSFrontier {
 public:
     virtual ~GDSFrontier() = default;
     virtual bool isActive(common::nodeID_t nodeID) = 0;
+    virtual void setActive(const common::SelectionVector& mask,
+        std::span<const common::nodeID_t> nodeIDs) = 0;
     virtual void setActive(common::nodeID_t nodeID) = 0;
     template<class TARGET>
     TARGET* ptrCast() {
@@ -161,6 +165,15 @@ public:
     bool isActive(common::nodeID_t nodeID) override {
         return getCurFrontierFixedMask()[nodeID.offset] ==
                curIter.load(std::memory_order_relaxed) - 1;
+    }
+
+    void setActive(const common::SelectionVector& mask,
+        std::span<const common::nodeID_t> nodeIDs) override {
+        auto frontierMask = getNextFrontierFixedMask();
+        mask.forEach([&](auto i) {
+            frontierMask[nodeIDs[i].offset].store(curIter.load(std::memory_order_relaxed),
+                std::memory_order_relaxed);
+        });
     }
 
     void setActive(common::nodeID_t nodeID) override {

--- a/test/storage/rel_scan_test.cpp
+++ b/test/storage/rel_scan_test.cpp
@@ -48,14 +48,14 @@ TEST_F(RelScanTest, ScanFwd) {
 
     const auto compare = [&](uint64_t node, std::vector<nodeID_t> expected) {
         std::vector<nodeID_t> result;
-        for (const auto [nodes, edges] : graph->scanFwd(nodeID_t{node, tableID}, *scanState)) {
-            result.insert(result.end(), nodes.begin(), nodes.end());
+        for (const auto chunk : graph->scanFwd(nodeID_t{node, tableID}, *scanState)) {
+            chunk.selVector.forEach([&](auto i) { result.push_back(chunk.nbrNodes[i]); });
         }
         EXPECT_EQ(result, expected);
         EXPECT_EQ(graph->scanFwd(nodeID_t{node, tableID}, *scanState).collectNbrNodes(), expected);
         result.clear();
-        for (const auto [nodes, edges] : graph->scanBwd(nodeID_t{node, tableID}, *scanState)) {
-            result.insert(result.end(), nodes.begin(), nodes.end());
+        for (const auto chunk : graph->scanBwd(nodeID_t{node, tableID}, *scanState)) {
+            chunk.selVector.forEach([&](auto i) { result.push_back(chunk.nbrNodes[i]); });
         }
         EXPECT_EQ(result, expected);
         EXPECT_EQ(graph->scanFwd(nodeID_t{node, tableID}, *scanState).collectNbrNodes(), expected);


### PR DESCRIPTION
The `edgeCompute` functions now take a range of values, and a mask indicating which values are actual inputs, and modify the mask to indicate the active values (i.e. the values where previously the function would have returned true). This improves performance by roughly 10% in the benchmarks I'd done.