### PR TITLE
Move `--break-system-packages` settings to env variables

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -45,7 +45,9 @@ on:
         type: boolean
         required: true
         default: false
-
+env:
+  PIP_BREAK_SYSTEM_PACKAGES: 1
+  
 jobs:
   build-extension:
     if: ${{ github.event_name == 'schedule' || github.event.inputs.skipExtensions != 'true' }}
@@ -86,6 +88,7 @@ jobs:
       GPG_SIGNING_KEY: ${{ secrets.PGP_PRIVATE_KEY }}
       GPG_SIGNING_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
       SKIP_CMAKE_BUILD: true
+      PIP_
 
     runs-on: ubuntu-latest
     steps:
@@ -94,7 +97,7 @@ jobs:
       - name: Update nightly version
         if: ${{ github.event_name == 'schedule' || github.event.inputs.isNightly == 'true' }}
         run: |
-          python3 -m pip install --break-system-package packaging
+          python3 -m pip install packaging
           python3 update-nightly-build-version.py
         working-directory: scripts
 
@@ -173,7 +176,7 @@ jobs:
       - name: Update nightly version
         if: ${{ github.event_name == 'schedule' || github.event.inputs.isNightly == 'true' }}
         run: |
-          pip3 install --break-system-package packaging
+          pip3 install packaging
           python3 update-nightly-build-version.py
         working-directory: scripts
 
@@ -269,7 +272,7 @@ jobs:
       - name: Update nightly version
         if: ${{ github.event_name == 'schedule' || github.event.inputs.isNightly == 'true' }}
         run: |
-          pip3 install --break-system-package packaging
+          pip3 install packaging
           python3 update-nightly-build-version.py
         working-directory: scripts
 
@@ -357,7 +360,7 @@ jobs:
       - name: Update nightly version
         if: ${{ github.event_name == 'schedule' || github.event.inputs.isNightly == 'true' }}
         run: |
-          pip3 install packaging --break-system-package
+          pip3 install packaging
           python3 update-nightly-build-version.py
         working-directory: scripts
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -47,7 +47,7 @@ on:
         default: false
 env:
   PIP_BREAK_SYSTEM_PACKAGES: 1
-  
+
 jobs:
   build-extension:
     if: ${{ github.event_name == 'schedule' || github.event.inputs.skipExtensions != 'true' }}
@@ -88,7 +88,6 @@ jobs:
       GPG_SIGNING_KEY: ${{ secrets.PGP_PRIVATE_KEY }}
       GPG_SIGNING_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
       SKIP_CMAKE_BUILD: true
-      PIP_
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -48,7 +48,7 @@ env:
   CHECKPOINT_THRESHOLD: ${{ github.event.inputs.checkpoint_threshold }}
   WERROR: 1
   RUSTFLAGS: --deny warnings
-
+  PIP_BREAK_SYSTEM_PACKAGES: 1
 
 # Only allow one run in this group to run at a time, and cancel any runs in progress in this group.
 # We use the workflow name and then add the pull request number, or (if it's a push to master), we use the name of the branch.
@@ -145,8 +145,8 @@ jobs:
 
       - name: Ensure Python dependencies
         run: |
-          pip install torch~=2.2.0 --break-system-package --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --break-system-package --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
+          pip install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
 
       - name: Ensure Node.js dependencies
         run: npm install --include=dev
@@ -220,8 +220,8 @@ jobs:
 
       - name: Ensure Python dependencies
         run: |
-          pip install torch~=2.2.0 --break-system-package --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --break-system-package --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
+          pip install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
 
       - name: Ensure Node.js dependencies
         run: npm install --include=dev
@@ -348,8 +348,8 @@ jobs:
 
       - name: Ensure Python dependencies
         run: |
-          pip install torch~=2.2.0 --break-system-package --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --break-system-package --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
+          pip install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
 
       - name: Ensure Node.js dependencies
         run: npm install --include=dev
@@ -395,8 +395,8 @@ jobs:
 
       - name: Ensure Python dependencies
         run: |
-          pip install torch~=2.2.0 --break-system-package --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --break-system-package --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
+          pip install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
 
       - name: Ensure Node.js dependencies
         run: npm install --include=dev
@@ -456,8 +456,8 @@ jobs:
 
       - name: Ensure Python dependencies
         run: |
-          pip install torch~=2.2.0 --break-system-package --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --break-system-package --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
+          pip install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
 
       - name: Ensure Node.js dependencies
         run: npm install --include=dev
@@ -745,8 +745,8 @@ jobs:
 
       - name: Ensure Python dependencies
         run: |
-          pip3 install torch~=2.2.0 --break-system-package --extra-index-url https://download.pytorch.org/whl/cpu
-          pip3 install --break-system-package --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
+          pip3 install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu
+          pip3 install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
 
       - name: Ensure Node.js dependencies
         run: npm install --include=dev
@@ -821,7 +821,7 @@ jobs:
       - name: Test
         working-directory: tools/shell/test
         run: |
-          pip3 install --break-system-package pytest pexpect
+          pip3 install pytest pexpect
           python3 -m pytest -v .
 
   linux-extension-test:
@@ -859,7 +859,7 @@ jobs:
           cat postgres.test
 
       - name: Install dependencies
-        run: pip install --break-system-package rangehttpserver
+        run: pip install rangehttpserver
 
       # shell needs to be built first to generate the dataset provided by the server
       - name: Extension test build
