### PR TITLE
Optimize column&ChunkedCSRHeader memory initialize

### DIFF
--- a/src/include/storage/store/column_chunk.h
+++ b/src/include/storage/store/column_chunk.h
@@ -41,7 +41,8 @@ public:
     // It would be better to take it by value so that the caller can choose to either move or copy
     // it
     ColumnChunk(MemoryManager& memoryManager, const common::LogicalType& dataType,
-        uint64_t capacity, bool enableCompression, ResidencyState residencyState);
+        uint64_t capacity, bool enableCompression, ResidencyState residencyState,
+        bool initializeToZero = true);
     ColumnChunk(MemoryManager& memoryManager, const common::LogicalType& dataType,
         bool enableCompression, ColumnChunkMetadata metadata);
     ColumnChunk(bool enableCompression, std::unique_ptr<ColumnChunkData> data);

--- a/src/include/storage/store/column_chunk_data.h
+++ b/src/include/storage/store/column_chunk_data.h
@@ -197,7 +197,10 @@ public:
     virtual void setToInMemory();
     // numValues must be at least the number of values the ColumnChunk was first initialized
     // with
-    virtual void resize(uint64_t newCapacity, bool reserveDataAndInitializeToZero = true);
+    //reverse data and zero the part exceeding the original size
+    virtual void resize(uint64_t newCapacity);
+    //the opposite of the resize method, just simple resize
+    virtual void resizeWithoutPreserve(uint64_t newCapacity);
 
     void populateWithDefaultVal(evaluator::ExpressionEvaluator& defaultEvaluator,
         uint64_t& numValues_);

--- a/src/include/storage/store/list_chunk_data.h
+++ b/src/include/storage/store/list_chunk_data.h
@@ -81,10 +81,16 @@ public:
         dataColumnChunk->setToInMemory();
         KU_ASSERT(offsetColumnChunk->getNumValues() == numValues);
     }
-    void resize(uint64_t newCapacity, bool reserveDataAndInitializeToZero = true) override {
-        ColumnChunkData::resize(newCapacity, reserveDataAndInitializeToZero);
-        sizeColumnChunk->resize(newCapacity, reserveDataAndInitializeToZero);
-        offsetColumnChunk->resize(newCapacity, reserveDataAndInitializeToZero);
+    void resize(uint64_t newCapacity) override {
+        ColumnChunkData::resize(newCapacity);
+        sizeColumnChunk->resize(newCapacity);
+        offsetColumnChunk->resize(newCapacity);
+    }
+
+    void resizeWithoutPreserve(uint64_t newCapacity) override {
+        ColumnChunkData::resizeWithoutPreserve(newCapacity);
+        sizeColumnChunk->resizeWithoutPreserve(newCapacity);
+        offsetColumnChunk->resizeWithoutPreserve(newCapacity);
     }
 
     common::offset_t getListStartOffset(common::offset_t offset) const;

--- a/src/include/storage/store/list_chunk_data.h
+++ b/src/include/storage/store/list_chunk_data.h
@@ -81,10 +81,10 @@ public:
         dataColumnChunk->setToInMemory();
         KU_ASSERT(offsetColumnChunk->getNumValues() == numValues);
     }
-    void resize(uint64_t newCapacity) override {
-        ColumnChunkData::resize(newCapacity);
-        sizeColumnChunk->resize(newCapacity);
-        offsetColumnChunk->resize(newCapacity);
+    void resize(uint64_t newCapacity, bool reserveDataAndInitializeToZero = true) override {
+        ColumnChunkData::resize(newCapacity, reserveDataAndInitializeToZero);
+        sizeColumnChunk->resize(newCapacity, reserveDataAndInitializeToZero);
+        offsetColumnChunk->resize(newCapacity, reserveDataAndInitializeToZero);
     }
 
     common::offset_t getListStartOffset(common::offset_t offset) const;

--- a/src/include/storage/store/string_chunk_data.h
+++ b/src/include/storage/store/string_chunk_data.h
@@ -72,7 +72,7 @@ public:
     }
 
     void setToInMemory() override;
