### PR TITLE
Make scan functions const

### DIFF
--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -35,7 +35,7 @@ static std::unique_ptr<RelTableScanState> getRelScanState(MemoryManager& mm,
     for (auto property : properties) {
         columnIDs.push_back(property->constCast<PropertyExpression>().getColumnID(relEntry));
     }
-    auto columns = std::vector<Column*>{};
+    auto columns = std::vector<const Column*>{};
     for (const auto columnID : columnIDs) {
         columns.push_back(table.getColumn(columnID, direction));
     }

--- a/src/include/storage/store/column.h
+++ b/src/include/storage/store/column.h
@@ -41,7 +41,7 @@ public:
         bool requireNullColumn = true);
     virtual ~Column();
 
-    void populateExtraChunkState(ChunkState& state);
+    void populateExtraChunkState(ChunkState& state) const;
 
     static std::unique_ptr<ColumnChunkData> flushChunkData(const ColumnChunkData& chunkData,
         FileHandle& dataFH);
@@ -51,18 +51,18 @@ public:
 
     virtual void scan(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInChunk, common::row_idx_t numValuesToScan,
-        common::ValueVector* resultVector);
+        common::ValueVector* resultVector) const;
     virtual void lookupValue(transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t nodeOffset, common::ValueVector* resultVector, uint32_t posInVector);
+        common::offset_t nodeOffset, common::ValueVector* resultVector, uint32_t posInVector) const;
 
     // Scan from [startOffsetInGroup, endOffsetInGroup).
     virtual void scan(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
-        common::ValueVector* resultVector, uint64_t offsetInVector);
+        common::ValueVector* resultVector, uint64_t offsetInVector) const;
     // Scan from [startOffsetInGroup, endOffsetInGroup).
     virtual void scan(transaction::Transaction* transaction, const ChunkState& state,
         ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
-        common::offset_t endOffset = common::INVALID_OFFSET);
+        common::offset_t endOffset = common::INVALID_OFFSET) const;
 
     common::LogicalType& getDataType() { return dataType; }
     const common::LogicalType& getDataType() const { return dataType; }
@@ -97,10 +97,10 @@ public:
 protected:
     virtual void scanInternal(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInChunk, common::row_idx_t numValuesToScan,
-        common::ValueVector* resultVector);
+        common::ValueVector* resultVector) const;
 
     virtual void lookupInternal(transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t nodeOffset, common::ValueVector* resultVector, uint32_t posInVector);
+        common::offset_t nodeOffset, common::ValueVector* resultVector, uint32_t posInVector) const;
 
     void writeValues(ChunkState& state, common::offset_t dstOffset, const uint8_t* data,
         const common::NullMask* nullChunkData, common::offset_t srcOffset = 0,
@@ -157,14 +157,14 @@ public:
 
     void scan(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInChunk, common::row_idx_t numValuesToScan,
-        common::ValueVector* resultVector) override {
+        common::ValueVector* resultVector) const override {
         Column::scan(transaction, state, startOffsetInChunk, numValuesToScan, resultVector);
         populateCommonTableID(resultVector);
     }
 
     void scan(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
-        common::ValueVector* resultVector, uint64_t offsetInVector) override {
+        common::ValueVector* resultVector, uint64_t offsetInVector) const override {
         Column::scan(transaction, state, startOffsetInGroup, endOffsetInGroup, resultVector,
             offsetInVector);
         populateCommonTableID(resultVector);
@@ -172,7 +172,7 @@ public:
 
     void lookupInternal(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t nodeOffset, common::ValueVector* resultVector,
-        uint32_t posInVector) override {
+        uint32_t posInVector) const override {
         Column::lookupInternal(transaction, state, nodeOffset, resultVector, posInVector);
         populateCommonTableID(resultVector);
     }

--- a/src/include/storage/store/column_chunk.h
+++ b/src/include/storage/store/column_chunk.h
@@ -47,7 +47,7 @@ public:
         bool enableCompression, ColumnChunkMetadata metadata);
     ColumnChunk(bool enableCompression, std::unique_ptr<ColumnChunkData> data);
 
-    void initializeScanState(ChunkState& state, Column* column) const;
+    void initializeScanState(ChunkState& state, const Column* column) const;
     void scan(const transaction::Transaction* transaction, const ChunkState& state,
         common::ValueVector& output, common::offset_t offsetInChunk, common::length_t length) const;
     template<ResidencyState SCAN_RESIDENCY_STATE>

--- a/src/include/storage/store/column_chunk_data.h
+++ b/src/include/storage/store/column_chunk_data.h
@@ -32,7 +32,7 @@ class NullChunkData;
 
 // TODO(bmwinger): Hide access to variables.
 struct ChunkState {
-    Column* column;
+    const Column* column;
     ColumnChunkMetadata metadata;
     uint64_t numValuesPerPage = UINT64_MAX;
     std::unique_ptr<ChunkState> nullState;
@@ -180,7 +180,7 @@ public:
     }
     uint64_t getBufferSize() const;
 
-    virtual void initializeScanState(ChunkState& state, Column* column) const;
+    virtual void initializeScanState(ChunkState& state, const Column* column) const;
     virtual void scan(common::ValueVector& output, common::offset_t offset, common::length_t length,
         common::sel_t posInOutputVector = 0) const;
     virtual void lookup(common::offset_t offsetInChunk, common::ValueVector& output,

--- a/src/include/storage/store/csr_node_group.h
+++ b/src/include/storage/store/csr_node_group.h
@@ -200,8 +200,10 @@ public:
         }
     }
 
-    void initializeScanState(transaction::Transaction* transaction, TableScanState& state) override;
-    NodeGroupScanResult scan(transaction::Transaction* transaction, TableScanState& state) override;
+    void initializeScanState(transaction::Transaction* transaction,
+        TableScanState& state) const override;
+    NodeGroupScanResult scan(transaction::Transaction* transaction,
+        TableScanState& state) const override;
 
     void appendChunkedCSRGroup(const transaction::Transaction* transaction,
         ChunkedCSRNodeGroup& chunkedGroup);
@@ -249,11 +251,11 @@ private:
         CSRNodeGroupScanState& nodeGroupScanState) const;
 
     NodeGroupScanResult scanCommittedInMem(transaction::Transaction* transaction,
-        RelTableScanState& tableState, CSRNodeGroupScanState& nodeGroupScanState);
+        RelTableScanState& tableState, CSRNodeGroupScanState& nodeGroupScanState) const;
     NodeGroupScanResult scanCommittedInMemSequential(const transaction::Transaction* transaction,
-        const RelTableScanState& tableState, CSRNodeGroupScanState& nodeGroupScanState);
+        const RelTableScanState& tableState, CSRNodeGroupScanState& nodeGroupScanState) const;
     NodeGroupScanResult scanCommittedInMemRandom(transaction::Transaction* transaction,
-        const RelTableScanState& tableState, CSRNodeGroupScanState& nodeGroupScanState);
+        const RelTableScanState& tableState, CSRNodeGroupScanState& nodeGroupScanState) const;
 
     void checkpointInMemOnly(const common::UniqLock& lock, NodeGroupCheckpointState& state);
     void checkpointInMemAndOnDisk(const common::UniqLock& lock, NodeGroupCheckpointState& state);

