### PR TITLE
Added cli command to toggle completion highlighting

### DIFF
--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -655,8 +655,8 @@ void EmbeddedShell::setErrors(const std::string& errorsString) {
 
 void EmbeddedShell::setComplete(const std::string& completeString) {
     std::string completeStringLower = completeString;
-    std::transform(completeStringLower.begin(), completeStringLower.end(), completeStringLower.begin(),
-        [](unsigned char c) { return std::tolower(c); });
+    std::transform(completeStringLower.begin(), completeStringLower.end(),
+        completeStringLower.begin(), [](unsigned char c) { return std::tolower(c); });
     if (completeStringLower == "on") {
         linenoiseSetCompletion(1);
         printf("enabled completion highlighting\n");

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -57,8 +57,9 @@ struct ShellCommand {
     const char* SINGLE = ":singleline";
     const char* HIGHLIGHT = ":highlight";
     const char* ERRORS = ":render_errors";
-    const std::array<const char*, 11> commandList = {HELP, CLEAR, QUIT, MAX_ROWS, MAX_WIDTH, MODE,
-        STATS, MULTI, SINGLE, HIGHLIGHT, ERRORS};
+    const char* COMPLETE = ":render_completion";
+    const std::array<const char*, 12> commandList = {HELP, CLEAR, QUIT, MAX_ROWS, MAX_WIDTH, MODE,
+        STATS, MULTI, SINGLE, HIGHLIGHT, ERRORS, COMPLETE};
 } shellCommand;
 
 const char* TAB = "    ";
@@ -338,6 +339,8 @@ int EmbeddedShell::processShellCommands(std::string lineStr) {
         setHighlighting(arg);
     } else if (command == shellCommand.ERRORS) {
         setErrors(arg);
+    } else if (command == shellCommand.COMPLETE) {
+        setComplete(arg);
     } else {
         printf("Error: Unknown command: \"%s\". Enter \":help\" for help\n", lineStr.c_str());
         printf("Did you mean: \"%s\"?\n", findClosestCommand(lineStr).c_str());
@@ -650,6 +653,23 @@ void EmbeddedShell::setErrors(const std::string& errorsString) {
     }
 }
 
+void EmbeddedShell::setComplete(const std::string& completeString) {
+    std::string completeStringLower = completeString;
+    std::transform(completeStringLower.begin(), completeStringLower.end(), completeStringLower.begin(),
+        [](unsigned char c) { return std::tolower(c); });
+    if (completeStringLower == "on") {
+        linenoiseSetCompletion(1);
+        printf("enabled completion highlighting\n");
+    } else if (completeStringLower == "off") {
+        linenoiseSetCompletion(0);
+        printf("disabled completion highlighting\n");
+    } else {
+        printf("Cannot parse '%s' to toggle completion highlighting. Expect 'on' or 'off'.\n",
+            completeStringLower.c_str());
+        return;
+    }
+}
+
 void EmbeddedShell::printHelp() {
     printf("%s%s %sget command list\n", TAB, shellCommand.HELP, TAB);
     printf("%s%s %sclear shell\n", TAB, shellCommand.CLEAR, TAB);
@@ -665,6 +685,8 @@ void EmbeddedShell::printHelp() {
     printf("%s%s [on|off] %stoggle syntax highlighting on or off\n", TAB, shellCommand.HIGHLIGHT,
         TAB);
     printf("%s%s [on|off] %stoggle error highlighting on or off\n", TAB, shellCommand.ERRORS, TAB);
+    printf("%s%s [on|off] %stoggle completion highlighting on or off\n", TAB, shellCommand.COMPLETE,
+        TAB);
     printf("\n");
     printf("%sNote: you can change and see several system configurations, such as num-threads, \n",
         TAB);

--- a/tools/shell/include/embedded_shell.h
+++ b/tools/shell/include/embedded_shell.h
@@ -67,6 +67,8 @@ private:
 
     void setErrors(const std::string& errorsString);
 
+    void setComplete(const std::string& completeString);
+
 private:
     std::shared_ptr<Database> database;
     std::shared_ptr<Connection> conn;

--- a/tools/shell/include/linenoise.h
+++ b/tools/shell/include/linenoise.h
@@ -89,6 +89,7 @@ void linenoiseSetFreeHintsCallback(linenoiseFreeHintsCallback*);
 void linenoiseSetHighlightCallback(linenoiseHighlightCallback*);
 void linenoiseSetErrors(int enabled);
 void linenoiseSetHighlighting(int enabled);
+void linenoiseSetCompletion(int enabled);
 void linenoiseAddCompletion(linenoiseCompletions*, const char*);
 
 char* linenoise(const char* prompt, const char* continuePrompt, const char* selectedContinuePrompt);

--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -1002,6 +1002,10 @@ void linenoiseSetHighlighting(int enabled) {
 
 /* ============================== Completion ================================ */
 
+void linenoiseSetCompletion(int enabled) {
+    completionEnabled = enabled;
+}
+
 /* Free a list of completion option populated by linenoiseAddCompletion(). */
 static void freeCompletions(linenoiseCompletions* lc) {
     size_t i;

--- a/tools/shell/test/test_shell_commands.py
+++ b/tools/shell/test/test_shell_commands.py
@@ -17,6 +17,7 @@ def test_help(temp_db) -> None:
             "    :singleline     set singleline mode",
             "    :highlight [on|off]     toggle syntax highlighting on or off",
             "    :render_errors [on|off]     toggle error highlighting on or off",
+            "    :render_completion [on|off]     toggle completion highlighting on or off",
             "",
             "    Note: you can change and see several system configurations, such as num-threads, ",
             "          timeout, and progress_bar using Cypher CALL statements.",
@@ -567,6 +568,14 @@ def test_highlight(temp_db) -> None:
     result = test.run()
     result.check_stdout("enabled syntax highlighting")
 
+    test = (
+        ShellTest()
+        .add_argument(temp_db)
+        .statement(":highlight o")
+    )
+    result = test.run()
+    result.check_stdout("Cannot parse 'o' to toggle highlighting. Expect 'on' or 'off'.")
+
 
 def test_render_errors(temp_db) -> None:
     test = (
@@ -584,6 +593,40 @@ def test_render_errors(temp_db) -> None:
     )
     result = test.run()
     result.check_stdout("enabled error highlighting")
+
+    test = (
+        ShellTest()
+        .add_argument(temp_db)
+        .statement(":render_errors o")
+    )
+    result = test.run()
+    result.check_stdout("Cannot parse 'o' to toggle error highlighting. Expect 'on' or 'off'.")
+
+
+def test_completion_highlighting(temp_db) -> None:
+    test = (
+        ShellTest()
+        .add_argument(temp_db)
+        .statement(":render_completion off")
+    )
+    result = test.run()
+    result.check_stdout("disabled completion highlighting")
+
+    test = (
+        ShellTest()
+        .add_argument(temp_db)
+        .statement(":render_completion on")
+    )
+    result = test.run()
+    result.check_stdout("enabled completion highlighting")
+
+    test = (
+        ShellTest()
+        .add_argument(temp_db)
+        .statement(":render_completion o")
+    )
+    result = test.run()
+    result.check_stdout("Cannot parse 'o' to toggle completion highlighting. Expect 'on' or 'off'.")
 
 
 def test_bad_command(temp_db) -> None:


### PR DESCRIPTION
# Description

Added cli command to toggle auto completion highlighting similar to the highlighting and error commands. Just a small change for people who don't want the grey completion words appearing while typing. 

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).