### PR TITLE
Some more ALP-related bug fixes

### DIFF
--- a/src/include/storage/store/column_chunk_data.h
+++ b/src/include/storage/store/column_chunk_data.h
@@ -234,14 +234,14 @@ public:
     void loadFromDisk();
     uint64_t spillToDisk();
 
-    // Note: This function is not setting child/null chunk data recursively.
-    void setToOnDisk(const ColumnChunkMetadata& metadata);
-
 protected:
     // Initializes the data buffer and functions. They are (and should be) only called in
     // constructor.
     void initializeBuffer(common::PhysicalTypeID physicalType, MemoryManager& mm);
     void initializeFunction(bool enableCompression);
+
+    // Note: This function is not setting child/null chunk data recursively.
+    void setToOnDisk(const ColumnChunkMetadata& metadata);
 
     virtual void copyVectorToBuffer(common::ValueVector* vector, common::offset_t startPosInChunk,
         const common::SelectionVector& selVector);

--- a/src/include/storage/store/column_chunk_data.h
+++ b/src/include/storage/store/column_chunk_data.h
@@ -234,14 +234,14 @@ public:
     void loadFromDisk();
     uint64_t spillToDisk();
 
+    // Note: This function is not setting child/null chunk data recursively.
+    void setToOnDisk(const ColumnChunkMetadata& metadata);
+
 protected:
     // Initializes the data buffer and functions. They are (and should be) only called in
     // constructor.
     void initializeBuffer(common::PhysicalTypeID physicalType, MemoryManager& mm);
     void initializeFunction(bool enableCompression);
-
-    // Note: This function is not setting child/null chunk data recursively.
-    void setToOnDisk(const ColumnChunkMetadata& metadata);
 
     virtual void copyVectorToBuffer(common::ValueVector* vector, common::offset_t startPosInChunk,
         const common::SelectionVector& selVector);

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -453,7 +453,7 @@ void Column::checkpointColumnChunk(ColumnCheckpointState& checkpointState) {
             } else {
                 KU_UNREACHABLE;
             }
-            checkpointState.persistentData.setToOnDisk(chunkState.metadata);
+            checkpointState.persistentData.getMetadata() = chunkState.metadata;
         }
     } else {
         checkpointColumnChunkOutOfPlace(chunkState, checkpointState);

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -227,11 +227,7 @@ void Column::scan(Transaction* transaction, const ChunkState& state, ColumnChunk
         return;
     }
 
-    const uint64_t numValuesPerPage = state.metadata.compMeta.numValues(PAGE_SIZE, dataType);
-    auto cursor = PageUtils::getPageCursorForPos(startOffset, numValuesPerPage);
-    cursor.pageIdx += state.metadata.pageIdx;
     KU_ASSERT((numValuesToScan + startOffset) <= state.metadata.numValues);
-
     const uint64_t numValuesScanned = columnReadWriter->readCompressedValuesToPage(transaction,
         state, columnChunk->getData(), 0, startOffset, endOffset, readToPageFunc);
 
@@ -454,7 +450,10 @@ void Column::checkpointColumnChunk(ColumnCheckpointState& checkpointState) {
                 chunkState.getExceptionChunk<double>()->finalizeAndFlushToDisk(chunkState);
             } else if (dataType.getPhysicalType() == common::PhysicalTypeID::FLOAT) {
                 chunkState.getExceptionChunk<float>()->finalizeAndFlushToDisk(chunkState);
+            } else {
+                KU_UNREACHABLE;
             }
+            checkpointState.persistentData.setToOnDisk(chunkState.metadata);
         }
     } else {
         checkpointColumnChunkOutOfPlace(chunkState, checkpointState);

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -453,7 +453,8 @@ void Column::checkpointColumnChunk(ColumnCheckpointState& checkpointState) {
             } else {
                 KU_UNREACHABLE;
             }
-            checkpointState.persistentData.getMetadata() = chunkState.metadata;
+            checkpointState.persistentData.getMetadata().compMeta.floatMetadata()->exceptionCount =
+                chunkState.metadata.compMeta.floatMetadata()->exceptionCount;
         }
     } else {
         checkpointColumnChunkOutOfPlace(chunkState, checkpointState);

--- a/src/storage/store/column_reader_writer.cpp
+++ b/src/storage/store/column_reader_writer.cpp
@@ -369,7 +369,6 @@ private:
                     curExceptionPosInChunk =
                         exceptionChunk->getExceptionAt(curExceptionIdx).posInChunk;
                 } else {
-
                     curExceptionPosInChunk = maxWrittenPosInChunk;
                 }
             }

