### PR TITLE
Allow scanning edge properties in GDS edgeCompute

### DIFF
--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -76,6 +76,10 @@ column_id_t TableCatalogEntry::getColumnID(const std::string& propertyName) cons
     return propertyCollection.getColumnID(propertyName);
 }
 
+common::column_id_t TableCatalogEntry::getColumnID(common::idx_t idx) const {
+    return propertyCollection.getColumnID(idx);
+}
+
 void TableCatalogEntry::addProperty(const PropertyDefinition& propertyDefinition) {
     propertyCollection.add(propertyDefinition);
 }

--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -1,6 +1,5 @@
 #include "function/gds/gds_task.h"
 
-#include "common/data_chunk/sel_vector.h"
 #include "graph/graph.h"
 
 using namespace kuzu::common;
@@ -8,13 +7,11 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace function {
 
-static uint64_t computeScanResult(nodeID_t sourceNodeID, std::span<const nodeID_t> nbrNodeIDs,
-    std::span<const relID_t> edgeIDs, SelectionVector& mask, EdgeCompute& ec,
-    FrontierPair& frontierPair, bool isFwd) {
-    KU_ASSERT(nbrNodeIDs.size() == edgeIDs.size());
-    ec.edgeCompute(sourceNodeID, nbrNodeIDs, edgeIDs, mask, isFwd);
-    frontierPair.getNextFrontierUnsafe().setActive(mask, nbrNodeIDs);
-    return mask.getSelSize();
+static uint64_t computeScanResult(nodeID_t sourceNodeID, graph::GraphScanState::Chunk& chunk,
+    EdgeCompute& ec, FrontierPair& frontierPair, bool isFwd) {
+    auto activeNodes = ec.edgeCompute(sourceNodeID, chunk, isFwd);
+    frontierPair.getNextFrontierUnsafe().setActive(activeNodes);
+    return chunk.size();
 }
 
 void FrontierTask::run() {
@@ -29,15 +26,15 @@ void FrontierTask::run() {
             if (sharedState->frontierPair.curFrontier->isActive(nodeID)) {
                 switch (info.direction) {
                 case ExtendDirection::FWD: {
-                    for (auto [nodes, edges, mask] : graph->scanFwd(nodeID, *scanState)) {
-                        numApproxActiveNodesForNextIter += computeScanResult(nodeID, nodes, edges,
-                            mask, *localEc, sharedState->frontierPair, true);
+                    for (auto chunk : graph->scanFwd(nodeID, *scanState)) {
+                        numApproxActiveNodesForNextIter += computeScanResult(nodeID, chunk,
+                            *localEc, sharedState->frontierPair, true);
                     }
                 } break;
                 case ExtendDirection::BWD: {
-                    for (auto [nodes, edges, mask] : graph->scanBwd(nodeID, *scanState)) {
-                        numApproxActiveNodesForNextIter += computeScanResult(nodeID, nodes, edges,
-                            mask, *localEc, sharedState->frontierPair, false);
+                    for (auto chunk : graph->scanBwd(nodeID, *scanState)) {
+                        numApproxActiveNodesForNextIter += computeScanResult(nodeID, chunk,
+                            *localEc, sharedState->frontierPair, false);
                     }
                 } break;
                 default:

--- a/src/function/gds/page_rank.cpp
+++ b/src/function/gds/page_rank.cpp
@@ -135,14 +135,12 @@ public:
                     auto rank = 0.0;
                     auto iter = graph->scanFwd(nodeID, *scanState);
                     for (const auto chunk : iter) {
-                        chunk.selVector.forEach([&](auto i) {
-                            auto numNbrOfNbr =
-                                graph->scanFwd(chunk.nbrNodes[i], *innerScanState).count();
+                        chunk.forEach([&](auto nbr, auto) {
+                            auto numNbrOfNbr = graph->scanFwd(nbr, *innerScanState).count();
                             if (numNbrOfNbr == 0) {
                                 numNbrOfNbr = numNodesInGraph;
                             }
-                            rank +=
-                                extraData->dampingFactor * (ranks[chunk.nbrNodes[i]] / numNbrOfNbr);
+                            rank += extraData->dampingFactor * (ranks[nbr] / numNbrOfNbr);
                         });
                     }
                     rank += dampingValue;

--- a/src/include/catalog/catalog_entry/table_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/table_catalog_entry.h
@@ -7,6 +7,7 @@
 #include "catalog/catalog_entry/catalog_entry.h"
 #include "catalog/property_definition_collection.h"
 #include "common/enums/table_type.h"
+#include "common/types/types.h"
 #include "function/table_functions.h"
 
 namespace kuzu {
@@ -58,6 +59,7 @@ public:
     const binder::PropertyDefinition& getProperty(const std::string& propertyName) const;
     const binder::PropertyDefinition& getProperty(common::idx_t idx) const;
     virtual common::column_id_t getColumnID(const std::string& propertyName) const;
+    common::column_id_t getColumnID(common::idx_t idx) const;
     void addProperty(const binder::PropertyDefinition& propertyDefinition);
     void dropProperty(const std::string& propertyName);
     void renameProperty(const std::string& propertyName, const std::string& newName);

--- a/src/include/common/vector/value_vector.h
+++ b/src/include/common/vector/value_vector.h
@@ -4,6 +4,7 @@
 
 #include "common/assert.h"
 #include "common/cast.h"
+#include "common/copy_constructors.h"
 #include "common/data_chunk/data_chunk_state.h"
 #include "common/null_mask.h"
 #include "common/types/ku_string.h"
@@ -30,6 +31,7 @@ public:
         KU_ASSERT(dataTypeID != LogicalTypeID::LIST);
     }
 
+    DELETE_COPY_AND_MOVE(ValueVector);
     ~ValueVector() = default;
 
     void setState(const std::shared_ptr<DataChunkState>& state_);

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -3,8 +3,8 @@
 #include <atomic>
 #include <mutex>
 
-#include "common/data_chunk/sel_vector.h"
 #include "common/types/types.h"
+#include "graph/graph.h"
 #include "storage/buffer_manager/memory_manager.h"
 
 namespace kuzu {
@@ -21,12 +21,11 @@ public:
 
     // Does any work that is needed while extending the (boundNodeID, nbrNodeID, edgeID) edge.
     // boundNodeID is the nodeID that is in the current frontier and currently executing.
-    // Updates the mask to indicate the neighbors which should be put in the next frontier.
+    // Returns a list of neighbors which should be put in the next frontier.
     // So if the implementing class has access to the next frontier as a field,
     // **do not** call setActive. Helper functions in GDSUtils will do that work.
-    virtual void edgeCompute(common::nodeID_t boundNodeID,
-        std::span<const common::nodeID_t> nbrNodeID, std::span<const common::relID_t> edgeID,
-        common::SelectionVector& mask, bool fwdEdge) = 0;
+    virtual std::vector<common::nodeID_t> edgeCompute(common::nodeID_t boundNodeID,
+        graph::GraphScanState::Chunk& results, bool fwdEdge) = 0;
 
     virtual std::unique_ptr<EdgeCompute> copy() = 0;
 };
@@ -116,8 +115,7 @@ class GDSFrontier {
 public:
     virtual ~GDSFrontier() = default;
     virtual bool isActive(common::nodeID_t nodeID) = 0;
-    virtual void setActive(const common::SelectionVector& mask,
-        std::span<const common::nodeID_t> nodeIDs) = 0;
+    virtual void setActive(std::span<const common::nodeID_t> nodeIDs) = 0;
     virtual void setActive(common::nodeID_t nodeID) = 0;
     template<class TARGET>
     TARGET* ptrCast() {
@@ -167,13 +165,12 @@ public:
                curIter.load(std::memory_order_relaxed) - 1;
     }
 
-    void setActive(const common::SelectionVector& mask,
-        std::span<const common::nodeID_t> nodeIDs) override {
+    void setActive(const std::span<const common::nodeID_t> nodeIDs) override {
         auto frontierMask = getNextFrontierFixedMask();
-        mask.forEach([&](auto i) {
-            frontierMask[nodeIDs[i].offset].store(curIter.load(std::memory_order_relaxed),
+        for (const auto nodeID : nodeIDs) {
+            frontierMask[nodeID.offset].store(curIter.load(std::memory_order_relaxed),
                 std::memory_order_relaxed);
-        });
+        }
     }
 
     void setActive(common::nodeID_t nodeID) override {

--- a/src/include/graph/on_disk_graph.h
+++ b/src/include/graph/on_disk_graph.h
@@ -82,7 +82,8 @@ class OnDiskGraphScanStates : public GraphScanState {
 public:
     GraphScanState::Chunk getChunk() override {
         auto& iter = getInnerIterator();
-        return Chunk{iter.getNbrNodes(), iter.getEdges(), iter.getSelVectorUnsafe()};
+        return createChunk(iter.getNbrNodes(), iter.getEdges(), iter.getSelVectorUnsafe(),
+            propertyVector.get());
     }
     bool next() override;
 
@@ -110,13 +111,15 @@ private:
     std::unique_ptr<common::ValueVector> srcNodeIDVector;
     std::unique_ptr<common::ValueVector> dstNodeIDVector;
     std::unique_ptr<common::ValueVector> relIDVector;
+    std::unique_ptr<common::ValueVector> propertyVector;
     size_t iteratorIndex;
     common::RelDataDirection direction;
 
     std::unique_ptr<evaluator::ExpressionEvaluator> relPredicateEvaluator;
 
     explicit OnDiskGraphScanStates(main::ClientContext* context,
-        std::span<storage::RelTable*> tableIDs, const GraphEntry& graphEntry);
+        std::span<storage::RelTable*> tableIDs, const GraphEntry& graphEntry,
+        std::optional<common::idx_t> edgePropertyIndex = std::nullopt);
     std::vector<std::pair<common::table_id_t, OnDiskGraphScanState>> scanStates;
 };
 
@@ -136,7 +139,8 @@ public:
 
     std::vector<RelTableIDInfo> getRelTableIDInfos() override;
 
-    std::unique_ptr<GraphScanState> prepareScan(common::table_id_t relTableID) override;
+    std::unique_ptr<GraphScanState> prepareScan(common::table_id_t relTableID,
+        std::optional<common::idx_t> edgePropertyIndex = std::nullopt) override;
     std::unique_ptr<GraphScanState> prepareMultiTableScanFwd(
         std::span<common::table_id_t> nodeTableIDs) override;
     std::unique_ptr<GraphScanState> prepareMultiTableScanBwd(

--- a/test/storage/rel_scan_test.cpp
+++ b/test/storage/rel_scan_test.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "catalog/catalog.h"
+#include "common/types/date_t.h"
 #include "common/types/types.h"
 #include "graph/graph_entry.h"
 #include "graph/on_disk_graph.h"
@@ -10,9 +11,12 @@
 #include "main/client_context.h"
 #include "main_test_helper/private_main_test_helper.h"
 
-using kuzu::common::nodeID_t;
-
 namespace kuzu {
+
+using common::Date;
+using common::date_t;
+using common::nodeID_t;
+using common::offset_t;
 namespace testing {
 
 class RelScanTest : public PrivateApiTest {
@@ -48,25 +52,83 @@ class RelScanTestAmazon : public RelScanTest {
 TEST_F(RelScanTest, ScanFwd) {
     auto tableID = catalog->getTableID(context->getTx(), "person");
     auto relTableID = catalog->getTableID(context->getTx(), "knows");
-    auto scanState = graph->prepareScan(relTableID);
+    auto datePropertyIndex =
+        catalog->getTableCatalogEntry(context->getTx(), relTableID)->getPropertyIdx("date");
+    auto scanState = graph->prepareScan(relTableID, datePropertyIndex);
 
-    const auto compare = [&](uint64_t node, std::vector<nodeID_t> expected) {
-        std::vector<nodeID_t> result;
-        for (const auto chunk : graph->scanFwd(nodeID_t{node, tableID}, *scanState)) {
-            chunk.selVector.forEach([&](auto i) { result.push_back(chunk.nbrNodes[i]); });
-        }
-        EXPECT_EQ(result, expected);
-        EXPECT_EQ(graph->scanFwd(nodeID_t{node, tableID}, *scanState).collectNbrNodes(), expected);
-        result.clear();
-        for (const auto chunk : graph->scanBwd(nodeID_t{node, tableID}, *scanState)) {
-            chunk.selVector.forEach([&](auto i) { result.push_back(chunk.nbrNodes[i]); });
-        }
-        EXPECT_EQ(result, expected);
-        EXPECT_EQ(graph->scanFwd(nodeID_t{node, tableID}, *scanState).collectNbrNodes(), expected);
+    std::unordered_map<offset_t, common::date_t> expectedDates = {
+        {0, Date::fromDate(2021, 6, 30)},
+        {1, Date::fromDate(2021, 6, 30)},
+        {2, Date::fromDate(2021, 6, 30)},
+        {3, Date::fromDate(2021, 6, 30)},
+        {4, Date::fromDate(1950, 5, 14)},
+        {5, Date::fromDate(1950, 5, 14)},
+        {6, Date::fromDate(2021, 6, 30)},
+        {7, Date::fromDate(1950, 5, 14)},
+        {8, Date::fromDate(2000, 1, 1)},
+        {9, Date::fromDate(2021, 6, 30)},
+        {10, Date::fromDate(1950, 05, 14)},
+        {11, Date::fromDate(2000, 1, 1)},
     };
-    compare(0, {nodeID_t{1, tableID}, nodeID_t{2, tableID}, nodeID_t{3, tableID}});
-    compare(1, {nodeID_t{0, tableID}, nodeID_t{2, tableID}, nodeID_t{3, tableID}});
-    compare(2, {nodeID_t{0, tableID}, nodeID_t{1, tableID}, nodeID_t{3, tableID}});
+
+    const auto compare = [&](uint64_t node, std::vector<offset_t> expectedNodeOffsets,
+                             std::vector<offset_t> expectedFwdRelOffsets,
+                             std::vector<offset_t> expectedBwdRelOffsets) {
+        std::vector<offset_t> resultNodeOffsets;
+        std::vector<common::nodeID_t> expectedNodes;
+        std::transform(expectedNodeOffsets.begin(), expectedNodeOffsets.end(),
+            std::back_inserter(expectedNodes),
+            [&](auto offset) { return nodeID_t{offset, tableID}; });
+
+        std::vector<offset_t> resultRelOffsets;
+        std::vector<common::date_t> resultDates;
+        for (const auto chunk : graph->scanFwd(nodeID_t{node, tableID}, *scanState)) {
+            chunk.forEach<common::date_t>([&](auto nbr, auto edgeID, auto date) {
+                EXPECT_EQ(nbr.tableID, tableID);
+                resultNodeOffsets.push_back(nbr.offset);
+                EXPECT_EQ(edgeID.tableID, relTableID);
+                resultRelOffsets.push_back(edgeID.offset);
+                resultDates.push_back(date);
+            });
+        }
+        EXPECT_EQ(resultNodeOffsets, expectedNodeOffsets);
+        EXPECT_EQ(resultRelOffsets, expectedFwdRelOffsets);
+        for (size_t i = 0; i < resultRelOffsets.size(); i++) {
+            EXPECT_EQ(expectedDates[resultRelOffsets[i]], resultDates[i])
+                << " Result " << i << " (rel offset " << resultRelOffsets[i] << ") was "
+                << Date::toString(resultDates[i]) << " but we expected "
+                << Date::toString(expectedDates[resultRelOffsets[i]]);
+        }
+        EXPECT_EQ(graph->scanFwd(nodeID_t{node, tableID}, *scanState).collectNbrNodes(),
+            expectedNodes);
+
+        resultNodeOffsets.clear();
+        resultRelOffsets.clear();
+        resultDates.clear();
+
+        for (const auto chunk : graph->scanBwd(nodeID_t{node, tableID}, *scanState)) {
+            chunk.forEach<common::date_t>([&](auto nbr, auto edgeID, auto date) {
+                EXPECT_EQ(nbr.tableID, tableID);
+                resultNodeOffsets.push_back(nbr.offset);
+                EXPECT_EQ(edgeID.tableID, relTableID);
+                resultRelOffsets.push_back(edgeID.offset);
+                resultDates.push_back(date);
+            });
+        }
+        EXPECT_EQ(resultNodeOffsets, expectedNodeOffsets);
+        EXPECT_EQ(resultRelOffsets, expectedBwdRelOffsets);
+        for (size_t i = 0; i < resultRelOffsets.size(); i++) {
+            EXPECT_EQ(expectedDates[resultRelOffsets[i]], resultDates[i])
+                << " Result " << i << " (rel offset " << resultRelOffsets[i] << ") was "
+                << Date::toString(resultDates[i]) << " but we expected "
+                << Date::toString(expectedDates[resultRelOffsets[i]]);
+        }
+        EXPECT_EQ(graph->scanFwd(nodeID_t{node, tableID}, *scanState).collectNbrNodes(),
+            expectedNodes);
+    };
+    compare(0, {1, 2, 3}, {0, 1, 2}, {3, 6, 9});
+    compare(1, {0, 2, 3}, {3, 4, 5}, {0, 7, 10});
+    compare(2, {0, 1, 3}, {6, 7, 8}, {1, 4, 11});
 }
 
 } // namespace testing


### PR DESCRIPTION
This just adds support for a single edge property. It should be relatively simple to extend it so that it provides a list of vectors instead of a single vector.
Note that this is assuming it's not being used in conjunction with the predicates added in #4361. If they were used together, it would scan the same property twice (though it could be changed to have the duplicates share the same output vector).