### PR TITLE
Gds no path track optimization

### DIFF
--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -239,10 +239,8 @@ FunctionCollection* FunctionCollection::getFunctions() {
         // Algorithm functions
         ALGORITHM_FUNCTION(WeaklyConnectedComponentsFunction),
         ALGORITHM_FUNCTION(VarLenJoinsFunction), ALGORITHM_FUNCTION(AllSPDestinationsFunction),
-        ALGORITHM_FUNCTION(AllSPLengthsFunction), ALGORITHM_FUNCTION(AllSPPathsFunction),
-        ALGORITHM_FUNCTION(SingleSPDestinationsFunction),
-        ALGORITHM_FUNCTION(SingleSPLengthsFunction), ALGORITHM_FUNCTION(SingleSPPathsFunction),
-        ALGORITHM_FUNCTION(PageRankFunction),
+        ALGORITHM_FUNCTION(AllSPPathsFunction), ALGORITHM_FUNCTION(SingleSPDestinationsFunction),
+        ALGORITHM_FUNCTION(SingleSPPathsFunction), ALGORITHM_FUNCTION(PageRankFunction),
 
         // Export functions
         EXPORT_FUNCTION(ExportCSVFunction), EXPORT_FUNCTION(ExportParquetFunction),

--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -133,9 +133,9 @@ std::vector<table_id_t> OnDiskGraph::getRelTableIDs() {
     return result;
 }
 
-std::unordered_map<common::table_id_t, offset_t> OnDiskGraph::getNodeTableIDAndNumNodes() {
-    std::unordered_map<common::table_id_t, offset_t> retVal;
-    for (common::table_id_t tableID : getNodeTableIDs()) {
+table_id_map_t<offset_t> OnDiskGraph::getNumNodesMap() {
+    table_id_map_t<offset_t> retVal;
+    for (auto tableID : getNodeTableIDs()) {
         retVal[tableID] = getNumNodes(tableID);
     }
     return retVal;

--- a/src/include/function/gds/bfs_graph.h
+++ b/src/include/function/gds/bfs_graph.h
@@ -57,10 +57,9 @@ class BFSGraph {
     using parent_entry_t = std::atomic<ParentList*>;
 
 public:
-    BFSGraph(std::unordered_map<common::table_id_t, common::offset_t> nodeTableIDAndNumNodes,
-        storage::MemoryManager* mm)
+    BFSGraph(common::table_id_map_t<common::offset_t> numNodesMap, storage::MemoryManager* mm)
         : mm{mm} {
-        for (auto& [tableID, numNodes] : nodeTableIDAndNumNodes) {
+        for (auto& [tableID, numNodes] : numNodesMap) {
             parentArray.allocate(tableID, numNodes, mm);
             auto data = parentArray.getData(tableID);
             for (uint64_t i = 0; i < numNodes; ++i) {

--- a/src/include/function/gds/gds.h
+++ b/src/include/function/gds/gds.h
@@ -74,7 +74,7 @@ public:
     // We skip binding and directly set bind data.
     void setBindData(std::unique_ptr<GDSBindData> bindData_) { bindData = std::move(bindData_); }
 
-    GDSBindData* getBindData() const { return bindData.get(); }
+    const GDSBindData* getBindData() const { return bindData.get(); }
 
     // Note: The reason this field is set separately here and not inside constructor is that the
     // original GDSAlgorithm is constructed in the binding stage. In contrast, sharedState is
@@ -89,6 +89,11 @@ public:
     virtual void exec(processor::ExecutionContext* executionContext) = 0;
 
     virtual std::unique_ptr<GDSAlgorithm> copy() const = 0;
+
+    template<class TARGET>
+    TARGET& cast() {
+        return common::ku_dynamic_cast<TARGET&>(*this);
+    }
 
 protected:
     // TODO(Semih/Xiyang): See if this will be still needed after PageRank and other algorithms are

--- a/src/include/function/gds/gds_function_collection.h
+++ b/src/include/function/gds/gds_function_collection.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "function/function.h"
+#include "function/gds_function.h"
 
 namespace kuzu {
 namespace function {
@@ -15,42 +15,35 @@ struct VarLenJoinsFunction {
     static constexpr const char* name = "VAR_LEN_JOINS";
 
     static function_set getFunctionSet();
+    static GDSFunction getFunction();
 };
 
 struct AllSPDestinationsFunction {
     static constexpr const char* name = "ALL_SP_DESTINATIONS";
 
     static function_set getFunctionSet();
-};
-
-struct AllSPLengthsFunction {
-    static constexpr const char* name = "ALL_SP_LENGTHS";
-
-    static function_set getFunctionSet();
+    static GDSFunction getFunction();
 };
 
 struct AllSPPathsFunction {
     static constexpr const char* name = "ALL_SP_PATHS";
 
     static function_set getFunctionSet();
+    static GDSFunction getFunction();
 };
 
 struct SingleSPDestinationsFunction {
     static constexpr const char* name = "SINGLE_SP_DESTINATIONS";
 
     static function_set getFunctionSet();
-};
-
-struct SingleSPLengthsFunction {
-    static constexpr const char* name = "SINGLE_SP_LENGTHS";
-
-    static function_set getFunctionSet();
+    static GDSFunction getFunction();
 };
 
 struct SingleSPPathsFunction {
     static constexpr const char* name = "SINGLE_SP_PATHS";
 
     static function_set getFunctionSet();
+    static GDSFunction getFunction();
 };
 
 struct PageRankFunction {

--- a/src/include/graph/graph.h
+++ b/src/include/graph/graph.h
@@ -104,7 +104,7 @@ public:
     // Get id for all relationship tables.
     virtual std::vector<common::table_id_t> getRelTableIDs() = 0;
 
-    virtual std::unordered_map<common::table_id_t, uint64_t> getNodeTableIDAndNumNodes() = 0;
+    virtual common::table_id_map_t<common::offset_t> getNumNodesMap() = 0;
 
     // Get num rows for all node tables.
     virtual common::offset_t getNumNodes() = 0;

--- a/src/include/graph/on_disk_graph.h
+++ b/src/include/graph/on_disk_graph.h
@@ -127,7 +127,7 @@ public:
     std::vector<common::table_id_t> getNodeTableIDs() override;
     std::vector<common::table_id_t> getRelTableIDs() override;
 
-    std::unordered_map<common::table_id_t, uint64_t> getNodeTableIDAndNumNodes() override;
+    common::table_id_map_t<common::offset_t> getNumNodesMap() override;
 
     common::offset_t getNumNodes() override;
     common::offset_t getNumNodes(common::table_id_t id) override;

--- a/src/include/planner/operator/logical_gds_call.h
+++ b/src/include/planner/operator/logical_gds_call.h
@@ -21,6 +21,7 @@ public:
     void computeFactorizedSchema() override;
 
     const binder::BoundGDSCallInfo& getInfo() const { return info; }
+    binder::BoundGDSCallInfo& getInfoUnsafe() { return info; }
 
     void setNodePredicateRoot(std::shared_ptr<LogicalOperator> op) {
         nodePredicateRoot = std::move(op);

--- a/src/include/processor/operator/semi_masker.h
+++ b/src/include/processor/operator/semi_masker.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "common/mask.h"
+#include "common/enums/extend_direction.h"
 #include "processor/operator/physical_operator.h"
-#include "processor/operator/scan/scan_multi_rel_tables.h"
 
 namespace kuzu {
 namespace processor {

--- a/src/include/processor/operator/semi_masker.h
+++ b/src/include/processor/operator/semi_masker.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "common/mask.h"
 #include "common/enums/extend_direction.h"
+#include "common/mask.h"
 #include "processor/operator/physical_operator.h"
 
 namespace kuzu {

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -143,20 +143,18 @@ void Planner::appendRecursiveExtendAsGDS(const std::shared_ptr<NodeExpression>& 
     if (recursiveInfo->relPredicate != nullptr) {
         graphEntry.setRelPredicate(recursiveInfo->relPredicate);
     }
-
     GDSFunction gdsFunction;
     switch (rel->getRelType()) {
     case common::QueryRelType::VARIABLE_LENGTH_WALK:
     case common::QueryRelType::VARIABLE_LENGTH_TRAIL:
     case common::QueryRelType::VARIABLE_LENGTH_ACYCLIC: {
-        gdsFunction = VarLenJoinsFunction::getFunctionSet()[0]->constPtrCast<GDSFunction>()->copy();
+        gdsFunction = VarLenJoinsFunction::getFunction();
     } break;
     case QueryRelType::SHORTEST: {
-        gdsFunction =
-            SingleSPPathsFunction::getFunctionSet()[0]->constPtrCast<GDSFunction>()->copy();
+        gdsFunction = SingleSPPathsFunction::getFunction();
     } break;
     case QueryRelType::ALL_SHORTEST: {
-        gdsFunction = AllSPPathsFunction::getFunctionSet()[0]->constPtrCast<GDSFunction>()->copy();
+        gdsFunction = AllSPPathsFunction::getFunction();
     } break;
     default:
         KU_UNREACHABLE;

--- a/test/test_files/function/gds/basic.test
+++ b/test/test_files/function/gds/basic.test
@@ -36,19 +36,19 @@ Dan|42
 Parser exception: Filtering or projecting properties in graph projection is not supported.
 -STATEMENT PROJECT GRAPH PK (person, knows)
            MATCH (a:person) WHERE a.ID = 0
-           CALL SINGLE_SP_LENGTHS(PK, a, 2, "FWD")
+           CALL SINGLE_SP_DESTINATIONS(PK, a, 2, "FWD")
            RETURN a.fName, _node.name, length;
 ---- error
 Binder exception: Cannot find property name for _node.
 -STATEMENT PROJECT GRAPH PK (person, knows)
            MATCH (a:person) WHERE a.ID = 0
-           CALL SINGLE_SP_LENGTHS(PK, a, 2, "X")
+           CALL SINGLE_SP_DESTINATIONS(PK, a, 2, "X")
            RETURN a.fName, _node.name, length;
 ---- error
 Runtime exception: Cannot parse X as ExtendDirection.
 -STATEMENT PROJECT GRAPH PK (person, knows)
            MATCH (a:person) WHERE a.ID = 0
-           CALL SINGLE_SP_LENGTHS(PK, a, 2, "FWD")
+           CALL SINGLE_SP_DESTINATIONS(PK, a, 2, "FWD")
            RETURN a.fName, _node.fName, length;
 ---- 3
 Alice|Bob|1
@@ -56,7 +56,7 @@ Alice|Carol|1
 Alice|Dan|1
 -STATEMENT PROJECT GRAPH PK (person, organisation, workAt, knows)
            MATCH (a:person) WHERE a.ID = 0
-           CALL SINGLE_SP_LENGTHS(PK, a, 2, "FWD")
+           CALL SINGLE_SP_DESTINATIONS(PK, a, 2, "FWD")
            RETURN a.fName, _node.fName, _node.name, length;
 ---- 5
 Alice|Bob||1

--- a/test/test_files/function/gds/rec_joins_large.test
+++ b/test/test_files/function/gds/rec_joins_large.test
@@ -116,7 +116,7 @@
 -LOG AllSPLengths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_lengths(PK, a, 30, "FWD")
+           CALL ALL_SP_DESTINATIONS(PK, a, 30, "FWD")
            RETURN length, count(*);
 ---- 3
 1|10
@@ -127,7 +127,7 @@
 -LOG AllSPLengthsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_lengths(PK, a, 30, "FWD")
+           CALL ALL_SP_DESTINATIONS(PK, a, 30, "FWD")
            RETURN length, count(*);
 ---- 4
 1|10
@@ -139,7 +139,7 @@
 -LOG AllSPLengthsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_lengths(PK, a, 30, "FWD")
+           CALL ALL_SP_DESTINATIONS(PK, a, 30, "FWD")
            RETURN length, count(*);
 ---- 3
 1|20
@@ -212,7 +212,7 @@
 -LOG SingleSPLengths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_lengths(PK, a, 30, "FWD")
+           CALL SINGLE_SP_DESTINATIONS(PK, a, 30, "FWD")
            RETURN length, count(*);
 ---- 3
 1|10
@@ -223,7 +223,7 @@
 -LOG SingleSPLengthsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_lengths(PK, a, 30, "FWD")
+           CALL SINGLE_SP_DESTINATIONS(PK, a, 30, "FWD")
            RETURN length, count(*);
 ---- 4
 1|10
@@ -235,7 +235,7 @@
 -LOG SingleSPLengthsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_lengths(PK, a, 30, "FWD")
+           CALL SINGLE_SP_DESTINATIONS(PK, a, 30, "FWD")
            RETURN length, count(*);
 ---- 3
 1|20

--- a/test/test_files/function/gds/rec_joins_small.test
+++ b/test/test_files/function/gds/rec_joins_small.test
@@ -330,7 +330,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPLengths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_lengths(PK, a, 30, "FWD")
+           CALL ALL_SP_DESTINATIONS(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID, length;
 ---- 5
 0|1|1
@@ -342,7 +342,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPLengthsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_lengths(PK, a, 30, "FWD")
+           CALL ALL_SP_DESTINATIONS(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID, length;
 ---- 6
 0|1|1
@@ -355,7 +355,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG AllSPLengthsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL all_sp_lengths(PK, a, 30, "FWD")
+           CALL ALL_SP_DESTINATIONS(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID, length;
 ---- 30
 0|1|1
@@ -466,7 +466,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPDestinations
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_destinations(PK, a, 30, "FWD")
+           CALL SINGLE_SP_DESTINATIONS(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID;
 ---- 4
 0|1
@@ -477,7 +477,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPDestinationsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_destinations(PK, a, 30, "FWD")
+           CALL SINGLE_SP_DESTINATIONS(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID;
 ---- 5
 0|1
@@ -504,7 +504,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPLengths
 -STATEMENT PROJECT GRAPH PK (person1, knows11)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_lengths(PK, a, 30, "FWD")
+           CALL SINGLE_SP_DESTINATIONS(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID, length;
 ---- 4
 0|1|1
@@ -515,7 +515,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPLengthsMultilabel1
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows12, knows21)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_lengths(PK, a, 30, "FWD")
+           CALL SINGLE_SP_DESTINATIONS(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID, length;
 ---- 5
 0|1|1
@@ -527,7 +527,7 @@ Runtime exception: Shortest path operations only works for positive upper bound 
 -LOG SingleSPLengthsMultilabel2
 -STATEMENT PROJECT GRAPH PK (person1, person2, knows11, knows12, knows21, knows22)
            MATCH (a:person1) WHERE a.ID = 0
-           CALL single_sp_lengths(PK, a, 30, "FWD")
+           CALL SINGLE_SP_DESTINATIONS(PK, a, 30, "FWD")
            RETURN a.ID, _node.ID, length
 ---- 8
 0|1|1

--- a/test/test_files/read_list/var_length_large_adj_list_extend.test
+++ b/test/test_files/read_list/var_length_large_adj_list_extend.test
@@ -30,7 +30,7 @@
 60003
 
 # By the above formula, 28th, 29th, and 30th levels will contain 29*5K + 1, 30*5K + 1, and 31*5K+1 = 90*5K+3=450003.
-#-LOG KnowsVeryLargeAdjListLongPathTest
-#-STATEMENT MATCH (a:person)-[:knows*28..30]->(b:person) RETURN COUNT(*)
-#---- 1
-#450003
+-LOG KnowsVeryLargeAdjListLongPathTest
+-STATEMENT MATCH (a:person)-[:knows*28..30]->(b:person) RETURN COUNT(*)
+---- 1
+450003

--- a/test/test_files/var_length_extend/n_n.test
+++ b/test/test_files/var_length_extend/n_n.test
@@ -40,11 +40,10 @@
 ---- 1
 1404
 
-# TODO(Xiyang): fix me
-#-LOG KnowsLongPathTest
-#-STATEMENT MATCH (a:person)-[:knows*8..11]->(b:person) RETURN COUNT(*)
-#---- 1
-#1049760
+-LOG KnowsLongPathTest
+-STATEMENT MATCH (a:person)-[:knows*8..11]->(b:person) RETURN COUNT(*)
+---- 1
+1049760
 
 -LOG KnowsOneToTwoHopWithFilterTest
 -STATEMENT MATCH (a:person)-[:knows*1..2]->(b:person) WHERE a.ID = 7 RETURN b.fName


### PR DESCRIPTION
# Description

This PR allows GDS framework to skip writing path to factorized table if not needed in later query processing. The optimization logic is written in projection_push_down_optimizer.

This PR contains a major refactor that removes some `SINGLE_SP_LENGTH` & `ALL_SP_LENGTH` functions. The previous organization of these functions is based on output columns. This is not ideal because we may have different combinations, e.g. write dst only, dst & length, dst & path, etc.

The new design keeps 5 functions
- SINGLE_SP_DESTINATIONS
- SINGLE_SP_PATHS
- ALL_SP_DESTINATIONS
- ALL_SP_PATHS
- VAR_LENGTH_PATHS

3 XX_PATHS functions are trivial to understand because they use `BFSGraph` to keep track path. `SINGLE_SP_DESTINATIONS` & `ALL_SP_DESTINATIONS` are able to track intermediate result with a more performant data structure so we create a separate function for them. 

Technically this is also doable for `VAR_LENGTH` but since it won't work with `trail` or `acyclic` semantic, we fall back to the easy solution to always track with `BFSGraph`


Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).