### PR TITLE
fix path semantic no work

### DIFF
--- a/src/include/graph/graph.h
+++ b/src/include/graph/graph.h
@@ -49,7 +49,7 @@ public:
         explicit constexpr Iterator(GraphScanState* scanState) : scanState{scanState} {}
         DEFAULT_BOTH_MOVE(Iterator);
         Iterator(const Iterator& other) = default;
-
+        Iterator() : scanState{nullptr} {}
         using iterator_category = std::input_iterator_tag;
         using difference_type = std::ptrdiff_t;
         using value_type = GraphScanState::Chunk;

--- a/src/include/optimizer/projection_push_down_optimizer.h
+++ b/src/include/optimizer/projection_push_down_optimizer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common/enums/path_semantic.h"
 #include "logical_operator_visitor.h"
 #include "planner/operator/logical_plan.h"
 
@@ -24,6 +25,7 @@ namespace optimizer {
 class ProjectionPushDownOptimizer : public LogicalOperatorVisitor {
 public:
     void rewrite(planner::LogicalPlan* plan);
+    inline void setPathSemantic(common::PathSemantic _semantic) { this->semantic = _semantic; }
 
 private:
     void visitOperator(planner::LogicalOperator* op);
@@ -58,6 +60,7 @@ private:
     binder::expression_set propertiesInUse;
     binder::expression_set variablesInUse;
     binder::expression_set nodeOrRelInUse;
+    common::PathSemantic semantic;
 };
 
 } // namespace optimizer

