### PR TITLE
Add operator id to explain output to make semiMasker output clearer

### DIFF
--- a/src/include/processor/operator/physical_operator.h
+++ b/src/include/processor/operator/physical_operator.h
@@ -71,6 +71,8 @@ enum class PhysicalOperatorType : uint8_t {
 
 class PhysicalOperatorUtils {
 public:
+    static std::string operatorToString(const PhysicalOperator* physicalOp);
+private:
     static std::string operatorTypeToString(PhysicalOperatorType operatorType);
 };
 

--- a/src/include/processor/operator/physical_operator.h
+++ b/src/include/processor/operator/physical_operator.h
@@ -72,6 +72,7 @@ enum class PhysicalOperatorType : uint8_t {
 class PhysicalOperatorUtils {
 public:
     static std::string operatorToString(const PhysicalOperator* physicalOp);
+
 private:
     static std::string operatorTypeToString(PhysicalOperatorType operatorType);
 };

--- a/src/main/plan_printer.cpp
+++ b/src/main/plan_printer.cpp
@@ -403,7 +403,7 @@ std::ostringstream PlanPrinter::printPlanToOstream(const LogicalPlan* logicalPla
 }
 
 std::string PlanPrinter::getOperatorName(const PhysicalOperator* physicalOperator) {
-    return PhysicalOperatorUtils::operatorTypeToString(physicalOperator->getOperatorType());
+    return PhysicalOperatorUtils::operatorToString(physicalOperator);
 }
 
 std::string PlanPrinter::getOperatorParams(const PhysicalOperator* physicalOperator) {

--- a/src/planner/operator/logical_limit.cpp
+++ b/src/planner/operator/logical_limit.cpp
@@ -8,10 +8,13 @@ namespace planner {
 std::string LogicalLimit::getExpressionsForPrinting() const {
     std::string result;
     if (hasSkipNum()) {
-        result += "SKIP " + std::to_string(skipNum) + "\n";
+        result += "SKIP " + std::to_string(skipNum);
     }
     if (hasLimitNum()) {
-        result += "LIMIT " + std::to_string(limitNum) + "\n";
+        if (!result.empty()) {
+            result += ",";
+        }
+        result += "LIMIT " + std::to_string(limitNum);
     }
     return result;
 }

--- a/src/processor/map/map_semi_masker.cpp
+++ b/src/processor/map/map_semi_masker.cpp
@@ -31,8 +31,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapSemiMasker(LogicalOperator* log
     std::vector<std::string> operatorNames;
     for (auto& op : semiMasker.getTargetOperators()) {
         const auto physicalOp = logicalOpToPhysicalOpMap.at(op);
-        operatorNames.push_back(
-            PhysicalOperatorUtils::operatorTypeToString(physicalOp->getOperatorType()));
+        operatorNames.push_back(PhysicalOperatorUtils::operatorToString(physicalOp));
         switch (physicalOp->getOperatorType()) {
         case PhysicalOperatorType::SCAN_NODE_TABLE: {
             KU_ASSERT(semiMasker.getTargetType() == SemiMaskTargetType::SCAN_NODE);

--- a/src/processor/operator/physical_operator.cpp
+++ b/src/processor/operator/physical_operator.cpp
@@ -128,6 +128,11 @@ std::string PhysicalOperatorUtils::operatorTypeToString(PhysicalOperatorType ope
         throw RuntimeException("Unknown physical operator type.");
     }
 }
+
+std::string PhysicalOperatorUtils::operatorToString(const PhysicalOperator* physicalOp) {
+    return PhysicalOperatorUtils::operatorTypeToString(physicalOp->getOperatorType()) + "[" +
+           std::to_string(physicalOp->getOperatorID()) + "]";
+}
 // LCOV_EXCL_STOP
 
 PhysicalOperator::PhysicalOperator(PhysicalOperatorType operatorType,


### PR DESCRIPTION
# Description

![image](https://github.com/user-attachments/assets/a514ddf4-56d7-4adb-b61e-362035c5b8e7)


# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).