### PR TITLE
Replacing Deprecated Finalize() with autoCloseable from JAVA_API

### DIFF
--- a/tools/java_api/src/main/java/com/kuzudb/Connection.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Connection.java
@@ -6,7 +6,7 @@ import java.util.Map;
  * Connection is used to interact with a Database instance. Each Connection is thread-safe. Multiple
  * connections can connect to the same Database instance in a multi-threaded environment.
  */
-public class Connection {
+public class Connection implements AutoCloseable {
 
     long conn_ref;
     boolean destroyed = false;
@@ -31,11 +31,11 @@ public class Connection {
     }
 
     /**
-    * Finalize.
+    * Close.
     * @throws ObjectRefDestroyedException If the connection has been destroyed.
     */
     @Override
-    protected void finalize() throws ObjectRefDestroyedException {
+    public void close() throws ObjectRefDestroyedException {
         destroy();
     }
 
@@ -43,7 +43,7 @@ public class Connection {
     * Destroy the connection.
     * @throws ObjectRefDestroyedException If the connection has been destroyed.
     */
-    public void destroy() throws ObjectRefDestroyedException {
+    private void destroy() throws ObjectRefDestroyedException {
         checkNotDestroyed();
         Native.kuzu_connection_destroy(this);
         destroyed = true;

--- a/tools/java_api/src/main/java/com/kuzudb/Connection.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Connection.java
@@ -31,7 +31,7 @@ public class Connection implements AutoCloseable {
     }
 
     /**
-    * Close.
+    * Used to destroy all allocated memory of the data. Automatically called by AutoCloseable within try-with-resouce clauses.
     * @throws ObjectRefDestroyedException If the connection has been destroyed.
     */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/Connection.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Connection.java
@@ -31,7 +31,7 @@ public class Connection implements AutoCloseable {
     }
 
     /**
-    * Used to destroy all allocated memory of the data. Automatically called by AutoCloseable within try-with-resouce clauses.
+    * Close the connection and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.    
     * @throws ObjectRefDestroyedException If the connection has been destroyed.
     */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/Connection.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Connection.java
@@ -31,7 +31,7 @@ public class Connection implements AutoCloseable {
     }
 
     /**
-    * Close the Connection and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.    
+    * Close the connection and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.    
     * @throws ObjectRefDestroyedException If the connection has been destroyed.
     */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/Connection.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Connection.java
@@ -31,7 +31,7 @@ public class Connection implements AutoCloseable {
     }
 
     /**
-    * Close the connection and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.    
+    * Close the Connection and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.    
     * @throws ObjectRefDestroyedException If the connection has been destroyed.
     */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/DataType.java
+++ b/tools/java_api/src/main/java/com/kuzudb/DataType.java
@@ -30,7 +30,7 @@ public class DataType implements AutoCloseable {
     }
 
     /**
-    * Close the connection and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
+    * Close the dataType and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
     * @throws ObjectRefDestroyedException If the data type instance has been destroyed.
     */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/DataType.java
+++ b/tools/java_api/src/main/java/com/kuzudb/DataType.java
@@ -30,7 +30,7 @@ public class DataType implements AutoCloseable {
     }
 
     /**
-    * Used to destroy all allocated memory of the data. Automatically called by AutoCloseable within try-with-resouce clauses.
+    * Close the connection and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
     * @throws ObjectRefDestroyedException If the data type instance has been destroyed.
     */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/DataType.java
+++ b/tools/java_api/src/main/java/com/kuzudb/DataType.java
@@ -30,7 +30,7 @@ public class DataType implements AutoCloseable {
     }
 
     /**
-    * Close the dataType and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
+    * Close the DataType and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
     * @throws ObjectRefDestroyedException If the data type instance has been destroyed.
     */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/DataType.java
+++ b/tools/java_api/src/main/java/com/kuzudb/DataType.java
@@ -3,7 +3,7 @@ package com.kuzudb;
 /**
 * DataType is the kuzu internal representation of data types.
 */
-public class DataType {
+public class DataType implements AutoCloseable {
     long dt_ref;
     boolean destroyed = false;
 
@@ -30,11 +30,11 @@ public class DataType {
     }
 
     /**
-    * Finalize.
+    * Close.
     * @throws ObjectRefDestroyedException If the data type instance has been destroyed.
     */
     @Override
-    protected void finalize() throws ObjectRefDestroyedException {
+    public void close() throws ObjectRefDestroyedException {
         destroy();
     }
 
@@ -42,7 +42,7 @@ public class DataType {
     * Destroy the data type instance.
     * @throws ObjectRefDestroyedException If the data type instance has been destroyed.
     */
-    public void destroy() throws ObjectRefDestroyedException {
+    private void destroy() throws ObjectRefDestroyedException {
         checkNotDestroyed();
         Native.kuzu_data_type_destroy(this);
         destroyed = true;

--- a/tools/java_api/src/main/java/com/kuzudb/DataType.java
+++ b/tools/java_api/src/main/java/com/kuzudb/DataType.java
@@ -30,7 +30,7 @@ public class DataType implements AutoCloseable {
     }
 
     /**
-    * Close the DataType and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
+    * Close the datatype and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
     * @throws ObjectRefDestroyedException If the data type instance has been destroyed.
     */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/DataType.java
+++ b/tools/java_api/src/main/java/com/kuzudb/DataType.java
@@ -30,7 +30,7 @@ public class DataType implements AutoCloseable {
     }
 
     /**
-    * Close.
+    * Used to destroy all allocated memory of the data. Automatically called by AutoCloseable within try-with-resouce clauses.
     * @throws ObjectRefDestroyedException If the data type instance has been destroyed.
     */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/Database.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Database.java
@@ -3,7 +3,7 @@ package com.kuzudb;
 /**
 * The Database class is the main class of KuzuDB. It manages all database components.
 */
-public class Database {
+public class Database implements AutoCloseable{
     long db_ref;
     String db_path;
     long buffer_size;
@@ -60,11 +60,11 @@ public class Database {
     }
 
     /**
-    * Finalize.
+    * Close.
     * @throws ObjectRefDestroyedException If the database instance has been destroyed.
     */
     @Override
-    protected void finalize() throws ObjectRefDestroyedException {
+    public void close() throws ObjectRefDestroyedException {
         destroy();
     }
 
@@ -72,7 +72,7 @@ public class Database {
     * Destroy the database instance.
     * @throws ObjectRefDestroyedException If the database instance has been destroyed.
     */
-    public void destroy() throws ObjectRefDestroyedException {
+    private void destroy() throws ObjectRefDestroyedException {
         checkNotDestroyed();
         Native.kuzu_database_destroy(this);
         destroyed = true;

--- a/tools/java_api/src/main/java/com/kuzudb/Database.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Database.java
@@ -60,7 +60,7 @@ public class Database implements AutoCloseable{
     }
 
     /**
-    * Close.
+    * Used to destroy all allocated memory of the data. Automatically called by AutoCloseable within try-with-resouce clauses.
     * @throws ObjectRefDestroyedException If the database instance has been destroyed.
     */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/Database.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Database.java
@@ -60,7 +60,7 @@ public class Database implements AutoCloseable{
     }
 
     /**
-    * Used to destroy all allocated memory of the data. Automatically called by AutoCloseable within try-with-resouce clauses.
+    * Close the connection and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
     * @throws ObjectRefDestroyedException If the database instance has been destroyed.
     */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/Database.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Database.java
@@ -51,7 +51,7 @@ public class Database implements AutoCloseable{
     }
 
     /**
-    * Checks if the Database instance has been destroyed.
+    * Checks if the database instance has been destroyed.
     * @throws ObjectRefDestroyedException If the database instance is destroyed.
     */
     private void checkNotDestroyed() throws ObjectRefDestroyedException {

--- a/tools/java_api/src/main/java/com/kuzudb/Database.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Database.java
@@ -51,7 +51,7 @@ public class Database implements AutoCloseable{
     }
 
     /**
-    * Checks if the database instance has been destroyed.
+    * Checks if the Database instance has been destroyed.
     * @throws ObjectRefDestroyedException If the database instance is destroyed.
     */
     private void checkNotDestroyed() throws ObjectRefDestroyedException {

--- a/tools/java_api/src/main/java/com/kuzudb/Database.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Database.java
@@ -60,7 +60,7 @@ public class Database implements AutoCloseable{
     }
 
     /**
-    * Close the connection and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
+    * Close the database and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
     * @throws ObjectRefDestroyedException If the database instance has been destroyed.
     */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/FlatTuple.java
+++ b/tools/java_api/src/main/java/com/kuzudb/FlatTuple.java
@@ -3,7 +3,7 @@ package com.kuzudb;
 /**
 * FlatTuple stores a vector of values.
 */
-public class FlatTuple {
+public class FlatTuple implements AutoCloseable {
     long ft_ref;
     boolean destroyed = false;
 
@@ -17,11 +17,11 @@ public class FlatTuple {
     }
 
     /**
-     * Finalize.
+     * Close.
      * @throws ObjectRefDestroyedException If the flat tuple has been destroyed.
      */
     @Override
-    protected void finalize() throws ObjectRefDestroyedException {
+    public void close() throws ObjectRefDestroyedException {
         destroy();
     }
 
@@ -29,7 +29,7 @@ public class FlatTuple {
      * Destroy the flat tuple.
      * @throws ObjectRefDestroyedException If the flat tuple has been destroyed.
      */
-    public void destroy() throws ObjectRefDestroyedException {
+    private void destroy() throws ObjectRefDestroyedException {
         checkNotDestroyed();
         Native.kuzu_flat_tuple_destroy(this);
         destroyed = true;

--- a/tools/java_api/src/main/java/com/kuzudb/FlatTuple.java
+++ b/tools/java_api/src/main/java/com/kuzudb/FlatTuple.java
@@ -17,7 +17,7 @@ public class FlatTuple implements AutoCloseable {
     }
 
     /**
-    * Used to destroy all allocated memory of the data. Automatically called by AutoCloseable within try-with-resouce clauses.
+    * Close the connection and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
      * @throws ObjectRefDestroyedException If the flat tuple has been destroyed.
      */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/FlatTuple.java
+++ b/tools/java_api/src/main/java/com/kuzudb/FlatTuple.java
@@ -17,7 +17,7 @@ public class FlatTuple implements AutoCloseable {
     }
 
     /**
-    * Close the FlatTuple and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
+    * Close the flat tuple and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
      * @throws ObjectRefDestroyedException If the flat tuple has been destroyed.
      */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/FlatTuple.java
+++ b/tools/java_api/src/main/java/com/kuzudb/FlatTuple.java
@@ -17,7 +17,7 @@ public class FlatTuple implements AutoCloseable {
     }
 
     /**
-     * Close.
+    * Used to destroy all allocated memory of the data. Automatically called by AutoCloseable within try-with-resouce clauses.
      * @throws ObjectRefDestroyedException If the flat tuple has been destroyed.
      */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/FlatTuple.java
+++ b/tools/java_api/src/main/java/com/kuzudb/FlatTuple.java
@@ -17,7 +17,7 @@ public class FlatTuple implements AutoCloseable {
     }
 
     /**
-    * Close the flatTuple and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
+    * Close the FlatTuple and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
      * @throws ObjectRefDestroyedException If the flat tuple has been destroyed.
      */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/FlatTuple.java
+++ b/tools/java_api/src/main/java/com/kuzudb/FlatTuple.java
@@ -17,7 +17,7 @@ public class FlatTuple implements AutoCloseable {
     }
 
     /**
-    * Close the connection and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
+    * Close the flatTuple and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
      * @throws ObjectRefDestroyedException If the flat tuple has been destroyed.
      */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/PreparedStatement.java
+++ b/tools/java_api/src/main/java/com/kuzudb/PreparedStatement.java
@@ -17,7 +17,7 @@ public class PreparedStatement implements AutoCloseable {
     }
 
     /**
-    * Close.
+    * Used to destroy all allocated memory of the data. Automatically called by AutoCloseable within try-with-resouce clauses.
     * @throws ObjectRefDestroyedException If the prepared statement has been destroyed.
     */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/PreparedStatement.java
+++ b/tools/java_api/src/main/java/com/kuzudb/PreparedStatement.java
@@ -17,7 +17,7 @@ public class PreparedStatement implements AutoCloseable {
     }
 
     /**
-    * Close the connection and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
+    * Close the perparedStatement and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
     * @throws ObjectRefDestroyedException If the prepared statement has been destroyed.
     */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/PreparedStatement.java
+++ b/tools/java_api/src/main/java/com/kuzudb/PreparedStatement.java
@@ -17,7 +17,7 @@ public class PreparedStatement implements AutoCloseable {
     }
 
     /**
-    * Close the perparedStatement and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
+    * Close the PreparedStatement and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
     * @throws ObjectRefDestroyedException If the prepared statement has been destroyed.
     */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/PreparedStatement.java
+++ b/tools/java_api/src/main/java/com/kuzudb/PreparedStatement.java
@@ -17,7 +17,7 @@ public class PreparedStatement implements AutoCloseable {
     }
 
     /**
-    * Used to destroy all allocated memory of the data. Automatically called by AutoCloseable within try-with-resouce clauses.
+    * Close the connection and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
     * @throws ObjectRefDestroyedException If the prepared statement has been destroyed.
     */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/PreparedStatement.java
+++ b/tools/java_api/src/main/java/com/kuzudb/PreparedStatement.java
@@ -17,7 +17,7 @@ public class PreparedStatement implements AutoCloseable {
     }
 
     /**
-    * Close the PreparedStatement and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
+    * Close the prepared statement and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
     * @throws ObjectRefDestroyedException If the prepared statement has been destroyed.
     */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/PreparedStatement.java
+++ b/tools/java_api/src/main/java/com/kuzudb/PreparedStatement.java
@@ -3,7 +3,7 @@ package com.kuzudb;
 /**
  * PreparedStatement is a parameterized query which can avoid planning the same query for repeated execution.
  */
-public class PreparedStatement {
+public class PreparedStatement implements AutoCloseable {
     long ps_ref;
     boolean destroyed = false;
 
@@ -17,11 +17,11 @@ public class PreparedStatement {
     }
 
     /**
-    * Finalize.
+    * Close.
     * @throws ObjectRefDestroyedException If the prepared statement has been destroyed.
     */
     @Override
-    protected void finalize() throws ObjectRefDestroyedException {
+    public void close() throws ObjectRefDestroyedException {
         destroy();
     }
 
@@ -29,7 +29,7 @@ public class PreparedStatement {
      * Destroy the prepared statement.
      * @throws ObjectRefDestroyedException If the prepared statement has been destroyed.
      */
-    public void destroy() throws ObjectRefDestroyedException {
+    private void destroy() throws ObjectRefDestroyedException {
         checkNotDestroyed();
         Native.kuzu_prepared_statement_destroy(this);
         destroyed = true;

--- a/tools/java_api/src/main/java/com/kuzudb/QueryResult.java
+++ b/tools/java_api/src/main/java/com/kuzudb/QueryResult.java
@@ -18,7 +18,7 @@ public class QueryResult implements AutoCloseable {
     }
 
     /**
-     * Close.
+    * Used to destroy all allocated memory of the data. Automatically called by AutoCloseable within try-with-resouce clauses.
      * @throws ObjectRefDestroyedException If the query result has been destroyed.
      */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/QueryResult.java
+++ b/tools/java_api/src/main/java/com/kuzudb/QueryResult.java
@@ -18,7 +18,7 @@ public class QueryResult implements AutoCloseable {
     }
 
     /**
-    * Close the connection and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
+    * Close the queryResult and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
      * @throws ObjectRefDestroyedException If the query result has been destroyed.
      */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/QueryResult.java
+++ b/tools/java_api/src/main/java/com/kuzudb/QueryResult.java
@@ -18,7 +18,7 @@ public class QueryResult implements AutoCloseable {
     }
 
     /**
-    * Close the QueryResult and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
+    * Close the query result and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
      * @throws ObjectRefDestroyedException If the query result has been destroyed.
      */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/QueryResult.java
+++ b/tools/java_api/src/main/java/com/kuzudb/QueryResult.java
@@ -18,7 +18,7 @@ public class QueryResult implements AutoCloseable {
     }
 
     /**
-    * Close the queryResult and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
+    * Close the QueryResult and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
      * @throws ObjectRefDestroyedException If the query result has been destroyed.
      */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/QueryResult.java
+++ b/tools/java_api/src/main/java/com/kuzudb/QueryResult.java
@@ -18,7 +18,7 @@ public class QueryResult implements AutoCloseable {
     }
 
     /**
-    * Used to destroy all allocated memory of the data. Automatically called by AutoCloseable within try-with-resouce clauses.
+    * Close the connection and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
      * @throws ObjectRefDestroyedException If the query result has been destroyed.
      */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/QueryResult.java
+++ b/tools/java_api/src/main/java/com/kuzudb/QueryResult.java
@@ -3,7 +3,7 @@ package com.kuzudb;
 /**
  * QueryResult stores the result of a query execution.
  */
-public class QueryResult {
+public class QueryResult implements AutoCloseable {
     long qr_ref;
     boolean destroyed = false;
     boolean isOwnedByCPP = false;
@@ -18,11 +18,11 @@ public class QueryResult {
     }
 
     /**
-     * Finalize.
+     * Close.
      * @throws ObjectRefDestroyedException If the query result has been destroyed.
      */
     @Override
-    protected void finalize() throws ObjectRefDestroyedException {
+    public void close() throws ObjectRefDestroyedException {
         destroy();
     }
 
@@ -34,7 +34,7 @@ public class QueryResult {
      * Destroy the query result.
      * @throws ObjectRefDestroyedException If the query result has been destroyed.
      */
-    public void destroy() throws ObjectRefDestroyedException {
+    private void destroy() throws ObjectRefDestroyedException {
         checkNotDestroyed();
         if (!isOwnedByCPP) {
             Native.kuzu_query_result_destroy(this);

--- a/tools/java_api/src/main/java/com/kuzudb/Value.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Value.java
@@ -52,7 +52,7 @@ public class Value implements AutoCloseable {
     }
 
     /**
-     * Close.
+    * Used to destroy all allocated memory of the data. Automatically called by AutoCloseable within try-with-resouce clauses.
      * @throws ObjectRefDestroyedException If the Value has been destroyed.
      */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/Value.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Value.java
@@ -52,7 +52,7 @@ public class Value implements AutoCloseable {
     }
 
     /**
-    * Used to destroy all allocated memory of the data. Automatically called by AutoCloseable within try-with-resouce clauses.
+    * Close the connection and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
      * @throws ObjectRefDestroyedException If the Value has been destroyed.
      */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/Value.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Value.java
@@ -3,7 +3,7 @@ package com.kuzudb;
 /**
  * Value can hold data of different types.
  */
-public class Value {
+public class Value implements AutoCloseable {
     public long v_ref;
     boolean destroyed = false;
     boolean isOwnedByCPP = false;
@@ -52,11 +52,11 @@ public class Value {
     }
 
     /**
-     * Finalize.
+     * Close.
      * @throws ObjectRefDestroyedException If the Value has been destroyed.
      */
     @Override
-    protected void finalize() throws ObjectRefDestroyedException {
+    public void close() throws ObjectRefDestroyedException {
         destroy();
     }
 
@@ -68,7 +68,7 @@ public class Value {
      * Destroy the Value.
      * @throws ObjectRefDestroyedException If the Value has been destroyed.
      */
-    public void destroy() throws ObjectRefDestroyedException {
+    private void destroy() throws ObjectRefDestroyedException {
         checkNotDestroyed();
         if (!isOwnedByCPP) {
             Native.kuzu_value_destroy(this);

--- a/tools/java_api/src/main/java/com/kuzudb/Value.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Value.java
@@ -52,7 +52,7 @@ public class Value implements AutoCloseable {
     }
 
     /**
-    * Close the Value and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
+    * Close the value and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
      * @throws ObjectRefDestroyedException If the Value has been destroyed.
      */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/Value.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Value.java
@@ -52,7 +52,7 @@ public class Value implements AutoCloseable {
     }
 
     /**
-    * Close the connection and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
+    * Close the value and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
      * @throws ObjectRefDestroyedException If the Value has been destroyed.
      */
     @Override

--- a/tools/java_api/src/main/java/com/kuzudb/Value.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Value.java
@@ -52,7 +52,7 @@ public class Value implements AutoCloseable {
     }
 
     /**
-    * Close the value and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
+    * Close the Value and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
      * @throws ObjectRefDestroyedException If the Value has been destroyed.
      */
     @Override

--- a/tools/java_api/src/test/java/com/kuzudb/ConnectionTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/ConnectionTest.java
@@ -72,6 +72,8 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 3);
+        statement.close();
+        result.close();
     }
 
     @Test
@@ -91,6 +93,8 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 4);
+        statement.close();
+        result.close();
     }
 
     @Test
@@ -108,6 +112,8 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 2);
+        statement.close();
+        result.close();
     }
 
     @Test
@@ -125,6 +131,8 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 2);
+        statement.close();
+        result.close();
     }
 
     @Test
@@ -142,6 +150,8 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 7);
+        statement.close();
+        result.close();
     }
 
     @Test
@@ -159,6 +169,8 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 1);
+        statement.close();
+        result.close();
     }
 
     @Test
@@ -176,6 +188,8 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 1);
+        statement.close();
+        result.close();
     }
 
     @Test
@@ -193,6 +207,8 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 4);
+        statement.close();
+        result.close();
     }
 
     @Test
@@ -210,6 +226,8 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 7);
+        statement.close();
+        result.close();
     }
 
     @Test
@@ -227,6 +245,8 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 3);
+        statement.close();
+        result.close();
     }
 
     @Test
@@ -247,6 +267,13 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 1);
+        statement.close();
+        result.close();
+
+        // Not strictly necessary, but this makes sure if we freed v1 or v2 in
+        // the execute() call, we segfault here.
+        v1.close();
+        v2.close();        
     }
 
     @Test

--- a/tools/java_api/src/test/java/com/kuzudb/ConnectionTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/ConnectionTest.java
@@ -18,9 +18,7 @@ public class ConnectionTest extends TestBase {
 
     @Test
     void ConnCreationAndDestroy() {
-        try {
-            Connection conn = new Connection(db);
-            conn.destroy();
+        try ( Connection conn = new Connection(db);) {
         } catch (AssertionError e) {
             fail("ConnCreationAndDestroy failed");
         } catch (ObjectRefDestroyedException e) {
@@ -40,15 +38,15 @@ public class ConnectionTest extends TestBase {
     @Test
     void ConnQuery() throws ObjectRefDestroyedException {
         String query = "MATCH (a:person) RETURN a.fName;";
-        QueryResult result = conn.query(query);
-        assertNotNull(result);
-        assertTrue(result.isSuccess());
-        assertTrue(result.hasNext());
-        assertTrue(result.getErrorMessage().equals(""));
-        assertEquals(result.getNumTuples(), 8);
-        assertEquals(result.getNumColumns(), 1);
-        assertTrue(result.getColumnName(0).equals("a.fName"));
-        result.destroy();
+        try (QueryResult result = conn.query(query)) {
+            assertNotNull(result);
+            assertTrue(result.isSuccess());
+            assertTrue(result.hasNext());
+            assertTrue(result.getErrorMessage().equals(""));
+            assertEquals(result.getNumTuples(), 8);
+            assertEquals(result.getNumColumns(), 1);
+            assertTrue(result.getColumnName(0).equals("a.fName"));
+        }        
     }
 
     @Test
@@ -74,8 +72,6 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 3);
-        statement.destroy();
-        result.destroy();
     }
 
     @Test
@@ -95,8 +91,6 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 4);
-        statement.destroy();
-        result.destroy();
     }
 
     @Test
@@ -114,8 +108,6 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 2);
-        statement.destroy();
-        result.destroy();
     }
 
     @Test
@@ -133,8 +125,6 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 2);
-        statement.destroy();
-        result.destroy();
     }
 
     @Test
@@ -152,8 +142,6 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 7);
-        statement.destroy();
-        result.destroy();
     }
 
     @Test
@@ -171,8 +159,6 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 1);
-        statement.destroy();
-        result.destroy();
     }
 
     @Test
@@ -190,8 +176,6 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 1);
-        statement.destroy();
-        result.destroy();
     }
 
     @Test
@@ -209,8 +193,6 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 4);
-        statement.destroy();
-        result.destroy();
     }
 
     @Test
@@ -228,8 +210,6 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 7);
-        statement.destroy();
-        result.destroy();
     }
 
     @Test
@@ -247,8 +227,6 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 3);
-        statement.destroy();
-        result.destroy();
     }
 
     @Test
@@ -269,23 +247,16 @@ public class ConnectionTest extends TestBase {
         assertEquals(result.getNumColumns(), 1);
         FlatTuple tuple = result.getNext();
         assertEquals(((long) tuple.getValue(0).getValue()), 1);
-        statement.destroy();
-        result.destroy();
-
-        // Not strictly necessary, but this makes sure if we freed v1 or v2 in
-        // the execute() call, we segfault here.
-        v1.destroy();
-        v2.destroy();
     }
 
     @Test
     void ConnQueryTimeout() throws ObjectRefDestroyedException {
         conn.setQueryTimeout(1);
-        QueryResult result = conn.query("MATCH (a:person)-[:knows*1..28]->(b:person) RETURN COUNT(*);");
-        assertNotNull(result);
-        assertFalse(result.isSuccess());
-        assertTrue(result.getErrorMessage().equals("Interrupted."));
-        result.destroy();
+        try (QueryResult result = conn.query("MATCH (a:person)-[:knows*1..28]->(b:person) RETURN COUNT(*);")) {
+            assertNotNull(result);
+            assertFalse(result.isSuccess());
+            assertTrue(result.getErrorMessage().equals("Interrupted."));
+        }        
     }
 
 }

--- a/tools/java_api/src/test/java/com/kuzudb/ConnectionTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/ConnectionTest.java
@@ -18,7 +18,7 @@ public class ConnectionTest extends TestBase {
 
     @Test
     void ConnCreationAndDestroy() {
-        try ( Connection conn = new Connection(db);) {
+        try ( Connection conn = new Connection(db)) {
         } catch (AssertionError e) {
             fail("ConnCreationAndDestroy failed");
         } catch (ObjectRefDestroyedException e) {

--- a/tools/java_api/src/test/java/com/kuzudb/DataTypeTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/DataTypeTest.java
@@ -31,6 +31,12 @@ public class DataTypeTest extends TestBase {
         assertEquals(dataTypeClone3.getFixedNumElementsInList(), 100);
 
         assertFalse(dataTypeClone2.equals(dataTypeClone3));
+        dataType.close();
+        dataType2.close();
+        dataType3.close();
+        dataTypeClone.close();
+        dataTypeClone2.close();
+        dataTypeClone3.close();
     }
 
     @Test
@@ -58,6 +64,12 @@ public class DataTypeTest extends TestBase {
         assertFalse(dataType2.equals(dataType3));
         assertFalse(dataTypeClone.equals(dataTypeClone3));
 
+        dataType.close();
+        dataType2.close();
+        dataType3.close();
+        dataTypeClone.close();
+        dataTypeClone2.close();
+        dataTypeClone3.close();
     }
 
     @Test
@@ -74,6 +86,9 @@ public class DataTypeTest extends TestBase {
         assertNotNull(dataType3);
         assertEquals(dataType3.getID(), DataTypeID.ARRAY);
 
+        dataType.close();
+        dataType2.close();
+        dataType3.close();
     }
 
     @Test
@@ -89,6 +104,9 @@ public class DataTypeTest extends TestBase {
         assertNotNull(dataType3);
         assertEquals(dataType3.getChildType().getID(), DataTypeID.INT64);
 
+        dataType.close();
+        dataType2.close();
+        dataType3.close();
     }
 
     @Test

--- a/tools/java_api/src/test/java/com/kuzudb/DataTypeTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/DataTypeTest.java
@@ -31,13 +31,6 @@ public class DataTypeTest extends TestBase {
         assertEquals(dataTypeClone3.getFixedNumElementsInList(), 100);
 
         assertFalse(dataTypeClone2.equals(dataTypeClone3));
-
-        dataType.destroy();
-        dataType2.destroy();
-        dataType3.destroy();
-        dataTypeClone.destroy();
-        dataTypeClone2.destroy();
-        dataTypeClone3.destroy();
     }
 
     @Test
@@ -65,12 +58,6 @@ public class DataTypeTest extends TestBase {
         assertFalse(dataType2.equals(dataType3));
         assertFalse(dataTypeClone.equals(dataTypeClone3));
 
-        dataType.destroy();
-        dataType2.destroy();
-        dataType3.destroy();
-        dataTypeClone.destroy();
-        dataTypeClone2.destroy();
-        dataTypeClone3.destroy();
     }
 
     @Test
@@ -87,9 +74,6 @@ public class DataTypeTest extends TestBase {
         assertNotNull(dataType3);
         assertEquals(dataType3.getID(), DataTypeID.ARRAY);
 
-        dataType.destroy();
-        dataType2.destroy();
-        dataType3.destroy();
     }
 
     @Test
@@ -105,9 +89,6 @@ public class DataTypeTest extends TestBase {
         assertNotNull(dataType3);
         assertEquals(dataType3.getChildType().getID(), DataTypeID.INT64);
 
-        dataType.destroy();
-        dataType2.destroy();
-        dataType3.destroy();
     }
 
     @Test
@@ -123,9 +104,23 @@ public class DataTypeTest extends TestBase {
         DataType dataType3 = new DataType(DataTypeID.ARRAY, dataType, 100);
         assertNotNull(dataType3);
         assertEquals(dataType3.getFixedNumElementsInList(), 100);
+    }
 
-        dataType.destroy();
-        dataType2.destroy();
-        dataType3.destroy();
+    @Test
+    void DataTypeTestDestroy() throws ObjectRefDestroyedException {
+        try (DataType dataType = new DataType(DataTypeID.INT64, null, 0)) {
+            assertNotNull(dataType);
+            assertEquals(dataType.getFixedNumElementsInList(), 0);
+        
+            try (DataType dataType2 = new DataType(DataTypeID.LIST, dataType, 0)) {
+                assertNotNull(dataType2);
+                assertEquals(dataType2.getFixedNumElementsInList(), 0);
+            }
+        
+            try (DataType dataType3 = new DataType(DataTypeID.ARRAY, dataType, 100)) {
+                assertNotNull(dataType3);
+                assertEquals(dataType3.getFixedNumElementsInList(), 100);
+            }
+        }          
     }
 }

--- a/tools/java_api/src/test/java/com/kuzudb/DatabaseTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/DatabaseTest.java
@@ -13,39 +13,45 @@ public class DatabaseTest extends TestBase {
 
     @Test
     void DBCreationAndDestroyWithArgs() {
+        String dbPath = "";
         try {
-            String dbPath = tempDir.toFile().getAbsolutePath();
-            try (Database database = new Database(
-                    dbPath,
-                    1 << 28 /* 256 MB */,
-                    true /* compression */,
-                    false /* readOnly */,
-                    1 << 30 /* 1 GB */)) {
-                // Database will be automatically destroyed after this block
-            }
+            dbPath = tempDir.toFile().getAbsolutePath();
         } catch (Exception e) {
-            fail("DBCreationAndDestroyWithArgs failed");
-        }        
+            fail("Cannot get database path: " + e.getMessage());
+        }
+
+        try (Database database = new Database(
+            dbPath,
+            1 << 28 /* 256 MB */,
+            true /* compression */,
+            false /* readOnly */,
+            1 << 30 /* 1 GB */)) {
+        // Database will be automatically destroyed after this block
+        } catch (Exception e) {
+            fail("DBCreationAndDestroyWithArgs failed: " + e.getMessage());
+        }
     }
 
     @Test
     void DBCreationAndDestroyWithPathOnly() {
+        String dbPath = "";
         try {
-            String dbPath = tempDir.toFile().getAbsolutePath();
-            try (Database database = new Database(dbPath)) {
-            }
+            dbPath = tempDir.toFile().getAbsolutePath();
         } catch (Exception e) {
-            fail("DBCreationAndDestroyWithPathOnly failed");
-        }        
+            fail("Cannot get database path: " + e.getMessage());
+        }  
+        
+        try (Database database = new Database(dbPath)) {
+        } catch (Exception e) {
+            fail("DBCreationAndDestroyWithPathOnly failed: " + e.getMessage());
+        }
     }
 
     @Test
     void DBCreationAndDestroyWithNoParam(){
-        try {
-            try (Database database = new Database()) {
-            }
+        try (Database database = new Database()) {
         } catch (Exception e) {
-            fail("DBCreationAndDestroyWithNoParam failed");
+            fail("DBCreationAndDestroyWithNoParam failed: " + e.getMessage());
         }
     }
 }

--- a/tools/java_api/src/test/java/com/kuzudb/DatabaseTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/DatabaseTest.java
@@ -15,35 +15,35 @@ public class DatabaseTest extends TestBase {
     void DBCreationAndDestroyWithArgs() {
         try {
             String dbPath = tempDir.toFile().getAbsolutePath();
-            Database database = new Database(
+            try (Database database = new Database(
                     dbPath,
                     1 << 28 /* 256 MB */,
                     true /* compression */,
                     false /* readOnly */,
-                    1 << 30 /* 1 GB */
-            );
-            database.destroy();
+                    1 << 30 /* 1 GB */)) {
+                // Database will be automatically destroyed after this block
+            }
         } catch (Exception e) {
             fail("DBCreationAndDestroyWithArgs failed");
-        }
+        }        
     }
 
     @Test
     void DBCreationAndDestroyWithPathOnly() {
         try {
             String dbPath = tempDir.toFile().getAbsolutePath();
-            Database database = new Database(dbPath);
-            database.destroy();
+            try (Database database = new Database(dbPath)) {
+            }
         } catch (Exception e) {
             fail("DBCreationAndDestroyWithPathOnly failed");
-        }
+        }        
     }
 
     @Test
     void DBCreationAndDestroyWithNoParam(){
         try {
-            Database database = new Database();
-            database.destroy();
+            try (Database database = new Database()) {
+            }
         } catch (Exception e) {
             fail("DBCreationAndDestroyWithNoParam failed");
         }

--- a/tools/java_api/src/test/java/com/kuzudb/FlatTupleTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/FlatTupleTest.java
@@ -8,50 +8,49 @@ public class FlatTupleTest extends TestBase {
 
     @Test
     void FlatTupleGetValue() throws ObjectRefDestroyedException {
-        QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.age, a.height ORDER BY a.fName LIMIT 1");
-        assertTrue(result.isSuccess());
-        assertTrue(result.hasNext());
-        FlatTuple flatTuple = result.getNext();
-        assertNotNull(flatTuple);
-
-        Value value = flatTuple.getValue(0);
-        assertNotNull(value);
-        assertEquals(value.getDataType().getID(), DataTypeID.STRING);
-        assertTrue(value.getValue().equals("Alice"));
-        value.destroy();
-
-        value = flatTuple.getValue(1);
-        assertNotNull(value);
-        assertEquals(value.getDataType().getID(), DataTypeID.INT64);
-        assertTrue(value.getValue().equals(35L));
-        value.destroy();
-
-        value = flatTuple.getValue(2);
-        assertNotNull(value);
-        assertEquals(value.getDataType().getID(), DataTypeID.FLOAT);
-        assertTrue(value.getValue().equals((float) 1.731));
-        value.destroy();
-
-        value = flatTuple.getValue(222);
-        assertNull(value);
-
-        result.destroy();
+        try (QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.age, a.height ORDER BY a.fName LIMIT 1")) {
+            assertTrue(result.isSuccess());
+            assertTrue(result.hasNext());
+        
+            FlatTuple flatTuple = result.getNext();
+            assertNotNull(flatTuple);
+        
+            try (Value value = flatTuple.getValue(0)) {
+                assertNotNull(value);
+                assertEquals(value.getDataType().getID(), DataTypeID.STRING);
+                assertTrue(value.getValue().equals("Alice"));
+            }
+        
+            try (Value value = flatTuple.getValue(1)) {
+                assertNotNull(value);
+                assertEquals(value.getDataType().getID(), DataTypeID.INT64);
+                assertTrue(value.getValue().equals(35L));
+            }
+        
+            try (Value value = flatTuple.getValue(2)) {
+                assertNotNull(value);
+                assertEquals(value.getDataType().getID(), DataTypeID.FLOAT);
+                assertTrue(value.getValue().equals((float) 1.731));
+            }
+        
+            Value value = flatTuple.getValue(222);
+            assertNull(value);
+        }        
     }
 
     @Test
     void FlatTupleToString() throws ObjectRefDestroyedException {
-        QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.age, a.height ORDER BY a.fName LIMIT 1");
-        assertTrue(result.isSuccess());
-        assertTrue(result.hasNext());
-        FlatTuple flatTuple = result.getNext();
-        assertNotNull(flatTuple);
-
-        String str = flatTuple.toString();
-        assertTrue(str.equals("Alice|35|1.731000\n"));
-
-        flatTuple.destroy();
-        result.destroy();
-
+        try (QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.age, a.height ORDER BY a.fName LIMIT 1")) {
+            assertTrue(result.isSuccess());
+            assertTrue(result.hasNext());
+        
+            try (FlatTuple flatTuple = result.getNext()) {
+                assertNotNull(flatTuple);
+        
+                String str = flatTuple.toString();
+                assertTrue(str.equals("Alice|35|1.731000\n"));
+            }
+        }        
     }
 
 }

--- a/tools/java_api/src/test/java/com/kuzudb/PreparedStatementTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/PreparedStatementTest.java
@@ -9,33 +9,33 @@ public class PreparedStatementTest extends TestBase {
     @Test
     void PrepStmtIsSuccess() throws ObjectRefDestroyedException {
         String query = "MATCH (a:person) WHERE a.isStudent = $1 RETURN COUNT(*)";
-        PreparedStatement preparedStatement1 = conn.prepare(query);
-        assertNotNull(preparedStatement1);
-        assertTrue(preparedStatement1.isSuccess());
-        preparedStatement1.destroy();
-
+        try (PreparedStatement preparedStatement1 = conn.prepare(query)) {
+            assertNotNull(preparedStatement1);
+            assertTrue(preparedStatement1.isSuccess());
+        }
+        
         query = "MATCH (a:personnnn) WHERE a.isStudent = $1 RETURN COUNT(*)";
-        PreparedStatement preparedStatement2 = conn.prepare(query);
-        assertNotNull(preparedStatement2);
-        assertFalse(preparedStatement2.isSuccess());
-        preparedStatement2.destroy();
+        try (PreparedStatement preparedStatement2 = conn.prepare(query)) {
+            assertNotNull(preparedStatement2);
+            assertFalse(preparedStatement2.isSuccess());
+        }
     }
 
     @Test
     void PrepStmtGetErrorMessage() throws ObjectRefDestroyedException {
         String query = "MATCH (a:person) WHERE a.isStudent = $1 RETURN COUNT(*)";
-        PreparedStatement preparedStatement1 = conn.prepare(query);
-        assertNotNull(preparedStatement1);
-        String message = preparedStatement1.getErrorMessage();
-        assertTrue(message.equals(""));
-        preparedStatement1.destroy();
-
+        try (PreparedStatement preparedStatement1 = conn.prepare(query)) {
+            assertNotNull(preparedStatement1);
+            String message = preparedStatement1.getErrorMessage();
+            assertTrue(message.equals(""));
+        }
+        
         query = "MATCH (a:personnnn) WHERE a.isStudent = $1 RETURN COUNT(*)";
-        PreparedStatement preparedStatement2 = conn.prepare(query);
-        assertNotNull(preparedStatement2);
-        message = preparedStatement2.getErrorMessage();
-        assertTrue(message.equals("Binder exception: Table personnnn does not exist."));
-        preparedStatement2.destroy();
+        try (PreparedStatement preparedStatement2 = conn.prepare(query)) {
+            assertNotNull(preparedStatement2);
+            String message = preparedStatement2.getErrorMessage();
+            assertTrue(message.equals("Binder exception: Table personnnn does not exist."));
+        }        
     }
 
 }

--- a/tools/java_api/src/test/java/com/kuzudb/QueryResultTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/QueryResultTest.java
@@ -13,148 +13,151 @@ public class QueryResultTest extends TestBase {
 
     @Test
     void QueryResultGetErrorMessage() throws ObjectRefDestroyedException {
-        QueryResult result = conn.query("MATCH (a:person) RETURN COUNT(*)");
-        assertTrue(result.isSuccess());
-        String errorMessage = result.getErrorMessage();
-        assertTrue(errorMessage.equals(""));
-        result.destroy();
-
-        result = conn.query("MATCH (a:personnnn) RETURN COUNT(*)");
-        assertFalse(result.isSuccess());
-        errorMessage = result.getErrorMessage();
-        assertTrue(errorMessage.equals("Binder exception: Table personnnn does not exist."));
-        result.destroy();
+        try (QueryResult result = conn.query("MATCH (a:person) RETURN COUNT(*)")) {
+            assertTrue(result.isSuccess());
+            String errorMessage = result.getErrorMessage();
+            assertTrue(errorMessage.equals(""));
+        }
+        
+        try (QueryResult result = conn.query("MATCH (a:personnnn) RETURN COUNT(*)")) {
+            assertFalse(result.isSuccess());
+            String errorMessage = result.getErrorMessage();
+            assertTrue(errorMessage.equals("Binder exception: Table personnnn does not exist."));
+        }        
     }
 
     @Test
     void QueryResultGetNumColumns() throws ObjectRefDestroyedException {
-        QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.age, a.height");
-        assertTrue(result.isSuccess());
-        assertEquals(result.getNumColumns(), 3);
-        result.destroy();
+        try (QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.age, a.height")) {
+            assertTrue(result.isSuccess());
+            assertEquals(result.getNumColumns(), 3);
+        }        
     }
 
     @Test
     void QueryResultGetColumnName() throws ObjectRefDestroyedException {
-        QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.age, a.height");
-        assertTrue(result.isSuccess());
-        String columnName = result.getColumnName(0);
-        assertTrue(columnName.equals("a.fName"));
-
-        columnName = result.getColumnName(1);
-        assertTrue(columnName.equals("a.age"));
-
-        columnName = result.getColumnName(2);
-        assertTrue(columnName.equals("a.height"));
-
-        columnName = result.getColumnName(222);
-        assertNull(columnName);
-
-        result.destroy();
+        try (QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.age, a.height")) {
+            assertTrue(result.isSuccess());
+        
+            String columnName = result.getColumnName(0);
+            assertTrue(columnName.equals("a.fName"));
+        
+            columnName = result.getColumnName(1);
+            assertTrue(columnName.equals("a.age"));
+        
+            columnName = result.getColumnName(2);
+            assertTrue(columnName.equals("a.height"));
+        
+            columnName = result.getColumnName(222);
+            assertNull(columnName);
+        }        
     }
 
     @Test
     void QueryResultGetColumnDataType() throws ObjectRefDestroyedException {
-        QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.age, a.height, cast(1 as decimal)");
-        assertTrue(result.isSuccess());
-        DataType type = result.getColumnDataType(0);
-        assertEquals(type.getID(), DataTypeID.STRING);
-        type.destroy();
-
-        type = result.getColumnDataType(1);
-        assertEquals(type.getID(), DataTypeID.INT64);
-        type.destroy();
-        type = result.getColumnDataType(2);
-        assertEquals(type.getID(), DataTypeID.FLOAT);
-        type.destroy();
-        type = result.getColumnDataType(3);
-        assertEquals(type.getID(), DataTypeID.DECIMAL);
-        type.destroy();
-
-        type = result.getColumnDataType(222);
-        assertNull(type);
+        try (QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.age, a.height, cast(1 as decimal)")) {
+            assertTrue(result.isSuccess());
+        
+            try (DataType type = result.getColumnDataType(0)) {
+                assertEquals(type.getID(), DataTypeID.STRING);
+            }
+        
+            try (DataType type = result.getColumnDataType(1)) {
+                assertEquals(type.getID(), DataTypeID.INT64);
+            }
+        
+            try (DataType type = result.getColumnDataType(2)) {
+                assertEquals(type.getID(), DataTypeID.FLOAT);
+            }
+        
+            try (DataType type = result.getColumnDataType(3)) {
+                assertEquals(type.getID(), DataTypeID.DECIMAL);
+            }
+        
+            DataType type = result.getColumnDataType(222);
+            assertNull(type);
+        }        
     }
 
     @Test
     void QueryResultGetQuerySummary() throws ObjectRefDestroyedException {
-        QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.age, a.height");
-        assertTrue(result.isSuccess());
-        QuerySummary summary = result.getQuerySummary();
-        assertNotNull(summary);
-        double compilingTime = summary.getCompilingTime();
-        assertTrue(compilingTime > 0);
-        double executionTime = summary.getExecutionTime();
-        assertTrue(executionTime > 0);
-        result.destroy();
+        try (QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.age, a.height")) {
+            assertTrue(result.isSuccess());
+        
+            QuerySummary summary = result.getQuerySummary();
+            assertNotNull(summary);
+        
+            double compilingTime = summary.getCompilingTime();
+            assertTrue(compilingTime > 0);
+        
+            double executionTime = summary.getExecutionTime();
+            assertTrue(executionTime > 0);
+        }        
     }
 
     @Test
     void QueryResultGetNext() throws ObjectRefDestroyedException {
-        QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.age ORDER BY a.fName");
-        assertTrue(result.isSuccess());
-
-        assertTrue(result.hasNext());
-        FlatTuple row = result.getNext();
-        assertNotNull(row);
-        assertTrue(row.getValue(0).getValue().equals("Alice"));
-        assertTrue(row.getValue(1).getValue().equals(35L));
-        row.destroy();
-
-        assertTrue(result.hasNext());
-        row = result.getNext();
-        assertNotNull(row);
-        assertTrue(row.getValue(0).getValue().equals("Bob"));
-        assertTrue(row.getValue(1).getValue().equals(30L));
-        row.destroy();
-
-        result.destroy();
+        try (QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.age ORDER BY a.fName")) {
+            assertTrue(result.isSuccess());
+        
+            assertTrue(result.hasNext());
+            try (FlatTuple row = result.getNext()) {
+                assertNotNull(row);
+                assertTrue(row.getValue(0).getValue().equals("Alice"));
+                assertTrue(row.getValue(1).getValue().equals(35L));
+            }
+        
+            assertTrue(result.hasNext());
+            try (FlatTuple row = result.getNext()) {
+                assertNotNull(row);
+                assertTrue(row.getValue(0).getValue().equals("Bob"));
+                assertTrue(row.getValue(1).getValue().equals(30L));
+            }
+        }        
     }
 
     @Test
     void QueryResultResetIterator() throws ObjectRefDestroyedException {
-        QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.age ORDER BY a.fName");
-        assertTrue(result.isSuccess());
-        assertTrue(result.hasNext());
-
-        FlatTuple row = result.getNext();
-        assertTrue(row.getValue(0).getValue().equals("Alice"));
-        assertTrue(row.getValue(1).getValue().equals(35L));
-        row.destroy();
-
-        result.resetIterator();
-
-        assertTrue(result.hasNext());
-        row = result.getNext();
-        assertNotNull(row);
-        assertTrue(row.getValue(0).getValue().equals("Alice"));
-        assertTrue(row.getValue(1).getValue().equals(35L));
-        row.destroy();
-
-        result.destroy();
+        try (QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.age ORDER BY a.fName")) {
+            assertTrue(result.isSuccess());
+            assertTrue(result.hasNext());
+        
+            try (FlatTuple row = result.getNext()) {
+                assertTrue(row.getValue(0).getValue().equals("Alice"));
+                assertTrue(row.getValue(1).getValue().equals(35L));
+            }
+        
+            result.resetIterator();
+        
+            assertTrue(result.hasNext());
+            try (FlatTuple row = result.getNext()) {
+                assertNotNull(row);
+                assertTrue(row.getValue(0).getValue().equals("Alice"));
+                assertTrue(row.getValue(1).getValue().equals(35L));
+            }
+        }        
     }
 
     @Test
     void getMultipleQueryResult() throws ObjectRefDestroyedException {
-        QueryResult result = conn.query("return 1; return 2; return 3;");
-        assertTrue(result.isSuccess());
-        String str = result.toString();
-        assertEquals(str, "1\n1\n");
-
-        QueryResult nextResult;
-        assertTrue(result.hasNextQueryResult());
-        nextResult = result.getNextQueryResult();
-        str = nextResult.toString();
-        assertEquals(str, "2\n2\n");
-        nextResult.destroy();
-
-        assertTrue(result.hasNextQueryResult());
-        nextResult = result.getNextQueryResult();
-        str = nextResult.toString();
-        assertEquals(str, "3\n3\n");
-        nextResult.destroy();
-
-        assertFalse(result.hasNextQueryResult());
+        try (QueryResult result = conn.query("return 1; return 2; return 3;")) {
+            assertTrue(result.isSuccess());
+            String str = result.toString();
+            assertEquals(str, "1\n1\n");
         
-        result.destroy();
+            assertTrue(result.hasNextQueryResult());
+            try (QueryResult nextResult = result.getNextQueryResult()) {
+                str = nextResult.toString();
+                assertEquals(str, "2\n2\n");
+            }
+        
+            assertTrue(result.hasNextQueryResult());
+            try (QueryResult nextResult = result.getNextQueryResult()) {
+                str = nextResult.toString();
+                assertEquals(str, "3\n3\n");
+            }
+        
+            assertFalse(result.hasNextQueryResult());
+        }        
     }
 }

--- a/tools/java_api/src/test/java/com/kuzudb/TestBase.java
+++ b/tools/java_api/src/test/java/com/kuzudb/TestBase.java
@@ -27,6 +27,8 @@ public class TestBase {
     @AfterAll
     static void destroyDBandConn() throws ObjectRefDestroyedException {
         try {
+            db.close();
+            conn.close();
         } catch (AssertionError e) {
             fail("destroyDBandConn failed: ");
         }

--- a/tools/java_api/src/test/java/com/kuzudb/TestBase.java
+++ b/tools/java_api/src/test/java/com/kuzudb/TestBase.java
@@ -27,8 +27,6 @@ public class TestBase {
     @AfterAll
     static void destroyDBandConn() throws ObjectRefDestroyedException {
         try {
-            db.destroy();
-            conn.destroy();
         } catch (AssertionError e) {
             fail("destroyDBandConn failed: ");
         }

--- a/tools/java_api/src/test/java/com/kuzudb/TestHelper.java
+++ b/tools/java_api/src/test/java/com/kuzudb/TestHelper.java
@@ -25,7 +25,6 @@ public class TestHelper {
         BufferedReader reader;
         db = new Database(dbPath);
         conn = new Connection(db);
-        QueryResult result;
 
         reader = new BufferedReader(new FileReader("../../dataset/tinysnb/schema.cypher"));
         String line;
@@ -35,8 +34,8 @@ public class TestHelper {
                 break;
             }
             line = line.replace("dataset/tinysnb", "../../dataset/tinysnb");
-            result = conn.query(line);
-            result.destroy();
+            try (QueryResult result = conn.query(line)) {
+            }
         } while (line != null);
         reader.close();
 
@@ -48,8 +47,8 @@ public class TestHelper {
                 break;
             }
             line = line.replace("dataset/tinysnb", "../../dataset/tinysnb");
-            result = conn.query(line);
-            result.destroy();
+            try (QueryResult result = conn.query(line)) {
+            }
         } while (line != null);
         reader.close();
 
@@ -59,8 +58,8 @@ public class TestHelper {
             if (line == null) {
                 break;
             }
-            result = conn.query(line);
-            result.destroy();
+            try (QueryResult result = conn.query(line)) {
+            }
         } while (line != null);
         reader.close();
 
@@ -70,13 +69,14 @@ public class TestHelper {
             if (line == null) {
                 break;
             }
-            result = conn.query(line);
-            result.destroy();
+            try (QueryResult result = conn.query(line)) {
+            }
         } while (line != null);
 
-        result = conn.query("create node table moviesSerial (ID SERIAL, name STRING, length INT32, note STRING, PRIMARY KEY (ID));");
-        result.destroy();
-        result = conn.query("copy moviesSerial from \"../../dataset/tinysnb-serial/vMovies.csv\"");
-        result.destroy();
+        try (QueryResult result = conn.query("create node table moviesSerial (ID SERIAL, name STRING, length INT32, note STRING, PRIMARY KEY (ID));")) {
+        }
+        
+        try (QueryResult result = conn.query("copy moviesSerial from \"../../dataset/tinysnb-serial/vMovies.csv\"")) {
+        }
     }
 }

--- a/tools/java_api/src/test/java/com/kuzudb/ValueTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/ValueTest.java
@@ -19,6 +19,7 @@ public class ValueTest extends TestBase {
         Value value = Value.createNull();
         assertFalse(value.isOwnedByCPP());
         assertEquals(value.getDataType().getID(), DataTypeID.ANY);
+        value.close();
     }
 
     @Test
@@ -26,8 +27,9 @@ public class ValueTest extends TestBase {
         DataType type = new DataType(DataTypeID.INT64, null, 0);
         Value value = Value.createNullWithDataType(type);
         assertFalse(value.isOwnedByCPP());
-
+        type.close();
         assertEquals(value.getDataType().getID(), DataTypeID.INT64);
+        value.close();
     }
 
     @Test
@@ -35,13 +37,17 @@ public class ValueTest extends TestBase {
         Value value = new Value(123L);
         assertFalse(value.isOwnedByCPP());
         assertFalse(value.isNull());
+        value.close();
 
         value = Value.createNull();
         assertTrue(value.isNull());
+        value.close();
 
         DataType type = new DataType(DataTypeID.INT64, null, 0);
         value = Value.createNullWithDataType(type);
         assertTrue(value.isNull());
+        type.close();
+        value.close();
     }
 
     @Test
@@ -55,6 +61,7 @@ public class ValueTest extends TestBase {
 
         value.setNull(false);
         assertFalse(value.isNull());
+        value.close();
     }
 
     @Test
@@ -62,18 +69,22 @@ public class ValueTest extends TestBase {
         DataType type = new DataType(DataTypeID.INT64, null, 0);
         Value value = Value.createDefault(type);
         assertFalse(value.isOwnedByCPP());
+        type.close();
 
         assertFalse(value.isNull());
         assertEquals(value.getDataType().getID(), DataTypeID.INT64);
         assertTrue(value.getValue().equals(0L));
+        value.close();
 
         type = new DataType(DataTypeID.STRING, null, 0);
         value = Value.createDefault(type);
         assertFalse(value.isOwnedByCPP());
+        type.close();
 
         assertFalse(value.isNull());
         assertEquals(value.getDataType().getID(), DataTypeID.STRING);
         assertTrue(value.getValue().equals(""));
+        value.close();
     }
 
     @Test
@@ -104,11 +115,13 @@ public class ValueTest extends TestBase {
         assertFalse(value.isOwnedByCPP());
         assertEquals(value.getDataType().getID(), DataTypeID.BOOL);
         assertTrue(value.getValue().equals(true));
+        value.close();
 
         value = new Value(false);
         assertFalse(value.isOwnedByCPP());
         assertEquals(value.getDataType().getID(), DataTypeID.BOOL);
         assertTrue(value.getValue().equals(false));
+        value.close();
     }
 
     @Test
@@ -118,6 +131,7 @@ public class ValueTest extends TestBase {
         assertFalse(value.isOwnedByCPP());
         assertEquals(value.getDataType().getID(), DataTypeID.INT16);
         assertTrue(value.getValue().equals((short) 123));
+        value.close();
     }
 
     @Test
@@ -127,6 +141,7 @@ public class ValueTest extends TestBase {
         assertFalse(value.isOwnedByCPP());
         assertEquals(value.getDataType().getID(), DataTypeID.INT32);
         assertTrue(value.getValue().equals(123));
+        value.close();
     }
 
     @Test
@@ -136,6 +151,7 @@ public class ValueTest extends TestBase {
         assertFalse(value.isOwnedByCPP());
         assertEquals(value.getDataType().getID(), DataTypeID.INT64);
         assertTrue(value.getValue().equals(123L));
+        value.close();
     }
 
     @Test
@@ -145,6 +161,7 @@ public class ValueTest extends TestBase {
         assertFalse(value.isOwnedByCPP());
         assertEquals(value.getDataType().getID(), DataTypeID.FLOAT);
         assertTrue(value.getValue().equals((float) 123.456));
+        value.close();
     }
 
     @Test
@@ -154,6 +171,7 @@ public class ValueTest extends TestBase {
         assertFalse(value.isOwnedByCPP());
         assertEquals(value.getDataType().getID(), DataTypeID.FLOAT);
         assertTrue(value.getValue().equals((float) 123.456));
+        value.close();
     }
 
     @Test
@@ -164,6 +182,7 @@ public class ValueTest extends TestBase {
         assertEquals(value.getDataType().getID(), DataTypeID.DECIMAL);
         BigDecimal val = (BigDecimal)value.getValue();
         assertTrue(val.compareTo(new BigDecimal("-3.14")) == 0);
+        value.close();
     }
 
     @Test
@@ -175,6 +194,7 @@ public class ValueTest extends TestBase {
         InternalID id = value.getValue();
         assertEquals(id.tableId, 1);
         assertEquals(id.offset, 123);
+        value.close();
     }
 
     @Test
@@ -185,6 +205,7 @@ public class ValueTest extends TestBase {
         assertEquals(value.getDataType().getID(), DataTypeID.DATE);
         LocalDate date = value.getValue();
         assertEquals(date.toEpochDay(), 123);
+        value.close();
     }
 
     @Test
@@ -196,6 +217,7 @@ public class ValueTest extends TestBase {
         Instant stamp = value.getValue();
         assertEquals(stamp.getEpochSecond(), 0);
         assertEquals(stamp.getNano(), 123000);
+        value.close();
 
         value = new Value(Instant.ofEpochSecond(123123123L / 1000000L, 123123123L % 1000000 * 1000));
         assertFalse(value.isOwnedByCPP());
@@ -203,6 +225,7 @@ public class ValueTest extends TestBase {
         stamp = value.getValue();
         assertEquals(stamp.getEpochSecond(), 123);
         assertEquals(stamp.getNano(), 123123000);
+        value.close();
     }
 
     @Test
@@ -214,6 +237,7 @@ public class ValueTest extends TestBase {
         assertEquals(value.getDataType().getID(), DataTypeID.INTERVAL);
         Duration interval = value.getValue();
         assertEquals(interval.toMillis(), inputDuration.toMillis());
+        value.close();
     }
 
     @Test
@@ -224,6 +248,7 @@ public class ValueTest extends TestBase {
         assertEquals(value.getDataType().getID(), DataTypeID.STRING);
         String str = value.getValue();
         assertTrue(str.equals("abcdefg"));
+        value.close();
     }
 
     @Test
@@ -235,11 +260,13 @@ public class ValueTest extends TestBase {
         assertTrue(str.equals("abcdefg"));
 
         Value clone = value.clone();
+        value.close();
 
         assertFalse(clone.isOwnedByCPP());
         assertEquals(clone.getDataType().getID(), DataTypeID.STRING);
         str = clone.getValue();
         assertTrue(str.equals("abcdefg"));
+        clone.close();
     }
 
     @Test
@@ -248,11 +275,13 @@ public class ValueTest extends TestBase {
         Value value2 = new Value("abcdefg");
 
         value.copy(value2);
+        value2.close();
 
         assertFalse(value.isNull());
         assertEquals(value.getDataType().getID(), DataTypeID.STRING);
         String str = value.getValue();
         assertTrue(str.equals("abcdefg"));
+        value.close();
     }
 
     @Test
@@ -267,6 +296,10 @@ public class ValueTest extends TestBase {
         assertTrue(value.isOwnedByCPP());
         assertFalse(value.isNull());
         assertEquals(ValueListUtil.getListSize(value), 2);
+
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -284,13 +317,19 @@ public class ValueTest extends TestBase {
         Value listElement = ValueListUtil.getListElement(value, 0);
         assertTrue(listElement.isOwnedByCPP());
         assertTrue(listElement.getValue().equals(10L));
+        listElement.close();
 
         listElement = ValueListUtil.getListElement(value, 1);
         assertTrue(listElement.isOwnedByCPP());
         assertTrue(listElement.getValue().equals(5L));
+        listElement.close();
 
         listElement = ValueListUtil.getListElement(value, 222);
         assertNull(listElement);
+
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -333,6 +372,9 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals(true));
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -347,6 +389,9 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals((byte) 5));
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -361,6 +406,9 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals((short) 5));
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -375,6 +423,9 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals(298));
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -389,6 +440,9 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals(0L));
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -403,6 +457,9 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals((short) 250));
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -417,6 +474,9 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals(33768));
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -431,6 +491,9 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals(32800L));
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -445,6 +508,9 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertEquals(value.getValue(), new BigInteger("1000043524"));
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -460,6 +526,9 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertEquals(value.getValue(), new BigInteger("1844674407370955161811111111"));
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -474,6 +543,9 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals(2L));
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
 
@@ -489,6 +561,9 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals((float) 1.731));
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -503,6 +578,9 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals((double) 5.0));
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -518,6 +596,9 @@ public class ValueTest extends TestBase {
 
         LocalDate date = value.getValue();
         assertEquals((long) date.toEpochDay(), -25567L);
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -533,6 +614,9 @@ public class ValueTest extends TestBase {
 
         Instant stamp = value.getValue();
         assertEquals(stamp.toEpochMilli(), 1313839530000L);
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -548,6 +632,9 @@ public class ValueTest extends TestBase {
 
         Instant stamp = value.getValue();
         assertEquals(stamp.toEpochMilli(), 1313839530123L);
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -563,6 +650,9 @@ public class ValueTest extends TestBase {
 
         Instant stamp = value.getValue();
         assertEquals(stamp.getNano(), 123456000L);
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -578,6 +668,9 @@ public class ValueTest extends TestBase {
 
         Instant stamp = value.getValue();
         assertEquals(stamp.toEpochMilli(), 1313839530123L);
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -594,6 +687,9 @@ public class ValueTest extends TestBase {
         Instant stamp = value.getValue();
         assertEquals(stamp.getEpochSecond(), 1313839530L);
         assertEquals(stamp.getNano(), 0L);
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -614,6 +710,9 @@ public class ValueTest extends TestBase {
         assertEquals(month, 36);
         assertEquals(day, 2);
         assertEquals(micros, 46920000000L);
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -629,6 +728,9 @@ public class ValueTest extends TestBase {
 
         String str = value.getValue();
         assertTrue(str.equals("Alice"));
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -661,6 +763,9 @@ public class ValueTest extends TestBase {
 
         UUID uid = value.getValue();
         assertTrue(uid.equals(UUID.fromString("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")));
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -701,6 +806,9 @@ public class ValueTest extends TestBase {
         InternalID id = ValueNodeUtil.getID(value);
         assertEquals(id.tableId, 0);
         assertEquals(id.offset, 0);
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -715,6 +823,9 @@ public class ValueTest extends TestBase {
 
         String label = ValueNodeUtil.getLabelName(value);
         assertEquals(label, "person");
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -737,15 +848,23 @@ public class ValueTest extends TestBase {
         Value propertyValue = ValueNodeUtil.getPropertyValueAt(value, 0);
         long propertyValueID = propertyValue.getValue();
         assertEquals(propertyValueID, 0);
+        propertyValue.close();
         propertyValue = ValueNodeUtil.getPropertyValueAt(value, 1);
         String propertyValuefName = propertyValue.getValue();
         assertTrue(propertyValuefName.equals("Alice"));
+        propertyValue.close();
         propertyValue = ValueNodeUtil.getPropertyValueAt(value, 2);
         long propertyValueGender = propertyValue.getValue();
         assertEquals(propertyValueGender, 1);
+        propertyValue.close();
         propertyValue = ValueNodeUtil.getPropertyValueAt(value, 3);
         boolean propertyValueIsStudent = propertyValue.getValue();
         assertEquals(propertyValueIsStudent, true);
+        propertyValue.close();
+
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -761,6 +880,9 @@ public class ValueTest extends TestBase {
                 "score: -2, history: 10 years 5 months 13 hours 24 us, licenseValidInterval: 3 years " +
                 "5 days, rating: 1.000000, state: {revenue: 138, location: ['toronto','montr,eal'], " +
                 "stock: {price: [96,56], volume: 1000}}, info: 3.120000}");
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
 
@@ -787,6 +909,10 @@ public class ValueTest extends TestBase {
 
         long size = ValueRelUtil.getPropertySize(value);
         assertEquals(size, 7);
+
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -810,6 +936,11 @@ public class ValueTest extends TestBase {
         Value propertyValue = ValueRelUtil.getPropertyValueAt(value, 0);
         long propertyValueYear = propertyValue.getValue();
         assertEquals(propertyValueYear, 2015);
+
+        propertyValue.close();
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -823,6 +954,9 @@ public class ValueTest extends TestBase {
         String str = ValueRelUtil.toString(value);
         assertEquals(str, "(0:2)-{_LABEL: workAt, _ID: 5:0, year: 2015, grading: [3.800000,2.500000], " +
                 "rating: 8.200000}->(1:1)");
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -834,6 +968,9 @@ public class ValueTest extends TestBase {
         Value value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         assertEquals(ValueStructUtil.getNumFields(value), 14);
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -854,6 +991,10 @@ public class ValueTest extends TestBase {
         assertEquals(ValueStructUtil.getIndexByFieldName(value, "release_sec"), 6);
         assertEquals(ValueStructUtil.getIndexByFieldName(value, "release_tz"), 7);
         assertEquals(ValueStructUtil.getIndexByFieldName(value, "film"), 8);
+    
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -874,6 +1015,10 @@ public class ValueTest extends TestBase {
         assertEquals(ValueStructUtil.getFieldNameByIndex(value, 6), "release_sec");
         assertEquals(ValueStructUtil.getFieldNameByIndex(value, 7), "release_tz");
         assertEquals(ValueStructUtil.getFieldNameByIndex(value, 8), "film");
+    
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -888,6 +1033,11 @@ public class ValueTest extends TestBase {
         assertNull(fieldValue);
         fieldValue = ValueStructUtil.getValueByFieldName(value, "rating");
         assertEquals(fieldValue.getValue(), 1223.0);
+
+        fieldValue.close();
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -904,6 +1054,11 @@ public class ValueTest extends TestBase {
         assertNull(fieldValue);
         fieldValue = ValueStructUtil.getValueByIndex(value, 0);
         assertEquals(fieldValue.getValue(), 1223.0);
+
+        fieldValue.close();
+        value.close();
+        flatTuple.close();
+        result.close();
     }
 
     @Test
@@ -915,18 +1070,25 @@ public class ValueTest extends TestBase {
         Value value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         assertEquals(ValueMapUtil.getNumFields(value), 2);
+        value.close();
+        flatTuple.close();
 
         flatTuple = result.getNext();
         value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         assertEquals(ValueMapUtil.getNumFields(value), 0);
+        value.close();
+        flatTuple.close();
 
         flatTuple = result.getNext();
         value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         assertEquals(ValueMapUtil.getNumFields(value), 1);
+        value.close();
+        flatTuple.close();
 
         assertFalse(result.hasNext());
+        result.close();
     }
 
     @Test
@@ -943,20 +1105,26 @@ public class ValueTest extends TestBase {
         assertEquals(index, -1);
         index = ValueMapUtil.getIndexByFieldName(value, "audience53");
         assertEquals(index, 1);
+        value.close();
+        flatTuple.close();
 
         flatTuple = result.getNext();
         value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         index = ValueMapUtil.getIndexByFieldName(value, "NOT_EXXIST");
         assertEquals(index, -1);
+        value.close();
 
         flatTuple = result.getNext();
         value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         index = ValueMapUtil.getIndexByFieldName(value, "audience1");
         assertEquals(index, 0);
+        value.close();
+        flatTuple.close();
 
         assertFalse(result.hasNext());
+        result.close();
     }
 
     @Test
@@ -969,24 +1137,34 @@ public class ValueTest extends TestBase {
         assertTrue(value.isOwnedByCPP());
         Value fieldValue = ValueMapUtil.getValueByFieldName(value, "audience1");
         assertEquals((long)fieldValue.getValue(), 52);
+        fieldValue.close();
         fieldValue = ValueMapUtil.getValueByFieldName(value, "audience53");
         assertEquals((long)fieldValue.getValue(), 42);
+        fieldValue.close();
         fieldValue = ValueMapUtil.getValueByFieldName(value, "NOT_EXIST");
         assertNull(fieldValue);
+        value.close();
+        flatTuple.close();
 
         flatTuple = result.getNext();
         value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         fieldValue = ValueMapUtil.getValueByFieldName(value, "NOT_EXIST");
         assertNull(fieldValue);
+        value.close();
+        flatTuple.close();
 
         flatTuple = result.getNext();
         value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         fieldValue = ValueMapUtil.getValueByFieldName(value, "audience1");
         assertEquals((long)fieldValue.getValue(), 33);
+        fieldValue.close();
+        value.close();
+        flatTuple.close();
 
         assertFalse(result.hasNext());
+        result.close();
     }
 
     @Test
@@ -1005,20 +1183,27 @@ public class ValueTest extends TestBase {
         assertNull(fieldName);
         fieldName = ValueMapUtil.getFieldNameByIndex(value, 1024);
         assertNull(fieldName);
+        value.close();
+        flatTuple.close();
 
         flatTuple = result.getNext();
         value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         fieldName = ValueMapUtil.getFieldNameByIndex(value, 0);
         assertNull(fieldName);
+        value.close();
+        flatTuple.close();
 
         flatTuple = result.getNext();
         value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         fieldName = ValueMapUtil.getFieldNameByIndex(value, 0);
         assertEquals(fieldName, "audience1");
+        value.close();
+        flatTuple.close();
 
         assertFalse(result.hasNext());
+        result.close();
     }
 
     @Test
@@ -1036,23 +1221,31 @@ public class ValueTest extends TestBase {
         assertNull(fieldValue);
         fieldValue = ValueMapUtil.getValueByIndex(value, 0);
         assertEquals((long)fieldValue.getValue(), 52);
+        fieldValue.close();
         fieldValue = ValueMapUtil.getValueByIndex(value, 1);
         assertEquals((long)fieldValue.getValue(), 42);
-
+        value.close();
+        flatTuple.close();
 
         flatTuple = result.getNext();
         value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         fieldValue = ValueMapUtil.getValueByIndex(value, 0);
         assertNull(fieldValue);
+        value.close();
+        flatTuple.close();
 
         flatTuple = result.getNext();
         value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         fieldValue = ValueMapUtil.getValueByIndex(value, 0);
         assertEquals((long)fieldValue.getValue(), 33);
+        fieldValue.close();
+        value.close();
+        flatTuple.close();
 
         assertFalse(result.hasNext());
+        result.close();
     }
 
     @Test
@@ -1193,8 +1386,12 @@ public class ValueTest extends TestBase {
                     break;
                 }
             }
+            value.close();
+            dataType.close();
+            flatTuple.close();
             i++;
         }
         assertEquals(i, 16);
+        result.close();
     }
 }

--- a/tools/java_api/src/test/java/com/kuzudb/ValueTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/ValueTest.java
@@ -19,7 +19,6 @@ public class ValueTest extends TestBase {
         Value value = Value.createNull();
         assertFalse(value.isOwnedByCPP());
         assertEquals(value.getDataType().getID(), DataTypeID.ANY);
-        value.destroy();
     }
 
     @Test
@@ -27,10 +26,8 @@ public class ValueTest extends TestBase {
         DataType type = new DataType(DataTypeID.INT64, null, 0);
         Value value = Value.createNullWithDataType(type);
         assertFalse(value.isOwnedByCPP());
-        type.destroy();
 
         assertEquals(value.getDataType().getID(), DataTypeID.INT64);
-        value.destroy();
     }
 
     @Test
@@ -38,17 +35,13 @@ public class ValueTest extends TestBase {
         Value value = new Value(123L);
         assertFalse(value.isOwnedByCPP());
         assertFalse(value.isNull());
-        value.destroy();
 
         value = Value.createNull();
         assertTrue(value.isNull());
-        value.destroy();
 
         DataType type = new DataType(DataTypeID.INT64, null, 0);
         value = Value.createNullWithDataType(type);
         assertTrue(value.isNull());
-        type.destroy();
-        value.destroy();
     }
 
     @Test
@@ -62,7 +55,6 @@ public class ValueTest extends TestBase {
 
         value.setNull(false);
         assertFalse(value.isNull());
-        value.destroy();
     }
 
     @Test
@@ -70,22 +62,39 @@ public class ValueTest extends TestBase {
         DataType type = new DataType(DataTypeID.INT64, null, 0);
         Value value = Value.createDefault(type);
         assertFalse(value.isOwnedByCPP());
-        type.destroy();
 
         assertFalse(value.isNull());
         assertEquals(value.getDataType().getID(), DataTypeID.INT64);
         assertTrue(value.getValue().equals(0L));
-        value.destroy();
 
         type = new DataType(DataTypeID.STRING, null, 0);
         value = Value.createDefault(type);
         assertFalse(value.isOwnedByCPP());
-        type.destroy();
 
         assertFalse(value.isNull());
         assertEquals(value.getDataType().getID(), DataTypeID.STRING);
         assertTrue(value.getValue().equals(""));
-        value.destroy();
+    }
+
+    @Test
+    void ValueCreateAndCloseDefault() throws ObjectRefDestroyedException {
+        try (DataType type = new DataType(DataTypeID.INT64, null, 0);
+            Value value = Value.createDefault(type)) {
+        
+            assertFalse(value.isOwnedByCPP());
+            assertFalse(value.isNull());
+            assertEquals(value.getDataType().getID(), DataTypeID.INT64);
+            assertTrue(value.getValue().equals(0L));
+        }
+   
+        try (DataType type = new DataType(DataTypeID.STRING, null, 0);
+            Value value = Value.createDefault(type)) {
+   
+            assertFalse(value.isOwnedByCPP());
+            assertFalse(value.isNull());
+            assertEquals(value.getDataType().getID(), DataTypeID.STRING);
+            assertTrue(value.getValue().equals(""));
+        }
     }
 
     @Test
@@ -95,13 +104,11 @@ public class ValueTest extends TestBase {
         assertFalse(value.isOwnedByCPP());
         assertEquals(value.getDataType().getID(), DataTypeID.BOOL);
         assertTrue(value.getValue().equals(true));
-        value.destroy();
 
         value = new Value(false);
         assertFalse(value.isOwnedByCPP());
         assertEquals(value.getDataType().getID(), DataTypeID.BOOL);
         assertTrue(value.getValue().equals(false));
-        value.destroy();
     }
 
     @Test
@@ -111,7 +118,6 @@ public class ValueTest extends TestBase {
         assertFalse(value.isOwnedByCPP());
         assertEquals(value.getDataType().getID(), DataTypeID.INT16);
         assertTrue(value.getValue().equals((short) 123));
-        value.destroy();
     }
 
     @Test
@@ -121,7 +127,6 @@ public class ValueTest extends TestBase {
         assertFalse(value.isOwnedByCPP());
         assertEquals(value.getDataType().getID(), DataTypeID.INT32);
         assertTrue(value.getValue().equals(123));
-        value.destroy();
     }
 
     @Test
@@ -131,7 +136,6 @@ public class ValueTest extends TestBase {
         assertFalse(value.isOwnedByCPP());
         assertEquals(value.getDataType().getID(), DataTypeID.INT64);
         assertTrue(value.getValue().equals(123L));
-        value.destroy();
     }
 
     @Test
@@ -141,7 +145,6 @@ public class ValueTest extends TestBase {
         assertFalse(value.isOwnedByCPP());
         assertEquals(value.getDataType().getID(), DataTypeID.FLOAT);
         assertTrue(value.getValue().equals((float) 123.456));
-        value.destroy();
     }
 
     @Test
@@ -151,7 +154,6 @@ public class ValueTest extends TestBase {
         assertFalse(value.isOwnedByCPP());
         assertEquals(value.getDataType().getID(), DataTypeID.FLOAT);
         assertTrue(value.getValue().equals((float) 123.456));
-        value.destroy();
     }
 
     @Test
@@ -162,7 +164,6 @@ public class ValueTest extends TestBase {
         assertEquals(value.getDataType().getID(), DataTypeID.DECIMAL);
         BigDecimal val = (BigDecimal)value.getValue();
         assertTrue(val.compareTo(new BigDecimal("-3.14")) == 0);
-        value.destroy();
     }
 
     @Test
@@ -174,7 +175,6 @@ public class ValueTest extends TestBase {
         InternalID id = value.getValue();
         assertEquals(id.tableId, 1);
         assertEquals(id.offset, 123);
-        value.destroy();
     }
 
     @Test
@@ -185,7 +185,6 @@ public class ValueTest extends TestBase {
         assertEquals(value.getDataType().getID(), DataTypeID.DATE);
         LocalDate date = value.getValue();
         assertEquals(date.toEpochDay(), 123);
-        value.destroy();
     }
 
     @Test
@@ -197,7 +196,6 @@ public class ValueTest extends TestBase {
         Instant stamp = value.getValue();
         assertEquals(stamp.getEpochSecond(), 0);
         assertEquals(stamp.getNano(), 123000);
-        value.destroy();
 
         value = new Value(Instant.ofEpochSecond(123123123L / 1000000L, 123123123L % 1000000 * 1000));
         assertFalse(value.isOwnedByCPP());
@@ -205,7 +203,6 @@ public class ValueTest extends TestBase {
         stamp = value.getValue();
         assertEquals(stamp.getEpochSecond(), 123);
         assertEquals(stamp.getNano(), 123123000);
-        value.destroy();
     }
 
     @Test
@@ -217,7 +214,6 @@ public class ValueTest extends TestBase {
         assertEquals(value.getDataType().getID(), DataTypeID.INTERVAL);
         Duration interval = value.getValue();
         assertEquals(interval.toMillis(), inputDuration.toMillis());
-        value.destroy();
     }
 
     @Test
@@ -228,7 +224,6 @@ public class ValueTest extends TestBase {
         assertEquals(value.getDataType().getID(), DataTypeID.STRING);
         String str = value.getValue();
         assertTrue(str.equals("abcdefg"));
-        value.destroy();
     }
 
     @Test
@@ -240,13 +235,11 @@ public class ValueTest extends TestBase {
         assertTrue(str.equals("abcdefg"));
 
         Value clone = value.clone();
-        value.destroy();
 
         assertFalse(clone.isOwnedByCPP());
         assertEquals(clone.getDataType().getID(), DataTypeID.STRING);
         str = clone.getValue();
         assertTrue(str.equals("abcdefg"));
-        clone.destroy();
     }
 
     @Test
@@ -255,13 +248,11 @@ public class ValueTest extends TestBase {
         Value value2 = new Value("abcdefg");
 
         value.copy(value2);
-        value2.destroy();
 
         assertFalse(value.isNull());
         assertEquals(value.getDataType().getID(), DataTypeID.STRING);
         String str = value.getValue();
         assertTrue(str.equals("abcdefg"));
-        value.destroy();
     }
 
     @Test
@@ -276,10 +267,6 @@ public class ValueTest extends TestBase {
         assertTrue(value.isOwnedByCPP());
         assertFalse(value.isNull());
         assertEquals(ValueListUtil.getListSize(value), 2);
-
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -297,52 +284,41 @@ public class ValueTest extends TestBase {
         Value listElement = ValueListUtil.getListElement(value, 0);
         assertTrue(listElement.isOwnedByCPP());
         assertTrue(listElement.getValue().equals(10L));
-        listElement.destroy();
 
         listElement = ValueListUtil.getListElement(value, 1);
         assertTrue(listElement.isOwnedByCPP());
         assertTrue(listElement.getValue().equals(5L));
-        listElement.destroy();
 
         listElement = ValueListUtil.getListElement(value, 222);
         assertNull(listElement);
-
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
     void ValueGetDatatype() throws ObjectRefDestroyedException {
-        QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.isStudent, a.workedHours");
-        assertTrue(result.isSuccess());
-        assertTrue(result.hasNext());
-
-        FlatTuple flatTuple = result.getNext();
-        Value value = flatTuple.getValue(0);
-
-        DataType dataType = value.getDataType();
-        assertEquals(dataType.getID(), DataTypeID.STRING);
-        dataType.destroy();
-        value.destroy();
-
-        value = flatTuple.getValue(1);
-        dataType = value.getDataType();
-        assertEquals(dataType.getID(), DataTypeID.BOOL);
-        dataType.destroy();
-        value.destroy();
-
-        value = flatTuple.getValue(2);
-        dataType = value.getDataType();
-        assertEquals(dataType.getID(), DataTypeID.LIST);
-        DataType childDataType = dataType.getChildType();
-        assertEquals(childDataType.getID(), DataTypeID.INT64);
-        childDataType.destroy();
-        dataType.destroy();
-        value.destroy();
-
-        flatTuple.destroy();
-        result.destroy();
+        try (QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.isStudent, a.workedHours")) {
+            assertTrue(result.isSuccess());
+            assertTrue(result.hasNext());
+        
+            try (FlatTuple flatTuple = result.getNext()) {
+                try (Value value = flatTuple.getValue(0)) {
+                    DataType dataType = value.getDataType();
+                    assertEquals(dataType.getID(), DataTypeID.STRING);
+                }
+        
+                try (Value value = flatTuple.getValue(1)) {
+                    DataType dataType = value.getDataType();
+                    assertEquals(dataType.getID(), DataTypeID.BOOL);
+                }
+        
+                try (Value value = flatTuple.getValue(2)) {
+                    DataType dataType = value.getDataType();
+                    assertEquals(dataType.getID(), DataTypeID.LIST);
+                    try (DataType childDataType = dataType.getChildType()) {
+                        assertEquals(childDataType.getID(), DataTypeID.INT64);
+                    }
+                }
+            }
+        }        
     }
 
     @Test
@@ -357,9 +333,6 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals(true));
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -374,9 +347,6 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals((byte) 5));
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -391,9 +361,6 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals((short) 5));
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -408,9 +375,6 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals(298));
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -425,9 +389,6 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals(0L));
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -442,9 +403,6 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals((short) 250));
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -459,9 +417,6 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals(33768));
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -476,9 +431,6 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals(32800L));
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -493,9 +445,6 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertEquals(value.getValue(), new BigInteger("1000043524"));
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -511,9 +460,6 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertEquals(value.getValue(), new BigInteger("1844674407370955161811111111"));
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -528,9 +474,6 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals(2L));
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
 
@@ -546,9 +489,6 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals((float) 1.731));
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -563,9 +503,6 @@ public class ValueTest extends TestBase {
         assertFalse(value.isNull());
 
         assertTrue(value.getValue().equals((double) 5.0));
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -581,9 +518,6 @@ public class ValueTest extends TestBase {
 
         LocalDate date = value.getValue();
         assertEquals((long) date.toEpochDay(), -25567L);
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -599,9 +533,6 @@ public class ValueTest extends TestBase {
 
         Instant stamp = value.getValue();
         assertEquals(stamp.toEpochMilli(), 1313839530000L);
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -617,9 +548,6 @@ public class ValueTest extends TestBase {
 
         Instant stamp = value.getValue();
         assertEquals(stamp.toEpochMilli(), 1313839530123L);
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -635,9 +563,6 @@ public class ValueTest extends TestBase {
 
         Instant stamp = value.getValue();
         assertEquals(stamp.getNano(), 123456000L);
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -653,9 +578,6 @@ public class ValueTest extends TestBase {
 
         Instant stamp = value.getValue();
         assertEquals(stamp.toEpochMilli(), 1313839530123L);
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -672,9 +594,6 @@ public class ValueTest extends TestBase {
         Instant stamp = value.getValue();
         assertEquals(stamp.getEpochSecond(), 1313839530L);
         assertEquals(stamp.getNano(), 0L);
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -695,9 +614,6 @@ public class ValueTest extends TestBase {
         assertEquals(month, 36);
         assertEquals(day, 2);
         assertEquals(micros, 46920000000L);
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -713,9 +629,6 @@ public class ValueTest extends TestBase {
 
         String str = value.getValue();
         assertTrue(str.equals("Alice"));
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -748,35 +661,31 @@ public class ValueTest extends TestBase {
 
         UUID uid = value.getValue();
         assertTrue(uid.equals(UUID.fromString("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")));
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
     void ValueToString() throws ObjectRefDestroyedException {
-        QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.isStudent, a.workedHours");
-        assertTrue(result.isSuccess());
-        assertTrue(result.hasNext());
-
-        FlatTuple flatTuple = result.getNext();
-        Value value = flatTuple.getValue(0);
-        String str = value.toString();
-        assertTrue(str.equals("Alice"));
-        value.destroy();
-
-        value = flatTuple.getValue(1);
-        str = value.toString();
-        assertTrue(str.equals("True"));
-        value.destroy();
-
-        value = flatTuple.getValue(2);
-        str = value.toString();
-        assertTrue(str.equals("[10,5]"));
-        value.destroy();
-
-        flatTuple.destroy();
-        result.destroy();
+        try (QueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.isStudent, a.workedHours")) {
+            assertTrue(result.isSuccess());
+            assertTrue(result.hasNext());
+        
+            try (FlatTuple flatTuple = result.getNext()) {
+                try (Value value = flatTuple.getValue(0)) {
+                    String str = value.toString();
+                    assertTrue(str.equals("Alice"));
+                }
+        
+                try (Value value = flatTuple.getValue(1)) {
+                    String str = value.toString();
+                    assertTrue(str.equals("True"));
+                }
+        
+                try (Value value = flatTuple.getValue(2)) {
+                    String str = value.toString();
+                    assertTrue(str.equals("[10,5]"));
+                }
+            }
+        }        
     }
 
     @Test
@@ -792,10 +701,6 @@ public class ValueTest extends TestBase {
         InternalID id = ValueNodeUtil.getID(value);
         assertEquals(id.tableId, 0);
         assertEquals(id.offset, 0);
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
-
     }
 
     @Test
@@ -810,9 +715,6 @@ public class ValueTest extends TestBase {
 
         String label = ValueNodeUtil.getLabelName(value);
         assertEquals(label, "person");
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -835,23 +737,15 @@ public class ValueTest extends TestBase {
         Value propertyValue = ValueNodeUtil.getPropertyValueAt(value, 0);
         long propertyValueID = propertyValue.getValue();
         assertEquals(propertyValueID, 0);
-        propertyValue.destroy();
         propertyValue = ValueNodeUtil.getPropertyValueAt(value, 1);
         String propertyValuefName = propertyValue.getValue();
         assertTrue(propertyValuefName.equals("Alice"));
-        propertyValue.destroy();
         propertyValue = ValueNodeUtil.getPropertyValueAt(value, 2);
         long propertyValueGender = propertyValue.getValue();
         assertEquals(propertyValueGender, 1);
-        propertyValue.destroy();
         propertyValue = ValueNodeUtil.getPropertyValueAt(value, 3);
         boolean propertyValueIsStudent = propertyValue.getValue();
         assertEquals(propertyValueIsStudent, true);
-        propertyValue.destroy();
-
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -867,9 +761,6 @@ public class ValueTest extends TestBase {
                 "score: -2, history: 10 years 5 months 13 hours 24 us, licenseValidInterval: 3 years " +
                 "5 days, rating: 1.000000, state: {revenue: 138, location: ['toronto','montr,eal'], " +
                 "stock: {price: [96,56], volume: 1000}}, info: 3.120000}");
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
 
@@ -896,10 +787,6 @@ public class ValueTest extends TestBase {
 
         long size = ValueRelUtil.getPropertySize(value);
         assertEquals(size, 7);
-
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -923,11 +810,6 @@ public class ValueTest extends TestBase {
         Value propertyValue = ValueRelUtil.getPropertyValueAt(value, 0);
         long propertyValueYear = propertyValue.getValue();
         assertEquals(propertyValueYear, 2015);
-
-        propertyValue.destroy();
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -941,9 +823,6 @@ public class ValueTest extends TestBase {
         String str = ValueRelUtil.toString(value);
         assertEquals(str, "(0:2)-{_LABEL: workAt, _ID: 5:0, year: 2015, grading: [3.800000,2.500000], " +
                 "rating: 8.200000}->(1:1)");
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -955,9 +834,6 @@ public class ValueTest extends TestBase {
         Value value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         assertEquals(ValueStructUtil.getNumFields(value), 14);
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -978,9 +854,6 @@ public class ValueTest extends TestBase {
         assertEquals(ValueStructUtil.getIndexByFieldName(value, "release_sec"), 6);
         assertEquals(ValueStructUtil.getIndexByFieldName(value, "release_tz"), 7);
         assertEquals(ValueStructUtil.getIndexByFieldName(value, "film"), 8);
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -1001,9 +874,6 @@ public class ValueTest extends TestBase {
         assertEquals(ValueStructUtil.getFieldNameByIndex(value, 6), "release_sec");
         assertEquals(ValueStructUtil.getFieldNameByIndex(value, 7), "release_tz");
         assertEquals(ValueStructUtil.getFieldNameByIndex(value, 8), "film");
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -1018,10 +888,6 @@ public class ValueTest extends TestBase {
         assertNull(fieldValue);
         fieldValue = ValueStructUtil.getValueByFieldName(value, "rating");
         assertEquals(fieldValue.getValue(), 1223.0);
-        fieldValue.destroy();
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -1038,10 +904,6 @@ public class ValueTest extends TestBase {
         assertNull(fieldValue);
         fieldValue = ValueStructUtil.getValueByIndex(value, 0);
         assertEquals(fieldValue.getValue(), 1223.0);
-        fieldValue.destroy();
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
     }
 
     @Test
@@ -1053,25 +915,18 @@ public class ValueTest extends TestBase {
         Value value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         assertEquals(ValueMapUtil.getNumFields(value), 2);
-        value.destroy();
-        flatTuple.destroy();
 
         flatTuple = result.getNext();
         value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         assertEquals(ValueMapUtil.getNumFields(value), 0);
-        value.destroy();
-        flatTuple.destroy();
 
         flatTuple = result.getNext();
         value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         assertEquals(ValueMapUtil.getNumFields(value), 1);
-        value.destroy();
-        flatTuple.destroy();
 
         assertFalse(result.hasNext());
-        result.destroy();
     }
 
     @Test
@@ -1088,26 +943,20 @@ public class ValueTest extends TestBase {
         assertEquals(index, -1);
         index = ValueMapUtil.getIndexByFieldName(value, "audience53");
         assertEquals(index, 1);
-        value.destroy();
-        flatTuple.destroy();
 
         flatTuple = result.getNext();
         value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         index = ValueMapUtil.getIndexByFieldName(value, "NOT_EXXIST");
         assertEquals(index, -1);
-        value.destroy();
 
         flatTuple = result.getNext();
         value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         index = ValueMapUtil.getIndexByFieldName(value, "audience1");
         assertEquals(index, 0);
-        value.destroy();
-        flatTuple.destroy();
 
         assertFalse(result.hasNext());
-        result.destroy();
     }
 
     @Test
@@ -1120,34 +969,24 @@ public class ValueTest extends TestBase {
         assertTrue(value.isOwnedByCPP());
         Value fieldValue = ValueMapUtil.getValueByFieldName(value, "audience1");
         assertEquals((long)fieldValue.getValue(), 52);
-        fieldValue.destroy();
         fieldValue = ValueMapUtil.getValueByFieldName(value, "audience53");
         assertEquals((long)fieldValue.getValue(), 42);
-        fieldValue.destroy();
         fieldValue = ValueMapUtil.getValueByFieldName(value, "NOT_EXIST");
         assertNull(fieldValue);
-        value.destroy();
-        flatTuple.destroy();
 
         flatTuple = result.getNext();
         value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         fieldValue = ValueMapUtil.getValueByFieldName(value, "NOT_EXIST");
         assertNull(fieldValue);
-        value.destroy();
-        flatTuple.destroy();
 
         flatTuple = result.getNext();
         value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         fieldValue = ValueMapUtil.getValueByFieldName(value, "audience1");
         assertEquals((long)fieldValue.getValue(), 33);
-        fieldValue.destroy();
-        value.destroy();
-        flatTuple.destroy();
 
         assertFalse(result.hasNext());
-        result.destroy();
     }
 
     @Test
@@ -1166,27 +1005,20 @@ public class ValueTest extends TestBase {
         assertNull(fieldName);
         fieldName = ValueMapUtil.getFieldNameByIndex(value, 1024);
         assertNull(fieldName);
-        value.destroy();
-        flatTuple.destroy();
 
         flatTuple = result.getNext();
         value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         fieldName = ValueMapUtil.getFieldNameByIndex(value, 0);
         assertNull(fieldName);
-        value.destroy();
-        flatTuple.destroy();
 
         flatTuple = result.getNext();
         value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         fieldName = ValueMapUtil.getFieldNameByIndex(value, 0);
         assertEquals(fieldName, "audience1");
-        value.destroy();
-        flatTuple.destroy();
 
         assertFalse(result.hasNext());
-        result.destroy();
     }
 
     @Test
@@ -1204,11 +1036,8 @@ public class ValueTest extends TestBase {
         assertNull(fieldValue);
         fieldValue = ValueMapUtil.getValueByIndex(value, 0);
         assertEquals((long)fieldValue.getValue(), 52);
-        fieldValue.destroy();
         fieldValue = ValueMapUtil.getValueByIndex(value, 1);
         assertEquals((long)fieldValue.getValue(), 42);
-        value.destroy();
-        flatTuple.destroy();
 
 
         flatTuple = result.getNext();
@@ -1216,55 +1045,50 @@ public class ValueTest extends TestBase {
         assertTrue(value.isOwnedByCPP());
         fieldValue = ValueMapUtil.getValueByIndex(value, 0);
         assertNull(fieldValue);
-        value.destroy();
-        flatTuple.destroy();
 
         flatTuple = result.getNext();
         value = flatTuple.getValue(0);
         assertTrue(value.isOwnedByCPP());
         fieldValue = ValueMapUtil.getValueByIndex(value, 0);
         assertEquals((long)fieldValue.getValue(), 33);
-        fieldValue.destroy();
-        value.destroy();
-        flatTuple.destroy();
 
         assertFalse(result.hasNext());
-        result.destroy();
     }
 
     @Test
     void RecursiveRelGetNodeAndRelList() throws ObjectRefDestroyedException {
-        QueryResult result = conn.query("MATCH (a:person)-[e:studyAt*1..1]->(b:organisation) WHERE a.fName = 'Alice' RETURN e;");
-        assertTrue(result.isSuccess());
-        assertTrue(result.hasNext());
-        FlatTuple flatTuple = result.getNext();
-        Value value = flatTuple.getValue(0);
-        assertTrue(value.isOwnedByCPP());
-
-        Value nodeList = ValueRecursiveRelUtil.getNodeList(value);
-        assertTrue(nodeList.isOwnedByCPP());
-        assertEquals(ValueListUtil.getListSize(nodeList), 0);
-        nodeList.destroy();
-
-        Value relList = ValueRecursiveRelUtil.getRelList(value);
-        assertTrue(relList.isOwnedByCPP());
-        assertEquals(ValueListUtil.getListSize(relList), 1);
-
-        Value rel = ValueListUtil.getListElement(relList, 0);
-        assertTrue(rel.isOwnedByCPP());
-        InternalID srcId = ValueRelUtil.getSrcID(rel);
-        assertEquals(srcId.tableId, 0);
-        assertEquals(srcId.offset, 0);
-
-        InternalID dstId = ValueRelUtil.getDstID(rel);
-        assertEquals(dstId.tableId, 1);
-        assertEquals(dstId.offset, 0);
-
-        rel.destroy();
-        relList.destroy();
-        value.destroy();
-        flatTuple.destroy();
-        result.destroy();
+        try (QueryResult result = conn.query("MATCH (a:person)-[e:studyAt*1..1]->(b:organisation) WHERE a.fName = 'Alice' RETURN e;")) {
+            assertTrue(result.isSuccess());
+            assertTrue(result.hasNext());
+        
+            try (FlatTuple flatTuple = result.getNext();
+                 Value value = flatTuple.getValue(0)) {
+                 
+                assertTrue(value.isOwnedByCPP());
+        
+                try (Value nodeList = ValueRecursiveRelUtil.getNodeList(value)) {
+                    assertTrue(nodeList.isOwnedByCPP());
+                    assertEquals(ValueListUtil.getListSize(nodeList), 0);
+                }
+        
+                try (Value relList = ValueRecursiveRelUtil.getRelList(value)) {
+                    assertTrue(relList.isOwnedByCPP());
+                    assertEquals(ValueListUtil.getListSize(relList), 1);
+        
+                    try (Value rel = ValueListUtil.getListElement(relList, 0)) {
+                        assertTrue(rel.isOwnedByCPP());
+                        
+                        InternalID srcId = ValueRelUtil.getSrcID(rel);
+                        assertEquals(srcId.tableId, 0);
+                        assertEquals(srcId.offset, 0);
+        
+                        InternalID dstId = ValueRelUtil.getDstID(rel);
+                        assertEquals(dstId.tableId, 1);
+                        assertEquals(dstId.offset, 0);
+                    }
+                }
+            }
+        }        
     }
 
     @Test
@@ -1369,12 +1193,8 @@ public class ValueTest extends TestBase {
                     break;
                 }
             }
-            value.destroy();
-            dataType.destroy();
-            flatTuple.destroy();
             i++;
         }
         assertEquals(i, 16);
-        result.destroy();
     }
 }


### PR DESCRIPTION
# Description

Replacing Deprecated `Finalize()` with `autoCloseable` from JAVA_API

Fixes # (issue) 
https://github.com/kuzudb/kuzu/issues/2974#event-14662134856

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).