--- a/src/include/storage/store/dictionary_column.h
+++ b/src/include/storage/store/dictionary_column.h
@@ -20,7 +20,7 @@ public:
     void scan(transaction::Transaction* transaction, const ChunkState& offsetState,
         const ChunkState& dataState,
         std::vector<std::pair<DictionaryChunk::string_index_t, uint64_t>>& offsetsToScan,
-        common::ValueVector* resultVector, const ColumnChunkMetadata& indexMeta);
+        common::ValueVector* resultVector, const ColumnChunkMetadata& indexMeta) const;
 
     DictionaryChunk::string_index_t append(const DictionaryChunk& dictChunk, ChunkState& state,
         std::string_view val);
@@ -34,10 +34,10 @@ public:
 private:
     void scanOffsets(transaction::Transaction* transaction, const ChunkState& state,
         DictionaryChunk::string_offset_t* offsets, uint64_t index, uint64_t numValues,
-        uint64_t dataSize);
+        uint64_t dataSize) const;
     void scanValueToVector(transaction::Transaction* transaction, const ChunkState& dataState,
         uint64_t startOffset, uint64_t endOffset, common::ValueVector* resultVector,
-        uint64_t offsetInVector);
+        uint64_t offsetInVector) const;
 
     bool canDataCommitInPlace(const ChunkState& dataState, uint64_t totalStringLengthToAdd);
     bool canOffsetCommitInPlace(const ChunkState& offsetState, const ChunkState& dataState,

--- a/src/include/storage/store/group_collection.h
+++ b/src/include/storage/store/group_collection.h
@@ -16,7 +16,7 @@ class GroupCollection {
 public:
     GroupCollection() {}
 
-    common::UniqLock lock() { return common::UniqLock{mtx}; }
+    common::UniqLock lock() const { return common::UniqLock{mtx}; }
 
     void deserializeGroups(MemoryManager& memoryManager, common::Deserializer& deSer) {
         lock();
@@ -34,7 +34,7 @@ public:
         KU_UNUSED(lock);
         groups.push_back(std::move(group));
     }
-    T* getGroup(const common::UniqLock& lock, common::idx_t groupIdx) {
+    T* getGroup(const common::UniqLock& lock, common::idx_t groupIdx) const {
         KU_ASSERT(lock.isLocked());
         KU_UNUSED(lock);
         if (groupIdx >= groups.size()) {
@@ -42,7 +42,7 @@ public:
         }
         return groups[groupIdx].get();
     }
-    T* getGroupNoLock(common::idx_t groupIdx) {
+    T* getGroupNoLock(common::idx_t groupIdx) const {
         if (groupIdx >= groups.size()) {
             return nullptr;
         }
@@ -68,7 +68,7 @@ public:
         groups.resize(newSize);
     }
 
-    bool isEmpty(const common::UniqLock& lock) {
+    bool isEmpty(const common::UniqLock& lock) const {
         KU_ASSERT(lock.isLocked());
         KU_UNUSED(lock);
         return groups.empty();
@@ -79,7 +79,7 @@ public:
         return groups.size();
     }
 
-    const std::vector<std::unique_ptr<T>>& getAllGroups(const common::UniqLock& lock) {
+    const std::vector<std::unique_ptr<T>>& getAllGroups(const common::UniqLock& lock) const {
         KU_ASSERT(lock.isLocked());
         KU_UNUSED(lock);
         return groups;
@@ -90,7 +90,7 @@ public:
         KU_UNUSED(lock);
         return std::move(groups[groupIdx]);
     }
-    T* getFirstGroup(const common::UniqLock& lock) {
+    T* getFirstGroup(const common::UniqLock& lock) const {
         KU_ASSERT(lock.isLocked());
         KU_UNUSED(lock);
         if (groups.empty()) {
@@ -98,13 +98,13 @@ public:
         }
         return groups.front().get();
     }
-    T* getFirstGroupNoLock() {
+    T* getFirstGroupNoLock() const {
         if (groups.empty()) {
             return nullptr;
         }
         return groups.front().get();
     }
-    T* getLastGroup(const common::UniqLock& lock) {
+    T* getLastGroup(const common::UniqLock& lock) const {
         KU_ASSERT(lock.isLocked());
         KU_UNUSED(lock);
         if (groups.empty()) {
@@ -120,7 +120,7 @@ public:
     }
 
 private:
-    std::mutex mtx;
+    mutable std::mutex mtx;
     std::vector<std::unique_ptr<T>> groups;
 };
 

--- a/src/include/storage/store/list_chunk_data.h
+++ b/src/include/storage/store/list_chunk_data.h
@@ -56,7 +56,7 @@ public:
 
     void append(common::ValueVector* vector, const common::SelectionVector& selVector) override;
 
-    void initializeScanState(ChunkState& state, Column* column) const override;
+    void initializeScanState(ChunkState& state, const Column* column) const override;
     void scan(common::ValueVector& output, common::offset_t offset, common::length_t length,
         common::sel_t posInOutputVector) const override;
     void lookup(common::offset_t offsetInChunk, common::ValueVector& output,

--- a/src/include/storage/store/list_column.h
+++ b/src/include/storage/store/list_column.h
@@ -58,10 +58,10 @@ public:
 
     void scan(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
-        common::ValueVector* resultVector, uint64_t offsetInVector = 0) override;
+        common::ValueVector* resultVector, uint64_t offsetInVector = 0) const override;
     void scan(transaction::Transaction* transaction, const ChunkState& state,
         ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
-        common::offset_t endOffset = common::INVALID_OFFSET) override;
+        common::offset_t endOffset = common::INVALID_OFFSET) const override;
 
     Column* getOffsetColumn() const { return offsetColumn.get(); }
     Column* getSizeColumn() const { return sizeColumn.get(); }
@@ -72,11 +72,11 @@ public:
 protected:
     void scanInternal(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInChunk, common::row_idx_t numValuesToScan,
-        common::ValueVector* resultVector) override;
+        common::ValueVector* resultVector) const override;
 
     void lookupInternal(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t nodeOffset, common::ValueVector* resultVector,
-        uint32_t posInVector) override;
+        uint32_t posInVector) const override;
 
 private:
     void scanUnfiltered(transaction::Transaction* transaction, const ChunkState& state,

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -131,10 +131,12 @@ public:
     void merge(transaction::Transaction* transaction,
         std::unique_ptr<ChunkedNodeGroup> chunkedGroup);
 
-    virtual void initializeScanState(transaction::Transaction* transaction, TableScanState& state);
+    virtual void initializeScanState(transaction::Transaction* transaction,
+        TableScanState& state) const;
     void initializeScanState(transaction::Transaction* transaction, const common::UniqLock& lock,
-        TableScanState& state);
-    virtual NodeGroupScanResult scan(transaction::Transaction* transaction, TableScanState& state);
+        TableScanState& state) const;
+    virtual NodeGroupScanResult scan(transaction::Transaction* transaction,
+        TableScanState& state) const;
 
     bool lookup(const common::UniqLock& lock, transaction::Transaction* transaction,
         const TableScanState& state);
@@ -194,11 +196,11 @@ private:
         const transaction::Transaction* transaction);
 
     template<ResidencyState SCAN_RESIDENCY_STATE>
-    common::row_idx_t getNumResidentRows(const common::UniqLock& lock);
+    common::row_idx_t getNumResidentRows(const common::UniqLock& lock) const;
     template<ResidencyState SCAN_RESIDENCY_STATE>
     std::unique_ptr<ChunkedNodeGroup> scanAllInsertedAndVersions(MemoryManager& memoryManager,
         const common::UniqLock& lock, const std::vector<common::column_id_t>& columnIDs,
-        const std::vector<Column*>& columns);
+        const std::vector<const Column*>& columns) const;
 
     static void populateNodeID(common::ValueVector& nodeIDVector, common::table_id_t tableID,
         common::offset_t startNodeOffset, common::row_idx_t numRows);

--- a/src/include/storage/store/node_group_collection.h
+++ b/src/include/storage/store/node_group_collection.h
@@ -38,7 +38,7 @@ public:
     NodeGroup* getNodeGroupNoLock(const common::node_group_idx_t groupIdx) {
         return nodeGroups.getGroupNoLock(groupIdx);
     }
-    NodeGroup* getNodeGroup(const common::node_group_idx_t groupIdx) {
+    NodeGroup* getNodeGroup(const common::node_group_idx_t groupIdx) const {
         const auto lock = nodeGroups.lock();
         return nodeGroups.getGroup(lock, groupIdx);
     }

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -29,11 +29,11 @@ struct NodeTableScanState final : TableScanState {
     NodeTableScanState(common::table_id_t tableID, std::vector<common::column_id_t> columnIDs)
         : NodeTableScanState{tableID, std::move(columnIDs), {}} {}
     NodeTableScanState(common::table_id_t tableID, std::vector<common::column_id_t> columnIDs,
-        std::vector<Column*> columns)
+        std::vector<const Column*> columns)
         : NodeTableScanState{tableID, std::move(columnIDs), std::move(columns),
               std::vector<ColumnPredicateSet>{}} {}
     NodeTableScanState(common::table_id_t tableID, std::vector<common::column_id_t> columnIDs,
-        std::vector<Column*> columns, std::vector<ColumnPredicateSet> columnPredicateSets)
+        std::vector<const Column*> columns, std::vector<ColumnPredicateSet> columnPredicateSets)
         : TableScanState{tableID, std::move(columnIDs), std::move(columns),
               std::move(columnPredicateSets)} {
         nodeGroupScanState = std::make_unique<NodeGroupScanState>(this->columnIDs.size());
@@ -98,7 +98,8 @@ public:
 
     common::row_idx_t getNumRows() override { return nodeGroups->getNumTotalRows(); }
 
-    void initScanState(transaction::Transaction* transaction, TableScanState& scanState) override;
+    void initScanState(transaction::Transaction* transaction,
+        TableScanState& scanState) const override;
 
     bool scanInternal(transaction::Transaction* transaction, TableScanState& scanState) override;
     bool lookup(transaction::Transaction* transaction, const TableScanState& scanState) const;

--- a/src/include/storage/store/null_column.h
+++ b/src/include/storage/store/null_column.h
@@ -20,13 +20,13 @@ public:
 
     void scan(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInChunk, common::row_idx_t numValuesToScan,
-        common::ValueVector* resultVector) override;
+        common::ValueVector* resultVector) const override;
     void scan(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
-        common::ValueVector* resultVector, uint64_t offsetInVector) override;
+        common::ValueVector* resultVector, uint64_t offsetInVector) const override;
     void scan(transaction::Transaction* transaction, const ChunkState& state,
         ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
-        common::offset_t endOffset = common::INVALID_OFFSET) override;
+        common::offset_t endOffset = common::INVALID_OFFSET) const override;
 
     void write(ColumnChunkData& persistentChunk, ChunkState& state, common::offset_t offsetInChunk,
         ColumnChunkData* data, common::offset_t dataOffset, common::length_t numValues) override;

--- a/src/include/storage/store/rel_table.h
+++ b/src/include/storage/store/rel_table.h
@@ -36,14 +36,15 @@ struct RelTableScanState : TableScanState {
     }
 
     RelTableScanState(MemoryManager& mm, common::table_id_t tableID,
-        const std::vector<common::column_id_t>& columnIDs, const std::vector<Column*>& columns,
-        Column* csrOffsetCol, Column* csrLengthCol, common::RelDataDirection direction)
+        const std::vector<common::column_id_t>& columnIDs,
+        const std::vector<const Column*>& columns, Column* csrOffsetCol, Column* csrLengthCol,
+        common::RelDataDirection direction)
         : RelTableScanState(mm, tableID, columnIDs, columns, csrOffsetCol, csrLengthCol, direction,
               std::vector<ColumnPredicateSet>{}) {}
     RelTableScanState(MemoryManager& mm, common::table_id_t tableID,
-        const std::vector<common::column_id_t>& columnIDs, const std::vector<Column*>& columns,
-        Column* csrOffsetCol, Column* csrLengthCol, common::RelDataDirection direction,
-        std::vector<ColumnPredicateSet> columnPredicateSets);
+        const std::vector<common::column_id_t>& columnIDs,
+        const std::vector<const Column*>& columns, Column* csrOffsetCol, Column* csrLengthCol,
+        common::RelDataDirection direction, std::vector<ColumnPredicateSet> columnPredicateSets);
 
     void initState(transaction::Transaction* transaction, NodeGroup* nodeGroup) override;
 
