### PR TITLE
Add option to regexp_replace function

### DIFF
--- a/src/function/struct/struct_extract_function.cpp
+++ b/src/function/struct/struct_extract_function.cpp
@@ -33,8 +33,8 @@ void StructExtractFunctions::compileFunc(FunctionBindData* bindData,
     const std::vector<std::shared_ptr<ValueVector>>& parameters,
     std::shared_ptr<ValueVector>& result) {
     KU_ASSERT(parameters[0]->dataType.getPhysicalType() == PhysicalTypeID::STRUCT);
-    auto structBindData = ku_dynamic_cast<StructExtractBindData*>(bindData);
-    result = StructVector::getFieldVector(parameters[0].get(), structBindData->childIdx);
+    auto& structBindData = bindData->cast<StructExtractBindData>();
+    result = StructVector::getFieldVector(parameters[0].get(), structBindData.childIdx);
     result->state = parameters[0]->state;
 }
 

--- a/src/function/vector_string_functions.cpp
+++ b/src/function/vector_string_functions.cpp
@@ -110,7 +110,7 @@ void ConcatFunction::execFunc(const std::vector<std::shared_ptr<ValueVector>>& p
     ValueVector& result, void* /*dataPtr*/) {
     result.resetAuxiliaryBuffer();
     for (auto selectedPos = 0u; selectedPos < result.state->getSelVector().getSelSize();
-         ++selectedPos) {
+        ++selectedPos) {
         auto pos = result.state->getSelVector()[selectedPos];
         auto strLen = 0u;
         for (auto i = 0u; i < parameters.size(); i++) {
@@ -260,11 +260,9 @@ std::unique_ptr<FunctionBindData> regexReplaceBindFunc(ScalarBindFuncInput input
         RegexpReplaceFunction::RegexReplaceOption::FIRST_OCCUR;
     if (input.arguments.size() == 4) {
         auto option = input.arguments[3];
-        if (option->expressionType != ExpressionType::LITERAL ||
-            option->getDataType() != LogicalType::STRING()) {
-            throw common::BinderException{"option of regex_replace must be a constant string."};
-        }
-        auto optionVal = option->constCast<binder::LiteralExpression>().getValue().strVal;
+        binder::ExpressionUtil::validateExpressionType(*option, ExpressionType::LITERAL);
+        binder::ExpressionUtil::validateDataType(*option, LogicalType::STRING());
+        auto optionVal = binder::ExpressionUtil::getLiteralValue<std::string>(*option);
         if (optionVal == RegexpReplaceFunction::GLOBAL_REPLACE_OPTION) {
             replaceOption = RegexpReplaceFunction::RegexReplaceOption::GLOBAL;
         } else {

--- a/src/function/vector_string_functions.cpp
+++ b/src/function/vector_string_functions.cpp
@@ -110,7 +110,7 @@ void ConcatFunction::execFunc(const std::vector<std::shared_ptr<ValueVector>>& p
     ValueVector& result, void* /*dataPtr*/) {
     result.resetAuxiliaryBuffer();
     for (auto selectedPos = 0u; selectedPos < result.state->getSelVector().getSelSize();
-        ++selectedPos) {
+         ++selectedPos) {
         auto pos = result.state->getSelVector()[selectedPos];
         auto strLen = 0u;
         for (auto i = 0u; i < parameters.size(); i++) {

--- a/src/function/vector_string_functions.cpp
+++ b/src/function/vector_string_functions.cpp
@@ -109,7 +109,7 @@ void ConcatFunction::execFunc(const std::vector<std::shared_ptr<ValueVector>>& p
     ValueVector& result, void* /*dataPtr*/) {
     result.resetAuxiliaryBuffer();
     for (auto selectedPos = 0u; selectedPos < result.state->getSelVector().getSelSize();
-        ++selectedPos) {
+         ++selectedPos) {
         auto pos = result.state->getSelVector()[selectedPos];
         auto strLen = 0u;
         for (auto i = 0u; i < parameters.size(); i++) {

--- a/src/function/vector_string_functions.cpp
+++ b/src/function/vector_string_functions.cpp
@@ -1,7 +1,6 @@
 #include "function/string/vector_string_functions.h"
 
 #include "binder/expression/expression_util.h"
-#include "binder/expression/literal_expression.h"
 #include "common/exception/binder.h"
 #include "function/string/functions/array_extract_function.h"
 #include "function/string/functions/contains_function.h"
@@ -110,7 +109,7 @@ void ConcatFunction::execFunc(const std::vector<std::shared_ptr<ValueVector>>& p
     ValueVector& result, void* /*dataPtr*/) {
     result.resetAuxiliaryBuffer();
     for (auto selectedPos = 0u; selectedPos < result.state->getSelVector().getSelSize();
-         ++selectedPos) {
+        ++selectedPos) {
         auto pos = result.state->getSelVector()[selectedPos];
         auto strLen = 0u;
         for (auto i = 0u; i < parameters.size(); i++) {

--- a/src/include/function/scalar_function.h
+++ b/src/include/function/scalar_function.h
@@ -81,6 +81,14 @@ struct ScalarFunction final : public ScalarOrAggregateFunction {
             *params[0], *params[1], *params[2], result);
     }
 
+    template<typename A_TYPE, typename B_TYPE, typename C_TYPE, typename RESULT_TYPE, typename FUNC>
+    static void TernaryRegexExecFunction(
+        const std::vector<std::shared_ptr<common::ValueVector>>& params,
+        common::ValueVector& result, void* dataPtr) {
+        TernaryFunctionExecutor::executeRegex<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC>(*params[0],
+            *params[1], *params[2], result, dataPtr);
+    }
+
     template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC>
     static void BinaryExecFunction(const std::vector<std::shared_ptr<common::ValueVector>>& params,
         common::ValueVector& result, void* /*dataPtr*/ = nullptr) {

--- a/src/include/function/string/functions/regexp_replace_function.h
+++ b/src/include/function/string/functions/regexp_replace_function.h
@@ -2,18 +2,30 @@
 
 #include "common/types/ku_string.h"
 #include "function/string/functions/base_regexp_function.h"
+#include "function/string/vector_string_functions.h"
 #include "re2.h"
 
 namespace kuzu {
 namespace function {
 
 struct RegexpReplace : BaseRegexpOperation {
-    static inline void operation(common::ku_string_t& value, common::ku_string_t& pattern,
+    static void operation(common::ku_string_t& value, common::ku_string_t& pattern,
         common::ku_string_t& replacement, common::ku_string_t& result,
-        common::ValueVector& resultValueVector) {
+        common::ValueVector& resultValueVector, void* bindData) {
+        auto regexBindData = reinterpret_cast<RegexReplaceBindData*>(bindData);
         std::string resultStr = value.getAsString();
-        RE2::Replace(&resultStr, parseCypherPattern(pattern.getAsString()),
-            replacement.getAsString());
+        switch (regexBindData->option) {
+        case RegexpReplaceFunction::RegexReplaceOption::GLOBAL: {
+            RE2::GlobalReplace(&resultStr, parseCypherPattern(pattern.getAsString()),
+                replacement.getAsString());
+        } break;
+        case RegexpReplaceFunction::RegexReplaceOption::FIRST_OCCUR: {
+            RE2::Replace(&resultStr, parseCypherPattern(pattern.getAsString()),
+                replacement.getAsString());
+        } break;
+        default:
+            KU_UNREACHABLE;
+        }
         copyToKuzuString(resultStr, result, resultValueVector);
     }
 };

--- a/src/include/function/string/vector_string_functions.h
+++ b/src/include/function/string/vector_string_functions.h
@@ -173,8 +173,23 @@ struct RegexpMatchesFunction : public VectorStringFunction {
 
 struct RegexpReplaceFunction : public VectorStringFunction {
     static constexpr const char* name = "REGEXP_REPLACE";
+    static constexpr const char* GLOBAL_REPLACE_OPTION = "g";
+    enum class RegexReplaceOption : uint8_t { GLOBAL = 0, FIRST_OCCUR = 1 };
 
     static function_set getFunctionSet();
+};
+
+struct RegexReplaceBindData : public FunctionBindData {
+    RegexpReplaceFunction::RegexReplaceOption option;
+
+    RegexReplaceBindData(std::vector<common::LogicalType> paramTypes,
+        common::LogicalType resultType, RegexpReplaceFunction::RegexReplaceOption option)
+        : FunctionBindData{std::move(paramTypes), std::move(resultType)}, option{option} {}
+
+    std::unique_ptr<FunctionBindData> copy() const override {
+        return std::make_unique<RegexReplaceBindData>(copyVector(paramTypes), resultType.copy(),
+            option);
+    }
 };
 
 struct RegexpExtractFunction : public VectorStringFunction {

--- a/src/include/function/ternary_function_executor.h
+++ b/src/include/function/ternary_function_executor.h
@@ -21,6 +21,14 @@ struct TernaryStringFunctionWrapper {
     }
 };
 
+struct TernaryRegexFunctionWrapper {
+    template<typename A_TYPE, typename B_TYPE, typename C_TYPE, typename RESULT_TYPE, typename OP>
+    static inline void operation(A_TYPE& a, B_TYPE& b, C_TYPE& c, RESULT_TYPE& result,
+        void* /*aValueVector*/, void* resultValueVector, void* dataPtr) {
+        OP::operation(a, b, c, result, *(common::ValueVector*)resultValueVector, dataPtr);
+    }
+};
+
 struct TernaryListFunctionWrapper {
     template<typename A_TYPE, typename B_TYPE, typename C_TYPE, typename RESULT_TYPE, typename OP>
     static inline void operation(A_TYPE& a, B_TYPE& b, C_TYPE& c, RESULT_TYPE& result,
@@ -416,6 +424,13 @@ struct TernaryFunctionExecutor {
         common::ValueVector& c, common::ValueVector& result) {
         executeSwitch<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, TernaryStringFunctionWrapper>(a, b,
             c, result, nullptr /* dataPtr */);
+    }
+
+    template<typename A_TYPE, typename B_TYPE, typename C_TYPE, typename RESULT_TYPE, typename FUNC>
+    static void executeRegex(common::ValueVector& a, common::ValueVector& b, common::ValueVector& c,
+        common::ValueVector& result, void* dataPtr) {
+        executeSwitch<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, TernaryRegexFunctionWrapper>(a, b,
+            c, result, dataPtr);
     }
 
     template<typename A_TYPE, typename B_TYPE, typename C_TYPE, typename RESULT_TYPE, typename FUNC>

--- a/test/test_files/function/string.test
+++ b/test/test_files/function/string.test
@@ -604,6 +604,21 @@ he---
 ---- 1
 th*?? *?? a team
 
+-LOG RegexpReplaceNonConstantOption
+-STATEMENT MATCH (p:person) Return REGEXP_REPLACE('this is a team', 'is', '*??', p.fName);
+---- error
+Binder exception: p.fName has type PROPERTY but LITERAL was expected.
+
+-LOG RegexpReplaceInvalidOptionType
+-STATEMENT MATCH (p:person) Return REGEXP_REPLACE('this is a team', 'is', '*??', 5);
+---- error
+Binder exception: 5 has data type INT64 but STRING was expected.
+
+-LOG RegexpReplaceNonConstantOption
+-STATEMENT MATCH (p:person) Return REGEXP_REPLACE('this is a team', 'is', '*??', 'l');
+---- error
+Binder exception: regex_replace can only support global replace option: g.
+
 -LOG RegexpReplaceSpace
 -STATEMENT Return REGEXP_REPLACE('65 landy street waterloo ontario canada', '\\s', '', 'g');
 ---- 1

--- a/test/test_files/function/string.test
+++ b/test/test_files/function/string.test
@@ -594,6 +594,21 @@ True
 ---- 1
 he-lo
 
+-LOG RegexpReplaceAll1
+-STATEMENT Return REGEXP_REPLACE('hello', '[lo]', '-', 'g');
+---- 1
+he---
+
+-LOG RegexpReplaceAll2
+-STATEMENT Return REGEXP_REPLACE('this is a team', 'is', '*??', 'g');
+---- 1
+th*?? *?? a team
+
+-LOG RegexpReplaceSpace
+-STATEMENT Return REGEXP_REPLACE('65 landy street waterloo ontario', '\\s', '', 'g');
+---- 1
+65landystreetwaterlooontario
+
 -LOG RegexpExtractWithoutGroup
 -STATEMENT Return regexp_extract('hello_world', '([a-z ]+)_?');
 ---- 1

--- a/test/test_files/function/string.test
+++ b/test/test_files/function/string.test
@@ -605,9 +605,9 @@ he---
 th*?? *?? a team
 
 -LOG RegexpReplaceSpace
--STATEMENT Return REGEXP_REPLACE('65 landy street waterloo ontario', '\\s', '', 'g');
+-STATEMENT Return REGEXP_REPLACE('65 landy street waterloo ontario canada', '\\s', '', 'g');
 ---- 1
-65landystreetwaterlooontario
+65landystreetwaterlooontariocanada
 
 -LOG RegexpExtractWithoutGroup
 -STATEMENT Return regexp_extract('hello_world', '([a-z ]+)_?');


### PR DESCRIPTION
# Description

This PR adds an option parameter to the regex_replace function.

Only global replace option ('g') is supported right now. 

#Close #4331