### PR TITLE
Rework logical op print info interface

### DIFF
--- a/src/include/binder/query/updating_clause/bound_delete_info.h
+++ b/src/include/binder/query/updating_clause/bound_delete_info.h
@@ -17,6 +17,8 @@ struct BoundDeleteInfo {
         : deleteType{deleteType}, tableType{tableType}, pattern{std::move(pattern)} {}
     EXPLICIT_COPY_DEFAULT_MOVE(BoundDeleteInfo);
 
+    std::string toString() const { return "Delete " + pattern->toString(); }
+
 private:
     BoundDeleteInfo(const BoundDeleteInfo& other)
         : deleteType{other.deleteType}, tableType{other.tableType}, pattern{other.pattern} {}

--- a/src/include/planner/operator/ddl/logical_alter.h
+++ b/src/include/planner/operator/ddl/logical_alter.h
@@ -7,13 +7,9 @@ namespace kuzu {
 namespace planner {
 
 struct LogicalAlterPrintInfo final : OPPrintInfo {
-    common::AlterType alterType;
-    std::string tableName;
     binder::BoundAlterInfo info;
 
-    LogicalAlterPrintInfo(common::AlterType alterType, std::string tableName,
-        binder::BoundAlterInfo info)
-        : alterType{std::move(alterType)}, tableName{std::move(tableName)}, info{std::move(info)} {}
+    explicit LogicalAlterPrintInfo(binder::BoundAlterInfo info) : info{std::move(info)} {}
 
     std::string toString() const override { return info.toString(); }
 
@@ -21,24 +17,24 @@ struct LogicalAlterPrintInfo final : OPPrintInfo {
         return std::unique_ptr<LogicalAlterPrintInfo>(new LogicalAlterPrintInfo(*this));
     }
 
-    LogicalAlterPrintInfo(const LogicalAlterPrintInfo& other)
-        : alterType{other.alterType}, tableName{other.tableName}, info{other.info.copy()} {}
+    LogicalAlterPrintInfo(const LogicalAlterPrintInfo& other) : info{other.info.copy()} {}
 };
 
 class LogicalAlter final : public LogicalDDL {
 public:
     LogicalAlter(binder::BoundAlterInfo info, std::string tableName,
-        std::shared_ptr<binder::Expression> outputExpression,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalDDL{LogicalOperatorType::ALTER, std::move(tableName), std::move(outputExpression),
-              std::move(printInfo)},
+        std::shared_ptr<binder::Expression> outputExpression)
+        : LogicalDDL{LogicalOperatorType::ALTER, std::move(tableName), std::move(outputExpression)},
           info{std::move(info)} {}
 
     const binder::BoundAlterInfo* getInfo() const { return &info; }
 
+    std::unique_ptr<OPPrintInfo> getPrintInfo() const override {
+        return std::make_unique<LogicalAlterPrintInfo>(info.copy());
+    }
+
     std::unique_ptr<LogicalOperator> copy() override {
-        return std::make_unique<LogicalAlter>(info.copy(), tableName, outputExpression,
-            printInfo->copy());
+        return std::make_unique<LogicalAlter>(info.copy(), tableName, outputExpression);
     }
 
 private:

--- a/src/include/planner/operator/ddl/logical_create_sequence.h
+++ b/src/include/planner/operator/ddl/logical_create_sequence.h
@@ -27,17 +27,19 @@ private:
 class LogicalCreateSequence : public LogicalDDL {
 public:
     LogicalCreateSequence(std::string sequenceName, binder::BoundCreateSequenceInfo info,
-        std::shared_ptr<binder::Expression> outputExpression,
-        std::unique_ptr<OPPrintInfo> printInfo)
+        std::shared_ptr<binder::Expression> outputExpression)
         : LogicalDDL{LogicalOperatorType::CREATE_SEQUENCE, std::move(sequenceName),
-              std::move(outputExpression), std::move(printInfo)},
+              std::move(outputExpression)},
           info{std::move(info)} {}
 
     binder::BoundCreateSequenceInfo getInfo() const { return info.copy(); }
 
+    std::unique_ptr<OPPrintInfo> getPrintInfo() const override {
+        return std::make_unique<LogicalCreateSequencePrintInfo>(tableName);
+    }
+
     inline std::unique_ptr<LogicalOperator> copy() final {
-        return std::make_unique<LogicalCreateSequence>(tableName, info.copy(), outputExpression,
-            printInfo->copy());
+        return std::make_unique<LogicalCreateSequence>(tableName, info.copy(), outputExpression);
     }
 
 private:

--- a/src/include/planner/operator/ddl/logical_create_table.h
+++ b/src/include/planner/operator/ddl/logical_create_table.h
@@ -7,13 +7,10 @@ namespace kuzu {
 namespace planner {
 
 struct LogicalCreateTablePrintInfo final : OPPrintInfo {
-    common::TableType tableType;
-    std::string tableName;
     binder::BoundCreateTableInfo info;
 
-    LogicalCreateTablePrintInfo(common::TableType tableType, std::string tableName,
-        binder::BoundCreateTableInfo info)
-        : tableType{std::move(tableType)}, tableName{std::move(tableName)}, info{std::move(info)} {}
+    explicit LogicalCreateTablePrintInfo(binder::BoundCreateTableInfo info)
+        : info{std::move(info)} {}
 
     std::string toString() const override { return info.toString(); }
 
@@ -22,23 +19,25 @@ struct LogicalCreateTablePrintInfo final : OPPrintInfo {
     }
 
     LogicalCreateTablePrintInfo(const LogicalCreateTablePrintInfo& other)
-        : tableType{other.tableType}, tableName{other.tableName}, info{other.info.copy()} {}
+        : info{other.info.copy()} {}
 };
 
 class LogicalCreateTable final : public LogicalDDL {
 public:
     LogicalCreateTable(std::string tableName, binder::BoundCreateTableInfo info,
-        std::shared_ptr<binder::Expression> outputExpression,
-        std::unique_ptr<OPPrintInfo> printInfo)
+        std::shared_ptr<binder::Expression> outputExpression)
         : LogicalDDL{LogicalOperatorType::CREATE_TABLE, std::move(tableName),
-              std::move(outputExpression), std::move(printInfo)},
+              std::move(outputExpression)},
           info{std::move(info)} {}
 
     const binder::BoundCreateTableInfo* getInfo() const { return &info; }
 
+    std::unique_ptr<OPPrintInfo> getPrintInfo() const override {
+        return std::make_unique<LogicalCreateTablePrintInfo>(info.copy());
+    }
+
     std::unique_ptr<LogicalOperator> copy() override {
-        return std::make_unique<LogicalCreateTable>(tableName, info.copy(), outputExpression,
-            printInfo->copy());
+        return std::make_unique<LogicalCreateTable>(tableName, info.copy(), outputExpression);
     }
 
 private:

--- a/src/include/planner/operator/ddl/logical_create_type.h
+++ b/src/include/planner/operator/ddl/logical_create_type.h
@@ -9,7 +9,7 @@ struct LogicalCreateTypePrintInfo final : OPPrintInfo {
     std::string typeName;
     std::string type;
 
-    explicit LogicalCreateTypePrintInfo(std::string typeName, std::string type)
+    LogicalCreateTypePrintInfo(std::string typeName, std::string type)
         : typeName(std::move(typeName)), type(std::move(type)) {}
 
     std::string toString() const override { return typeName + " As " + type; };
@@ -28,16 +28,17 @@ class LogicalCreateType : public LogicalDDL {
 
 public:
     LogicalCreateType(std::string name, common::LogicalType type,
-        std::shared_ptr<binder::Expression> outputExpression,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalDDL{type_, std::move(name), std::move(outputExpression), std::move(printInfo)},
-          type{std::move(type)} {}
+        std::shared_ptr<binder::Expression> outputExpression)
+        : LogicalDDL{type_, std::move(name), std::move(outputExpression)}, type{std::move(type)} {}
 
     const common::LogicalType& getType() const { return type; }
 
+    std::unique_ptr<OPPrintInfo> getPrintInfo() const override {
+        return std::make_unique<LogicalCreateTypePrintInfo>(tableName, type.toString());
+    }
+
     inline std::unique_ptr<LogicalOperator> copy() final {
-        return std::make_unique<LogicalCreateType>(tableName, type.copy(), outputExpression,
-            printInfo->copy());
+        return std::make_unique<LogicalCreateType>(tableName, type.copy(), outputExpression);
     }
 
 private:

--- a/src/include/planner/operator/ddl/logical_ddl.h
+++ b/src/include/planner/operator/ddl/logical_ddl.h
@@ -9,9 +9,8 @@ namespace planner {
 class LogicalDDL : public LogicalOperator {
 public:
     LogicalDDL(LogicalOperatorType operatorType, std::string tableName,
-        std::shared_ptr<binder::Expression> outputExpression,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{operatorType, std::move(printInfo)}, tableName{std::move(tableName)},
+        std::shared_ptr<binder::Expression> outputExpression)
+        : LogicalOperator{operatorType}, tableName{std::move(tableName)},
           outputExpression{std::move(outputExpression)} {}
 
     void computeFactorizedSchema() override;

--- a/src/include/planner/operator/ddl/logical_drop.h
+++ b/src/include/planner/operator/ddl/logical_drop.h
@@ -7,19 +7,29 @@
 namespace kuzu {
 namespace planner {
 
+struct LogicalDropPrintInfo : OPPrintInfo {
+    std::string name;
+
+    explicit LogicalDropPrintInfo(std::string name) : name{std::move(name)} {}
+
+    std::string toString() const override { return name; }
+};
+
 class LogicalDrop : public LogicalDDL {
 public:
     LogicalDrop(const parser::DropInfo& dropInfo,
-        std::shared_ptr<binder::Expression> outputExpression,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalDDL{LogicalOperatorType::DROP, dropInfo.name, std::move(outputExpression),
-              std::move(printInfo)},
+        std::shared_ptr<binder::Expression> outputExpression)
+        : LogicalDDL{LogicalOperatorType::DROP, dropInfo.name, std::move(outputExpression)},
           dropInfo{dropInfo} {}
 
     const parser::DropInfo& getDropInfo() const { return dropInfo; }
 
+    std::unique_ptr<OPPrintInfo> getPrintInfo() const override {
+        return std::make_unique<LogicalDropPrintInfo>(dropInfo.name);
+    }
+
     std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalDrop>(dropInfo, outputExpression, printInfo->copy());
+        return make_unique<LogicalDrop>(dropInfo, outputExpression);
     }
 
 private:

--- a/src/include/planner/operator/extend/base_logical_extend.h
+++ b/src/include/planner/operator/extend/base_logical_extend.h
@@ -7,16 +7,51 @@
 namespace kuzu {
 namespace planner {
 
+struct BaseLogicalExtendPrintInfo : OPPrintInfo {
+    // Start node of extension.
+    std::shared_ptr<binder::NodeExpression> boundNode;
+    // End node of extension.
+    std::shared_ptr<binder::NodeExpression> nbrNode;
+    std::shared_ptr<binder::RelExpression> rel;
+    common::ExtendDirection direction;
+
+    BaseLogicalExtendPrintInfo(std::shared_ptr<binder::NodeExpression> boundNode,
+        std::shared_ptr<binder::NodeExpression> nbrNode, std::shared_ptr<binder::RelExpression> rel,
+        common::ExtendDirection direction)
+        : boundNode{std::move(boundNode)}, nbrNode{std::move(nbrNode)}, rel{std::move(rel)},
+          direction{direction} {}
+
+    std::string toString() const override {
+        switch (direction) {
+        case common::ExtendDirection::FWD: {
+            return "(" + boundNode->toString() + ")-[" + rel->toString() + "]->(" +
+                   nbrNode->toString() + ")";
+        }
+        case common::ExtendDirection::BWD: {
+            return "(" + nbrNode->toString() + ")-[" + rel->toString() + "]->(" +
+                   boundNode->toString() + ")";
+        }
+        case common::ExtendDirection::BOTH: {
+            return "(" + boundNode->toString() + ")-[" + rel->toString() + "]-(" +
+                   nbrNode->toString() + ")";
+        }
+        default: {
+            KU_UNREACHABLE;
+        }
+        }
+    }
+};
+
 class BaseLogicalExtend : public LogicalOperator {
 public:
     BaseLogicalExtend(LogicalOperatorType operatorType,
         std::shared_ptr<binder::NodeExpression> boundNode,
         std::shared_ptr<binder::NodeExpression> nbrNode, std::shared_ptr<binder::RelExpression> rel,
         common::ExtendDirection direction, bool extendFromSource_,
-        std::shared_ptr<LogicalOperator> child, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{operatorType, std::move(child), std::move(printInfo)},
-          boundNode{std::move(boundNode)}, nbrNode{std::move(nbrNode)}, rel{std::move(rel)},
-          direction{direction}, extendFromSource_{extendFromSource_} {}
+        std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{operatorType, std::move(child)}, boundNode{std::move(boundNode)},
+          nbrNode{std::move(nbrNode)}, rel{std::move(rel)}, direction{direction},
+          extendFromSource_{extendFromSource_} {}
 
     std::shared_ptr<binder::NodeExpression> getBoundNode() const { return boundNode; }
     std::shared_ptr<binder::NodeExpression> getNbrNode() const { return nbrNode; }
@@ -29,6 +64,10 @@ public:
     virtual f_group_pos_set getGroupsPosToFlatten() = 0;
 
     std::string getExpressionsForPrinting() const override;
+
+    std::unique_ptr<OPPrintInfo> getPrintInfo() const override {
+        return std::make_unique<BaseLogicalExtendPrintInfo>(boundNode, nbrNode, rel, direction);
+    }
 
 protected:
     // Start node of extension.

--- a/src/include/planner/operator/extend/logical_extend.h
+++ b/src/include/planner/operator/extend/logical_extend.h
@@ -13,10 +13,9 @@ public:
     LogicalExtend(std::shared_ptr<binder::NodeExpression> boundNode,
         std::shared_ptr<binder::NodeExpression> nbrNode, std::shared_ptr<binder::RelExpression> rel,
         common::ExtendDirection direction, bool extendFromSource,
-        binder::expression_vector properties, std::shared_ptr<LogicalOperator> child,
-        std::unique_ptr<OPPrintInfo> printInfo)
+        binder::expression_vector properties, std::shared_ptr<LogicalOperator> child)
         : BaseLogicalExtend{type_, std::move(boundNode), std::move(nbrNode), std::move(rel),
-              direction, extendFromSource, std::move(child), std::move(printInfo)},
+              direction, extendFromSource, std::move(child)},
           scanNbrID{true}, properties{std::move(properties)} {}
 
     f_group_pos_set getGroupsPosToFlatten() override { return f_group_pos_set{}; }

--- a/src/include/planner/operator/extend/logical_recursive_extend.h
+++ b/src/include/planner/operator/extend/logical_recursive_extend.h
@@ -14,10 +14,9 @@ public:
     LogicalRecursiveExtend(std::shared_ptr<binder::NodeExpression> boundNode,
         std::shared_ptr<binder::NodeExpression> nbrNode, std::shared_ptr<binder::RelExpression> rel,
         common::ExtendDirection direction, bool extendFromSource, RecursiveJoinType joinType,
-        std::shared_ptr<LogicalOperator> child, std::shared_ptr<LogicalOperator> recursiveChild,
-        std::unique_ptr<OPPrintInfo> printInfo)
+        std::shared_ptr<LogicalOperator> child, std::shared_ptr<LogicalOperator> recursiveChild)
         : BaseLogicalExtend{type_, std::move(boundNode), std::move(nbrNode), std::move(rel),
-              direction, extendFromSource, std::move(child), std::move(printInfo)},
+              direction, extendFromSource, std::move(child)},
           joinType{joinType}, recursiveChild{std::move(recursiveChild)} {}
 
     f_group_pos_set getGroupsPosToFlatten() override;
@@ -31,8 +30,7 @@ public:
 
     std::unique_ptr<LogicalOperator> copy() override {
         return std::make_unique<LogicalRecursiveExtend>(boundNode, nbrNode, rel, direction,
-            extendFromSource_, joinType, children[0]->copy(), recursiveChild->copy(),
-            printInfo->copy());
+            extendFromSource_, joinType, children[0]->copy(), recursiveChild->copy());
     }
 
 private:
@@ -46,11 +44,9 @@ class LogicalPathPropertyProbe : public LogicalOperator {
 public:
     LogicalPathPropertyProbe(std::shared_ptr<binder::RelExpression> rel,
         std::shared_ptr<LogicalOperator> probeChild, std::shared_ptr<LogicalOperator> nodeChild,
-        std::shared_ptr<LogicalOperator> relChild, RecursiveJoinType joinType,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{type_, std::move(probeChild), std::move(printInfo)},
-          recursiveRel{std::move(rel)}, nodeChild{std::move(nodeChild)},
-          relChild{std::move(relChild)}, joinType{joinType} {}
+        std::shared_ptr<LogicalOperator> relChild, RecursiveJoinType joinType)
+        : LogicalOperator{type_, std::move(probeChild)}, recursiveRel{std::move(rel)},
+          nodeChild{std::move(nodeChild)}, relChild{std::move(relChild)}, joinType{joinType} {}
 
     void computeFactorizedSchema() final;
     void computeFlatSchema() final;

--- a/src/include/planner/operator/logical_accumulate.h
+++ b/src/include/planner/operator/logical_accumulate.h
@@ -10,8 +10,8 @@ class LogicalAccumulate final : public LogicalOperator {
 public:
     LogicalAccumulate(common::AccumulateType accumulateType, binder::expression_vector flatExprs,
         std::shared_ptr<binder::Expression> offset, std::shared_ptr<binder::Expression> mark,
-        std::shared_ptr<LogicalOperator> child, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{LogicalOperatorType::ACCUMULATE, std::move(child), std::move(printInfo)},
+        std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{LogicalOperatorType::ACCUMULATE, std::move(child)},
           accumulateType{accumulateType}, flatExprs{std::move(flatExprs)},
           offset{std::move(offset)}, mark{std::move(mark)} {}
 
@@ -32,7 +32,7 @@ public:
 
     std::unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalAccumulate>(accumulateType, flatExprs, offset, mark,
-            children[0]->copy(), printInfo->copy());
+            children[0]->copy());
     }
 
 private:

--- a/src/include/planner/operator/logical_aggregate.h
+++ b/src/include/planner/operator/logical_aggregate.h
@@ -23,20 +23,18 @@ private:
         : OPPrintInfo(other), keys(other.keys), aggregates(other.aggregates) {}
 };
 
-class LogicalAggregate : public LogicalOperator {
+class LogicalAggregate final : public LogicalOperator {
     static constexpr LogicalOperatorType operatorType_ = LogicalOperatorType::AGGREGATE;
 
 public:
     LogicalAggregate(binder::expression_vector keys, binder::expression_vector aggregates,
-        std::shared_ptr<LogicalOperator> child, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{operatorType_, std::move(child), std::move(printInfo)},
-          keys{std::move(keys)}, aggregates{std::move(aggregates)} {}
-    LogicalAggregate(binder::expression_vector keys, binder::expression_vector dependentKeys,
-        binder::expression_vector aggregates, std::shared_ptr<LogicalOperator> child,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{operatorType_, std::move(child), std::move(printInfo)},
-          keys{std::move(keys)}, dependentKeys{std::move(dependentKeys)},
+        std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{operatorType_, std::move(child)}, keys{std::move(keys)},
           aggregates{std::move(aggregates)} {}
+    LogicalAggregate(binder::expression_vector keys, binder::expression_vector dependentKeys,
+        binder::expression_vector aggregates, std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{operatorType_, std::move(child)}, keys{std::move(keys)},
+          dependentKeys{std::move(dependentKeys)}, aggregates{std::move(aggregates)} {}
 
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
@@ -62,8 +60,7 @@ public:
     binder::expression_vector getAggregates() const { return aggregates; }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalAggregate>(keys, dependentKeys, aggregates, children[0]->copy(),
-            printInfo->copy());
+        return make_unique<LogicalAggregate>(keys, dependentKeys, aggregates, children[0]->copy());
     }
 
 private:

--- a/src/include/planner/operator/logical_create_macro.h
+++ b/src/include/planner/operator/logical_create_macro.h
@@ -22,12 +22,11 @@ private:
         : OPPrintInfo(other), macroName(other.macroName) {}
 };
 
-class LogicalCreateMacro : public LogicalOperator {
+class LogicalCreateMacro final : public LogicalOperator {
 public:
     LogicalCreateMacro(std::shared_ptr<binder::Expression> outputExpression, std::string macroName,
-        std::unique_ptr<function::ScalarMacroFunction> macro,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{LogicalOperatorType::CREATE_MACRO, std::move(printInfo)},
+        std::unique_ptr<function::ScalarMacroFunction> macro)
+        : LogicalOperator{LogicalOperatorType::CREATE_MACRO},
           outputExpression{std::move(outputExpression)}, macroName{std::move(macroName)},
           macro{std::move(macro)} {}
 
@@ -45,8 +44,7 @@ public:
     inline std::string getExpressionsForPrinting() const override { return macroName; }
 
     inline std::unique_ptr<LogicalOperator> copy() override {
-        return std::make_unique<LogicalCreateMacro>(outputExpression, macroName, macro->copy(),
-            printInfo->copy());
+        return std::make_unique<LogicalCreateMacro>(outputExpression, macroName, macro->copy());
     }
 
 private:

--- a/src/include/planner/operator/logical_cross_product.h
+++ b/src/include/planner/operator/logical_cross_product.h
@@ -7,14 +7,14 @@
 namespace kuzu {
 namespace planner {
 
-class LogicalCrossProduct : public LogicalOperator {
+class LogicalCrossProduct final : public LogicalOperator {
     static constexpr LogicalOperatorType type_ = LogicalOperatorType::CROSS_PRODUCT;
 
 public:
     LogicalCrossProduct(common::AccumulateType accumulateType,
         std::shared_ptr<binder::Expression> mark, std::shared_ptr<LogicalOperator> probeChild,
-        std::shared_ptr<LogicalOperator> buildChild, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{type_, std::move(probeChild), std::move(buildChild), printInfo->copy()},
+        std::shared_ptr<LogicalOperator> buildChild)
+        : LogicalOperator{type_, std::move(probeChild), std::move(buildChild)},
           accumulateType{accumulateType}, mark{std::move(mark)} {}
 
     void computeFactorizedSchema() override;
@@ -31,7 +31,7 @@ public:
 
     std::unique_ptr<LogicalOperator> copy() override {
         auto op = make_unique<LogicalCrossProduct>(accumulateType, mark, children[0]->copy(),
-            children[1]->copy(), printInfo->copy());
+            children[1]->copy());
         op->sipInfo = sipInfo;
         return op;
     }

--- a/src/include/planner/operator/logical_distinct.h
+++ b/src/include/planner/operator/logical_distinct.h
@@ -5,16 +5,14 @@
 namespace kuzu {
 namespace planner {
 
-class LogicalDistinct : public LogicalOperator {
+class LogicalDistinct final : public LogicalOperator {
 public:
-    LogicalDistinct(binder::expression_vector keys, std::shared_ptr<LogicalOperator> child,
-        std::unique_ptr<OPPrintInfo> printInfo)
+    LogicalDistinct(binder::expression_vector keys, std::shared_ptr<LogicalOperator> child)
         : LogicalDistinct{LogicalOperatorType::DISTINCT, keys, binder::expression_vector{},
-              std::move(child), std::move(printInfo)} {}
+              std::move(child)} {}
     LogicalDistinct(LogicalOperatorType type, binder::expression_vector keys,
-        binder::expression_vector payloads, std::shared_ptr<LogicalOperator> child,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{type, std::move(child), std::move(printInfo)}, keys{std::move(keys)},
+        binder::expression_vector payloads, std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{type, std::move(child)}, keys{std::move(keys)},
           payloads{std::move(payloads)} {}
 
     void computeFactorizedSchema() override;
@@ -30,8 +28,7 @@ public:
     void setPayloads(binder::expression_vector expressions) { payloads = std::move(expressions); }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalDistinct>(operatorType, keys, payloads, children[0]->copy(),
-            printInfo->copy());
+        return make_unique<LogicalDistinct>(operatorType, keys, payloads, children[0]->copy());
     }
 
 protected:

--- a/src/include/planner/operator/logical_empty_result.h
+++ b/src/include/planner/operator/logical_empty_result.h
@@ -7,9 +7,8 @@ namespace planner {
 
 class LogicalEmptyResult final : public LogicalOperator {
 public:
-    explicit LogicalEmptyResult(const Schema& schema, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{LogicalOperatorType::EMPTY_RESULT, std::move(printInfo)},
-          originalSchema{schema.copy()} {
+    explicit LogicalEmptyResult(const Schema& schema)
+        : LogicalOperator{LogicalOperatorType::EMPTY_RESULT}, originalSchema{schema.copy()} {
         this->schema = schema.copy();
     }
 
@@ -25,7 +24,7 @@ public:
     std::string getExpressionsForPrinting() const override { return std::string{}; }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return std::make_unique<LogicalEmptyResult>(*originalSchema, printInfo->copy());
+        return std::make_unique<LogicalEmptyResult>(*originalSchema);
     }
 
 private:

--- a/src/include/planner/operator/logical_explain.h
+++ b/src/include/planner/operator/logical_explain.h
@@ -8,13 +8,12 @@
 namespace kuzu {
 namespace planner {
 
-class LogicalExplain : public LogicalOperator {
+class LogicalExplain final : public LogicalOperator {
 public:
     LogicalExplain(std::shared_ptr<LogicalOperator> child,
         std::shared_ptr<binder::Expression> outputExpression, common::ExplainType explainType,
-        binder::expression_vector outputExpressionsToExplain,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{LogicalOperatorType::EXPLAIN, std::move(child), std::move(printInfo)},
+        binder::expression_vector outputExpressionsToExplain)
+        : LogicalOperator{LogicalOperatorType::EXPLAIN, std::move(child)},
           outputExpression{std::move(outputExpression)}, explainType{explainType},
           outputExpressionsToExplain{std::move(outputExpressionsToExplain)} {}
 
@@ -36,7 +35,7 @@ public:
 
     inline std::unique_ptr<LogicalOperator> copy() override {
         return std::make_unique<LogicalExplain>(children[0], outputExpression, explainType,
-            outputExpressionsToExplain, printInfo->copy());
+            outputExpressionsToExplain);
     }
 
 private:

--- a/src/include/planner/operator/logical_filter.h
+++ b/src/include/planner/operator/logical_filter.h
@@ -6,11 +6,11 @@
 namespace kuzu {
 namespace planner {
 
-class LogicalFilter : public LogicalOperator {
+class LogicalFilter final : public LogicalOperator {
 public:
     LogicalFilter(std::shared_ptr<binder::Expression> expression,
-        std::shared_ptr<LogicalOperator> child, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{LogicalOperatorType::FILTER, std::move(child), std::move(printInfo)},
+        std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{LogicalOperatorType::FILTER, std::move(child)},
           expression{std::move(expression)} {}
 
     inline void computeFactorizedSchema() override { copyChildSchema(0); }
@@ -25,7 +25,7 @@ public:
     f_group_pos getGroupPosToSelect() const;
 
     inline std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalFilter>(expression, children[0]->copy(), printInfo->copy());
+        return make_unique<LogicalFilter>(expression, children[0]->copy());
     }
 
 private:

--- a/src/include/planner/operator/logical_flatten.h
+++ b/src/include/planner/operator/logical_flatten.h
@@ -5,12 +5,10 @@
 namespace kuzu {
 namespace planner {
 
-class LogicalFlatten : public LogicalOperator {
+class LogicalFlatten final : public LogicalOperator {
 public:
-    LogicalFlatten(f_group_pos groupPos, std::shared_ptr<LogicalOperator> child,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{LogicalOperatorType::FLATTEN, std::move(child), std::move(printInfo)},
-          groupPos{groupPos} {}
+    LogicalFlatten(f_group_pos groupPos, std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{LogicalOperatorType::FLATTEN, std::move(child)}, groupPos{groupPos} {}
 
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
@@ -20,7 +18,7 @@ public:
     inline f_group_pos getGroupPos() const { return groupPos; }
 
     inline std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalFlatten>(groupPos, children[0]->copy(), printInfo->copy());
+        return make_unique<LogicalFlatten>(groupPos, children[0]->copy());
     }
 
 private:

--- a/src/include/planner/operator/logical_gds_call.h
+++ b/src/include/planner/operator/logical_gds_call.h
@@ -10,8 +10,8 @@ class LogicalGDSCall final : public LogicalOperator {
     static constexpr LogicalOperatorType operatorType_ = LogicalOperatorType::GDS_CALL;
 
 public:
-    explicit LogicalGDSCall(binder::BoundGDSCallInfo info, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{operatorType_, std::move(printInfo)}, info{std::move(info)} {}
+    explicit LogicalGDSCall(binder::BoundGDSCallInfo info)
+        : LogicalOperator{operatorType_}, info{std::move(info)} {}
 
     void computeFlatSchema() override;
     void computeFactorizedSchema() override;
@@ -21,7 +21,7 @@ public:
     std::string getExpressionsForPrinting() const override { return info.func.name; }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return std::make_unique<LogicalGDSCall>(info.copy(), printInfo->copy());
+        return std::make_unique<LogicalGDSCall>(info.copy());
     }
 
 private:

--- a/src/include/planner/operator/logical_hash_join.h
+++ b/src/include/planner/operator/logical_hash_join.h
@@ -11,15 +11,14 @@ namespace planner {
 using join_condition_t = binder::expression_pair;
 
 // Probe side on left, i.e. children[0]. Build side on right, i.e. children[1].
-class LogicalHashJoin : public LogicalOperator {
+class LogicalHashJoin final : public LogicalOperator {
     static constexpr LogicalOperatorType type_ = LogicalOperatorType::HASH_JOIN;
 
 public:
     LogicalHashJoin(std::vector<join_condition_t> joinConditions, common::JoinType joinType,
         std::shared_ptr<binder::Expression> mark, std::shared_ptr<LogicalOperator> probeChild,
-        std::shared_ptr<LogicalOperator> buildChild, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{type_, std::move(probeChild), std::move(buildChild),
-              std::move(printInfo)},
+        std::shared_ptr<LogicalOperator> buildChild)
+        : LogicalOperator{type_, std::move(probeChild), std::move(buildChild)},
           joinConditions(std::move(joinConditions)), joinType{joinType}, mark{std::move(mark)} {}
 
     f_group_pos_set getGroupsPosToFlattenOnProbeSide();

--- a/src/include/planner/operator/logical_intersect.h
+++ b/src/include/planner/operator/logical_intersect.h
@@ -6,15 +6,14 @@
 namespace kuzu {
 namespace planner {
 
-class LogicalIntersect : public LogicalOperator {
+class LogicalIntersect final : public LogicalOperator {
     static constexpr LogicalOperatorType type_ = LogicalOperatorType::INTERSECT;
 
 public:
     LogicalIntersect(std::shared_ptr<binder::Expression> intersectNodeID,
         binder::expression_vector keyNodeIDs, std::shared_ptr<LogicalOperator> probeChild,
-        std::vector<std::shared_ptr<LogicalOperator>> buildChildren,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{type_, std::move(probeChild), std::move(printInfo)},
+        std::vector<std::shared_ptr<LogicalOperator>> buildChildren)
+        : LogicalOperator{type_, std::move(probeChild)},
           intersectNodeID{std::move(intersectNodeID)}, keyNodeIDs{std::move(keyNodeIDs)} {
         for (auto& child : buildChildren) {
             children.push_back(std::move(child));

--- a/src/include/planner/operator/logical_limit.h
+++ b/src/include/planner/operator/logical_limit.h
@@ -5,19 +5,18 @@
 namespace kuzu {
 namespace planner {
 
-class LogicalLimit : public LogicalOperator {
+class LogicalLimit final : public LogicalOperator {
 public:
-    LogicalLimit(uint64_t skipNum, uint64_t limitNum, std::shared_ptr<LogicalOperator> child,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{LogicalOperatorType::LIMIT, std::move(child), std::move(printInfo)},
-          skipNum{skipNum}, limitNum{limitNum} {}
+    LogicalLimit(uint64_t skipNum, uint64_t limitNum, std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{LogicalOperatorType::LIMIT, std::move(child)}, skipNum{skipNum},
+          limitNum{limitNum} {}
 
     f_group_pos_set getGroupsPosToFlatten();
 
-    inline void computeFactorizedSchema() final { copyChildSchema(0); }
-    inline void computeFlatSchema() final { copyChildSchema(0); }
+    inline void computeFactorizedSchema() override { copyChildSchema(0); }
+    inline void computeFlatSchema() override { copyChildSchema(0); }
 
-    std::string getExpressionsForPrinting() const final;
+    std::string getExpressionsForPrinting() const override;
 
     inline bool hasSkipNum() const { return skipNum != UINT64_MAX; }
     inline uint64_t getSkipNum() const { return skipNum; }
@@ -30,8 +29,8 @@ public:
         return schema->getGroupsPosInScope();
     }
 
-    inline std::unique_ptr<LogicalOperator> copy() final {
-        return make_unique<LogicalLimit>(skipNum, limitNum, children[0]->copy(), printInfo->copy());
+    inline std::unique_ptr<LogicalOperator> copy() override {
+        return make_unique<LogicalLimit>(skipNum, limitNum, children[0]->copy());
     }
 
 private:

--- a/src/include/planner/operator/logical_multiplcity_reducer.h
+++ b/src/include/planner/operator/logical_multiplcity_reducer.h
@@ -5,12 +5,10 @@
 namespace kuzu {
 namespace planner {
 
-class LogicalMultiplicityReducer : public LogicalOperator {
+class LogicalMultiplicityReducer final : public LogicalOperator {
 public:
-    explicit LogicalMultiplicityReducer(std::shared_ptr<LogicalOperator> child,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator(LogicalOperatorType::MULTIPLICITY_REDUCER, std::move(child),
-              std::move(printInfo)) {}
+    explicit LogicalMultiplicityReducer(std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator(LogicalOperatorType::MULTIPLICITY_REDUCER, std::move(child)) {}
 
     inline void computeFactorizedSchema() override { copyChildSchema(0); }
     inline void computeFlatSchema() override { copyChildSchema(0); }
@@ -18,7 +16,7 @@ public:
     inline std::string getExpressionsForPrinting() const override { return std::string(); }
 
     inline std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalMultiplicityReducer>(children[0]->copy(), printInfo->copy());
+        return make_unique<LogicalMultiplicityReducer>(children[0]->copy());
     }
 };
 

--- a/src/include/planner/operator/logical_node_label_filter.h
+++ b/src/include/planner/operator/logical_node_label_filter.h
@@ -5,26 +5,23 @@
 namespace kuzu {
 namespace planner {
 
-class LogicalNodeLabelFilter : public LogicalOperator {
+class LogicalNodeLabelFilter final : public LogicalOperator {
 public:
     LogicalNodeLabelFilter(std::shared_ptr<binder::Expression> nodeID,
-        std::unordered_set<common::table_id_t> tableIDSet, std::shared_ptr<LogicalOperator> child,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{LogicalOperatorType::NODE_LABEL_FILTER, std::move(child),
-              std::move(printInfo)},
+        std::unordered_set<common::table_id_t> tableIDSet, std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{LogicalOperatorType::NODE_LABEL_FILTER, std::move(child)},
           nodeID{std::move(nodeID)}, tableIDSet{std::move(tableIDSet)} {}
 
-    inline void computeFactorizedSchema() final { copyChildSchema(0); }
-    inline void computeFlatSchema() final { copyChildSchema(0); }
+    inline void computeFactorizedSchema() override { copyChildSchema(0); }
+    inline void computeFlatSchema() override { copyChildSchema(0); }
 
-    inline std::string getExpressionsForPrinting() const final { return nodeID->toString(); }
+    inline std::string getExpressionsForPrinting() const override { return nodeID->toString(); }
 
     inline std::shared_ptr<binder::Expression> getNodeID() const { return nodeID; }
     inline std::unordered_set<common::table_id_t> getTableIDSet() const { return tableIDSet; }
 
-    std::unique_ptr<LogicalOperator> copy() final {
-        return std::make_unique<LogicalNodeLabelFilter>(nodeID, tableIDSet, children[0]->copy(),
-            printInfo->copy());
+    std::unique_ptr<LogicalOperator> copy() override {
+        return std::make_unique<LogicalNodeLabelFilter>(nodeID, tableIDSet, children[0]->copy());
     }
 
 private:

--- a/src/include/planner/operator/logical_order_by.h
+++ b/src/include/planner/operator/logical_order_by.h
@@ -5,20 +5,20 @@
 namespace kuzu {
 namespace planner {
 
-class LogicalOrderBy : public LogicalOperator {
+class LogicalOrderBy final : public LogicalOperator {
 public:
     LogicalOrderBy(binder::expression_vector expressionsToOrderBy, std::vector<bool> sortOrders,
-        std::shared_ptr<LogicalOperator> child, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{LogicalOperatorType::ORDER_BY, std::move(child), std::move(printInfo)},
+        std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{LogicalOperatorType::ORDER_BY, std::move(child)},
           expressionsToOrderBy{std::move(expressionsToOrderBy)},
           isAscOrders{std::move(sortOrders)} {}
 
     f_group_pos_set getGroupsPosToFlatten();
 
-    void computeFactorizedSchema() final;
-    void computeFlatSchema() final;
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
 
-    std::string getExpressionsForPrinting() const final;
+    std::string getExpressionsForPrinting() const override;
 
     inline binder::expression_vector getExpressionsToOrderBy() const {
         return expressionsToOrderBy;
@@ -32,9 +32,8 @@ public:
     inline bool hasLimitNum() const { return limitNum != UINT64_MAX; }
     inline uint64_t getLimitNum() const { return limitNum; }
 
-    inline std::unique_ptr<LogicalOperator> copy() final {
-        return make_unique<LogicalOrderBy>(expressionsToOrderBy, isAscOrders, children[0]->copy(),
-            printInfo->copy());
+    inline std::unique_ptr<LogicalOperator> copy() override {
+        return make_unique<LogicalOrderBy>(expressionsToOrderBy, isAscOrders, children[0]->copy());
     }
 
 private:

--- a/src/include/planner/operator/logical_partitioner.h
+++ b/src/include/planner/operator/logical_partitioner.h
@@ -46,8 +46,8 @@ struct LogicalPartitionerInfo {
 class LogicalPartitioner final : public LogicalOperator {
 public:
     LogicalPartitioner(LogicalPartitionerInfo info, binder::BoundCopyFromInfo copyFromInfo,
-        std::shared_ptr<LogicalOperator> child, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{LogicalOperatorType::PARTITIONER, std::move(child), std::move(printInfo)},
+        std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{LogicalOperatorType::PARTITIONER, std::move(child)},
           info{std::move(info)}, copyFromInfo{std::move(copyFromInfo)} {}
 
     void computeFactorizedSchema() override;
@@ -60,7 +60,7 @@ public:
 
     std::unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalPartitioner>(info.copy(), copyFromInfo.copy(),
-            children[0]->copy(), printInfo->copy());
+            children[0]->copy());
     }
 
 private:

--- a/src/include/planner/operator/logical_projection.h
+++ b/src/include/planner/operator/logical_projection.h
@@ -10,8 +10,8 @@ namespace planner {
 class LogicalProjection : public LogicalOperator {
 public:
     explicit LogicalProjection(binder::expression_vector expressions,
-        std::shared_ptr<LogicalOperator> child, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{LogicalOperatorType::PROJECTION, std::move(child), std::move(printInfo)},
+        std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{LogicalOperatorType::PROJECTION, std::move(child)},
           expressions{std::move(expressions)} {}
 
     void computeFactorizedSchema() override;
@@ -26,7 +26,7 @@ public:
     std::unordered_set<uint32_t> getDiscardedGroupsPos() const;
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalProjection>(expressions, children[0]->copy(), printInfo->copy());
+        return make_unique<LogicalProjection>(expressions, children[0]->copy());
     }
 
 private:

--- a/src/include/planner/operator/logical_standalone_call.h
+++ b/src/include/planner/operator/logical_standalone_call.h
@@ -8,10 +8,9 @@ namespace planner {
 
 class LogicalStandaloneCall : public LogicalOperator {
 public:
-    LogicalStandaloneCall(main::Option* option, std::shared_ptr<binder::Expression> optionValue,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{LogicalOperatorType::STANDALONE_CALL, std::move(printInfo)},
-          option{option}, optionValue{std::move(optionValue)} {}
+    LogicalStandaloneCall(main::Option* option, std::shared_ptr<binder::Expression> optionValue)
+        : LogicalOperator{LogicalOperatorType::STANDALONE_CALL}, option{option},
+          optionValue{std::move(optionValue)} {}
 
     inline main::Option* getOption() const { return option; }
     inline std::shared_ptr<binder::Expression> getOptionValue() const { return optionValue; }
@@ -23,7 +22,7 @@ public:
     inline void computeFactorizedSchema() override { createEmptySchema(); }
 
     inline std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalStandaloneCall>(option, optionValue, printInfo->copy());
+        return make_unique<LogicalStandaloneCall>(option, optionValue);
     }
 
 protected:

--- a/src/include/planner/operator/logical_table_function_call.h
+++ b/src/include/planner/operator/logical_table_function_call.h
@@ -13,9 +13,9 @@ class LogicalTableFunctionCall : public LogicalOperator {
 public:
     LogicalTableFunctionCall(function::TableFunction tableFunc,
         std::unique_ptr<function::TableFuncBindData> bindData, binder::expression_vector columns,
-        std::shared_ptr<binder::Expression> offset, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{operatorType_, std::move(printInfo)}, tableFunc{tableFunc},
-          bindData{std::move(bindData)}, columns{std::move(columns)}, offset{std::move(offset)} {}
+        std::shared_ptr<binder::Expression> offset)
+        : LogicalOperator{operatorType_}, tableFunc{tableFunc}, bindData{std::move(bindData)},
+          columns{std::move(columns)}, offset{std::move(offset)} {}
 
     const function::TableFunction& getTableFunc() const { return tableFunc; }
     const function::TableFuncBindData* getBindData() const { return bindData.get(); }
@@ -38,7 +38,7 @@ public:
 
     std::unique_ptr<LogicalOperator> copy() override {
         return std::make_unique<LogicalTableFunctionCall>(tableFunc, bindData->copy(), columns,
-            offset, printInfo->copy());
+            offset);
     }
 
 private:

--- a/src/include/planner/operator/logical_transaction.h
+++ b/src/include/planner/operator/logical_transaction.h
@@ -10,9 +10,8 @@ class LogicalTransaction : public LogicalOperator {
     static constexpr LogicalOperatorType type_ = LogicalOperatorType::TRANSACTION;
 
 public:
-    LogicalTransaction(transaction::TransactionAction transactionAction,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{type_, std::move(printInfo)}, transactionAction{transactionAction} {}
+    explicit LogicalTransaction(transaction::TransactionAction transactionAction)
+        : LogicalOperator{type_}, transactionAction{transactionAction} {}
 
     std::string getExpressionsForPrinting() const final { return std::string(); }
 
@@ -22,7 +21,7 @@ public:
     transaction::TransactionAction getTransactionAction() const { return transactionAction; }
 
     std::unique_ptr<LogicalOperator> copy() final {
-        return std::make_unique<LogicalTransaction>(transactionAction, printInfo->copy());
+        return std::make_unique<LogicalTransaction>(transactionAction);
     }
 
 private:

--- a/src/include/planner/operator/logical_union.h
+++ b/src/include/planner/operator/logical_union.h
@@ -8,9 +8,8 @@ namespace planner {
 class LogicalUnion : public LogicalOperator {
 public:
     LogicalUnion(binder::expression_vector expressions,
-        const std::vector<std::shared_ptr<LogicalOperator>>& children,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{LogicalOperatorType::UNION_ALL, children, std::move(printInfo)},
+        const std::vector<std::shared_ptr<LogicalOperator>>& children)
+        : LogicalOperator{LogicalOperatorType::UNION_ALL, children},
           expressionsToUnion{std::move(expressions)} {}
 
     f_group_pos_set getGroupsPosToFlatten(uint32_t childIdx);

--- a/src/include/planner/operator/logical_unwind.h
+++ b/src/include/planner/operator/logical_unwind.h
@@ -9,9 +9,8 @@ class LogicalUnwind : public LogicalOperator {
 public:
     LogicalUnwind(std::shared_ptr<binder::Expression> inExpr,
         std::shared_ptr<binder::Expression> outExpr, std::shared_ptr<binder::Expression> idExpr,
-        std::shared_ptr<LogicalOperator> childOperator, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{LogicalOperatorType::UNWIND, std::move(childOperator),
-              std::move(printInfo)},
+        std::shared_ptr<LogicalOperator> childOperator)
+        : LogicalOperator{LogicalOperatorType::UNWIND, std::move(childOperator)},
           inExpr{std::move(inExpr)}, outExpr{std::move(outExpr)}, idExpr{std::move(idExpr)} {}
 
     f_group_pos_set getGroupsPosToFlatten();
@@ -27,8 +26,7 @@ public:
     std::string getExpressionsForPrinting() const override { return inExpr->toString(); }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalUnwind>(inExpr, outExpr, idExpr, children[0]->copy(),
-            printInfo->copy());
+        return make_unique<LogicalUnwind>(inExpr, outExpr, idExpr, children[0]->copy());
     }
 
 private:

--- a/src/include/planner/operator/persistent/logical_copy_from.h
+++ b/src/include/planner/operator/persistent/logical_copy_from.h
@@ -28,12 +28,12 @@ class LogicalCopyFrom final : public LogicalOperator {
 
 public:
     LogicalCopyFrom(binder::BoundCopyFromInfo info, binder::expression_vector outExprs,
-        std::shared_ptr<LogicalOperator> child, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{type_, std::move(child), std::move(printInfo)}, info{std::move(info)},
+        std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{type_, std::move(child)}, info{std::move(info)},
           outExprs{std::move(outExprs)} {}
     LogicalCopyFrom(binder::BoundCopyFromInfo info, binder::expression_vector outExprs,
-        logical_op_vector_t children, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{type_, std::move(children), std::move(printInfo)}, info{std::move(info)},
+        logical_op_vector_t children)
+        : LogicalOperator{type_, std::move(children)}, info{std::move(info)},
           outExprs{std::move(outExprs)} {}
 
     std::string getExpressionsForPrinting() const override { return info.tableEntry->getName(); }
@@ -44,9 +44,12 @@ public:
     const binder::BoundCopyFromInfo* getInfo() const { return &info; }
     binder::expression_vector getOutExprs() const { return outExprs; }
 
+    std::unique_ptr<OPPrintInfo> getPrintInfo() const override {
+        return std::make_unique<LogicalCopyFromPrintInfo>(info.tableEntry->getName());
+    }
+
     std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalCopyFrom>(info.copy(), outExprs, LogicalOperator::copy(children),
-            printInfo->copy());
+        return make_unique<LogicalCopyFrom>(info.copy(), outExprs, LogicalOperator::copy(children));
     }
 
 private:

--- a/src/include/planner/operator/persistent/logical_copy_to.h
+++ b/src/include/planner/operator/persistent/logical_copy_to.h
@@ -24,12 +24,11 @@ private:
         : OPPrintInfo(other), columnNames(other.columnNames), fileName(other.fileName) {}
 };
 
-class LogicalCopyTo : public LogicalOperator {
+class LogicalCopyTo final : public LogicalOperator {
 public:
     LogicalCopyTo(std::unique_ptr<function::ExportFuncBindData> bindData,
-        function::ExportFunction exportFunc, std::shared_ptr<LogicalOperator> child,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{LogicalOperatorType::COPY_TO, std::move(child), std::move(printInfo)},
+        function::ExportFunction exportFunc, std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{LogicalOperatorType::COPY_TO, std::move(child)},
           bindData{std::move(bindData)}, exportFunc{std::move(exportFunc)} {}
 
     f_group_pos_set getGroupsPosToFlatten();
@@ -42,9 +41,12 @@ public:
     std::unique_ptr<function::ExportFuncBindData> getBindData() const { return bindData->copy(); }
     function::ExportFunction getExportFunc() const { return exportFunc; };
 
+    std::unique_ptr<OPPrintInfo> getPrintInfo() const override {
+        return std::make_unique<LogicalCopyToPrintInfo>(bindData->columnNames, bindData->fileName);
+    }
+
     std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalCopyTo>(bindData->copy(), exportFunc, children[0]->copy(),
-            printInfo->copy());
+        return make_unique<LogicalCopyTo>(bindData->copy(), exportFunc, children[0]->copy());
     }
 
 private:

--- a/src/include/planner/operator/persistent/logical_insert.h
+++ b/src/include/planner/operator/persistent/logical_insert.h
@@ -33,9 +33,8 @@ class LogicalInsert final : public LogicalOperator {
     static constexpr LogicalOperatorType type_ = LogicalOperatorType::INSERT;
 
 public:
-    LogicalInsert(std::vector<LogicalInsertInfo> infos, std::shared_ptr<LogicalOperator> child,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{type_, std::move(child), std::move(printInfo)}, infos{std::move(infos)} {}
+    LogicalInsert(std::vector<LogicalInsertInfo> infos, std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{type_, std::move(child)}, infos{std::move(infos)} {}
 
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
@@ -47,8 +46,7 @@ public:
     const std::vector<LogicalInsertInfo>& getInfos() const { return infos; }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return std::make_unique<LogicalInsert>(copyVector(infos), children[0]->copy(),
-            printInfo->copy());
+        return std::make_unique<LogicalInsert>(copyVector(infos), children[0]->copy());
     }
 
 private:

--- a/src/include/planner/operator/persistent/logical_merge.h
+++ b/src/include/planner/operator/persistent/logical_merge.h
@@ -12,9 +12,9 @@ class LogicalMerge final : public LogicalOperator {
 
 public:
     LogicalMerge(std::shared_ptr<binder::Expression> existenceMark, binder::expression_vector keys,
-        std::shared_ptr<LogicalOperator> child, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{type_, std::move(child), std::move(printInfo)},
-          existenceMark{std::move(existenceMark)}, keys{std::move(keys)} {}
+        std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{type_, std::move(child)}, existenceMark{std::move(existenceMark)},
+          keys{std::move(keys)} {}
 
     void computeFactorizedSchema() final;
     void computeFlatSchema() final;

--- a/src/include/planner/operator/persistent/logical_set.h
+++ b/src/include/planner/operator/persistent/logical_set.h
@@ -11,8 +11,8 @@ class LogicalSetProperty final : public LogicalOperator {
 
 public:
     LogicalSetProperty(std::vector<binder::BoundSetPropertyInfo> infos,
-        std::shared_ptr<LogicalOperator> child, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{type_, std::move(child), std::move(printInfo)}, infos{std::move(infos)} {}
+        std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{type_, std::move(child)}, infos{std::move(infos)} {}
 
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
@@ -26,8 +26,7 @@ public:
     const binder::BoundSetPropertyInfo& getInfo(uint32_t idx) const { return infos[idx]; }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return std::make_unique<LogicalSetProperty>(copyVector(infos), children[0]->copy(),
-            printInfo->copy());
+        return std::make_unique<LogicalSetProperty>(copyVector(infos), children[0]->copy());
     }
 
 private:

--- a/src/include/planner/operator/scan/logical_dummy_scan.h
+++ b/src/include/planner/operator/scan/logical_dummy_scan.h
@@ -5,20 +5,19 @@
 namespace kuzu {
 namespace planner {
 
-class LogicalDummyScan : public LogicalOperator {
+class LogicalDummyScan final : public LogicalOperator {
 public:
-    explicit LogicalDummyScan(std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{LogicalOperatorType::DUMMY_SCAN, std::move(printInfo)} {}
+    explicit LogicalDummyScan() : LogicalOperator{LogicalOperatorType::DUMMY_SCAN} {}
 
-    void computeFactorizedSchema() final;
-    void computeFlatSchema() final;
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
 
     inline std::string getExpressionsForPrinting() const override { return std::string(); }
 
     static std::shared_ptr<binder::Expression> getDummyExpression();
 
-    inline std::unique_ptr<LogicalOperator> copy() final {
-        return std::make_unique<LogicalDummyScan>(printInfo->copy());
+    inline std::unique_ptr<LogicalOperator> copy() override {
+        return std::make_unique<LogicalDummyScan>();
     }
 };
 

--- a/src/include/planner/operator/scan/logical_expressions_scan.h
+++ b/src/include/planner/operator/scan/logical_expressions_scan.h
@@ -7,17 +7,16 @@ namespace kuzu {
 namespace planner {
 
 // LogicalExpressionsScan scans from an outer factorize table
-class LogicalExpressionsScan : public LogicalOperator {
+class LogicalExpressionsScan final : public LogicalOperator {
 public:
-    LogicalExpressionsScan(binder::expression_vector expressions,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{LogicalOperatorType::EXPRESSIONS_SCAN, std::move(printInfo)},
+    explicit LogicalExpressionsScan(binder::expression_vector expressions)
+        : LogicalOperator{LogicalOperatorType::EXPRESSIONS_SCAN},
           expressions{std::move(expressions)}, outerAccumulate{nullptr} {}
 
-    inline void computeFactorizedSchema() final { computeSchema(); }
-    inline void computeFlatSchema() final { computeSchema(); }
+    inline void computeFactorizedSchema() override { computeSchema(); }
+    inline void computeFlatSchema() override { computeSchema(); }
 
-    inline std::string getExpressionsForPrinting() const final {
+    inline std::string getExpressionsForPrinting() const override {
         return binder::ExpressionUtil::toString(expressions);
     }
 
@@ -25,8 +24,8 @@ public:
     inline void setOuterAccumulate(LogicalOperator* op) { outerAccumulate = op; }
     inline LogicalOperator* getOuterAccumulate() const { return outerAccumulate; }
 
-    inline std::unique_ptr<LogicalOperator> copy() final {
-        return std::make_unique<LogicalExpressionsScan>(expressions, printInfo->copy());
+    inline std::unique_ptr<LogicalOperator> copy() override {
+        return std::make_unique<LogicalExpressionsScan>(expressions);
     }
 
 private:

--- a/src/include/planner/operator/scan/logical_index_look_up.h
+++ b/src/include/planner/operator/scan/logical_index_look_up.h
@@ -9,13 +9,13 @@ namespace planner {
 // This operator is specifically used to transform primary key to offset during relationship copy.
 // So it is not a source operator. I would suggest move this logic into rel copy instead of
 // maintaining an operator.
-class LogicalPrimaryKeyLookup : public LogicalOperator {
+class LogicalPrimaryKeyLookup final : public LogicalOperator {
     static constexpr LogicalOperatorType type_ = LogicalOperatorType::INDEX_LOOK_UP;
 
 public:
     LogicalPrimaryKeyLookup(std::vector<binder::IndexLookupInfo> infos,
-        std::shared_ptr<LogicalOperator> child, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{type_, std::move(child), std::move(printInfo)}, infos{std::move(infos)} {}
+        std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{type_, std::move(child)}, infos{std::move(infos)} {}
 
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
@@ -26,7 +26,7 @@ public:
     const binder::IndexLookupInfo& getInfo(uint32_t idx) const { return infos[idx]; }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalPrimaryKeyLookup>(infos, children[0]->copy(), printInfo->copy());
+        return make_unique<LogicalPrimaryKeyLookup>(infos, children[0]->copy());
     }
 
 private:

--- a/src/include/planner/operator/simple/logical_attach_database.h
+++ b/src/include/planner/operator/simple/logical_attach_database.h
@@ -26,10 +26,8 @@ private:
 class LogicalAttachDatabase final : public LogicalSimple {
 public:
     explicit LogicalAttachDatabase(binder::AttachInfo attachInfo,
-        std::shared_ptr<binder::Expression> outputExpression,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalSimple{LogicalOperatorType::ATTACH_DATABASE, std::move(outputExpression),
-              std::move(printInfo)},
+        std::shared_ptr<binder::Expression> outputExpression)
+        : LogicalSimple{LogicalOperatorType::ATTACH_DATABASE, std::move(outputExpression)},
           attachInfo{std::move(attachInfo)} {}
 
     binder::AttachInfo getAttachInfo() const { return attachInfo; }
@@ -37,8 +35,7 @@ public:
     std::string getExpressionsForPrinting() const override { return attachInfo.dbPath; }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return std::make_unique<LogicalAttachDatabase>(attachInfo, outputExpression,
-            printInfo->copy());
+        return std::make_unique<LogicalAttachDatabase>(attachInfo, outputExpression);
     }
 
 private:

--- a/src/include/planner/operator/simple/logical_database.h
+++ b/src/include/planner/operator/simple/logical_database.h
@@ -8,10 +8,8 @@ namespace planner {
 class LogicalDatabase : public LogicalSimple {
 public:
     explicit LogicalDatabase(LogicalOperatorType operatorType,
-        std::shared_ptr<binder::Expression> outputExpression, std::string dbName,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalSimple{operatorType, outputExpression, std::move(printInfo)},
-          dbName{std::move(dbName)} {}
+        std::shared_ptr<binder::Expression> outputExpression, std::string dbName)
+        : LogicalSimple{operatorType, outputExpression}, dbName{std::move(dbName)} {}
 
     std::string getDBName() const { return dbName; }
 

--- a/src/include/planner/operator/simple/logical_detach_database.h
+++ b/src/include/planner/operator/simple/logical_detach_database.h
@@ -8,13 +8,12 @@ namespace planner {
 class LogicalDetachDatabase final : public LogicalDatabase {
 public:
     explicit LogicalDetachDatabase(std::string dbName,
-        std::shared_ptr<binder::Expression> outputExpression,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalDatabase{LogicalOperatorType::DETACH_DATABASE, outputExpression, std::move(dbName),
-              std::move(printInfo)} {}
+        std::shared_ptr<binder::Expression> outputExpression)
+        : LogicalDatabase{LogicalOperatorType::DETACH_DATABASE, outputExpression,
+              std::move(dbName)} {}
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return std::make_unique<LogicalDetachDatabase>(dbName, outputExpression, printInfo->copy());
+        return std::make_unique<LogicalDetachDatabase>(dbName, outputExpression);
     }
 };
 

--- a/src/include/planner/operator/simple/logical_export_db.h
+++ b/src/include/planner/operator/simple/logical_export_db.h
@@ -11,9 +11,8 @@ class LogicalExportDatabase : public LogicalSimple {
 public:
     explicit LogicalExportDatabase(common::ReaderConfig boundFileInfo,
         std::shared_ptr<binder::Expression> outputExpression,
-        std::vector<std::shared_ptr<LogicalOperator>> plans, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalSimple{LogicalOperatorType::EXPORT_DATABASE, std::move(plans), outputExpression,
-              std::move(printInfo)},
+        std::vector<std::shared_ptr<LogicalOperator>> plans)
+        : LogicalSimple{LogicalOperatorType::EXPORT_DATABASE, std::move(plans), outputExpression},
           boundFileInfo{std::move(boundFileInfo)} {}
 
     std::string getFilePath() const { return boundFileInfo.filePaths[0]; }
@@ -27,7 +26,7 @@ public:
 
     std::unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalExportDatabase>(std::move(boundFileInfo),
-            std::move(outputExpression), std::move(children), printInfo->copy());
+            std::move(outputExpression), std::move(children));
     }
 
 private:

--- a/src/include/planner/operator/simple/logical_extension.h
+++ b/src/include/planner/operator/simple/logical_extension.h
@@ -11,10 +11,8 @@ using namespace kuzu::extension;
 class LogicalExtension final : public LogicalSimple {
 public:
     LogicalExtension(ExtensionAction action, std::string path,
-        std::shared_ptr<binder::Expression> outputExpression,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalSimple{LogicalOperatorType::EXTENSION, std::move(outputExpression),
-              std::move(printInfo)},
+        std::shared_ptr<binder::Expression> outputExpression)
+        : LogicalSimple{LogicalOperatorType::EXTENSION, std::move(outputExpression)},
           action{action}, path{std::move(path)} {}
 
     std::string getExpressionsForPrinting() const override { return path; }
@@ -23,8 +21,7 @@ public:
     std::string getPath() const { return path; }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return std::make_unique<LogicalExtension>(action, path, outputExpression,
-            printInfo->copy());
+        return std::make_unique<LogicalExtension>(action, path, outputExpression);
     }
 
 private:

--- a/src/include/planner/operator/simple/logical_import_db.h
+++ b/src/include/planner/operator/simple/logical_import_db.h
@@ -7,10 +7,8 @@ namespace planner {
 
 class LogicalImportDatabase : public LogicalSimple {
 public:
-    LogicalImportDatabase(std::string query, std::shared_ptr<binder::Expression> outputExpression,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalSimple{LogicalOperatorType::IMPORT_DATABASE, std::move(outputExpression),
-              std::move(printInfo)},
+    LogicalImportDatabase(std::string query, std::shared_ptr<binder::Expression> outputExpression)
+        : LogicalSimple{LogicalOperatorType::IMPORT_DATABASE, std::move(outputExpression)},
           query{query} {}
 
     std::string getQuery() const { return query; }
@@ -18,7 +16,7 @@ public:
     std::string getExpressionsForPrinting() const override { return std::string{}; }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalImportDatabase>(query, outputExpression, printInfo->copy());
+        return make_unique<LogicalImportDatabase>(query, outputExpression);
     }
 
 private:

--- a/src/include/planner/operator/simple/logical_simple.h
+++ b/src/include/planner/operator/simple/logical_simple.h
@@ -8,15 +8,12 @@ namespace planner {
 class LogicalSimple : public LogicalOperator {
 public:
     LogicalSimple(LogicalOperatorType operatorType,
-        std::shared_ptr<binder::Expression> outputExpression,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{operatorType, std::move(printInfo)},
-          outputExpression{std::move(outputExpression)} {}
+        std::shared_ptr<binder::Expression> outputExpression)
+        : LogicalOperator{operatorType}, outputExpression{std::move(outputExpression)} {}
     LogicalSimple(LogicalOperatorType operatorType,
         std::vector<std::shared_ptr<LogicalOperator>> plans,
-        std::shared_ptr<binder::Expression> outputExpression,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{operatorType, std::move(plans), std::move(printInfo)},
+        std::shared_ptr<binder::Expression> outputExpression)
+        : LogicalOperator{operatorType, std::move(plans)},
           outputExpression{std::move(outputExpression)} {}
 
     void computeFactorizedSchema() override;

--- a/src/include/planner/operator/simple/logical_use_database.h
+++ b/src/include/planner/operator/simple/logical_use_database.h
@@ -8,13 +8,11 @@ namespace planner {
 class LogicalUseDatabase final : public LogicalDatabase {
 public:
     explicit LogicalUseDatabase(std::string dbName,
-        std::shared_ptr<binder::Expression> outputExpression,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalDatabase{LogicalOperatorType::USE_DATABASE, outputExpression, std::move(dbName),
-              std::move(printInfo)} {}
+        std::shared_ptr<binder::Expression> outputExpression)
+        : LogicalDatabase{LogicalOperatorType::USE_DATABASE, outputExpression, std::move(dbName)} {}
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return std::make_unique<LogicalUseDatabase>(dbName, outputExpression, printInfo->copy());
+        return std::make_unique<LogicalUseDatabase>(dbName, outputExpression);
     }
 };
 

--- a/src/include/planner/operator/sip/logical_semi_masker.h
+++ b/src/include/planner/operator/sip/logical_semi_masker.h
@@ -27,9 +27,9 @@ class LogicalSemiMasker : public LogicalOperator {
 public:
     LogicalSemiMasker(SemiMaskConstructionType type, std::shared_ptr<binder::Expression> key,
         std::vector<common::table_id_t> nodeTableIDs, std::vector<LogicalOperator*> ops,
-        std::shared_ptr<LogicalOperator> child, std::unique_ptr<OPPrintInfo> printInfo)
-        : LogicalOperator{type_, std::move(child), std::move(printInfo)}, type{type},
-          key{std::move(key)}, nodeTableIDs{std::move(nodeTableIDs)}, ops{std::move(ops)} {}
+        std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{type_, std::move(child)}, type{type}, key{std::move(key)},
+          nodeTableIDs{std::move(nodeTableIDs)}, ops{std::move(ops)} {}
 
     void computeFactorizedSchema() override { copyChildSchema(0); }
     void computeFlatSchema() override { copyChildSchema(0); }

--- a/src/main/plan_printer.cpp
+++ b/src/main/plan_printer.cpp
@@ -180,7 +180,8 @@ uint32_t OpProfileTree::fillOpProfileBoxes(const PhysicalOperator* op, uint32_t 
 uint32_t OpProfileTree::fillOpProfileBoxes(const LogicalOperator* op, uint32_t rowIdx,
     uint32_t colIdx, uint32_t& maxFieldWidth) {
     auto opProfileBox = std::make_unique<OpProfileBox>(PlanPrinter::getOperatorName(op),
-        PlanPrinter::getOperatorParams(op), std::vector<std::string>());
+        PlanPrinter::getOperatorParams(op),
+        std::vector<std::string>{"Cardinality: " + std::to_string(op->getCardinality())});
     maxFieldWidth = std::max(opProfileBox->getAttributeMaxLen(), maxFieldWidth);
     insertOpProfileBox(rowIdx, colIdx, std::move(opProfileBox));
     if (!op->getNumChildren()) {
@@ -414,7 +415,7 @@ std::string PlanPrinter::getOperatorName(const LogicalOperator* logicalOperator)
 }
 
 std::string PlanPrinter::getOperatorParams(const LogicalOperator* logicalOperator) {
-    return logicalOperator->getPrintInfo().toString();
+    return logicalOperator->getPrintInfo()->toString();
 }
 
 nlohmann::json PlanPrinter::toJson(const PhysicalOperator* physicalOperator, Profiler& profiler_) {

--- a/src/optimizer/acc_hash_join_optimizer.cpp
+++ b/src/optimizer/acc_hash_join_optimizer.cpp
@@ -1,7 +1,6 @@
 #include "optimizer/acc_hash_join_optimizer.h"
 
 #include "catalog/catalog_entry/table_catalog_entry.h"
-#include "function/gds/gds.h"
 #include "optimizer/logical_operator_collector.h"
 #include "planner/operator/extend/logical_recursive_extend.h"
 #include "planner/operator/logical_accumulate.h"
@@ -20,10 +19,8 @@ namespace kuzu {
 namespace optimizer {
 
 static std::shared_ptr<LogicalOperator> appendAccumulate(std::shared_ptr<LogicalOperator> child) {
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto accumulate =
-        std::make_shared<LogicalAccumulate>(AccumulateType::REGULAR, expression_vector{},
-            nullptr /* offset */, nullptr /* mark */, std::move(child), std::move(printInfo));
+    auto accumulate = std::make_shared<LogicalAccumulate>(AccumulateType::REGULAR,
+        expression_vector{}, nullptr /* offset */, nullptr /* mark */, std::move(child));
     accumulate->computeFlatSchema();
     return accumulate;
 }
@@ -106,9 +103,7 @@ static std::shared_ptr<LogicalOperator> appendSemiMasker(SemiMaskConstructionTyp
     std::shared_ptr<Expression> key, std::vector<LogicalOperator*> candidates,
     std::shared_ptr<LogicalOperator> child) {
     auto tableIDs = getTableIDs(candidates[0]);
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto semiMasker = std::make_shared<LogicalSemiMasker>(type, key, tableIDs, candidates, child,
-        std::move(printInfo));
+    auto semiMasker = std::make_shared<LogicalSemiMasker>(type, key, tableIDs, candidates, child);
     semiMasker->computeFlatSchema();
     return semiMasker;
 }

--- a/src/optimizer/factorization_rewriter.cpp
+++ b/src/optimizer/factorization_rewriter.cpp
@@ -189,8 +189,7 @@ std::shared_ptr<planner::LogicalOperator> FactorizationRewriter::appendFlattenIf
     if (op->getSchema()->getGroup(groupPos)->isFlat()) {
         return op;
     }
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto flatten = std::make_shared<LogicalFlatten>(groupPos, std::move(op), std::move(printInfo));
+    auto flatten = std::make_shared<LogicalFlatten>(groupPos, std::move(op));
     flatten->computeFactorizedSchema();
     return flatten;
 }

--- a/src/optimizer/projection_push_down_optimizer.cpp
+++ b/src/optimizer/projection_push_down_optimizer.cpp
@@ -349,9 +349,8 @@ void ProjectionPushDownOptimizer::preAppendProjection(LogicalOperator* op, idx_t
         // We don't have a way to handle
         return;
     }
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto projection = std::make_shared<LogicalProjection>(std::move(expressions),
-        op->getChild(childIdx), std::move(printInfo));
+    auto projection =
+        std::make_shared<LogicalProjection>(std::move(expressions), op->getChild(childIdx));
     projection->computeFlatSchema();
     op->setChild(childIdx, std::move(projection));
 }

--- a/src/planner/operator/extend/logical_extend.cpp
+++ b/src/planner/operator/extend/logical_extend.cpp
@@ -33,7 +33,7 @@ void LogicalExtend::computeFlatSchema() {
 
 std::unique_ptr<LogicalOperator> LogicalExtend::copy() {
     auto extend = std::make_unique<LogicalExtend>(boundNode, nbrNode, rel, direction,
-        extendFromSource_, properties, children[0]->copy(), printInfo->copy());
+        extendFromSource_, properties, children[0]->copy());
     extend->setPropertyPredicates(copyVector(propertyPredicates));
     extend->scanNbrID = scanNbrID;
     return extend;

--- a/src/planner/operator/extend/logical_recursive_extend.cpp
+++ b/src/planner/operator/extend/logical_recursive_extend.cpp
@@ -85,7 +85,7 @@ std::unique_ptr<LogicalOperator> LogicalPathPropertyProbe::copy() {
     auto nodeChildCopy = nodeChild == nullptr ? nullptr : nodeChild->copy();
     auto relChildCopy = relChild == nullptr ? nullptr : relChild->copy();
     auto op = std::make_unique<LogicalPathPropertyProbe>(recursiveRel, children[0]->copy(),
-        std::move(nodeChildCopy), std::move(relChildCopy), joinType, printInfo->copy());
+        std::move(nodeChildCopy), std::move(relChildCopy), joinType);
     op->sipInfo = sipInfo;
     op->direction = direction;
     op->extendFromSource_ = extendFromSource_;

--- a/src/planner/operator/logical_hash_join.cpp
+++ b/src/planner/operator/logical_hash_join.cpp
@@ -136,7 +136,7 @@ binder::expression_vector LogicalHashJoin::getExpressionsToMaterialize() const {
 
 std::unique_ptr<LogicalOperator> LogicalHashJoin::copy() {
     auto op = std::make_unique<LogicalHashJoin>(joinConditions, joinType, mark, children[0]->copy(),
-        children[1]->copy(), printInfo->copy());
+        children[1]->copy());
     op->sipInfo = sipInfo;
     return op;
 }

--- a/src/planner/operator/logical_intersect.cpp
+++ b/src/planner/operator/logical_intersect.cpp
@@ -61,7 +61,7 @@ std::unique_ptr<LogicalOperator> LogicalIntersect::copy() {
         buildChildren.push_back(children[i]->copy());
     }
     auto op = make_unique<LogicalIntersect>(intersectNodeID, keyNodeIDs, children[0]->copy(),
-        std::move(buildChildren), printInfo->copy());
+        std::move(buildChildren));
     op->sipInfo = sipInfo;
     return op;
 }

--- a/src/planner/operator/logical_operator.cpp
+++ b/src/planner/operator/logical_operator.cpp
@@ -130,22 +130,21 @@ bool LogicalOperatorUtils::isAccHashJoin(const LogicalOperator& op) {
 }
 
 LogicalOperator::LogicalOperator(LogicalOperatorType operatorType,
-    std::shared_ptr<LogicalOperator> child, std::unique_ptr<OPPrintInfo> printInfo)
-    : operatorType{operatorType}, printInfo{std::move(printInfo)} {
+    std::shared_ptr<LogicalOperator> child)
+    : operatorType{operatorType}, cardinality{0} {
     children.push_back(std::move(child));
 }
 
 LogicalOperator::LogicalOperator(LogicalOperatorType operatorType,
-    std::shared_ptr<LogicalOperator> left, std::shared_ptr<LogicalOperator> right,
-    std::unique_ptr<OPPrintInfo> printInfo)
-    : LogicalOperator{operatorType, std::move(printInfo)} {
+    std::shared_ptr<LogicalOperator> left, std::shared_ptr<LogicalOperator> right)
+    : LogicalOperator{operatorType} {
     children.push_back(std::move(left));
     children.push_back(std::move(right));
 }
 
 LogicalOperator::LogicalOperator(LogicalOperatorType operatorType,
-    const logical_op_vector_t& children, std::unique_ptr<OPPrintInfo> printInfo)
-    : LogicalOperator{operatorType, std::move(printInfo)} {
+    const logical_op_vector_t& children)
+    : LogicalOperator{operatorType} {
     for (auto& child : children) {
         this->children.push_back(child);
     }

--- a/src/planner/operator/logical_union.cpp
+++ b/src/planner/operator/logical_union.cpp
@@ -39,8 +39,7 @@ std::unique_ptr<LogicalOperator> LogicalUnion::copy() {
     for (auto i = 0u; i < getNumChildren(); ++i) {
         copiedChildren.push_back(getChild(i)->copy());
     }
-    return make_unique<LogicalUnion>(expressionsToUnion, std::move(copiedChildren),
-        printInfo->copy());
+    return make_unique<LogicalUnion>(expressionsToUnion, std::move(copiedChildren));
 }
 
 bool LogicalUnion::requireFlatExpression(uint32_t expressionIdx) {

--- a/src/planner/operator/persistent/logical_merge.cpp
+++ b/src/planner/operator/persistent/logical_merge.cpp
@@ -37,8 +37,7 @@ f_group_pos_set LogicalMerge::getGroupsPosToFlatten() {
 }
 
 std::unique_ptr<LogicalOperator> LogicalMerge::copy() {
-    auto merge =
-        std::make_unique<LogicalMerge>(existenceMark, keys, children[0]->copy(), printInfo->copy());
+    auto merge = std::make_unique<LogicalMerge>(existenceMark, keys, children[0]->copy());
     merge->insertNodeInfos = copyVector(insertNodeInfos);
     merge->insertRelInfos = copyVector(insertRelInfos);
     merge->onCreateSetNodeInfos = copyVector(onCreateSetNodeInfos);

--- a/src/planner/operator/scan/logical_scan_node_table.cpp
+++ b/src/planner/operator/scan/logical_scan_node_table.cpp
@@ -4,8 +4,8 @@ namespace kuzu {
 namespace planner {
 
 LogicalScanNodeTable::LogicalScanNodeTable(const LogicalScanNodeTable& other)
-    : LogicalOperator{type_, other.printInfo->copy()}, scanType{other.scanType},
-      nodeID{other.nodeID}, nodeTableIDs{other.nodeTableIDs}, properties{other.properties},
+    : LogicalOperator{type_}, scanType{other.scanType}, nodeID{other.nodeID},
+      nodeTableIDs{other.nodeTableIDs}, properties{other.properties},
       propertyPredicates{copyVector(other.propertyPredicates)} {
     if (other.extraInfo != nullptr) {
         setExtraInfo(other.extraInfo->copy());

--- a/src/planner/plan/append_accumulate.cpp
+++ b/src/planner/plan/append_accumulate.cpp
@@ -31,9 +31,8 @@ void Planner::appendAccumulate(const expression_vector& flatExprs, LogicalPlan& 
 
 void Planner::appendAccumulate(AccumulateType accumulateType, const expression_vector& flatExprs,
     std::shared_ptr<Expression> offset, std::shared_ptr<Expression> mark, LogicalPlan& plan) {
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto op = make_shared<LogicalAccumulate>(accumulateType, flatExprs, offset, mark,
-        plan.getLastOperator(), std::move(printInfo));
+        plan.getLastOperator());
     appendFlattens(op->getGroupPositionsToFlatten(), plan);
     op->setChild(0, plan.getLastOperator());
     op->computeFactorizedSchema();

--- a/src/planner/plan/append_aggregate.cpp
+++ b/src/planner/plan/append_aggregate.cpp
@@ -8,10 +8,8 @@ namespace planner {
 
 void Planner::appendAggregate(const expression_vector& expressionsToGroupBy,
     const expression_vector& expressionsToAggregate, LogicalPlan& plan) {
-    auto printInfo =
-        std::make_unique<LogicalAggregatePrintInfo>(expressionsToGroupBy, expressionsToAggregate);
     auto aggregate = make_shared<LogicalAggregate>(expressionsToGroupBy, expressionsToAggregate,
-        plan.getLastOperator(), std::move(printInfo));
+        plan.getLastOperator());
     appendFlattens(aggregate->getGroupsPosToFlattenForGroupBy(), plan);
     aggregate->setChild(0, plan.getLastOperator());
     appendFlattens(aggregate->getGroupsPosToFlattenForAggregate(), plan);

--- a/src/planner/plan/append_cross_product.cpp
+++ b/src/planner/plan/append_cross_product.cpp
@@ -29,9 +29,8 @@ void Planner::appendAccOptionalCrossProduct(std::shared_ptr<Expression> mark,
 
 void Planner::appendCrossProduct(AccumulateType accumulateType, std::shared_ptr<Expression> mark,
     const LogicalPlan& probePlan, const LogicalPlan& buildPlan, LogicalPlan& resultPlan) {
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto crossProduct = make_shared<LogicalCrossProduct>(accumulateType, mark,
-        probePlan.getLastOperator(), buildPlan.getLastOperator(), std::move(printInfo));
+        probePlan.getLastOperator(), buildPlan.getLastOperator());
     crossProduct->computeFactorizedSchema();
     // update cost
     resultPlan.setCost(probePlan.getCardinality() + buildPlan.getCardinality());

--- a/src/planner/plan/append_delete.cpp
+++ b/src/planner/plan/append_delete.cpp
@@ -8,9 +8,7 @@ namespace kuzu {
 namespace planner {
 
 void Planner::appendDelete(const std::vector<BoundDeleteInfo>& infos, LogicalPlan& plan) {
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto delete_ = std::make_shared<LogicalDelete>(copyVector(infos), plan.getLastOperator(),
-        std::move(printInfo));
+    auto delete_ = std::make_shared<LogicalDelete>(copyVector(infos), plan.getLastOperator());
     appendFlattens(delete_->getGroupsPosToFlatten(), plan);
     delete_->setChild(0, plan.getLastOperator());
     delete_->computeFactorizedSchema();

--- a/src/planner/plan/append_distinct.cpp
+++ b/src/planner/plan/append_distinct.cpp
@@ -7,9 +7,7 @@ namespace kuzu {
 namespace planner {
 
 void Planner::appendDistinct(const expression_vector& keys, LogicalPlan& plan) {
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto distinct =
-        make_shared<LogicalDistinct>(keys, plan.getLastOperator(), std::move(printInfo));
+    auto distinct = make_shared<LogicalDistinct>(keys, plan.getLastOperator());
     appendFlattens(distinct->getGroupsPosToFlatten(), plan);
     distinct->setChild(0, plan.getLastOperator());
     distinct->computeFactorizedSchema();

--- a/src/planner/plan/append_dummy_scan.cpp
+++ b/src/planner/plan/append_dummy_scan.cpp
@@ -6,8 +6,7 @@ namespace planner {
 
 void Planner::appendDummyScan(LogicalPlan& plan) {
     KU_ASSERT(plan.isEmpty());
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto dummyScan = std::make_shared<LogicalDummyScan>(std::move(printInfo));
+    auto dummyScan = std::make_shared<LogicalDummyScan>();
     dummyScan->computeFactorizedSchema();
     plan.setLastOperator(std::move(dummyScan));
 }

--- a/src/planner/plan/append_empty_result.cpp
+++ b/src/planner/plan/append_empty_result.cpp
@@ -5,8 +5,7 @@ namespace kuzu {
 namespace planner {
 
 void Planner::appendEmptyResult(LogicalPlan& plan) {
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto op = std::make_shared<LogicalEmptyResult>(*plan.getSchema(), std::move(printInfo));
+    auto op = std::make_shared<LogicalEmptyResult>(*plan.getSchema());
     op->computeFactorizedSchema();
     plan.setLastOperator(std::move(op));
 }

--- a/src/planner/plan/append_expressions_scan.cpp
+++ b/src/planner/plan/append_expressions_scan.cpp
@@ -7,9 +7,7 @@ namespace kuzu {
 namespace planner {
 
 void Planner::appendExpressionsScan(const expression_vector& expressions, LogicalPlan& plan) {
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto expressionsScan =
-        std::make_shared<LogicalExpressionsScan>(expressions, std::move(printInfo));
+    auto expressionsScan = std::make_shared<LogicalExpressionsScan>(expressions);
     expressionsScan->computeFactorizedSchema();
     plan.setLastOperator(expressionsScan);
 }

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -103,9 +103,8 @@ void Planner::appendNonRecursiveExtend(const std::shared_ptr<NodeExpression>& bo
         properties_ = ExpressionUtil::removeDuplication(properties_);
     }
     // Append extend
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto extend = make_shared<LogicalExtend>(boundNode, nbrNode, rel, direction, extendFromSource,
-        properties_, plan.getLastOperator(), std::move(printInfo));
+        properties_, plan.getLastOperator());
     extend->computeFactorizedSchema();
     // Update cost & cardinality. Note that extend does not change cardinality.
     plan.setCost(CostModel::computeExtendCost(plan));
@@ -183,9 +182,9 @@ void Planner::appendRecursiveExtendAsGDS(const std::shared_ptr<NodeExpression>& 
         pathRelPropertyScanRoot = pathRelPropertyScanPlan->getLastOperator();
     }
     // Construct path by probing scanned properties
-    auto pathPropertyProbe = std::make_shared<LogicalPathPropertyProbe>(rel,
-        probePlan.getLastOperator(), pathNodePropertyScanRoot, pathRelPropertyScanRoot,
-        RecursiveJoinType::TRACK_PATH, std::make_unique<OPPrintInfo>());
+    auto pathPropertyProbe =
+        std::make_shared<LogicalPathPropertyProbe>(rel, probePlan.getLastOperator(),
+            pathNodePropertyScanRoot, pathRelPropertyScanRoot, RecursiveJoinType::TRACK_PATH);
     pathPropertyProbe->direction = direction;
     pathPropertyProbe->extendFromSource_ = *boundNode == *rel->getSrcNode();
     pathPropertyProbe->pathNodeIDs = recursiveInfo->pathNodeIDsExpr;
@@ -212,10 +211,9 @@ void Planner::appendRecursiveExtend(const std::shared_ptr<NodeExpression>& bound
         appendNodeLabelFilter(boundNode->getInternalID(), recursiveInfo->node->getTableIDsSet(),
             plan);
     }
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto extend = std::make_shared<LogicalRecursiveExtend>(boundNode, nbrNode, rel, direction,
         extendFromSource, RecursiveJoinType::TRACK_PATH, plan.getLastOperator(),
-        recursivePlan->getLastOperator(), printInfo->copy());
+        recursivePlan->getLastOperator());
     appendFlattens(extend->getGroupsPosToFlatten(), plan);
     extend->setChild(0, plan.getLastOperator());
     extend->computeFactorizedSchema();
@@ -243,7 +241,7 @@ void Planner::appendRecursiveExtend(const std::shared_ptr<NodeExpression>& bound
     }
     // Create path property probe
     auto pathPropertyProbe = std::make_shared<LogicalPathPropertyProbe>(rel, extend, nodeScanRoot,
-        relScanRoot, RecursiveJoinType::TRACK_PATH, printInfo->copy());
+        relScanRoot, RecursiveJoinType::TRACK_PATH);
     pathPropertyProbe->computeFactorizedSchema();
     // Check for sip
     auto ratio = plan.getCardinality() / relScanCardinality;
@@ -323,9 +321,8 @@ void Planner::createPathRelPropertyScanPlan(const std::shared_ptr<NodeExpression
 
 void Planner::appendNodeLabelFilter(std::shared_ptr<Expression> nodeID,
     std::unordered_set<table_id_t> tableIDSet, LogicalPlan& plan) {
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto filter = std::make_shared<LogicalNodeLabelFilter>(std::move(nodeID), std::move(tableIDSet),
-        plan.getLastOperator(), std::move(printInfo));
+        plan.getLastOperator());
     filter->computeFactorizedSchema();
     plan.setLastOperator(std::move(filter));
 }

--- a/src/planner/plan/append_filter.cpp
+++ b/src/planner/plan/append_filter.cpp
@@ -15,9 +15,7 @@ void Planner::appendFilters(const binder::expression_vector& predicates,
 
 void Planner::appendFilter(const std::shared_ptr<Expression>& predicate, LogicalPlan& plan) {
     planSubqueryIfNecessary(predicate, plan);
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto filter =
-        make_shared<LogicalFilter>(predicate, plan.getLastOperator(), std::move(printInfo));
+    auto filter = make_shared<LogicalFilter>(predicate, plan.getLastOperator());
     appendFlattens(filter->getGroupsPosToFlatten(), plan);
     filter->setChild(0, plan.getLastOperator());
     filter->computeFactorizedSchema();

--- a/src/planner/plan/append_flatten.cpp
+++ b/src/planner/plan/append_flatten.cpp
@@ -15,9 +15,7 @@ void Planner::appendFlattenIfNecessary(f_group_pos groupPos, LogicalPlan& plan) 
     if (group->isFlat()) {
         return;
     }
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto flatten =
-        make_shared<LogicalFlatten>(groupPos, plan.getLastOperator(), std::move(printInfo));
+    auto flatten = make_shared<LogicalFlatten>(groupPos, plan.getLastOperator());
     flatten->computeFactorizedSchema();
     // update cardinality
     plan.setCardinality(cardinalityEstimator.estimateFlatten(plan, groupPos));

--- a/src/planner/plan/append_gds_call.cpp
+++ b/src/planner/plan/append_gds_call.cpp
@@ -8,8 +8,7 @@ namespace kuzu {
 namespace planner {
 
 std::shared_ptr<LogicalOperator> Planner::getGDSCall(const BoundGDSCallInfo& info) {
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    return std::make_shared<LogicalGDSCall>(info.copy(), std::move(printInfo));
+    return std::make_shared<LogicalGDSCall>(info.copy());
 }
 
 } // namespace planner

--- a/src/planner/plan/append_insert.cpp
+++ b/src/planner/plan/append_insert.cpp
@@ -40,9 +40,8 @@ void Planner::appendInsertNode(const std::vector<const binder::BoundInsertInfo*>
     for (auto& boundInfo : boundInsertInfos) {
         logicalInfos.push_back(createLogicalInsertInfo(boundInfo)->copy());
     }
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto insertNode = std::make_shared<LogicalInsert>(std::move(logicalInfos),
-        plan.getLastOperator(), std::move(printInfo));
+    auto insertNode =
+        std::make_shared<LogicalInsert>(std::move(logicalInfos), plan.getLastOperator());
     appendFlattens(insertNode->getGroupsPosToFlatten(), plan);
     insertNode->setChild(0, plan.getLastOperator());
     insertNode->computeFactorizedSchema();
@@ -56,9 +55,8 @@ void Planner::appendInsertRel(const std::vector<const binder::BoundInsertInfo*>&
     for (auto& boundInfo : boundInsertInfos) {
         logicalInfos.push_back(createLogicalInsertInfo(boundInfo)->copy());
     }
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto insertRel = std::make_shared<LogicalInsert>(std::move(logicalInfos),
-        plan.getLastOperator(), std::move(printInfo));
+    auto insertRel =
+        std::make_shared<LogicalInsert>(std::move(logicalInfos), plan.getLastOperator());
     appendFlattens(insertRel->getGroupsPosToFlatten(), plan);
     insertRel->setChild(0, plan.getLastOperator());
     insertRel->computeFactorizedSchema();

--- a/src/planner/plan/append_join.cpp
+++ b/src/planner/plan/append_join.cpp
@@ -21,9 +21,8 @@ void Planner::appendHashJoin(const expression_vector& joinNodeIDs, JoinType join
     for (auto& joinNodeID : joinNodeIDs) {
         joinConditions.emplace_back(joinNodeID, joinNodeID);
     }
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto hashJoin = make_shared<LogicalHashJoin>(joinConditions, joinType, mark,
-        probePlan.getLastOperator(), buildPlan.getLastOperator(), std::move(printInfo));
+        probePlan.getLastOperator(), buildPlan.getLastOperator());
     // Apply flattening to probe side
     auto groupsPosToFlattenOnProbeSide = hashJoin->getGroupsPosToFlattenOnProbeSide();
     appendFlattens(groupsPosToFlattenOnProbeSide, probePlan);
@@ -61,9 +60,8 @@ void Planner::appendMarkJoin(const expression_vector& joinNodeIDs,
     for (auto& joinNodeID : joinNodeIDs) {
         joinConditions.emplace_back(joinNodeID, joinNodeID);
     }
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto hashJoin = make_shared<LogicalHashJoin>(joinConditions, JoinType::MARK, mark,
-        probePlan.getLastOperator(), buildPlan.getLastOperator(), std::move(printInfo));
+        probePlan.getLastOperator(), buildPlan.getLastOperator());
     // Apply flattening to probe side
     appendFlattens(hashJoin->getGroupsPosToFlattenOnProbeSide(), probePlan);
     hashJoin->setChild(0, probePlan.getLastOperator());
@@ -86,9 +84,8 @@ void Planner::appendIntersect(const std::shared_ptr<Expression>& intersectNodeID
         keyNodeIDs.push_back(boundNodeIDs[i]);
         buildChildren.push_back(buildPlans[i]->getLastOperator());
     }
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto intersect = make_shared<LogicalIntersect>(intersectNodeID, std::move(keyNodeIDs),
-        probePlan.getLastOperator(), std::move(buildChildren), std::move(printInfo));
+        probePlan.getLastOperator(), std::move(buildChildren));
     appendFlattens(intersect->getGroupsPosToFlattenOnProbeSide(), probePlan);
     intersect->setChild(0, probePlan.getLastOperator());
     for (auto i = 0u; i < buildPlans.size(); ++i) {

--- a/src/planner/plan/append_limit.cpp
+++ b/src/planner/plan/append_limit.cpp
@@ -5,9 +5,7 @@ namespace kuzu {
 namespace planner {
 
 void Planner::appendLimit(uint64_t skipNum, uint64_t limitNum, LogicalPlan& plan) {
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto limit =
-        make_shared<LogicalLimit>(skipNum, limitNum, plan.getLastOperator(), std::move(printInfo));
+    auto limit = make_shared<LogicalLimit>(skipNum, limitNum, plan.getLastOperator());
     appendFlattens(limit->getGroupsPosToFlatten(), plan);
     limit->setChild(0, plan.getLastOperator());
     limit->computeFactorizedSchema();

--- a/src/planner/plan/append_multiplicity_reducer.cpp
+++ b/src/planner/plan/append_multiplicity_reducer.cpp
@@ -5,9 +5,7 @@ namespace kuzu {
 namespace planner {
 
 void Planner::appendMultiplicityReducer(LogicalPlan& plan) {
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto multiplicityReducer =
-        make_shared<LogicalMultiplicityReducer>(plan.getLastOperator(), std::move(printInfo));
+    auto multiplicityReducer = make_shared<LogicalMultiplicityReducer>(plan.getLastOperator());
     multiplicityReducer->computeFactorizedSchema();
     plan.setLastOperator(std::move(multiplicityReducer));
 }

--- a/src/planner/plan/append_order_by.cpp
+++ b/src/planner/plan/append_order_by.cpp
@@ -8,9 +8,7 @@ namespace planner {
 
 void Planner::appendOrderBy(const expression_vector& expressions,
     const std::vector<bool>& isAscOrders, LogicalPlan& plan) {
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto orderBy = make_shared<LogicalOrderBy>(expressions, isAscOrders, plan.getLastOperator(),
-        std::move(printInfo));
+    auto orderBy = make_shared<LogicalOrderBy>(expressions, isAscOrders, plan.getLastOperator());
     appendFlattens(orderBy->getGroupsPosToFlatten(), plan);
     orderBy->setChild(0, plan.getLastOperator());
     orderBy->computeFactorizedSchema();

--- a/src/planner/plan/append_projection.cpp
+++ b/src/planner/plan/append_projection.cpp
@@ -29,9 +29,7 @@ void Planner::appendProjection(const expression_vector& expressionsToProject, Lo
             appendFlattens(groupsPosToFlatten, plan);
         }
     }
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto projection = make_shared<LogicalProjection>(expressionsToProject, plan.getLastOperator(),
-        std::move(printInfo));
+    auto projection = make_shared<LogicalProjection>(expressionsToProject, plan.getLastOperator());
     projection->computeFactorizedSchema();
     plan.setLastOperator(std::move(projection));
 }

--- a/src/planner/plan/append_scan_node_table.cpp
+++ b/src/planner/plan/append_scan_node_table.cpp
@@ -22,9 +22,8 @@ static expression_vector removeInternalIDProperty(const expression_vector& expre
 void Planner::appendScanNodeTable(std::shared_ptr<Expression> nodeID,
     std::vector<table_id_t> tableIDs, const expression_vector& properties, LogicalPlan& plan) {
     auto propertiesToScan_ = removeInternalIDProperty(properties);
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto scan = make_shared<LogicalScanNodeTable>(std::move(nodeID), std::move(tableIDs),
-        propertiesToScan_, std::move(printInfo));
+        propertiesToScan_);
     scan->computeFactorizedSchema();
     plan.setCardinality(cardinalityEstimator.estimateScanNode(scan.get()));
     plan.setLastOperator(std::move(scan));

--- a/src/planner/plan/append_set.cpp
+++ b/src/planner/plan/append_set.cpp
@@ -8,9 +8,7 @@ namespace kuzu {
 namespace planner {
 
 void Planner::appendSetProperty(const std::vector<BoundSetPropertyInfo>& infos, LogicalPlan& plan) {
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto set = std::make_shared<LogicalSetProperty>(copyVector(infos), plan.getLastOperator(),
-        std::move(printInfo));
+    auto set = std::make_shared<LogicalSetProperty>(copyVector(infos), plan.getLastOperator());
     for (auto i = 0u; i < set->getInfos().size(); ++i) {
         auto groupsPos = set->getGroupsPosToFlatten(i);
         appendFlattens(groupsPos, plan);

--- a/src/planner/plan/append_simple.cpp
+++ b/src/planner/plan/append_simple.cpp
@@ -81,11 +81,10 @@ void Planner::appendStandaloneCall(const BoundStatement& statement, LogicalPlan&
 
 void Planner::appendStandaloneCallFunction(const BoundStatement& statement, LogicalPlan& plan) {
     auto& standaloneCallFunctionClause = statement.constCast<BoundStandaloneCallFunction>();
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto op =
         std::make_shared<LogicalTableFunctionCall>(standaloneCallFunctionClause.getTableFunction(),
             standaloneCallFunctionClause.getBindData()->copy(), binder::expression_vector{},
-            standaloneCallFunctionClause.getOffset(), std::move(printInfo));
+            standaloneCallFunctionClause.getOffset());
     plan.setLastOperator(std::move(op));
 }
 

--- a/src/planner/plan/append_simple.cpp
+++ b/src/planner/plan/append_simple.cpp
@@ -37,54 +37,45 @@ namespace planner {
 void Planner::appendCreateTable(const BoundStatement& statement, LogicalPlan& plan) {
     auto& createTable = statement.constCast<BoundCreateTable>();
     auto info = createTable.getInfo();
-    auto printInfo =
-        std::make_unique<LogicalCreateTablePrintInfo>(info->type, info->tableName, info->copy());
     auto op = make_shared<LogicalCreateTable>(info->tableName, info->copy(),
-        statement.getStatementResult()->getSingleColumnExpr(), std::move(printInfo));
+        statement.getStatementResult()->getSingleColumnExpr());
     plan.setLastOperator(std::move(op));
 }
 
 void Planner::appendCreateType(const BoundStatement& statement, LogicalPlan& plan) {
     auto& createType = statement.constCast<BoundCreateType>();
-    auto printInfo = std::make_unique<LogicalCreateTypePrintInfo>(createType.getName(),
-        createType.getType().toString());
     auto op = make_shared<LogicalCreateType>(createType.getName(), createType.getType().copy(),
-        statement.getStatementResult()->getSingleColumnExpr(), std::move(printInfo));
+        statement.getStatementResult()->getSingleColumnExpr());
     plan.setLastOperator(std::move(op));
 }
 
 void Planner::appendCreateSequence(const BoundStatement& statement, LogicalPlan& plan) {
     auto& createSequence = statement.constCast<BoundCreateSequence>();
     auto info = createSequence.getInfo();
-    auto printInfo = std::make_unique<LogicalCreateSequencePrintInfo>(info->sequenceName);
     auto op = make_shared<LogicalCreateSequence>(info->sequenceName, info->copy(),
-        statement.getStatementResult()->getSingleColumnExpr(), std::move(printInfo));
+        statement.getStatementResult()->getSingleColumnExpr());
     plan.setLastOperator(std::move(op));
 }
 
 void Planner::appendDrop(const BoundStatement& statement, LogicalPlan& plan) {
     auto& dropTable = statement.constCast<BoundDrop>();
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto op = make_shared<LogicalDrop>(dropTable.getDropInfo(),
-        statement.getStatementResult()->getSingleColumnExpr(), std::move(printInfo));
+        statement.getStatementResult()->getSingleColumnExpr());
     plan.setLastOperator(std::move(op));
 }
 
 void Planner::appendAlter(const BoundStatement& statement, LogicalPlan& plan) {
     auto& alter = statement.constCast<BoundAlter>();
     auto info = alter.getInfo();
-    auto printInfo =
-        std::make_unique<LogicalAlterPrintInfo>(info->alterType, info->tableName, info->copy());
     auto op = std::make_shared<LogicalAlter>(info->copy(), info->tableName,
-        statement.getStatementResult()->getSingleColumnExpr(), std::move(printInfo));
+        statement.getStatementResult()->getSingleColumnExpr());
     plan.setLastOperator(std::move(op));
 }
 
 void Planner::appendStandaloneCall(const BoundStatement& statement, LogicalPlan& plan) {
     auto& standaloneCallClause = statement.constCast<BoundStandaloneCall>();
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto op = make_shared<LogicalStandaloneCall>(standaloneCallClause.getOption(),
-        standaloneCallClause.getOptionValue(), std::move(printInfo));
+        standaloneCallClause.getOptionValue());
     plan.setLastOperator(std::move(op));
 }
 
@@ -102,61 +93,50 @@ void Planner::appendExplain(const BoundStatement& statement, LogicalPlan& plan) 
     auto& explain = statement.constCast<BoundExplain>();
     auto statementToExplain = explain.getStatementToExplain();
     auto planToExplain = getBestPlan(*statementToExplain);
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto op = make_shared<LogicalExplain>(planToExplain->getLastOperator(),
         statement.getStatementResult()->getSingleColumnExpr(), explain.getExplainType(),
-        explain.getStatementToExplain()->getStatementResult()->getColumns(), std::move(printInfo));
+        explain.getStatementToExplain()->getStatementResult()->getColumns());
     plan.setLastOperator(std::move(op));
 }
 
 void Planner::appendCreateMacro(const BoundStatement& statement, LogicalPlan& plan) {
     auto& createMacro = statement.constCast<BoundCreateMacro>();
-    auto printInfo = std::make_unique<LogicalCreateMacroPrintInfo>(createMacro.getMacroName());
     auto op = make_shared<LogicalCreateMacro>(statement.getStatementResult()->getSingleColumnExpr(),
-        createMacro.getMacroName(), createMacro.getMacro(), std::move(printInfo));
+        createMacro.getMacroName(), createMacro.getMacro());
     plan.setLastOperator(std::move(op));
 }
 
 void Planner::appendTransaction(const BoundStatement& statement, LogicalPlan& plan) {
     auto& transactionStatement = statement.constCast<BoundTransactionStatement>();
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto op = std::make_shared<LogicalTransaction>(transactionStatement.getTransactionAction(),
-        std::move(printInfo));
+    auto op = std::make_shared<LogicalTransaction>(transactionStatement.getTransactionAction());
     plan.setLastOperator(std::move(op));
 }
 
 void Planner::appendExtension(const BoundStatement& statement, LogicalPlan& plan) {
     auto& extensionStatement = statement.constCast<BoundExtensionStatement>();
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto op = std::make_shared<LogicalExtension>(extensionStatement.getAction(),
-        extensionStatement.getPath(), statement.getStatementResult()->getSingleColumnExpr(),
-        std::move(printInfo));
+        extensionStatement.getPath(), statement.getStatementResult()->getSingleColumnExpr());
     plan.setLastOperator(std::move(op));
 }
 
 void Planner::appendAttachDatabase(const BoundStatement& statement, LogicalPlan& plan) {
     auto& boundAttachDatabase = statement.constCast<BoundAttachDatabase>();
-    auto printInfo = std::make_unique<LogicalAttachDatabasePrintInfo>(
-        boundAttachDatabase.getAttachInfo().dbAlias);
-    auto attachDatabase =
-        std::make_shared<LogicalAttachDatabase>(boundAttachDatabase.getAttachInfo(),
-            statement.getStatementResult()->getSingleColumnExpr(), std::move(printInfo));
+    auto attachDatabase = std::make_shared<LogicalAttachDatabase>(
+        boundAttachDatabase.getAttachInfo(), statement.getStatementResult()->getSingleColumnExpr());
     plan.setLastOperator(std::move(attachDatabase));
 }
 
 void Planner::appendDetachDatabase(const BoundStatement& statement, LogicalPlan& plan) {
     auto& boundDetachDatabase = statement.constCast<BoundDetachDatabase>();
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto detachDatabase = std::make_shared<LogicalDetachDatabase>(boundDetachDatabase.getDBName(),
-        statement.getStatementResult()->getSingleColumnExpr(), std::move(printInfo));
+        statement.getStatementResult()->getSingleColumnExpr());
     plan.setLastOperator(std::move(detachDatabase));
 }
 
 void Planner::appendUseDatabase(const BoundStatement& statement, LogicalPlan& plan) {
     auto& boundUseDatabase = statement.constCast<BoundUseDatabase>();
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto useDatabase = std::make_shared<LogicalUseDatabase>(boundUseDatabase.getDBName(),
-        statement.getStatementResult()->getSingleColumnExpr(), std::move(printInfo));
+        statement.getStatementResult()->getSingleColumnExpr());
     plan.setLastOperator(std::move(useDatabase));
 }
 

--- a/src/planner/plan/append_table_function_call.cpp
+++ b/src/planner/plan/append_table_function_call.cpp
@@ -14,26 +14,23 @@ void Planner::appendTableFunctionCall(const BoundTableScanSourceInfo& info, Logi
 
 void Planner::appendTableFunctionCall(const BoundTableScanSourceInfo& info,
     std::shared_ptr<Expression> offset, LogicalPlan& plan) {
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto call = std::make_shared<LogicalTableFunctionCall>(info.func, info.bindData->copy(),
-        info.columns, offset, std::move(printInfo));
+        info.columns, offset);
     call->computeFactorizedSchema();
     plan.setLastOperator(std::move(call));
 }
 
 std::shared_ptr<LogicalOperator> Planner::getTableFunctionCall(
     const binder::BoundTableScanSourceInfo& info) {
-    auto printInfo = std::make_unique<OPPrintInfo>();
     return std::make_shared<LogicalTableFunctionCall>(info.func, info.bindData->copy(),
-        info.columns, nullptr /* offset */, std::move(printInfo));
+        info.columns, nullptr /* offset */);
 }
 
 std::shared_ptr<LogicalOperator> Planner::getTableFunctionCall(
     const BoundReadingClause& readingClause) {
     auto& call = readingClause.constCast<BoundTableFunctionCall>();
-    auto printInfo = std::make_unique<OPPrintInfo>();
     return std::make_shared<LogicalTableFunctionCall>(call.getTableFunc(),
-        call.getBindData()->copy(), call.getColumns(), call.getOffset(), std::move(printInfo));
+        call.getBindData()->copy(), call.getColumns(), call.getOffset());
 }
 
 } // namespace planner

--- a/src/planner/plan/append_unwind.cpp
+++ b/src/planner/plan/append_unwind.cpp
@@ -10,9 +10,8 @@ namespace planner {
 
 void Planner::appendUnwind(const BoundReadingClause& readingClause, LogicalPlan& plan) {
     auto& unwindClause = ku_dynamic_cast<const BoundUnwindClause&>(readingClause);
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto unwind = make_shared<LogicalUnwind>(unwindClause.getInExpr(), unwindClause.getOutExpr(),
-        unwindClause.getIDExpr(), plan.getLastOperator(), std::move(printInfo));
+        unwindClause.getIDExpr(), plan.getLastOperator());
     appendFlattens(unwind->getGroupsPosToFlatten(), plan);
     unwind->setChild(0, plan.getLastOperator());
     unwind->computeFactorizedSchema();

--- a/src/planner/plan/plan_copy.cpp
+++ b/src/planner/plan/plan_copy.cpp
@@ -16,9 +16,8 @@ namespace kuzu {
 namespace planner {
 
 static void appendIndexScan(const ExtraBoundCopyRelInfo& extraInfo, LogicalPlan& plan) {
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto indexScan = std::make_shared<LogicalPrimaryKeyLookup>(extraInfo.infos,
-        plan.getLastOperator(), std::move(printInfo));
+    auto indexScan =
+        std::make_shared<LogicalPrimaryKeyLookup>(extraInfo.infos, plan.getLastOperator());
     indexScan->computeFactorizedSchema();
     plan.setLastOperator(std::move(indexScan));
 }
@@ -29,18 +28,16 @@ static void appendPartitioner(const BoundCopyFromInfo& copyFromInfo, LogicalPlan
     info.partitioningInfos.push_back(LogicalPartitioningInfo(RelKeyIdx::FWD /* keyIdx */));
     // Partitioner for BWD direction rel data.
     info.partitioningInfos.push_back(LogicalPartitioningInfo(RelKeyIdx::BWD /* keyIdx */));
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto partitioner = std::make_shared<LogicalPartitioner>(std::move(info), copyFromInfo.copy(),
-        plan.getLastOperator(), std::move(printInfo));
+        plan.getLastOperator());
     partitioner->computeFactorizedSchema();
     plan.setLastOperator(std::move(partitioner));
 }
 
 static void appendCopyFrom(const BoundCopyFromInfo& info, expression_vector outExprs,
     LogicalPlan& plan) {
-    auto printInfo = std::make_unique<LogicalCopyFromPrintInfo>(info.tableEntry->getName());
-    auto op = make_shared<LogicalCopyFrom>(info.copy(), std::move(outExprs), plan.getLastOperator(),
-        std::move(printInfo));
+    auto op =
+        make_shared<LogicalCopyFrom>(info.copy(), std::move(outExprs), plan.getLastOperator());
     op->computeFactorizedSchema();
     plan.setLastOperator(std::move(op));
 }
@@ -139,8 +136,7 @@ std::unique_ptr<LogicalPlan> Planner::planCopyRdfFrom(const BoundCopyFromInfo* i
         children.push_back(readerPlan.getLastOperator());
     }
     auto resultPlan = std::make_unique<LogicalPlan>();
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto op = make_shared<LogicalCopyFrom>(info->copy(), results, children, std::move(printInfo));
+    auto op = make_shared<LogicalCopyFrom>(info->copy(), results, children);
     op->computeFactorizedSchema();
     resultPlan->setLastOperator(std::move(op));
     return resultPlan;
@@ -155,10 +151,8 @@ std::unique_ptr<LogicalPlan> Planner::planCopyTo(const BoundStatement& statement
     }
     KU_ASSERT(regularQuery->getStatementType() == StatementType::QUERY);
     auto plan = getBestPlan(*regularQuery);
-    auto printInfo =
-        std::make_unique<LogicalCopyToPrintInfo>(columnNames, boundCopyTo.getBindData()->fileName);
     auto copyTo = make_shared<LogicalCopyTo>(boundCopyTo.getBindData()->copy(),
-        boundCopyTo.getExportFunc(), plan->getLastOperator(), std::move(printInfo));
+        boundCopyTo.getExportFunc(), plan->getLastOperator());
     plan->setLastOperator(std::move(copyTo));
     return plan;
 }

--- a/src/planner/plan/plan_port_db.cpp
+++ b/src/planner/plan/plan_port_db.cpp
@@ -41,16 +41,13 @@ std::unique_ptr<LogicalPlan> Planner::planExportDatabase(const BoundStatement& s
         auto path = filePath + "/" + exportTableData.tableName + copyToSuffix;
         function::ExportFuncBindInput bindInput{exportTableData.columnNames, std::move(path),
             boundExportDatabase.getExportOptions()};
-        auto printInfo = std::make_unique<OPPrintInfo>();
         auto copyTo = std::make_shared<LogicalCopyTo>(exportFunc.bind(bindInput), exportFunc,
-            tablePlan->getLastOperator(), std::move(printInfo));
+            tablePlan->getLastOperator());
         logicalOperators.push_back(std::move(copyTo));
     }
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto exportDatabase =
         make_shared<LogicalExportDatabase>(boundExportDatabase.getBoundFileInfo()->copy(),
-            statement.getStatementResult()->getSingleColumnExpr(), std::move(logicalOperators),
-            std::move(printInfo));
+            statement.getStatementResult()->getSingleColumnExpr(), std::move(logicalOperators));
     plan->setLastOperator(std::move(exportDatabase));
     return plan;
 }
@@ -59,9 +56,8 @@ std::unique_ptr<LogicalPlan> Planner::planImportDatabase(const BoundStatement& s
     auto& boundImportDatabase = statement.constCast<BoundImportDatabase>();
     auto query = boundImportDatabase.getQuery();
     auto plan = std::make_unique<LogicalPlan>();
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto importDatabase = make_shared<LogicalImportDatabase>(query,
-        statement.getStatementResult()->getSingleColumnExpr(), std::move(printInfo));
+        statement.getStatementResult()->getSingleColumnExpr());
     plan->setLastOperator(std::move(importDatabase));
     return plan;
 }

--- a/src/planner/plan/plan_update.cpp
+++ b/src/planner/plan/plan_update.cpp
@@ -70,9 +70,8 @@ void Planner::planMergeClause(const BoundUpdatingClause* updatingClause, Logical
     auto existenceMark = mergeClause.getExistenceMark();
     planOptionalMatch(*mergeClause.getQueryGraphCollection(), predicates, corrExprs, existenceMark,
         plan);
-    auto printInfo = std::make_unique<OPPrintInfo>();
-    auto merge = std::make_shared<LogicalMerge>(existenceMark, std::move(corrExprs),
-        plan.getLastOperator(), std::move(printInfo));
+    auto merge =
+        std::make_shared<LogicalMerge>(existenceMark, std::move(corrExprs), plan.getLastOperator());
     if (mergeClause.hasInsertNodeInfo()) {
         for (auto& info : mergeClause.getInsertNodeInfos()) {
             merge->addInsertNodeInfo(createLogicalInsertInfo(info)->copy());

--- a/src/planner/query_planner.cpp
+++ b/src/planner/query_planner.cpp
@@ -74,9 +74,8 @@ std::unique_ptr<LogicalPlan> Planner::createUnionPlan(
         children.push_back(childPlan->getLastOperator());
     }
     // we compute the schema based on first child
-    auto printInfo = std::make_unique<OPPrintInfo>();
     auto union_ = make_shared<LogicalUnion>(childrenPlans[0]->getSchema()->getExpressionsInScope(),
-        std::move(children), std::move(printInfo));
+        std::move(children));
     for (auto i = 0u; i < childrenPlans.size(); ++i) {
         appendFlattens(union_->getGroupsPosToFlatten(i), *childrenPlans[i]);
         union_->setChild(i, childrenPlans[i]->getLastOperator());

--- a/src/processor/map/map_ddl.cpp
+++ b/src/processor/map/map_ddl.cpp
@@ -25,8 +25,7 @@ static DataPos getOutputPos(const LogicalDDL& logicalDDL) {
 
 std::unique_ptr<PhysicalOperator> PlanMapper::mapCreateTable(LogicalOperator* logicalOperator) {
     auto& createTable = logicalOperator->constCast<LogicalCreateTable>();
-    auto printInfo = std::make_unique<LogicalCreateTablePrintInfo>(createTable.getInfo()->type,
-        createTable.getInfo()->tableName, createTable.getInfo()->copy());
+    auto printInfo = std::make_unique<LogicalCreateTablePrintInfo>(createTable.getInfo()->copy());
     return std::make_unique<CreateTable>(createTable.getInfo()->copy(), getOutputPos(createTable),
         getOperatorID(), std::move(printInfo));
 }
@@ -62,8 +61,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapAlter(LogicalOperator* logicalO
         auto& addPropInfo = alter.getInfo()->extraInfo->constCast<BoundExtraAddPropertyInfo>();
         defaultValueEvaluator = exprMapper.getEvaluator(addPropInfo.boundDefault);
     }
-    auto printInfo = std::make_unique<LogicalAlterPrintInfo>(alter.getInfo()->alterType,
-        alter.getInfo()->tableName, alter.getInfo()->copy());
+    auto printInfo = std::make_unique<LogicalAlterPrintInfo>(alter.getInfo()->copy());
     return std::make_unique<Alter>(alter.getInfo()->copy(), std::move(defaultValueEvaluator),
         getOutputPos(alter), getOperatorID(), std::move(printInfo));
 }

--- a/src/processor/operator/persistent/reader/copy_from_error.cpp
+++ b/src/processor/operator/persistent/reader/copy_from_error.cpp
@@ -1,7 +1,5 @@
 #include "processor/operator/persistent/reader/copy_from_error.h"
 
-#include "common/constants.h"
-#include "common/type_utils.h"
 #include "common/vector/value_vector.h"
 #include "storage/store/column_chunk_data.h"
 

--- a/src/storage/index/in_mem_hash_index.cpp
+++ b/src/storage/index/in_mem_hash_index.cpp
@@ -10,7 +10,6 @@
 #include "storage/index/hash_index_utils.h"
 #include "storage/storage_structure/disk_array.h"
 #include "storage/storage_structure/overflow_file.h"
-#include <bit>
 
 using namespace kuzu::common;
 

--- a/test/test_files/explain/explain.test
+++ b/test/test_files/explain/explain.test
@@ -1,4 +1,4 @@
--DATASET CSV empty
+-DATASET CSV tinysnb
 
 --
 
@@ -31,6 +31,16 @@
 -STATEMENT create node table npytable1 (id INT64,i64 INT64, PRIMARY KEY(id));
 ---- ok
 -STATEMENT EXPLAIN LOGICAL copy npytable1 from ("${KUZU_ROOT_DIRECTORY}/dataset/npy-20k/id_int64.npy", "${KUZU_ROOT_DIRECTORY}/dataset/npy-20k/id_int64.npy") BY COLUMN;
+---- ok
+
+-LOG ExplainLogicalMatch
+-STATEMENT EXPLAIN LOGICAL MATCH (p:person) RETURN p;
+---- ok
+-STATEMENT EXPLAIN LOGICAL MATCH (p1:person)-[e:knows]->(p2:person) RETURN *;
+---- ok
+
+-LOG ExplainLogicalFilter
+-STATEMENT EXPLAIN LOGICAL MATCH (p:person) WHERE p.gender='F' RETURN p;
 ---- ok
 
 -LOG ExplainLogicalCall


### PR DESCRIPTION
# Description

Follow up of #3987. Most changes are boilerplate.
- Removed `OPPrintInfo` being passed as parameter of LogicalOperator's constructor, instead generated only when needed and fed to the PlanPrinter.
- Added cardinality to be printed. Always initialized as 0 now. Will feed the actual values in next PR.