@@ -913,7 +913,7 @@ jobs:
           cat postgres.test
 
       - name: Install dependencies
-        run: pip3 install --break-system-package rangehttpserver
+        run: pip3 install rangehttpserver
 
       # shell needs to be built first to generate the dataset provided by the server
       - name: Extension test build

--- a/.github/workflows/mac-java-workflow.yml
+++ b/.github/workflows/mac-java-workflow.yml
@@ -7,6 +7,8 @@ on:
         type: boolean
         required: true
         default: false
+env:
+  PIP_BREAK_SYSTEM_PACKAGES: 1
 
 jobs:
   build-mac-java-arm:
@@ -17,7 +19,7 @@ jobs:
       - name: Update nightly version
         if: ${{ inputs.isNightly == true }}
         run: |
-          pip3 install packaging --break-system-packages
+          pip3 install packaging
           python3 update-nightly-build-version.py
         working-directory: scripts
 
@@ -41,7 +43,7 @@ jobs:
       - name: Update nightly version
         if: ${{ inputs.isNightly == true }}
         run: |
-          pip3 install packaging --break-system-packages
+          pip3 install packaging
           python3 update-nightly-build-version.py
         working-directory: scripts
 

--- a/.github/workflows/mac-nodejs-workflow.yml
+++ b/.github/workflows/mac-nodejs-workflow.yml
@@ -8,6 +8,8 @@ on:
         type: boolean
         required: true
         default: false
+env:
+  PIP_BREAK_SYSTEM_PACKAGES: 1
 
 jobs:
   build-mac-nodejs-arm64:
@@ -18,7 +20,7 @@ jobs:
       - name: Update nightly version
         if: ${{ inputs.isNightly == true }}
         run: |
-          pip3 install packaging --break-system-packages
+          pip3 install packaging
           python3 update-nightly-build-version.py
         working-directory: scripts
 
@@ -60,7 +62,7 @@ jobs:
       - name: Update nightly version
         if: ${{ inputs.isNightly == true }}
         run: |
-          pip3 install packaging --break-system-packages
+          pip3 install packaging
           python3 update-nightly-build-version.py
         working-directory: scripts
 

--- a/.github/workflows/mac-precompiled-bin-workflow.yml
+++ b/.github/workflows/mac-precompiled-bin-workflow.yml
@@ -8,6 +8,8 @@ on:
         type: boolean
         required: true
         default: false
+env:
+  PIP_BREAK_SYSTEM_PACKAGES: 1
 
 jobs:
   build-precompiled-bin-universal:
@@ -18,7 +20,7 @@ jobs:
       - name: Update nightly version
         if: ${{ inputs.isNightly == true }}
         run: |
-          pip3 install packaging --break-system-packages
+          pip3 install packaging
           python3 update-nightly-build-version.py
         working-directory: scripts
 

--- a/.github/workflows/mac-wheel-workflow.yml
+++ b/.github/workflows/mac-wheel-workflow.yml
@@ -8,6 +8,8 @@ on:
         type: boolean
         required: true
         default: false
+env:
+  PIP_BREAK_SYSTEM_PACKAGES: 1
 
 jobs:
   build-wheels-arm64:
@@ -18,7 +20,7 @@ jobs:
       - name: Update nightly version
         if: ${{ inputs.isNightly == true }}
         run: |
-          pip3 install packaging --break-system-packages
+          pip3 install packaging
           python3 update-nightly-build-version.py
         working-directory: scripts
 
@@ -53,7 +55,7 @@ jobs:
       - name: Update nightly version
         if: ${{ inputs.isNightly == true }}
         run: |
-          pip3 install packaging --break-system-packages
+          pip3 install packaging
           python3 update-nightly-build-version.py
         working-directory: scripts
 

--- a/.github/workflows/multiplatform-build-test.yml
+++ b/.github/workflows/multiplatform-build-test.yml
@@ -2,6 +2,7 @@ name: Multiplatform Build and Test
 
 env:
   USE_EXISTING_BINARY_DATASET: 1
+  PIP_BREAK_SYSTEM_PACKAGES: 1
 
 on:
   workflow_dispatch:
@@ -337,8 +338,8 @@ jobs:
       - name: Ensure Python dependencies
         continue-on-error: true
         run: |
-          pip install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu ${{ matrix.image != 'ubuntu:22.04' && '--break-system-packages' || '' }}
-          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html ${{ matrix.image != 'ubuntu:22.04' && '--break-system-packages' || '' }}
+          pip install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
 
       - name: Ensure Node.js dependencies
         working-directory: tools/nodejs_api
@@ -627,8 +628,8 @@ jobs:
       - name: Ensure Python dependencies
         continue-on-error: true
         run: |
-          pip install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu --break-system-packages
-          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html --break-system-packages
+          pip install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
 
       - name: Ensure Node.js dependencies
         continue-on-error: true

--- a/tools/java_api/build.gradle
+++ b/tools/java_api/build.gradle
@@ -144,3 +144,7 @@ tasks.sourcesJar {
 test {
     useJUnitPlatform()
 }
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}


### PR DESCRIPTION
# Description

We used `--break-system-packages` flags to work around PEP 668. However, this is not very robust. If the Python version is lower than expected, it will fail due to having an extra flag set. In this PR, we remove the flag and use env variables to pass it instead. The higher versions of Python should recognize the env and automaitcally set it for each `pip install`, while for lower versions this will be safely ignored.