@@ -134,7 +135,8 @@ public:
     common::table_id_t getFromNodeTableID() const { return fromNodeTableID; }
     common::table_id_t getToNodeTableID() const { return toNodeTableID; }
 
-    void initScanState(transaction::Transaction* transaction, TableScanState& scanState) override;
+    void initScanState(transaction::Transaction* transaction,
+        TableScanState& scanState) const override;
 
     bool scanInternal(transaction::Transaction* transaction, TableScanState& scanState) override;
 

--- a/src/include/storage/store/rel_table_data.h
+++ b/src/include/storage/store/rel_table_data.h
@@ -41,8 +41,8 @@ public:
     Column* getCSRLengthColumn() const { return csrHeaderColumns.length.get(); }
     common::column_id_t getNumColumns() const { return columns.size(); }
     Column* getColumn(common::column_id_t columnID) const { return columns[columnID].get(); }
-    std::vector<Column*> getColumns() const {
-        std::vector<Column*> columns;
+    std::vector<const Column*> getColumns() const {
+        std::vector<const Column*> columns;
         columns.reserve(this->columns.size());
         for (const auto& column : this->columns) {
             columns.push_back(column.get());

--- a/src/include/storage/store/string_chunk_data.h
+++ b/src/include/storage/store/string_chunk_data.h
@@ -29,7 +29,7 @@ public:
     ColumnChunkData* getIndexColumnChunk();
     const ColumnChunkData* getIndexColumnChunk() const;
 
-    void initializeScanState(ChunkState& state, Column* column) const override;
+    void initializeScanState(ChunkState& state, const Column* column) const override;
     void scan(common::ValueVector& output, common::offset_t offset, common::length_t length,
         common::sel_t posInOutputVector = 0) const override;
     void lookup(common::offset_t offsetInChunk, common::ValueVector& output,

--- a/src/include/storage/store/string_column.h
+++ b/src/include/storage/store/string_column.h
@@ -19,10 +19,10 @@ public:
 
     void scan(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
-        common::ValueVector* resultVector, uint64_t offsetInVector = 0) override;
+        common::ValueVector* resultVector, uint64_t offsetInVector = 0) const override;
     void scan(transaction::Transaction* transaction, const ChunkState& state,
         ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
-        common::offset_t endOffset = common::INVALID_OFFSET) override;
+        common::offset_t endOffset = common::INVALID_OFFSET) const override;
 
     void write(ColumnChunkData& persistentChunk, ChunkState& state, common::offset_t dstOffset,
         ColumnChunkData* data, common::offset_t srcOffset, common::length_t numValues) override;
@@ -30,7 +30,7 @@ public:
     void checkpointColumnChunk(ColumnCheckpointState& checkpointState) override;
 
     const DictionaryColumn& getDictionary() const { return dictionary; }
-    Column* getIndexColumn() { return indexColumn.get(); }
+    const Column* getIndexColumn() const { return indexColumn.get(); }
 
     static ChunkState& getChildState(ChunkState& state, ChildStateIndex child);
     static const ChunkState& getChildState(const ChunkState& state, ChildStateIndex child);
@@ -38,16 +38,16 @@ public:
 protected:
     void scanInternal(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInChunk, common::row_idx_t numValuesToScan,
-        common::ValueVector* resultVector) override;
+        common::ValueVector* resultVector) const override;
     void scanUnfiltered(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInChunk, common::offset_t numValuesToRead,
-        common::ValueVector* resultVector, common::sel_t startPosInVector = 0);
+        common::ValueVector* resultVector, common::sel_t startPosInVector = 0) const;
     void scanFiltered(transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t startOffsetInChunk, common::ValueVector* resultVector);
