### PR TITLE
isVisible returns false if chunkedGroup is nullptr (instead of crashing)

### DIFF
--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -180,6 +180,8 @@ public:
     }
 
     bool isVisible(const transaction::Transaction* transaction, common::row_idx_t rowIdxInGroup);
+    bool isVisibleNoLock(const transaction::Transaction* transaction,
+        common::row_idx_t rowIdxInGroup);
     bool isDeleted(const transaction::Transaction* transaction, common::offset_t offsetInGroup);
     bool isInserted(const transaction::Transaction* transaction, common::offset_t offsetInGroup);
 

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -417,7 +417,7 @@ bool NodeTable::isVisible(const Transaction* transaction, offset_t offset) const
 bool NodeTable::isVisibleNoLock(const Transaction* transaction, offset_t offset) const {
     auto [nodeGroupIdx, offsetInGroup] = StorageUtils::getNodeGroupIdxAndOffsetInChunk(offset);
     auto* nodeGroup = getNodeGroupNoLock(nodeGroupIdx);
-    return nodeGroup->isVisible(transaction, offsetInGroup);
+    return nodeGroup->isVisibleNoLock(transaction, offsetInGroup);
 }
 
 bool NodeTable::lookupPK(const Transaction* transaction, ValueVector* keyVector, uint64_t vectorPos,

--- a/test/test_files/copy/copy_after_error.test
+++ b/test/test_files/copy/copy_after_error.test
@@ -1,0 +1,29 @@
+-DATASET CSV empty
+--
+
+-CASE CopyNodeAfterError
+-STATEMENT CREATE NODE TABLE Comment(ID INT64, creationDate TIMESTAMP, locationIP STRING, browserUsed STRING, content STRING, length INT64, PRIMARY KEY(ID));
+---- ok
+-STATEMENT COPY Comment FROM '${KUZU_ROOT_DIRECTORY}/dataset/ldbc-1/csv/comment_0_0.csv' (DELIM="|", header=false);
+---- error
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/ldbc-1/csv/comment_0_0.csv on line 1: Conversion exception: Cast failed. Could not convert "id" to INT64. Line/record containing the error: 'id...'
+-STATEMENT COPY Comment FROM '${KUZU_ROOT_DIRECTORY}/dataset/ldbc-1/csv/comment_0_0.csv' (DELIM="|", header=true);
+---- ok
+-STATEMENT MATCH (c:Comment) WHERE c.ID = 1786706395169 RETURN c.locationIP
+---- 1
+92.39.58.88
+
+-CASE CopyRelAfterNodeCopyError
+-STATEMENT CREATE NODE TABLE Comment(ID INT64, creationDate TIMESTAMP, locationIP STRING, browserUsed STRING, content STRING, length INT64, PRIMARY KEY(ID));
+---- ok
+-STATEMENT CREATE REL TABLE replyOfComment(FROM Comment TO Comment, MANY_ONE);
+---- ok
+-STATEMENT COPY Comment FROM '${KUZU_ROOT_DIRECTORY}/dataset/ldbc-1/csv/comment_0_0.csv' (DELIM="|", header=false);
+---- error
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/ldbc-1/csv/comment_0_0.csv on line 1: Conversion exception: Cast failed. Could not convert "id" to INT64. Line/record containing the error: 'id...'
+-STATEMENT COPY replyOfComment FROM '${KUZU_ROOT_DIRECTORY}/dataset/ldbc-1/csv/comment_replyOf_comment_0_0.csv' (DELIM="|", header=true);
+---- error(regex)
+Copy exception: Unable to find primary key value \d+.
+-STATEMENT MATCH (a:Comment)-[r:replyOfComment]->(b:Comment) RETURN COUNT(*);
+---- 1
+0


### PR DESCRIPTION
# Description

If a copy fails the changes to the in memory PK index may still remain from the failed copy. `isVisible` should handle this gracefully instead of crashing when it finds a row in the hash index that doesn't exist in the node table.

Fixes #4251 

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).