### PR TITLE
Fix bugs in GDS vertex property scanning

### DIFF
--- a/src/include/storage/store/csr_node_group.h
+++ b/src/include/storage/store/csr_node_group.h
@@ -127,18 +127,16 @@ struct CSRNodeGroupScanState final : NodeGroupScanState {
     common::row_idx_t nextCachedRowToScan;
 
     // States at the csr list level. Cached during scan over a single csr list.
-    common::row_idx_t nextRowToScan;
     NodeCSRIndex inMemCSRList;
 
     CSRNodeGroupScanSource source;
 
     explicit CSRNodeGroupScanState(common::idx_t numChunks)
         : NodeGroupScanState{numChunks}, header{nullptr}, numTotalRows{0}, numCachedRows{0},
-          nextCachedRowToScan{0}, nextRowToScan{0},
-          source{CSRNodeGroupScanSource::COMMITTED_PERSISTENT} {}
+          nextCachedRowToScan{0}, source{CSRNodeGroupScanSource::COMMITTED_PERSISTENT} {}
     CSRNodeGroupScanState(MemoryManager& mm, common::idx_t numChunks)
         : NodeGroupScanState{numChunks}, numTotalRows{0}, numCachedRows{0}, nextCachedRowToScan{0},
-          nextRowToScan{0}, source{CSRNodeGroupScanSource::COMMITTED_PERSISTENT} {
+          source{CSRNodeGroupScanSource::COMMITTED_PERSISTENT} {
         header = std::make_unique<ChunkedCSRHeader>(mm, false,
             common::StorageConstants::NODE_GROUP_SIZE, ResidencyState::IN_MEMORY);
         cachedScannedVectorsSelBitset.set();
@@ -151,7 +149,6 @@ struct CSRNodeGroupScanState final : NodeGroupScanState {
         numTotalRows = 0;
         numCachedRows = 0;
         nextCachedRowToScan = 0;
-        nextRowToScan = 0;
         inMemCSRList = NodeCSRIndex{};
         source = CSRNodeGroupScanSource::COMMITTED_PERSISTENT;
     }


### PR DESCRIPTION
Based on #4416

I fixed some edge cases in the NodeGroup::scan variant used by GDS vertex property scanning, and also fixed handling scans that run across node group boundaries.

I renamed `NodeGroupScanState::numScannedRows` to `nextRowToScan` since they are functionally equivalent and nothing was ever using `numScannedRows` as a size, just as an indication of the next row to scan. There was also a field called `nextRowToScan` already in `CSRNodeGroupScanState`, so that was just removed and the other field is now used in its place.