+        common::offset_t startOffsetInChunk, common::ValueVector* resultVector) const;
 
     void lookupInternal(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t nodeOffset, common::ValueVector* resultVector,
-        uint32_t posInVector) override;
+        uint32_t posInVector) const override;
 
 private:
     bool canCheckpointInPlace(const ChunkState& state,

--- a/src/include/storage/store/struct_chunk_data.h
+++ b/src/include/storage/store/struct_chunk_data.h
@@ -60,7 +60,7 @@ protected:
         common::sel_t posInOutputVector = 0) const override;
     void lookup(common::offset_t offsetInChunk, common::ValueVector& output,
         common::sel_t posInOutputVector) const override;
-    void initializeScanState(ChunkState& state, Column* column) const override;
+    void initializeScanState(ChunkState& state, const Column* column) const override;
 
     void write(const common::ValueVector* vector, common::offset_t offsetInVector,
         common::offset_t offsetInChunk) override;

--- a/src/include/storage/store/struct_column.h
+++ b/src/include/storage/store/struct_column.h
@@ -16,10 +16,10 @@ public:
 
     void scan(transaction::Transaction* transaction, const ChunkState& state,
         ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
-        common::offset_t endOffset = common::INVALID_OFFSET) override;
+        common::offset_t endOffset = common::INVALID_OFFSET) const override;
     void scan(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
-        common::ValueVector* resultVector, uint64_t offsetInVector) override;
+        common::ValueVector* resultVector, uint64_t offsetInVector) const override;
 
     Column* getChild(common::idx_t childIdx) const {
         KU_ASSERT(childIdx < childColumns.size());
@@ -33,11 +33,11 @@ public:
 protected:
     void scanInternal(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInChunk, common::row_idx_t numValuesToScan,
-        common::ValueVector* resultVector) override;
+        common::ValueVector* resultVector) const override;
 
     void lookupInternal(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t nodeOffset, common::ValueVector* resultVector,
-        uint32_t posInVector) override;
+        uint32_t posInVector) const override;
 
 private:
     std::vector<std::unique_ptr<Column>> childColumns;

--- a/src/include/storage/store/table.h
+++ b/src/include/storage/store/table.h
@@ -26,7 +26,7 @@ struct TableScanState {
     common::NodeSemiMask* semiMask;
 
     // Only used when scan from persistent data.
-    std::vector<Column*> columns;
+    std::vector<const Column*> columns;
 
     TableScanSource source = TableScanSource::NONE;
     common::node_group_idx_t nodeGroupIdx = common::INVALID_NODE_GROUP_IDX;
@@ -38,10 +38,10 @@ struct TableScanState {
     TableScanState(common::table_id_t tableID, std::vector<common::column_id_t> columnIDs)
         : TableScanState{tableID, std::move(columnIDs), {}} {}
     TableScanState(common::table_id_t tableID, std::vector<common::column_id_t> columnIDs,
-        std::vector<Column*> columns)
+        std::vector<const Column*> columns)
         : TableScanState{tableID, std::move(columnIDs), std::move(columns), {}} {}
     TableScanState(common::table_id_t tableID, std::vector<common::column_id_t> columnIDs,
-        std::vector<Column*> columns, std::vector<ColumnPredicateSet> columnPredicateSets)
+        std::vector<const Column*> columns, std::vector<ColumnPredicateSet> columnPredicateSets)
         : tableID{tableID}, nodeIDVector(nullptr), outState{nullptr},
           columnIDs{std::move(columnIDs)}, semiMask{nullptr}, columns{std::move(columns)},
           columnPredicateSets{std::move(columnPredicateSets)} {
@@ -154,7 +154,7 @@ public:
     FileHandle* getDataFH() const { return dataFH; }
 
     virtual void initScanState(transaction::Transaction* transaction,
-        TableScanState& readState) = 0;
+        TableScanState& readState) const = 0;
     bool scan(transaction::Transaction* transaction, TableScanState& scanState);
 
     virtual void insert(transaction::Transaction* transaction, TableInsertState& insertState) = 0;

