### PR TITLE
support path semantic in non-recursive-path

### DIFF
--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -55,8 +55,13 @@ QueryGraph Binder::bindPatternElement(const PatternElement& patternElement) {
         nodeAndRels.push_back(rightNode);
         leftNode = rightNode;
     }
-    if (patternElement.hasPathName()) {
-        auto pathName = patternElement.getPathName();
+
+    if (patternElement.hasPathName() ||
+        this->clientContext->getClientConfig()->recursivePatternSemantic != PathSemantic::WALK) {
+        // query may not explicitly define a path name, but it requires a path for semantic filter;
+        // therefore, an implicitly defined path is added internally.
+        auto pathName =
+            patternElement.hasPathName() ? patternElement.getPathName() : getInternalPathName();
         auto pathExpression = createPath(pathName, nodeAndRels);
         addToScope(pathName, pathExpression);
     }

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -144,6 +144,10 @@ std::string Binder::getUniqueExpressionName(const std::string& name) {
     return "_" + std::to_string(lastExpressionId++) + "_" + name;
 }
 
+std::string Binder::getInternalPathName() {
+    return InternalKeyword::INTERNAL_PATH + std::to_string(lastInternalPathId++);
+}
+
 struct ReservedNames {
     // Column name that might conflict with internal names.
     static std::unordered_set<std::string> getColumnNames() {
@@ -238,6 +242,16 @@ function::TableFunction Binder::getScanFunction(FileTypeInfo typeInfo, const Rea
         KU_UNREACHABLE;
     }
     return *func->ptrCast<function::TableFunction>();
+}
+
+expression_vector Binder::findPathExpressionInScope() {
+    expression_vector result;
+    for (auto expr : this->scope.getExpressions()) {
+        if (expr->expressionType == ExpressionType::PATH) {
+            result.push_back(expr);
+        }
+    }
+    return result;
 }
 
 } // namespace binder

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -73,8 +73,8 @@ class Binder {
 
 public:
     explicit Binder(main::ClientContext* clientContext)
-        : lastExpressionId{0}, scope{}, graphEntrySet{}, expressionBinder{this, clientContext},
-          clientContext{clientContext} {}
+        : lastInternalPathId{0}, lastExpressionId{0}, scope{}, graphEntrySet{},
+          expressionBinder{this, clientContext}, clientContext{clientContext} {}
 
     std::unique_ptr<BoundStatement> bind(const parser::Statement& statement);
 
@@ -303,6 +303,7 @@ public:
     void validateDropSequence(const parser::Statement& dropTable);
     /*** helpers ***/
     std::string getUniqueExpressionName(const std::string& name);
+    std::string getInternalPathName();
 
     static bool reservedInColumnName(const std::string& name);
     static bool reservedInPropertyLookup(const std::string& name);
@@ -317,7 +318,10 @@ public:
 
     ExpressionBinder* getExpressionBinder() { return &expressionBinder; }
 
+    expression_vector findPathExpressionInScope();
+
 private:
+    uint32_t lastInternalPathId;
     uint32_t lastExpressionId;
     BinderScope scope;
     graph::GraphEntrySet graphEntrySet;

--- a/src/include/binder/visitor/property_collector.h
+++ b/src/include/binder/visitor/property_collector.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "binder/bound_statement_visitor.h"
+#include "common/enums/path_semantic.h"
+#include "main/client_config.h"
 
 namespace kuzu {
 namespace binder {
@@ -13,6 +15,11 @@ public:
     // Skip collecting node/rel properties if they are in WITH projection list.
     // See with_clause_projection_rewriter for more details.
     void visitSingleQuerySkipNodeRel(const NormalizedSingleQuery& singleQuery);
+
+    inline void setRecursivePatternSemantic(common::PathSemantic semantic) {
+        recursivePatternSemantic = semantic;
+    }
+    inline common::PathSemantic getRecursivePatternSemantic() { return recursivePatternSemantic; }
 
 private:
     void visitQueryPartSkipNodeRel(const NormalizedQueryPart& queryPart);
@@ -36,6 +43,8 @@ private:
 
 private:
     expression_set properties;
+    common::PathSemantic recursivePatternSemantic =
+        main::ClientConfigDefault::RECURSIVE_PATTERN_SEMANTIC;
 };
 
 } // namespace binder

--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -49,6 +49,7 @@ struct InternalKeyword {
     static constexpr char PLACE_HOLDER[] = "_PLACE_HOLDER";
     static constexpr char MAP_KEY[] = "KEY";
     static constexpr char MAP_VALUE[] = "VALUE";
+    static constexpr char INTERNAL_PATH[] = "_INTERNAL_PATH";
 
     static constexpr std::string_view ROW_OFFSET = "_row_offset";
     static constexpr std::string_view SRC_OFFSET = "_src_offset";

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -110,6 +110,9 @@ public:
     common::VirtualFileSystem* getVFSUnsafe() const;
     common::RandomEngine* getRandomEngine();
 
+    // binder
+    binder::Binder* getBinder() const;
+
     // Query.
     std::unique_ptr<PreparedStatement> prepare(std::string_view query);
     std::unique_ptr<QueryResult> executeWithParams(PreparedStatement* preparedStatement,
@@ -194,6 +197,7 @@ private:
     // Warning information
     processor::WarningContext warningContext;
     std::mutex mtx;
+    std::unique_ptr<binder::Binder> binder;
 };
 
 } // namespace main

--- a/src/include/optimizer/path_semantic_rewriter.h
+++ b/src/include/optimizer/path_semantic_rewriter.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "binder/binder.h"
+#include "binder/expression/expression.h"
+#include "logical_operator_visitor.h"
+#include "planner/operator/logical_plan.h"
+namespace kuzu {
+namespace main {
+class ClientContext;
+}
+namespace catalog {
+class Catalog;
+}
+namespace binder {}
+namespace optimizer {
+
+class PathSemanticRewriter : public LogicalOperatorVisitor {
+public:
+    explicit PathSemanticRewriter(main::ClientContext* context)
+        : hasReplace(false), context{context} {}
+    void rewrite(planner::LogicalPlan* plan);
+
+private:
+    void visitOperator(const std::shared_ptr<planner::LogicalOperator>& op,
+        const std::shared_ptr<planner::LogicalOperator>& parent, int index);
+    std::shared_ptr<planner::LogicalOperator> visitHashJoinReplace(
+        std::shared_ptr<planner::LogicalOperator> op) override;
+    std::shared_ptr<planner::LogicalOperator> visitCrossProductReplace(
+        std::shared_ptr<planner::LogicalOperator> op);
+
+private:
+    bool hasReplace;
+    main::ClientContext* context;
+    binder::expression_vector scanExpression;
+    std::shared_ptr<planner::LogicalOperator> appendPathSemanticFilter(
+        const std::shared_ptr<planner::LogicalOperator> op);
+};
+
+} // namespace optimizer
+} // namespace kuzu

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -331,12 +331,12 @@ std::unique_ptr<PreparedStatement> ClientContext::prepareNoLock(
             }
         }
         // binding
-        auto binder = Binder(this);
+        binder = std::make_unique<binder::Binder>((this));
         if (inputParams) {
-            binder.setInputParameters(*inputParams);
+            binder->setInputParameters(*inputParams);
         }
-        auto boundStatement = binder.bind(*parsedStatement);
-        preparedStatement->parameterMap = binder.getParameterMap();
+        auto boundStatement = binder->bind(*parsedStatement);
+        preparedStatement->parameterMap = binder->getParameterMap();
         preparedStatement->statementResult =
             std::make_unique<BoundStatementResult>(boundStatement->getStatementResult()->copy());
         // planning
@@ -594,6 +594,9 @@ processor::WarningContext& ClientContext::getWarningContextUnsafe() {
 
 const processor::WarningContext& ClientContext::getWarningContext() const {
     return warningContext;
+}
+binder::Binder* ClientContext::getBinder() const {
+    return binder.get();
 }
 } // namespace main
 } // namespace kuzu

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -11,7 +11,8 @@ add_library(kuzu_optimizer
         projection_push_down_optimizer.cpp
         remove_factorization_rewriter.cpp
         remove_unnecessary_join_optimizer.cpp
-        top_k_optimizer.cpp)
+        top_k_optimizer.cpp
+        path_semantic_rewriter.cpp)
 
 set(ALL_OBJECT_FILES
         ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_optimizer>

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -6,6 +6,7 @@
 #include "optimizer/correlated_subquery_unnest_solver.h"
 #include "optimizer/factorization_rewriter.h"
 #include "optimizer/filter_push_down_optimizer.h"
+#include "optimizer/path_semantic_rewriter.h"
 #include "optimizer/projection_push_down_optimizer.h"
 #include "optimizer/remove_factorization_rewriter.h"
 #include "optimizer/remove_unnecessary_join_optimizer.h"
@@ -21,6 +22,9 @@ void Optimizer::optimize(planner::LogicalPlan* plan, main::ClientContext* contex
 
     auto correlatedSubqueryUnnestSolver = CorrelatedSubqueryUnnestSolver(nullptr);
     correlatedSubqueryUnnestSolver.solve(plan->getLastOperator().get());
+
+    auto pathSemanticRewriter = PathSemanticRewriter(context);
+    pathSemanticRewriter.rewrite(plan);
 
     auto removeUnnecessaryJoinOptimizer = RemoveUnnecessaryJoinOptimizer();
     removeUnnecessaryJoinOptimizer.rewrite(plan);

--- a/src/optimizer/path_semantic_rewriter.cpp
+++ b/src/optimizer/path_semantic_rewriter.cpp
@@ -1,0 +1,123 @@
+#include "optimizer/path_semantic_rewriter.h"
+
+#include "binder/expression/path_expression.h"
+#include "binder/expression/scalar_function_expression.h"
+#include "binder/expression_visitor.h"
+#include "catalog/catalog.h"
+#include "common/exception/internal.h"
+#include "function/built_in_function_utils.h"
+#include "function/path/vector_path_functions.h"
+#include "function/scalar_function.h"
+#include "main/client_context.h"
+#include "planner/operator/logical_filter.h"
+using namespace kuzu::common;
+using namespace kuzu::planner;
+
+namespace kuzu {
+namespace optimizer {
+
+void PathSemanticRewriter::rewrite(planner::LogicalPlan* plan) {
+    auto root = plan->getLastOperator();
+    visitOperator(root, nullptr, 0);
+}
+
+void PathSemanticRewriter::visitOperator(const std::shared_ptr<planner::LogicalOperator>& op,
+    const std::shared_ptr<planner::LogicalOperator>& parent, int index) {
+
+    auto result = op;
+    switch (op->getOperatorType()) {
+    case planner::LogicalOperatorType::HASH_JOIN:
+        result = visitHashJoinReplace(op);
+        break;
+    case planner::LogicalOperatorType::CROSS_PRODUCT:
+        result = visitCrossProductReplace(op);
+        break;
+    default:
+        break;
+    }
+
+    if (hasReplace && parent != nullptr) {
+        parent->setChild(index, result);
+
+    } else {
+        for (auto i = 0u; i < op->getNumChildren(); ++i) {
+            visitOperator(op->getChild(i), op, i);
+        }
+    }
+}
+
+std::string semanticSwitch(const common::PathSemantic& semantic) {
+    switch (semantic) {
+    case common::PathSemantic::TRAIL:
+        return function::IsTrailFunction::name;
+    case common::PathSemantic::ACYCLIC:
+        return function::IsACyclicFunction::name;
+    default:
+        return std::string();
+    }
+}
+
+std::shared_ptr<LogicalOperator> PathSemanticRewriter::visitHashJoinReplace(
+    std::shared_ptr<LogicalOperator> op) {
+    return appendPathSemanticFilter(op);
+}
+
+std::shared_ptr<LogicalOperator> PathSemanticRewriter::appendPathSemanticFilter(
+    const std::shared_ptr<LogicalOperator> op) {
+    // get path expression from binder
+    auto pathExpressions = context->getBinder()->findPathExpressionInScope();
+    auto catalog = context->getCatalog();
+    auto transaction = context->getTx();
+    auto semanticFunctionName =
+        semanticSwitch(context->getClientConfig()->recursivePatternSemantic);
+    if (semanticFunctionName.empty()) {
+        return op;
+    }
+
+    auto resultOp = op;
+    // append is_trail or is_acyclic function filter
+    for (auto& expr : pathExpressions) {
+
+        std::vector<LogicalType> childrenTypes;
+        childrenTypes.push_back(expr->getDataType().copy());
+
+        auto bindExpr = binder::expression_vector{expr};
+        auto functions = catalog->getFunctions(transaction);
+        auto function = function::BuiltInFunctionsUtils::matchFunction(transaction,
+            semanticFunctionName, childrenTypes, functions)
+                            ->ptrCast<function::ScalarFunction>()
+                            ->copy();
+
+        std::unique_ptr<function::FunctionBindData> bindData;
+        {
+            if (function.bindFunc) {
+                bindData = function.bindFunc({bindExpr, &function, context});
+            } else {
+                bindData = std::make_unique<function::FunctionBindData>(
+                    LogicalType(function.returnTypeID));
+            }
+        }
+
+        auto uniqueExpressionName =
+            binder::ScalarFunctionExpression::getUniqueName(function.name, bindExpr);
+        auto filterExpression =
+            std::make_shared<binder::ScalarFunctionExpression>(ExpressionType::FUNCTION,
+                std::move(function), std::move(bindData), bindExpr, uniqueExpressionName);
+        auto printInfo = std::make_unique<OPPrintInfo>();
+
+        auto filter = std::make_shared<LogicalFilter>(
+            std::static_pointer_cast<binder::Expression>(filterExpression), resultOp,
+            std::move(printInfo));
+        hasReplace = true;
+        filter->computeFlatSchema();
+        resultOp = filter;
+    }
+    return resultOp;
+}
+std::shared_ptr<planner::LogicalOperator> PathSemanticRewriter::visitCrossProductReplace(
+    std::shared_ptr<planner::LogicalOperator> op) {
+    return appendPathSemanticFilter(op);
+}
+
+} // namespace optimizer
+} // namespace kuzu

--- a/src/planner/plan/plan_single_query.cpp
+++ b/src/planner/plan/plan_single_query.cpp
@@ -1,5 +1,6 @@
 #include "binder/expression/property_expression.h"
 #include "binder/visitor/property_collector.h"
+#include "main/client_context.h"
 #include "planner/planner.h"
 
 using namespace kuzu::binder;
@@ -13,6 +14,10 @@ namespace planner {
 std::vector<std::unique_ptr<LogicalPlan>> Planner::planSingleQuery(
     const NormalizedSingleQuery* singleQuery) {
     auto propertyCollector = binder::PropertyCollector();
+    // path semantic in query will append a semantic filter like is_trail/is_acyclic，
+    // requiring that schema includes all patterns.
+    propertyCollector.setRecursivePatternSemantic(
+        clientContext->getClientConfig()->recursivePatternSemantic);
     propertyCollector.visitSingleQuery(*singleQuery);
     auto properties = propertyCollector.getProperties();
     for (auto& expr : propertyCollector.getProperties()) {

--- a/src/processor/map/expression_mapper.cpp
+++ b/src/processor/map/expression_mapper.cpp
@@ -74,8 +74,8 @@ std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getEvaluator(
         return getLambdaParamEvaluator(expression);
     } else {
         // LCOV_EXCL_START
-        throw NotImplementedException(stringFormat("Cannot evaluate expression with type {}.",
-            ExpressionTypeUtil::toString(expressionType)));
+        throw NotImplementedException(stringFormat("Cannot evaluate expression {} with type {}.",
+            expression->toString(), ExpressionTypeUtil::toString(expressionType)));
         // LCOV_EXCL_STOP
     }
 }
@@ -93,7 +93,7 @@ std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getConstantEvaluator(
     } else {
         // LCOV_EXCL_START
         throw NotImplementedException(stringFormat("Cannot evaluate expression with type {}.",
-            ExpressionTypeUtil::toString(expressionType)));
+            expression->toString(), ExpressionTypeUtil::toString(expressionType)));
         // LCOV_EXCL_STOP
     }
 }


### PR DESCRIPTION
# Description

For non-recursive paths，such as "match (a)-[b]-(c)-[d]-(e) return e;", path semantics do not work.
support has been added:
1. If a path name is not explicitly defined, it will be implicitly created for use in the path semantics filter.
2. An additional path semantic filter plan, such as is_trail or is_acyclic, will append on top of the hash join or cross process.


Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).