-    void resize(uint64_t newCapacity) override;
+    void resize(uint64_t newCapacity, bool reserveDataAndInitializeToZero = true) override;
     uint64_t getEstimatedMemoryUsage() const override;
 
     void serialize(common::Serializer& serializer) const override;

--- a/src/include/storage/store/string_chunk_data.h
+++ b/src/include/storage/store/string_chunk_data.h
@@ -72,7 +72,8 @@ public:
     }
 
     void setToInMemory() override;
-    void resize(uint64_t newCapacity, bool reserveDataAndInitializeToZero = true) override;
+    void resize(uint64_t newCapacity) override;
+    void resizeWithoutPreserve(uint64_t newCapacity) override;
     uint64_t getEstimatedMemoryUsage() const override;
 
     void serialize(common::Serializer& serializer) const override;

--- a/src/include/storage/store/struct_chunk_data.h
+++ b/src/include/storage/store/struct_chunk_data.h
@@ -72,7 +72,8 @@ protected:
         common::offset_t dstOffsetInChunk, common::offset_t numValuesToCopy) override;
 
     void setToInMemory() override;
-    void resize(uint64_t newCapacity, bool reserveDataAndInitializeToZero = true) override;
+    void resize(uint64_t newCapacity) override;
+    void resizeWithoutPreserve(uint64_t newCapacity) override;
 
     void resetToEmpty() override;
     void resetToAllNull() override;

--- a/src/include/storage/store/struct_chunk_data.h
+++ b/src/include/storage/store/struct_chunk_data.h
@@ -72,7 +72,7 @@ protected:
         common::offset_t dstOffsetInChunk, common::offset_t numValuesToCopy) override;
 
     void setToInMemory() override;