--- a/src/storage/store/in_memory_exception_chunk.cpp
+++ b/src/storage/store/in_memory_exception_chunk.cpp
@@ -53,7 +53,7 @@ template<std::floating_point T>
 void InMemoryExceptionChunk<T>::finalizeAndFlushToDisk(ChunkState& state) {
     finalize(state);
 
-    column->write(*chunkData, *chunkState, 0, chunkData.get(), 0, finalizedExceptionCount);
+    column->write(*chunkData, *chunkState, 0, chunkData.get(), 0, exceptionCapacity);
 }
 
 template<std::floating_point T>

--- a/test/storage/compress_chunk_test.cpp
+++ b/test/storage/compress_chunk_test.cpp
@@ -555,7 +555,6 @@ TEST_F(CompressChunkTest, TestDoubleInPlaceUpdateWithExceptionsMultiPage) {
 
 TEST_F(CompressChunkTest, TestDoubleInPlaceUpdateWithExceptionsMultiPageNullMask) {
     if (!inMemMode) {
-        // numValues not not fit in uint16
         std::vector<double> src(4 * 1024, 5.6);
         src[1] = 123456789012.56;
         src[3] = 1;

--- a/test/storage/compress_chunk_test.cpp
+++ b/test/storage/compress_chunk_test.cpp
@@ -554,46 +554,49 @@ TEST_F(CompressChunkTest, TestDoubleInPlaceUpdateWithExceptionsMultiPage) {
 }
 
 TEST_F(CompressChunkTest, TestDoubleInPlaceUpdateWithExceptionsMultiPageNullMask) {
-    // numValues not not fit in uint16
-    std::vector<double> src(4 * 1024, 5.6);
-    src[1] = 123456789012.56;
-    src[3] = 1;
-    for (size_t i = 11; i < src.size(); i += 10) {
-        src[i] = src[i - 10] + 7890123.567;
-    }
-
-    testCompressChunk(src, [&src, this](ColumnReadWriter* reader,
-                               transaction::Transaction* transaction, ChunkState& state,
-                               const LogicalType& dataType) {
-        auto* mm = getMemoryManager(*database);
-        auto* storageManager = getStorageManager(*database);
-        auto* dataFH = storageManager->getDataFH();
-
-        static constexpr size_t numValuesToSet = 50;
-        const size_t cpyOffset = 2100;
-        src[cpyOffset] = 10101010;
-        for (size_t i = 1; i < numValuesToSet; i++) {
-            src[cpyOffset + i] = src[cpyOffset + i - 1] + 1;
+    if (!inMemMode) {
+        // numValues not not fit in uint16
+        std::vector<double> src(4 * 1024, 5.6);
+        src[1] = 123456789012.56;
+        src[3] = 1;
+        for (size_t i = 11; i < src.size(); i += 10) {
+            src[i] = src[i - 10] + 7890123.567;
         }
 
-        std::optional<NullMask> nullMask(src.size());
-        nullMask->setNullFromRange(0, cpyOffset, true);
-        InPlaceUpdateLocalState localUpdateState{};
-        ASSERT_TRUE(state.metadata.compMeta.canUpdateInPlace((uint8_t*)src.data(), 0,
-            cpyOffset + numValuesToSet, dataType.getPhysicalType(), localUpdateState, nullMask));
-        reader->writeValuesToPageFromBuffer(state, 0, (uint8_t*)src.data(), &nullMask.value(), 0,
-            cpyOffset + numValuesToSet, WriteCompressedValuesToPage(dataType));
+        testCompressChunk(src, [&src, this](ColumnReadWriter* reader,
+                                   transaction::Transaction* transaction, ChunkState& state,
+                                   const LogicalType& dataType) {
+            auto* mm = getMemoryManager(*database);
+            auto* storageManager = getStorageManager(*database);
+            auto* dataFH = storageManager->getDataFH();
 
-        commitUpdate<double>(transaction, state, dataFH, mm, &storageManager->getShadowFile());
+            static constexpr size_t numValuesToSet = 50;
+            const size_t cpyOffset = 2100;
+            src[cpyOffset] = 10101010;
+            for (size_t i = 1; i < numValuesToSet; i++) {
+                src[cpyOffset + i] = src[cpyOffset + i - 1] + 1;
+            }
 
-        // our compression algorithms don't actually respect the null mask but we can check if the
-        // non-null values match
-        std::vector<double> out(numValuesToSet);
-        reader->readCompressedValuesToPage(transaction, state, (uint8_t*)out.data(), 0, cpyOffset,
-            cpyOffset + numValuesToSet, ReadCompressedValuesFromPage(dataType));
-        EXPECT_THAT(out, ::testing::ContainerEq(std::vector<double>(src.begin() + cpyOffset,
-                             src.begin() + cpyOffset + numValuesToSet)));
-    });
+            std::optional<NullMask> nullMask(src.size());
+            nullMask->setNullFromRange(0, cpyOffset, true);
+            InPlaceUpdateLocalState localUpdateState{};
+            ASSERT_TRUE(state.metadata.compMeta.canUpdateInPlace((uint8_t*)src.data(), 0,
+                cpyOffset + numValuesToSet, dataType.getPhysicalType(), localUpdateState,
+                nullMask));
+            reader->writeValuesToPageFromBuffer(state, 0, (uint8_t*)src.data(), &nullMask.value(),
+                0, cpyOffset + numValuesToSet, WriteCompressedValuesToPage(dataType));
+
+            commitUpdate<double>(transaction, state, dataFH, mm, &storageManager->getShadowFile());
+
+            // our compression algorithms don't actually respect the null mask but we can check if
+            // the non-null values match
+            std::vector<double> out(numValuesToSet);
+            reader->readCompressedValuesToPage(transaction, state, (uint8_t*)out.data(), 0,
+                cpyOffset, cpyOffset + numValuesToSet, ReadCompressedValuesFromPage(dataType));
+            EXPECT_THAT(out, ::testing::ContainerEq(std::vector<double>(src.begin() + cpyOffset,
+                                 src.begin() + cpyOffset + numValuesToSet)));
+        });
+    }
 }
 
 TEST_F(CompressChunkTest, TestInPlaceUpdateConstant) {

--- a/test/storage/compress_chunk_test.cpp
+++ b/test/storage/compress_chunk_test.cpp
@@ -553,6 +553,49 @@ TEST_F(CompressChunkTest, TestDoubleInPlaceUpdateWithExceptionsMultiPage) {
     });
 }
 
+TEST_F(CompressChunkTest, TestDoubleInPlaceUpdateWithExceptionsMultiPageNullMask) {
+    // numValues not not fit in uint16
+    std::vector<double> src(4 * 1024, 5.6);
+    src[1] = 123456789012.56;
+    src[3] = 1;
+    for (size_t i = 11; i < src.size(); i += 10) {
+        src[i] = src[i - 10] + 7890123.567;
+    }
+
+    testCompressChunk(src, [&src, this](ColumnReadWriter* reader,
+                               transaction::Transaction* transaction, ChunkState& state,
+                               const LogicalType& dataType) {
+        auto* mm = getMemoryManager(*database);
+        auto* storageManager = getStorageManager(*database);
+        auto* dataFH = storageManager->getDataFH();
+
+        static constexpr size_t numValuesToSet = 50;
+        const size_t cpyOffset = 2100;
+        src[cpyOffset] = 10101010;
+        for (size_t i = 1; i < numValuesToSet; i++) {
+            src[cpyOffset + i] = src[cpyOffset + i - 1] + 1;
+        }
+
+        std::optional<NullMask> nullMask(src.size());
+        nullMask->setNullFromRange(0, cpyOffset, true);
+        InPlaceUpdateLocalState localUpdateState{};
+        ASSERT_TRUE(state.metadata.compMeta.canUpdateInPlace((uint8_t*)src.data(), 0,
+            cpyOffset + numValuesToSet, dataType.getPhysicalType(), localUpdateState, nullMask));
+        reader->writeValuesToPageFromBuffer(state, 0, (uint8_t*)src.data(), &nullMask.value(), 0,
+            cpyOffset + numValuesToSet, WriteCompressedValuesToPage(dataType));
+
+        commitUpdate<double>(transaction, state, dataFH, mm, &storageManager->getShadowFile());
+
+        // our compression algorithms don't actually respect the null mask but we can check if the
+        // non-null values match
+        std::vector<double> out(numValuesToSet);
+        reader->readCompressedValuesToPage(transaction, state, (uint8_t*)out.data(), 0, cpyOffset,
+            cpyOffset + numValuesToSet, ReadCompressedValuesFromPage(dataType));
+        EXPECT_THAT(out, ::testing::ContainerEq(std::vector<double>(src.begin() + cpyOffset,
+                             src.begin() + cpyOffset + numValuesToSet)));
+    });
+}
+
 TEST_F(CompressChunkTest, TestInPlaceUpdateConstant) {
     std::vector<double> src(256, 0.54);
     testCompressChunk(src, [](ColumnReadWriter*, transaction::Transaction*, ChunkState& state,

--- a/test/test_files/dml_rel/delete/delete_empty.test
+++ b/test/test_files/dml_rel/delete/delete_empty.test
@@ -1,0 +1,45 @@
+-DATASET CSV EMPTY
+
+--
+
+-CASE DeleteALPException
+-STATEMENT CREATE NODE TABLE person (id INT64, PRIMARY KEY (id));
+---- ok
+-STATEMENT CREATE REL TABLE knows (FROM person TO person, val DOUBLE);
+---- ok
+-STATEMENT CREATE (a:person {ID: 88})
+---- ok
+-STATEMENT CREATE (a:person {ID: 77})
+---- ok
+-STATEMENT CREATE (a:person {ID: 66})
+---- ok
+-STATEMENT CREATE (a:person {ID: 55})
+---- ok
+-STATEMENT MATCH (a:person), (b:person) WHERE a.ID = 77 AND b.ID = 88 CREATE (a)-[e:knows {val:5.1}]->(b) RETURN COUNT(*);
+---- 1
+1
+-STATEMENT MATCH (a:person), (b:person) WHERE a.ID = 77 AND b.ID = 66 CREATE (a)-[e:knows {val:123456789.123}]->(b) RETURN COUNT(*);
+---- 1
+1
+-STATEMENT MATCH (a:person), (b:person) WHERE a.ID = 77 AND b.ID = 55 CREATE (a)-[e:knows {val:1.2}]->(b) RETURN COUNT(*);
+---- 1
+1
+-STATEMENT MATCH (a:person), (b:person) WHERE a.ID = 66 AND b.ID = 55 CREATE (a)-[e:knows {val:2.3}]->(b) RETURN COUNT(*);
+---- 1
+1
+-STATEMENT CHECKPOINT;
+---- ok
+-STATEMENT MATCH (a:person)-[e:knows]->(b:person) RETURN a.ID, b.ID, e.val;
+---- 4
+77|88|5.100000
+77|66|123456789.123000
+77|55|1.200000
+66|55|2.300000
+-STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE b.ID = 66 DETACH DELETE b;
+---- ok
+-STATEMENT CHECKPOINT;
+---- ok
+-STATEMENT MATCH (a:person)-[e:knows]->(b:person) RETURN a.ID, b.ID, e.val;
+---- 2
+77|88|5.100000
+77|55|1.200000


### PR DESCRIPTION
# Description

More ALP bug fixes caught when running the fintech benchmark:
- Update persistent ALP metadata (exception count) after in-place writes are performed
- Having values populated in the null mask doesn't break exception patching for in-place writes

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).