--- a/src/include/optimizer/projection_push_down_optimizer.h
+++ b/src/include/optimizer/projection_push_down_optimizer.h
@@ -25,7 +25,7 @@ namespace optimizer {
 class ProjectionPushDownOptimizer : public LogicalOperatorVisitor {
 public:
     void rewrite(planner::LogicalPlan* plan);
-    inline void setPathSemantic(common::PathSemantic _semantic) { this->semantic = _semantic; }
+    explicit ProjectionPushDownOptimizer(common::PathSemantic semantic) : semantic(semantic) {};
 
 private:
     void visitOperator(planner::LogicalOperator* op);

--- a/src/include/processor/operator/recursive_extend/frontier.h
+++ b/src/include/processor/operator/recursive_extend/frontier.h
@@ -48,6 +48,9 @@ struct RelIDMasker {
     static void markFlip(common::internalID_t& relID) { relID.offset |= FLIP_SRC_DST_MASK; }
     static bool needFlip(common::internalID_t& relID) { return relID.offset & FLIP_SRC_DST_MASK; }
     static void clearMark(common::internalID_t& relID) { relID.offset &= CLEAR_FLIP_SRC_DST_MASK; }
+    static common::internalID_t getWithoutMark(common::internalID_t& relID) {
+        return common::internalID_t(relID.offset & CLEAR_FLIP_SRC_DST_MASK, relID.tableID);
+    }
 };
 
 } // namespace processor

--- a/src/include/processor/operator/recursive_extend/frontier.h
+++ b/src/include/processor/operator/recursive_extend/frontier.h
@@ -48,7 +48,7 @@ struct RelIDMasker {
     static void markFlip(common::internalID_t& relID) { relID.offset |= FLIP_SRC_DST_MASK; }
     static bool needFlip(common::internalID_t& relID) { return relID.offset & FLIP_SRC_DST_MASK; }
     static void clearMark(common::internalID_t& relID) { relID.offset &= CLEAR_FLIP_SRC_DST_MASK; }
-    static common::internalID_t getWithoutMark(common::internalID_t& relID) {
+    static common::internalID_t getWithoutMark(const common::internalID_t& relID) {
         return common::internalID_t(relID.offset & CLEAR_FLIP_SRC_DST_MASK, relID.tableID);
     }
 };

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -28,8 +28,7 @@ void Optimizer::optimize(planner::LogicalPlan* plan, main::ClientContext* contex
     auto filterPushDownOptimizer = FilterPushDownOptimizer(context);
     filterPushDownOptimizer.rewrite(plan);
 
-    auto projectionPushDownOptimizer = ProjectionPushDownOptimizer();
-    projectionPushDownOptimizer.setPathSemantic(context->getClientConfig()->recursivePatternSemantic);
+    auto projectionPushDownOptimizer = ProjectionPushDownOptimizer(context->getClientConfig()->recursivePatternSemantic);
     projectionPushDownOptimizer.rewrite(plan);
 
     if (context->getClientConfig()->enableSemiMask) {

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -29,6 +29,7 @@ void Optimizer::optimize(planner::LogicalPlan* plan, main::ClientContext* contex
     filterPushDownOptimizer.rewrite(plan);
 
     auto projectionPushDownOptimizer = ProjectionPushDownOptimizer();
+    projectionPushDownOptimizer.setPathSemantic(context->getClientConfig()->recursivePatternSemantic);
     projectionPushDownOptimizer.rewrite(plan);
 
     if (context->getClientConfig()->enableSemiMask) {

--- a/src/optimizer/projection_push_down_optimizer.cpp
+++ b/src/optimizer/projection_push_down_optimizer.cpp
@@ -51,7 +51,8 @@ void ProjectionPushDownOptimizer::visitPathPropertyProbe(LogicalOperator* op) {
     auto boundNodeID = recursiveExtend.getBoundNode()->getInternalID();
     collectExpressionsInUse(boundNodeID);
     auto rel = recursiveExtend.getRel();
-    if (!nodeOrRelInUse.contains(rel)) {
+    // set TRACK_NONE only when PathSemantic=walk
+    if (!nodeOrRelInUse.contains(rel) && semantic == common::PathSemantic::WALK) {
         pathPropertyProbe.setJoinType(RecursiveJoinType::TRACK_NONE);
         recursiveExtend.setJoinType(RecursiveJoinType::TRACK_NONE);
     }

--- a/src/optimizer/projection_push_down_optimizer.cpp
+++ b/src/optimizer/projection_push_down_optimizer.cpp
@@ -138,7 +138,7 @@ void ProjectionPushDownOptimizer::visitIntersect(LogicalOperator* op) {
 void ProjectionPushDownOptimizer::visitProjection(LogicalOperator* op) {
     // Projection operator defines the start of a projection push down until the next projection
     // operator is seen.
-    ProjectionPushDownOptimizer optimizer;
+    ProjectionPushDownOptimizer optimizer(this->semantic);
     auto& projection = op->constCast<LogicalProjection>();
     for (auto& expression : projection.getExpressionsToProject()) {
         optimizer.collectExpressionsInUse(expression);

--- a/src/processor/operator/recursive_extend/frontier_scanner.cpp
+++ b/src/processor/operator/recursive_extend/frontier_scanner.cpp
@@ -51,10 +51,15 @@ bool PathScanner::trailSemanticCheck(const std::vector<nodeID_t>&,
     const std::vector<relID_t>& edgeIDs) {
     common::rel_id_set_t set;
     for (auto i = 0u; i < edgeIDs.size() - 1; ++i) {
-        if (set.contains(edgeIDs[i])) {
+        internalID_t edgeID = edgeIDs[i];
+        if (RelIDMasker::needFlip(const_cast<internalID_t&>(edgeIDs[i]))) {
+            edgeID = RelIDMasker::getWithoutMark(const_cast<internalID_t&>(edgeIDs[i]));
+        } else {
+        }
+        if (set.contains(edgeID)) {
             return false;
         }
-        set.insert(edgeIDs[i]);
+        set.insert(edgeID);
     }
     return true;
 }

--- a/src/processor/operator/recursive_extend/frontier_scanner.cpp
+++ b/src/processor/operator/recursive_extend/frontier_scanner.cpp
@@ -52,9 +52,8 @@ bool PathScanner::trailSemanticCheck(const std::vector<nodeID_t>&,
     common::rel_id_set_t set;
     for (auto i = 0u; i < edgeIDs.size() - 1; ++i) {
         internalID_t edgeID = edgeIDs[i];
-        if (RelIDMasker::needFlip(const_cast<internalID_t&>(edgeIDs[i]))) {
-            edgeID = RelIDMasker::getWithoutMark(const_cast<internalID_t&>(edgeIDs[i]));
-        } else {
+        if (RelIDMasker::needFlip(edgeID)) {
+            edgeID = RelIDMasker::getWithoutMark(edgeID);
         }
         if (set.contains(edgeID)) {
             return false;


### PR DESCRIPTION
# Description

path semantic do not work in this case

call recursive_pattern_semantic='TRAIL';
match p=(a )-[f*2]-(b) where a.id=1 return p;

In the graph, there is only a relationship from 1->2 and not 2->1. This means that when the 'TRAIL' option is set, the end node b should not include the start node, which id=1. However, the result set includes: {_NODES:[1,2,1],_RELS:[1->2,1->2]}.

The cause of this issue is that in the trailSemanticCheck Function, some edgeIDs have been processed with markFlip. When comparing these edges with those that have not undergone markFlip, they cannot be correctly filtered.

Additionally, the path semantics do not work in the case:
match p=(a)-[f*2]-(b) where a.id=1 return b;

This is because the optimizer has set TRACK_NONE, and this option  only support WALK. My approach is to set TRACK_NONE only when WALK is specified.


# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).