-    void resize(uint64_t newCapacity) override;
+    void resize(uint64_t newCapacity, bool reserveDataAndInitializeToZero = true) override;
 
     void resetToEmpty() override;
     void resetToAllNull() override;

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -168,7 +168,7 @@ std::unique_ptr<ColumnChunkData> Column::flushNonNestedChunkData(const ColumnChu
     auto chunkMeta = flushData(chunkData, dataFH);
     auto flushedChunk = ColumnChunkFactory::createColumnChunkData(chunkData.getMemoryManager(),
         chunkData.getDataType().copy(), chunkData.isCompressionEnabled(), chunkMeta,
-        chunkData.hasNullData());
+        chunkData.hasNullData(), true);
     if (chunkData.hasNullData()) {
         auto nullChunkMeta = flushData(chunkData.getNullData(), dataFH);
         auto nullData = std::make_unique<NullChunkData>(chunkData.getMemoryManager(),
@@ -220,7 +220,7 @@ void Column::scan(Transaction* transaction, const ChunkState& state, ColumnChunk
     KU_ASSERT(endOffset >= startOffset);
     const auto numValuesToScan = endOffset - startOffset;
     if (numValuesToScan > columnChunk->getCapacity()) {
-        columnChunk->resize(std::bit_ceil(numValuesToScan));
+        columnChunk->resize(std::bit_ceil(numValuesToScan), false);
     }
     if (getDataTypeSizeInChunk(dataType) == 0) {
         columnChunk->setNumValues(numValuesToScan);

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -220,7 +220,7 @@ void Column::scan(Transaction* transaction, const ChunkState& state, ColumnChunk
     KU_ASSERT(endOffset >= startOffset);
     const auto numValuesToScan = endOffset - startOffset;
     if (numValuesToScan > columnChunk->getCapacity()) {
-        columnChunk->resize(std::bit_ceil(numValuesToScan), false);
+        columnChunk->resizeWithoutPreserve(std::bit_ceil(numValuesToScan));
     }
     if (getDataTypeSizeInChunk(dataType) == 0) {
         columnChunk->setNumValues(numValuesToScan);

--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -17,10 +17,10 @@ namespace kuzu {
 namespace storage {
 
 ColumnChunk::ColumnChunk(MemoryManager& memoryManager, const LogicalType& dataType,
-    uint64_t capacity, bool enableCompression, ResidencyState residencyState)
+    uint64_t capacity, bool enableCompression, ResidencyState residencyState, bool initializeToZero)
     : enableCompression{enableCompression} {
     data = ColumnChunkFactory::createColumnChunkData(memoryManager, dataType.copy(),
-        enableCompression, capacity, residencyState);
+        enableCompression, capacity, residencyState, true, initializeToZero);
     KU_ASSERT(residencyState != ResidencyState::ON_DISK);
 }
 
@@ -28,7 +28,7 @@ ColumnChunk::ColumnChunk(MemoryManager& memoryManager, const LogicalType& dataTy
     bool enableCompression, ColumnChunkMetadata metadata)
     : enableCompression{enableCompression} {
     data = ColumnChunkFactory::createColumnChunkData(memoryManager, dataType.copy(),
-        enableCompression, metadata, true);
+        enableCompression, metadata, true, true);
 }
 
 ColumnChunk::ColumnChunk(bool enableCompression, std::unique_ptr<ColumnChunkData> data)

--- a/src/storage/store/csr_chunked_node_group.cpp
+++ b/src/storage/store/csr_chunked_node_group.cpp
@@ -41,13 +41,13 @@ CSRRegion CSRRegion::upgradeLevel(const std::vector<CSRRegion>& leafRegions,
     const idx_t leftLeafRegionIdx = newRegion.getLeftLeafRegionIdx();
     const idx_t rightLeafRegionIdx = newRegion.getRightLeafRegionIdx();
     for (auto leafRegionIdx = leftLeafRegionIdx; leafRegionIdx <= rightLeafRegionIdx;
-         leafRegionIdx++) {
+        leafRegionIdx++) {
         KU_ASSERT(leafRegionIdx < leafRegions.size());
         newRegion.sizeChange += leafRegions[leafRegionIdx].sizeChange;
         newRegion.hasPersistentDeletions |= leafRegions[leafRegionIdx].hasPersistentDeletions;
         newRegion.hasInsertions |= leafRegions[leafRegionIdx].hasInsertions;
         for (auto columnID = 0u; columnID < leafRegions[leafRegionIdx].hasUpdates.size();
-             columnID++) {
+            columnID++) {
             newRegion.hasUpdates[columnID] =
                 static_cast<bool>(newRegion.hasUpdates[columnID]) ||
                 static_cast<bool>(leafRegions[leafRegionIdx].hasUpdates[columnID]);
@@ -59,29 +59,31 @@ CSRRegion CSRRegion::upgradeLevel(const std::vector<CSRRegion>& leafRegions,
 ChunkedCSRHeader::ChunkedCSRHeader(MemoryManager& memoryManager, bool enableCompression,
     uint64_t capacity, ResidencyState residencyState) {
     offset = std::make_unique<ColumnChunk>(memoryManager, LogicalType::UINT64(), capacity,
-        enableCompression, residencyState);
+        enableCompression, residencyState, false);
     length = std::make_unique<ColumnChunk>(memoryManager, LogicalType::UINT64(), capacity,
-        enableCompression, residencyState);
+        enableCompression, residencyState, false);
 }
 
 offset_t ChunkedCSRHeader::getStartCSROffset(offset_t nodeOffset) const {
     // TODO(Guodong): I think we can simplify the check here by getting rid of some of the
     // conditions.
-    if (nodeOffset == 0 || offset->getNumValues() == 0) {
+    auto numValues = offset->getNumValues();
+    if (nodeOffset == 0 || numValues == 0) {
         return 0;
     }
     return offset->getData().getValue<offset_t>(
-        nodeOffset >= offset->getNumValues() ? (offset->getNumValues() - 1) : nodeOffset - 1);
+        nodeOffset >= numValues ? (numValues - 1) : nodeOffset - 1);
 }
 
 offset_t ChunkedCSRHeader::getEndCSROffset(offset_t nodeOffset) const {
     // TODO(Guodong): I think we can simplify the check here by getting rid of some of the
     // conditions.
-    if (offset->getNumValues() == 0) {
+    auto numValues = offset->getNumValues();
+    if (numValues == 0) {
         return 0;
     }
     return offset->getData().getValue<offset_t>(
-        nodeOffset >= offset->getNumValues() ? (offset->getNumValues() - 1) : nodeOffset);
+        nodeOffset >= numValues ? (numValues - 1) : nodeOffset);
 }
 
 length_t ChunkedCSRHeader::getCSRLength(offset_t nodeOffset) const {

--- a/src/storage/store/string_chunk_data.cpp
+++ b/src/storage/store/string_chunk_data.cpp
@@ -56,9 +56,9 @@ void StringChunkData::setToInMemory() {
     dictionaryChunk->setToInMemory();
 }
 
-void StringChunkData::resize(uint64_t newCapacity) {
-    ColumnChunkData::resize(newCapacity);
-    indexColumnChunk->resize(newCapacity);
+void StringChunkData::resize(uint64_t newCapacity, bool reserveDataAndInitializeToZero) {
+    ColumnChunkData::resize(newCapacity, reserveDataAndInitializeToZero);
+    indexColumnChunk->resize(newCapacity, reserveDataAndInitializeToZero);
 }
 
 void StringChunkData::resetToEmpty() {

--- a/src/storage/store/string_chunk_data.cpp
+++ b/src/storage/store/string_chunk_data.cpp
@@ -56,9 +56,14 @@ void StringChunkData::setToInMemory() {
     dictionaryChunk->setToInMemory();
 }
 
-void StringChunkData::resize(uint64_t newCapacity, bool reserveDataAndInitializeToZero) {
-    ColumnChunkData::resize(newCapacity, reserveDataAndInitializeToZero);
-    indexColumnChunk->resize(newCapacity, reserveDataAndInitializeToZero);
+void StringChunkData::resize(uint64_t newCapacity) {
+    ColumnChunkData::resize(newCapacity);
+    indexColumnChunk->resize(newCapacity);
+}
+
+void StringChunkData::resizeWithoutPreserve(uint64_t newCapacity) {
+    ColumnChunkData::resizeWithoutPreserve(newCapacity);
+    indexColumnChunk->resizeWithoutPreserve(newCapacity);
 }
 
 void StringChunkData::resetToEmpty() {

--- a/src/storage/store/struct_chunk_data.cpp
+++ b/src/storage/store/struct_chunk_data.cpp
@@ -152,11 +152,19 @@ void StructChunkData::setToInMemory() {
     }
 }
 
-void StructChunkData::resize(uint64_t newCapacity, bool reserveDataAndInitializeToZero) {
-    ColumnChunkData::resize(newCapacity, reserveDataAndInitializeToZero);
+void StructChunkData::resize(uint64_t newCapacity) {
+    ColumnChunkData::resize(newCapacity);
     capacity = newCapacity;
     for (const auto& child : childChunks) {
-        child->resize(newCapacity, reserveDataAndInitializeToZero);
+        child->resize(newCapacity);
+    }
+}
+
+void StructChunkData::resizeWithoutPreserve(uint64_t newCapacity) {
+    ColumnChunkData::resizeWithoutPreserve(newCapacity);
+    capacity = newCapacity;
+    for (const auto& child : childChunks) {
+        child->resizeWithoutPreserve(newCapacity);
     }
 }
 

--- a/src/storage/store/struct_chunk_data.cpp
+++ b/src/storage/store/struct_chunk_data.cpp
@@ -152,11 +152,11 @@ void StructChunkData::setToInMemory() {
     }
 }
 
-void StructChunkData::resize(uint64_t newCapacity) {
-    ColumnChunkData::resize(newCapacity);
+void StructChunkData::resize(uint64_t newCapacity, bool reserveDataAndInitializeToZero) {
+    ColumnChunkData::resize(newCapacity, reserveDataAndInitializeToZero);
     capacity = newCapacity;
     for (const auto& child : childChunks) {
-        child->resize(newCapacity);
+        child->resize(newCapacity, reserveDataAndInitializeToZero);
     }
 }
 


### PR DESCRIPTION
# Description

Optimize short query QPS.

1. ChunkedCSRHeader no need initialize offset/length field memory to 0.
2. Inside Column::scan method , columnChunk->resize() no need reserve data.

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).