### PR TITLE
Fix CI after GitHub environment change

### DIFF
--- a/.github/workflows/build-and-deploy-extension.yml
+++ b/.github/workflows/build-and-deploy-extension.yml
@@ -25,7 +25,7 @@ jobs:
     uses: ./.github/workflows/get-extensions-from-dockerhub.yml
 
   package-built-extensions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - build-extensions
       - get-dockerhub-extensions

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Update nightly version
         if: ${{ github.event_name == 'schedule' || github.event.inputs.isNightly == 'true' }}
         run: |
-          python3 -m pip install packaging
+          python3 -m pip install --break-system-package packaging
           python3 update-nightly-build-version.py
         working-directory: scripts
 
@@ -173,7 +173,7 @@ jobs:
       - name: Update nightly version
         if: ${{ github.event_name == 'schedule' || github.event.inputs.isNightly == 'true' }}
         run: |
-          pip3 install packaging
+          pip3 install --break-system-package packaging
           python3 update-nightly-build-version.py
         working-directory: scripts
 
@@ -269,7 +269,7 @@ jobs:
       - name: Update nightly version
         if: ${{ github.event_name == 'schedule' || github.event.inputs.isNightly == 'true' }}
         run: |
-          pip3 install packaging
+          pip3 install --break-system-package packaging
           python3 update-nightly-build-version.py
         working-directory: scripts
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -821,7 +821,7 @@ jobs:
       - name: Test
         working-directory: tools/shell/test
         run: |
-          pip3 install pytest pexpect
+          pip3 install --break-system-package pytest pexpect
           python3 -m pytest -v .
 
   linux-extension-test:

--- a/.github/workflows/deploy-extension.yml
+++ b/.github/workflows/deploy-extension.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   deploy-extensions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Free disk space on Ubuntu runner
         uses: kfir4444/free-disk-space@main

--- a/.github/workflows/gen-docs.yml
+++ b/.github/workflows/gen-docs.yml
@@ -126,7 +126,7 @@ jobs:
           path: ./scripts/generate-cpp-docs/c/docs/html
 
   update-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [generate-python-docs, generate-nodejs-docs, generate-java-docs, generate-cpp-docs]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/get-extensions-from-dockerhub.yml
+++ b/.github/workflows/get-extensions-from-dockerhub.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   get-dockerhub-extensions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Free disk space on Ubuntu runner
         uses: kfir4444/free-disk-space@main

--- a/.github/workflows/purge-extension.yml
+++ b/.github/workflows/purge-extension.yml
@@ -9,7 +9,7 @@ jobs:
     
   purge-extensions:
     needs: get-dockerhub-extensions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Free disk space on Ubuntu runner
         uses: kfir4444/free-disk-space@main


### PR DESCRIPTION
This PR fixes CI pipeline due to GitHub upgrading to Ubuntu 24.04 for `ubuntu-latest` tag now.