### PR TITLE
Optimize short query and avoid scheduling overhead

### DIFF
--- a/src/include/processor/operator/scan/primary_key_scan_node_table.h
+++ b/src/include/processor/operator/scan/primary_key_scan_node_table.h
@@ -54,6 +54,8 @@ public:
 
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
+    bool isParallel() const override { return false; }
+
     std::unique_ptr<PhysicalOperator> clone() override {
         return std::make_unique<PrimaryKeyScanNodeTable>(info.copy(), copyVector(nodeInfos),
             indexEvaluator->clone(), sharedState, id, printInfo->copy());


### PR DESCRIPTION
# Description

Optimizing query like ‘match (a:person {id:24189255912498})-[f]-(b) return count(1);’ ,  Query time dropped from 50ms to 15ms

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).