### PR TITLE
Properly enable progress bar

### DIFF
--- a/src/include/main/client_config.h
+++ b/src/include/main/client_config.h
@@ -15,7 +15,7 @@ struct ClientConfigDefault {
     static constexpr bool ENABLE_SEMI_MASK = true;
     static constexpr bool ENABLE_ZONE_MAP = true;
     static constexpr bool ENABLE_GDS = true;
-    static constexpr bool ENABLE_PROGRESS_BAR = true;
+    static constexpr bool ENABLE_PROGRESS_BAR = false;
     static constexpr uint64_t SHOW_PROGRESS_AFTER = 1000;
     static constexpr common::PathSemantic RECURSIVE_PATTERN_SEMANTIC = common::PathSemantic::WALK;
     static constexpr uint32_t RECURSIVE_PATTERN_FACTOR = 1;

--- a/tools/shell/shell_runner.cpp
+++ b/tools/shell/shell_runner.cpp
@@ -2,6 +2,7 @@
 
 #include "args.hxx"
 #include "common/file_system/local_file_system.h"
+#include "common/task_system/progress_bar.h"
 #include "embedded_shell.h"
 #include "linenoise.h"
 #include "main/db_config.h"
@@ -88,9 +89,8 @@ int main(int argc, char* argv[]) {
     args::ValueFlag<std::string> mode(parser, "", "Set the output mode of the shell",
         {'m', "mode"});
     args::Flag stats(parser, "no_stats", "Disable query stats", {'s', "no_stats", "nostats"});
-    // TODO: re-enable when progress bar performance issues are fixed
-    /*args::Flag progress_bar(parser, "no_progress_bar", "Disable query progress bar",
-        {'b', "no_progress_bar", "noprogressbar"});*/
+    args::Flag progress_bar(parser, "no_progress_bar", "Disable query progress bar",
+        {'b', "no_progress_bar", "noprogressbar"});
     args::ValueFlag<std::string> init(parser, "", "Path to file with script to run on startup",
         {'i', "init"});
 
@@ -174,11 +174,10 @@ int main(int argc, char* argv[]) {
         std::cerr << e.what() << '\n';
         return 1;
     }
-    // TODO: re-enable when progress bar performance issues are fixed
-    /*if (!progress_bar) {
+    if (!progress_bar) {
         conn->getClientContext()->getClientConfigUnsafe()->enableProgressBar = true;
         conn->getClientContext()->getProgressBar()->toggleProgressBarPrinting(true);
-    }*/
+    }
 
     std::string initFile = ".kuzurc";
     if (init) {

--- a/tools/shell/test/test_shell_flags.py
+++ b/tools/shell/test/test_shell_flags.py
@@ -489,36 +489,35 @@ def test_no_stats(temp_db, flag) -> None:
     result.check_stdout("(1 column)")
     result.check_stdout("Time: ")
 
-#TODO: re-enable when progress bar performance issues are fixed
-# @pytest.mark.parametrize(
-#     "flag",
-#     [
-#         "-b",
-#         "--no_progress_bar",
-#         "--noprogressbar"
-#     ],
-# )
-# def test_no_progress_bar(temp_db, flag) -> None:
-#     # progress bar on by default
-#     test = (
-#         ShellTest()
-#         .add_argument(temp_db)
-#         .statement("CALL current_setting('progress_bar') RETURN *;")
-#     )
-#     result = test.run()
-#     result.check_stdout("True")
-# 
-#     # progress bar off
-#     test = (
-#         ShellTest()
-#         .add_argument(temp_db)
-#         .add_argument(flag)
-#         .statement("CALL current_setting('progress_bar') RETURN *;")
-#     )
-#     result = test.run()
-#     print(result.stdout)
-#     print(result.stderr)
-#     result.check_stdout("False")
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "-b",
+        "--no_progress_bar",
+        "--noprogressbar"
+    ],
+)
+def test_no_progress_bar(temp_db, flag) -> None:
+    # progress bar on by default
+    test = (
+        ShellTest()
+        .add_argument(temp_db)
+        .statement("CALL current_setting('progress_bar') RETURN *;")
+    )
+    result = test.run()
+    result.check_stdout("True")
+
+    # progress bar off
+    test = (
+        ShellTest()
+        .add_argument(temp_db)
+        .add_argument(flag)
+        .statement("CALL current_setting('progress_bar') RETURN *;")
+    )
+    result = test.run()
+    print(result.stdout)
+    print(result.stderr)
+    result.check_stdout("False")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Undo changes in https://github.com/kuzudb/kuzu/pull/4115 instead of setting `ENABLE_PROGRESS_BAR` in `ClientConfig` to true so that progress bar is only enabled by default in the shell (and not in tests, other APIs, etc.`

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).