--- a/src/main/storage_driver.cpp
+++ b/src/main/storage_driver.cpp
@@ -131,7 +131,7 @@ void StorageDriver::scanColumn(storage::Table* table, column_id_t columnID, offs
     auto columnIDs = std::vector<column_id_t>{columnID};
     auto nodeTable = table->ptrCast<NodeTable>();
     auto column = &nodeTable->getColumn(columnID);
-    std::vector<Column*> columns;
+    std::vector<const Column*> columns;
     columns.push_back(column);
     auto scanState = std::make_unique<NodeTableScanState>(table->getTableID(), columnIDs, columns);
     // Create value vectors

--- a/src/processor/operator/scan/primary_key_scan_node_table.cpp
+++ b/src/processor/operator/scan/primary_key_scan_node_table.cpp
@@ -28,7 +28,7 @@ idx_t PrimaryKeyScanSharedState::getTableIdx() {
 void PrimaryKeyScanNodeTable::initLocalStateInternal(ResultSet* resultSet,
     ExecutionContext* context) {
     for (auto& nodeInfo : nodeInfos) {
-        std::vector<Column*> columns;
+        std::vector<const Column*> columns;
         columns.reserve(nodeInfo.columnIDs.size());
         for (const auto columnID : nodeInfo.columnIDs) {
             if (columnID == INVALID_COLUMN_ID) {

--- a/src/processor/operator/scan/scan_node_table.cpp
+++ b/src/processor/operator/scan/scan_node_table.cpp
@@ -59,7 +59,7 @@ void ScanNodeTableSharedState::nextMorsel(NodeTableScanState& scanState,
 }
 
 void ScanNodeTableInfo::initScanState(NodeSemiMask* semiMask) {
-    std::vector<Column*> columns;
+    std::vector<const Column*> columns;
     columns.reserve(columnIDs.size());
     for (const auto columnID : columnIDs) {
         if (columnID == INVALID_COLUMN_ID) {

--- a/src/processor/operator/scan/scan_rel_table.cpp
+++ b/src/processor/operator/scan/scan_rel_table.cpp
@@ -51,7 +51,7 @@ std::string ScanRelTablePrintInfo::toString() const {
 }
 
 void ScanRelTableInfo::initScanState(const ExecutionContext* context) {
-    std::vector<Column*> columns;
+    std::vector<const Column*> columns;
     columns.reserve(columnIDs.size());
     for (const auto columnID : columnIDs) {
         if (columnID == INVALID_COLUMN_ID) {

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -131,7 +131,7 @@ Column* Column::getNullColumn() const {
     return nullColumn.get();
 }
 
-void Column::populateExtraChunkState(ChunkState& state) {
+void Column::populateExtraChunkState(ChunkState& state) const {
     if (state.metadata.compMeta.compression == CompressionType::ALP) {
         Transaction& transaction = DUMMY_CHECKPOINT_TRANSACTION;
         if (dataType.getPhysicalType() == common::PhysicalTypeID::DOUBLE) {
@@ -188,7 +188,7 @@ ColumnChunkMetadata Column::flushData(const ColumnChunkData& chunkData, FileHand
 }
 
 void Column::scan(Transaction* transaction, const ChunkState& state, offset_t startOffsetInChunk,
-    row_idx_t numValuesToScan, ValueVector* resultVector) {
+    row_idx_t numValuesToScan, ValueVector* resultVector) const {
     if (nullColumn) {
         KU_ASSERT(state.nullState);
         nullColumn->scan(transaction, *state.nullState, startOffsetInChunk, numValuesToScan,
@@ -198,7 +198,7 @@ void Column::scan(Transaction* transaction, const ChunkState& state, offset_t st
 }
 
 void Column::scan(Transaction* transaction, const ChunkState& state, offset_t startOffsetInGroup,
-    offset_t endOffsetInGroup, ValueVector* resultVector, uint64_t offsetInVector) {
+    offset_t endOffsetInGroup, ValueVector* resultVector, uint64_t offsetInVector) const {
     if (nullColumn) {
         KU_ASSERT(state.nullState);
         nullColumn->scan(transaction, *state.nullState, startOffsetInGroup, endOffsetInGroup,
@@ -209,7 +209,7 @@ void Column::scan(Transaction* transaction, const ChunkState& state, offset_t st
 }
 
 void Column::scan(Transaction* transaction, const ChunkState& state, ColumnChunkData* columnChunk,
-    offset_t startOffset, offset_t endOffset) {
+    offset_t startOffset, offset_t endOffset) const {
     if (nullColumn) {
         nullColumn->scan(transaction, *state.nullState, columnChunk->getNullData(), startOffset,
             endOffset);
@@ -241,7 +241,7 @@ void Column::scan(Transaction* transaction, const ChunkState& state, offset_t st
 }
 
 void Column::scanInternal(Transaction* transaction, const ChunkState& state,
-    offset_t startOffsetInChunk, row_idx_t numValuesToScan, ValueVector* resultVector) {
+    offset_t startOffsetInChunk, row_idx_t numValuesToScan, ValueVector* resultVector) const {
     if (resultVector->state->getSelVector().isUnfiltered()) {
         columnReadWriter->readCompressedValuesToVector(transaction, state, resultVector, 0,
             startOffsetInChunk, startOffsetInChunk + numValuesToScan, readToVectorFunc);
@@ -269,7 +269,7 @@ void Column::scanInternal(Transaction* transaction, const ChunkState& state,
 }
 
 void Column::lookupValue(Transaction* transaction, const ChunkState& state, offset_t nodeOffset,
-    ValueVector* resultVector, uint32_t posInVector) {
+    ValueVector* resultVector, uint32_t posInVector) const {
     if (nullColumn) {
         nullColumn->lookupValue(transaction, *state.nullState, nodeOffset, resultVector,
             posInVector);
@@ -281,7 +281,7 @@ void Column::lookupValue(Transaction* transaction, const ChunkState& state, offs
 }
 
 void Column::lookupInternal(Transaction* transaction, const ChunkState& state, offset_t nodeOffset,
-    ValueVector* resultVector, uint32_t posInVector) {
+    ValueVector* resultVector, uint32_t posInVector) const {
     columnReadWriter->readCompressedValueToVector(transaction, state, nodeOffset, resultVector,
         posInVector, readToVectorFunc);
 }

--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -34,7 +34,7 @@ ColumnChunk::ColumnChunk(MemoryManager& memoryManager, const LogicalType& dataTy
 ColumnChunk::ColumnChunk(bool enableCompression, std::unique_ptr<ColumnChunkData> data)
     : enableCompression{enableCompression}, data{std::move(data)} {}
 
-void ColumnChunk::initializeScanState(ChunkState& state, Column* column) const {
+void ColumnChunk::initializeScanState(ChunkState& state, const Column* column) const {
     data->initializeScanState(state, column);
 }
 

--- a/src/storage/store/column_chunk_data.cpp
+++ b/src/storage/store/column_chunk_data.cpp
@@ -302,7 +302,7 @@ uint64_t ColumnChunkData::getBufferSize(uint64_t capacity_) const {
     }
 }
 
-void ColumnChunkData::initializeScanState(ChunkState& state, Column* column) const {
+void ColumnChunkData::initializeScanState(ChunkState& state, const Column* column) const {
     if (nullData) {
         KU_ASSERT(state.nullState);
         nullData->initializeScanState(*state.nullState, column->getNullColumn());

--- a/src/storage/store/csr_node_group.cpp
+++ b/src/storage/store/csr_node_group.cpp
@@ -49,7 +49,7 @@ bool CSRNodeGroupScanState::tryScanCachedTuples(RelTableScanState& tableScanStat
     return true;
 }
 
-void CSRNodeGroup::initializeScanState(Transaction* transaction, TableScanState& state) {
+void CSRNodeGroup::initializeScanState(Transaction* transaction, TableScanState& state) const {
     auto& relScanState = state.cast<RelTableScanState>();
     KU_ASSERT(relScanState.nodeGroupScanState);
     auto& nodeGroupScanState = relScanState.nodeGroupScanState->cast<CSRNodeGroupScanState>();
@@ -112,7 +112,7 @@ void CSRNodeGroup::initScanForCommittedInMem(RelTableScanState& relScanState,
     nodeGroupScanState.inMemCSRList.clear();
 }
 
-NodeGroupScanResult CSRNodeGroup::scan(Transaction* transaction, TableScanState& state) {
+NodeGroupScanResult CSRNodeGroup::scan(Transaction* transaction, TableScanState& state) const {
     auto& relScanState = state.cast<RelTableScanState>();
     auto& nodeGroupScanState = relScanState.nodeGroupScanState->cast<CSRNodeGroupScanState>();
     while (true) {
@@ -217,7 +217,7 @@ NodeGroupScanResult CSRNodeGroup::scanCommittedPersistentWtihoutCache(
 }
 
 NodeGroupScanResult CSRNodeGroup::scanCommittedInMem(Transaction* transaction,
-    RelTableScanState& tableState, CSRNodeGroupScanState& nodeGroupScanState) {
+    RelTableScanState& tableState, CSRNodeGroupScanState& nodeGroupScanState) const {
     while (true) {
         if (tableState.currBoundNodeIdx >= tableState.cachedBoundNodeSelVector.getSelSize()) {
             return NODE_GROUP_SCAN_EMMPTY_RESULT;
@@ -250,7 +250,7 @@ NodeGroupScanResult CSRNodeGroup::scanCommittedInMem(Transaction* transaction,
 }
 
 NodeGroupScanResult CSRNodeGroup::scanCommittedInMemSequential(const Transaction* transaction,
-    const RelTableScanState& tableState, CSRNodeGroupScanState& nodeGroupScanState) {
+    const RelTableScanState& tableState, CSRNodeGroupScanState& nodeGroupScanState) const {
     const auto startRow =
         nodeGroupScanState.inMemCSRList.rowIndices[0] + nodeGroupScanState.nextRowToScan;
     auto numRows =
@@ -273,7 +273,7 @@ NodeGroupScanResult CSRNodeGroup::scanCommittedInMemSequential(const Transaction
 }
 
 NodeGroupScanResult CSRNodeGroup::scanCommittedInMemRandom(Transaction* transaction,
-    const RelTableScanState& tableState, CSRNodeGroupScanState& nodeGroupScanState) {
+    const RelTableScanState& tableState, CSRNodeGroupScanState& nodeGroupScanState) const {
     const auto numRows = std::min(nodeGroupScanState.inMemCSRList.rowIndices.size() -
                                       nodeGroupScanState.nextRowToScan,
         DEFAULT_VECTOR_CAPACITY);

--- a/src/storage/store/dictionary_column.cpp
+++ b/src/storage/store/dictionary_column.cpp
@@ -53,7 +53,7 @@ void DictionaryColumn::scan(Transaction* transaction, const ChunkState& state,
 
 void DictionaryColumn::scan(Transaction* transaction, const ChunkState& offsetState,
     const ChunkState& dataState, std::vector<std::pair<string_index_t, uint64_t>>& offsetsToScan,
-    ValueVector* resultVector, const ColumnChunkMetadata& indexMeta) {
+    ValueVector* resultVector, const ColumnChunkMetadata& indexMeta) const {
     string_index_t firstOffsetToScan = 0, lastOffsetToScan = 0;
     auto comp = [](auto pair1, auto pair2) { return pair1.first < pair2.first; };
     auto duplicationFactor = (double)offsetState.metadata.numValues / indexMeta.numValues;
@@ -110,7 +110,7 @@ string_index_t DictionaryColumn::append(const DictionaryChunk& dictChunk, ChunkS
 
 void DictionaryColumn::scanOffsets(Transaction* transaction, const ChunkState& state,
     DictionaryChunk::string_offset_t* offsets, uint64_t index, uint64_t numValues,
-    uint64_t dataSize) {
+    uint64_t dataSize) const {
     // We either need to read the next value, or store the maximum string offset at the end.
     // Otherwise we won't know what the length of the last string is.
     if (index + numValues < state.metadata.numValues) {
@@ -122,7 +122,8 @@ void DictionaryColumn::scanOffsets(Transaction* transaction, const ChunkState& s
 }
 
 void DictionaryColumn::scanValueToVector(Transaction* transaction, const ChunkState& dataState,
-    uint64_t startOffset, uint64_t endOffset, ValueVector* resultVector, uint64_t offsetInVector) {
+    uint64_t startOffset, uint64_t endOffset, ValueVector* resultVector,
+    uint64_t offsetInVector) const {
     KU_ASSERT(endOffset >= startOffset);
     // Add string to vector first and read directly into the vector
     auto& kuString =

--- a/src/storage/store/list_chunk_data.cpp
+++ b/src/storage/store/list_chunk_data.cpp
@@ -218,10 +218,10 @@ void ListChunkData::lookup(offset_t offsetInChunk, ValueVector& output,
     output.setValue<list_entry_t>(posInOutputVector, list_entry_t{currentListDataSize, listSize});
 }
 
-void ListChunkData::initializeScanState(ChunkState& state, Column* column) const {
+void ListChunkData::initializeScanState(ChunkState& state, const Column* column) const {
     ColumnChunkData::initializeScanState(state, column);
 
-    auto* listColumn = ku_dynamic_cast<ListColumn*>(column);
+    auto* listColumn = ku_dynamic_cast<const ListColumn*>(column);
     state.childrenStates.resize(CHILD_COLUMN_COUNT);
     sizeColumnChunk->initializeScanState(state.childrenStates[SIZE_COLUMN_CHILD_READ_STATE_IDX],
         listColumn->getSizeColumn());

--- a/src/storage/store/list_column.cpp
+++ b/src/storage/store/list_column.cpp
@@ -87,7 +87,7 @@ std::unique_ptr<ColumnChunkData> ListColumn::flushChunkData(const ColumnChunkDat
 
 void ListColumn::scan(Transaction* transaction, const ChunkState& state,
     offset_t startOffsetInGroup, offset_t endOffsetInGroup, ValueVector* resultVector,
-    uint64_t offsetInVector) {
+    uint64_t offsetInVector) const {
     nullColumn->scan(transaction, *state.nullState, startOffsetInGroup, endOffsetInGroup,
         resultVector, offsetInVector);
     auto listOffsetInfoInStorage =
@@ -127,7 +127,7 @@ void ListColumn::scan(Transaction* transaction, const ChunkState& state,
 }
 
 void ListColumn::scan(Transaction* transaction, const ChunkState& state,
-    ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) {
+    ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) const {
     Column::scan(transaction, state, columnChunk, startOffset, endOffset);
     if (columnChunk->getNumValues() == 0) {
         return;
@@ -179,7 +179,7 @@ void ListColumn::scan(Transaction* transaction, const ChunkState& state,
 }
 
 void ListColumn::scanInternal(Transaction* transaction, const ChunkState& state,
-    offset_t startOffsetInChunk, row_idx_t numValuesToScan, ValueVector* resultVector) {
+    offset_t startOffsetInChunk, row_idx_t numValuesToScan, ValueVector* resultVector) const {
     KU_ASSERT(resultVector->state);
     auto listOffsetSizeInfo = getListOffsetSizeInfo(transaction, state, startOffsetInChunk,
         startOffsetInChunk + numValuesToScan);
@@ -191,7 +191,7 @@ void ListColumn::scanInternal(Transaction* transaction, const ChunkState& state,
 }
 
 void ListColumn::lookupInternal(Transaction* transaction, const ChunkState& state,
-    offset_t nodeOffset, ValueVector* resultVector, uint32_t posInVector) {
+    offset_t nodeOffset, ValueVector* resultVector, uint32_t posInVector) const {
     auto [nodeGroupIdx, offsetInChunk] = StorageUtils::getNodeGroupIdxAndOffsetInChunk(nodeOffset);
     const auto listEndOffset = readOffset(transaction, state, offsetInChunk);
     const auto size = readSize(transaction, state, offsetInChunk);

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -88,7 +88,7 @@ void NodeTable::initializePKIndex(const std::string& databasePath,
         *memoryManager->getBufferManager(), shadowFile, vfs, context);
 }
 
-void NodeTable::initScanState(Transaction* transaction, TableScanState& scanState) {
+void NodeTable::initScanState(Transaction* transaction, TableScanState& scanState) const {
     auto& nodeScanState = scanState.cast<NodeTableScanState>();
     NodeGroup* nodeGroup = nullptr;
     switch (nodeScanState.source) {

--- a/src/storage/store/null_column.cpp
+++ b/src/storage/store/null_column.cpp
@@ -38,19 +38,19 @@ NullColumn::NullColumn(const std::string& name, FileHandle* dataFH, MemoryManage
 }
 
 void NullColumn::scan(Transaction* transaction, const ChunkState& state,
-    offset_t startOffsetInChunk, row_idx_t numValuesToScan, ValueVector* resultVector) {
+    offset_t startOffsetInChunk, row_idx_t numValuesToScan, ValueVector* resultVector) const {
     scanInternal(transaction, state, startOffsetInChunk, numValuesToScan, resultVector);
 }
 
 void NullColumn::scan(Transaction* transaction, const ChunkState& state,
     offset_t startOffsetInGroup, offset_t endOffsetInGroup, ValueVector* resultVector,
-    uint64_t offsetInVector) {
+    uint64_t offsetInVector) const {
     Column::scan(transaction, state, startOffsetInGroup, endOffsetInGroup, resultVector,
         offsetInVector);
 }
 
 void NullColumn::scan(Transaction* transaction, const ChunkState& state,
-    ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) {
+    ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) const {
     Column::scan(transaction, state, columnChunk, startOffset, endOffset);
 }
 

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -21,7 +21,7 @@ namespace kuzu {
 namespace storage {
 
 RelTableScanState::RelTableScanState(MemoryManager& mm, table_id_t tableID,
-    const std::vector<column_id_t>& columnIDs, const std::vector<Column*>& columns,
+    const std::vector<column_id_t>& columnIDs, const std::vector<const Column*>& columns,
     Column* csrOffsetCol, Column* csrLengthCol, RelDataDirection direction,
     std::vector<ColumnPredicateSet> columnPredicateSets)
     : TableScanState{tableID, columnIDs, columns, std::move(columnPredicateSets)},
@@ -142,7 +142,7 @@ std::unique_ptr<RelTable> RelTable::loadTable(Deserializer& deSer, const Catalog
     return relTable;
 }
 
-void RelTable::initScanState(Transaction* transaction, TableScanState& scanState) {
+void RelTable::initScanState(Transaction* transaction, TableScanState& scanState) const {
     auto& relScanState = scanState.cast<RelTableScanState>();
     // Note there we directly read node at pos 0 here regardless the selVector is filtered or not.
     // This is because we're assuming the nodeIDVector is always a sequence here.

--- a/src/storage/store/rel_table_data.cpp
+++ b/src/storage/store/rel_table_data.cpp
@@ -120,7 +120,7 @@ std::pair<CSRNodeGroupScanSource, row_idx_t> RelTableData::findMatchingRow(Trans
     // RelID output vector.
     scanChunk.insert(0, std::make_shared<ValueVector>(LogicalType::INTERNAL_ID()));
     std::vector<column_id_t> columnIDs = {REL_ID_COLUMN_ID, ROW_IDX_COLUMN_ID};
-    std::vector<Column*> columns{getColumn(REL_ID_COLUMN_ID), nullptr};
+    std::vector<const Column*> columns{getColumn(REL_ID_COLUMN_ID), nullptr};
     const auto scanState = std::make_unique<RelTableScanState>(
         *transaction->getClientContext()->getMemoryManager(), tableID, columnIDs, columns,
         csrHeaderColumns.offset.get(), csrHeaderColumns.length.get(), direction);
@@ -166,7 +166,7 @@ bool RelTableData::checkIfNodeHasRels(Transaction* transaction,
     // RelID output vector.
     scanChunk.insert(0, std::make_shared<ValueVector>(LogicalType::INTERNAL_ID()));
     std::vector<column_id_t> columnIDs = {REL_ID_COLUMN_ID};
-    std::vector<Column*> columns{getColumn(REL_ID_COLUMN_ID)};
+    std::vector<const Column*> columns{getColumn(REL_ID_COLUMN_ID)};
     const auto scanState = std::make_unique<RelTableScanState>(
         *transaction->getClientContext()->getMemoryManager(), tableID, columnIDs, columns,
         csrHeaderColumns.offset.get(), csrHeaderColumns.length.get(), direction);

--- a/src/storage/store/string_chunk_data.cpp
+++ b/src/storage/store/string_chunk_data.cpp
@@ -134,10 +134,10 @@ void StringChunkData::lookup(offset_t offsetInChunk, ValueVector& output,
     output.setValue<std::string_view>(posInOutputVector, str);
 }
 
-void StringChunkData::initializeScanState(ChunkState& state, Column* column) const {
+void StringChunkData::initializeScanState(ChunkState& state, const Column* column) const {
     ColumnChunkData::initializeScanState(state, column);
 
-    auto* stringColumn = ku_dynamic_cast<StringColumn*>(column);
+    auto* stringColumn = ku_dynamic_cast<const StringColumn*>(column);
     state.childrenStates.resize(CHILD_COLUMN_COUNT);
     indexColumnChunk->initializeScanState(state.childrenStates[INDEX_COLUMN_CHILD_READ_STATE_IDX],
         stringColumn->getIndexColumn());

--- a/src/storage/store/string_column.cpp
+++ b/src/storage/store/string_column.cpp
@@ -61,7 +61,7 @@ std::unique_ptr<ColumnChunkData> StringColumn::flushChunkData(const ColumnChunkD
 
 void StringColumn::scan(Transaction* transaction, const ChunkState& state,
     offset_t startOffsetInGroup, offset_t endOffsetInGroup, ValueVector* resultVector,
-    uint64_t offsetInVector) {
+    uint64_t offsetInVector) const {
     nullColumn->scan(transaction, *state.nullState, startOffsetInGroup, endOffsetInGroup,
         resultVector, offsetInVector);
     scanUnfiltered(transaction, state, startOffsetInGroup, endOffsetInGroup - startOffsetInGroup,
@@ -69,7 +69,7 @@ void StringColumn::scan(Transaction* transaction, const ChunkState& state,
 }
 
 void StringColumn::scan(Transaction* transaction, const ChunkState& state,
-    ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) {
+    ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) const {
     KU_ASSERT(state.nullState);
     Column::scan(transaction, state, columnChunk, startOffset, endOffset);
     if (columnChunk->getNumValues() == 0) {
@@ -83,7 +83,7 @@ void StringColumn::scan(Transaction* transaction, const ChunkState& state,
 }
 
 void StringColumn::lookupInternal(Transaction* transaction, const ChunkState& state,
-    offset_t nodeOffset, ValueVector* resultVector, uint32_t posInVector) {
+    offset_t nodeOffset, ValueVector* resultVector, uint32_t posInVector) const {
     auto [nodeGroupIdx, offsetInChunk] = StorageUtils::getNodeGroupIdxAndOffsetInChunk(nodeOffset);
     string_index_t index = 0;
     indexColumn->scan(transaction, getChildState(state, ChildStateIndex::INDEX), offsetInChunk,
@@ -132,7 +132,7 @@ void StringColumn::checkpointColumnChunk(ColumnCheckpointState& checkpointState)
 }
 
 void StringColumn::scanInternal(Transaction* transaction, const ChunkState& state,
-    offset_t startOffsetInChunk, row_idx_t numValuesToScan, ValueVector* resultVector) {
+    offset_t startOffsetInChunk, row_idx_t numValuesToScan, ValueVector* resultVector) const {
     KU_ASSERT(resultVector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
     if (resultVector->state->getSelVector().isUnfiltered()) {
         scanUnfiltered(transaction, state, startOffsetInChunk, numValuesToScan, resultVector);
@@ -143,7 +143,7 @@ void StringColumn::scanInternal(Transaction* transaction, const ChunkState& stat
 
 void StringColumn::scanUnfiltered(Transaction* transaction, const ChunkState& state,
     offset_t startOffsetInChunk, offset_t numValuesToRead, ValueVector* resultVector,
-    sel_t startPosInVector) {
+    sel_t startPosInVector) const {
     // TODO: Replace indices with ValueVector to avoid maintaining `scan` interface from
     // uint8_t*.
     auto indices = std::make_unique<string_index_t[]>(numValuesToRead);
@@ -167,7 +167,7 @@ void StringColumn::scanUnfiltered(Transaction* transaction, const ChunkState& st
 }
 
 void StringColumn::scanFiltered(Transaction* transaction, const ChunkState& state,
-    offset_t startOffsetInChunk, ValueVector* resultVector) {
+    offset_t startOffsetInChunk, ValueVector* resultVector) const {
     std::vector<std::pair<string_index_t, uint64_t>> offsetsToScan;
     for (auto i = 0u; i < resultVector->state->getSelVector().getSelSize(); i++) {
         const auto pos = resultVector->state->getSelVector()[i];

--- a/src/storage/store/struct_chunk_data.cpp
+++ b/src/storage/store/struct_chunk_data.cpp
@@ -135,10 +135,10 @@ void StructChunkData::lookup(offset_t offsetInChunk, ValueVector& output,
     }
 }
 
-void StructChunkData::initializeScanState(ChunkState& state, Column* column) const {
+void StructChunkData::initializeScanState(ChunkState& state, const Column* column) const {
     ColumnChunkData::initializeScanState(state, column);
 
-    auto* structColumn = ku_dynamic_cast<StructColumn*>(column);
+    auto* structColumn = ku_dynamic_cast<const StructColumn*>(column);
     state.childrenStates.resize(childChunks.size());
     for (auto i = 0u; i < childChunks.size(); i++) {
         childChunks[i]->initializeScanState(state.childrenStates[i], structColumn->getChild(i));

--- a/src/storage/store/struct_column.cpp
+++ b/src/storage/store/struct_column.cpp
@@ -40,7 +40,7 @@ std::unique_ptr<ColumnChunkData> StructColumn::flushChunkData(const ColumnChunkD
 }
 
 void StructColumn::scan(Transaction* transaction, const ChunkState& state,
-    ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) {
+    ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) const {
     KU_ASSERT(columnChunk->getDataType().getPhysicalType() == PhysicalTypeID::STRUCT);
     Column::scan(transaction, state, columnChunk, startOffset, endOffset);
     auto& structColumnChunk = columnChunk->cast<StructChunkData>();
@@ -52,7 +52,7 @@ void StructColumn::scan(Transaction* transaction, const ChunkState& state,
 
 void StructColumn::scan(Transaction* transaction, const ChunkState& state,
     offset_t startOffsetInGroup, offset_t endOffsetInGroup, ValueVector* resultVector,
-    uint64_t offsetInVector) {
+    uint64_t offsetInVector) const {
     nullColumn->scan(transaction, *state.nullState, startOffsetInGroup, endOffsetInGroup,
         resultVector, offsetInVector);
     for (auto i = 0u; i < childColumns.size(); i++) {
@@ -63,7 +63,7 @@ void StructColumn::scan(Transaction* transaction, const ChunkState& state,
 }
 
 void StructColumn::scanInternal(Transaction* transaction, const ChunkState& state,
-    offset_t startOffsetInChunk, row_idx_t numValuesToScan, ValueVector* resultVector) {
+    offset_t startOffsetInChunk, row_idx_t numValuesToScan, ValueVector* resultVector) const {
     for (auto i = 0u; i < childColumns.size(); i++) {
         const auto fieldVector = StructVector::getFieldVector(resultVector, i).get();
         childColumns[i]->scan(transaction, state.childrenStates[i], startOffsetInChunk,
@@ -72,7 +72,7 @@ void StructColumn::scanInternal(Transaction* transaction, const ChunkState& stat
 }
 
 void StructColumn::lookupInternal(Transaction* transaction, const ChunkState& state,
-    offset_t nodeOffset, ValueVector* resultVector, uint32_t posInVector) {
+    offset_t nodeOffset, ValueVector* resultVector, uint32_t posInVector) const {
     for (auto i = 0u; i < childColumns.size(); i++) {
         const auto fieldVector = StructVector::getFieldVector(resultVector, i).get();
         childColumns[i]->lookupValue(transaction, state.childrenStates[i], nodeOffset, fieldVector,


### PR DESCRIPTION
Notably, the lock in GroupCollection has been made mutable since it does not change the logical state of the group collection (see https://isocpp.org/wiki/faq/const-correctness#logical-vs-physical-const).