### PR TITLE
Change uncommitted local node offsets to be consecutive with committed ones

### DIFF
--- a/src/include/storage/local_storage/local_node_table.h
+++ b/src/include/storage/local_storage/local_node_table.h
@@ -11,7 +11,6 @@ namespace storage {
 struct TableScanState;
 class MemoryManager;
 
-struct TableReadState;
 class LocalNodeTable final : public LocalTable {
 public:
     explicit LocalNodeTable(Table& table);

--- a/src/include/storage/local_storage/local_table.h
+++ b/src/include/storage/local_storage/local_table.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <map>
-
 #include "common/enums/table_type.h"
-#include "common/types/types.h"
 #include "storage/store/table.h"
 
 namespace kuzu {
@@ -13,10 +10,6 @@ class Transaction;
 
 namespace storage {
 class MemoryManager;
-
-using offset_to_row_idx_t = std::map<common::offset_t, common::row_idx_t>;
-using offset_to_row_idx_vec_t = std::map<common::offset_t, std::vector<common::row_idx_t>>;
-using offset_set_t = std::unordered_set<common::offset_t>;
 
 struct TableAddColumnState;
 struct TableInsertState;

--- a/src/processor/operator/scan/offset_scan_node_table.cpp
+++ b/src/processor/operator/scan/offset_scan_node_table.cpp
@@ -34,10 +34,10 @@ bool OffsetScanNodeTable::getNextTuplesInternal(ExecutionContext* context) {
     auto nodeID = nodeIDVector->getValue<nodeID_t>(0);
     KU_ASSERT(tableIDToNodeInfo.contains(nodeID.tableID));
     auto& nodeInfo = tableIDToNodeInfo.at(nodeID.tableID);
-    if (nodeID.offset >= StorageConstants::MAX_NUM_ROWS_IN_TABLE) {
+    if (transaction->isUnCommitted(nodeID.tableID, nodeID.offset)) {
         nodeInfo.localScanState->source = TableScanSource::UNCOMMITTED;
-        nodeInfo.localScanState->nodeGroupIdx =
-            StorageUtils::getNodeGroupIdx(nodeID.offset - StorageConstants::MAX_NUM_ROWS_IN_TABLE);
+        nodeInfo.localScanState->nodeGroupIdx = StorageUtils::getNodeGroupIdx(
+            transaction->getLocalRowIdx(nodeID.tableID, nodeID.offset));
     } else {
         nodeInfo.localScanState->source = TableScanSource::COMMITTED;
         nodeInfo.localScanState->nodeGroupIdx = StorageUtils::getNodeGroupIdx(nodeID.offset);

--- a/src/processor/operator/scan/primary_key_scan_node_table.cpp
+++ b/src/processor/operator/scan/primary_key_scan_node_table.cpp
@@ -75,10 +75,10 @@ bool PrimaryKeyScanNodeTable::getNextTuplesInternal(ExecutionContext* context) {
     }
     auto nodeID = nodeID_t{nodeOffset, nodeInfo.table->getTableID()};
     nodeInfo.localScanState->nodeIDVector->setValue<nodeID_t>(pos, nodeID);
-    if (nodeOffset >= StorageConstants::MAX_NUM_ROWS_IN_TABLE) {
+    if (transaction->isUnCommitted(nodeID.tableID, nodeOffset)) {
         nodeInfo.localScanState->source = TableScanSource::UNCOMMITTED;
         nodeInfo.localScanState->nodeGroupIdx =
-            StorageUtils::getNodeGroupIdx(nodeOffset - StorageConstants::MAX_NUM_ROWS_IN_TABLE);
+            StorageUtils::getNodeGroupIdx(transaction->getLocalRowIdx(nodeID.tableID, nodeOffset));
     } else {
         nodeInfo.localScanState->source = TableScanSource::COMMITTED;
         nodeInfo.localScanState->nodeGroupIdx = StorageUtils::getNodeGroupIdx(nodeOffset);

--- a/src/storage/local_storage/local_rel_table.cpp
+++ b/src/storage/local_storage/local_rel_table.cpp
@@ -84,7 +84,7 @@ bool LocalRelTable::update(Transaction* transaction, TableUpdateState& state) {
     const auto srcNodeOffset = updateState.srcNodeIDVector.readNodeOffset(srcNodePos);
     const auto dstNodeOffset = updateState.dstNodeIDVector.readNodeOffset(dstNodePos);
     const auto relOffset = updateState.relIDVector.readNodeOffset(relIDPos);
-    const auto matchedRow = findMatchingRow(srcNodeOffset, dstNodeOffset, relOffset);
+    const auto matchedRow = findMatchingRow(transaction, srcNodeOffset, dstNodeOffset, relOffset);
     if (matchedRow == INVALID_ROW_IDX) {
         return false;
     }
@@ -96,7 +96,7 @@ bool LocalRelTable::update(Transaction* transaction, TableUpdateState& state) {
     return true;
 }
 
-bool LocalRelTable::delete_(Transaction*, TableDeleteState& state) {
+bool LocalRelTable::delete_(Transaction* transaction, TableDeleteState& state) {
     const auto& deleteState = state.cast<RelTableDeleteState>();
     const auto srcNodePos = deleteState.srcNodeIDVector.state->getSelVector()[0];
     const auto dstNodePos = deleteState.dstNodeIDVector.state->getSelVector()[0];
@@ -108,7 +108,7 @@ bool LocalRelTable::delete_(Transaction*, TableDeleteState& state) {
     const auto srcNodeOffset = deleteState.srcNodeIDVector.readNodeOffset(srcNodePos);
     const auto dstNodeOffset = deleteState.dstNodeIDVector.readNodeOffset(dstNodePos);
     const auto relOffset = deleteState.relIDVector.readNodeOffset(relIDPos);
-    const auto matchedRow = findMatchingRow(srcNodeOffset, dstNodeOffset, relOffset);
+    const auto matchedRow = findMatchingRow(transaction, srcNodeOffset, dstNodeOffset, relOffset);
     if (matchedRow == INVALID_ROW_IDX) {
         return false;
     }
@@ -216,8 +216,8 @@ bool LocalRelTable::scan(Transaction* transaction, TableScanState& state) const 
     }
 }
 
-row_idx_t LocalRelTable::findMatchingRow(offset_t srcNodeOffset, offset_t dstNodeOffset,
-    offset_t relOffset) {
+row_idx_t LocalRelTable::findMatchingRow(Transaction* transaction, offset_t srcNodeOffset,
+    offset_t dstNodeOffset, offset_t relOffset) {
     auto& fwdRows = fwdIndex[srcNodeOffset];
     std::sort(fwdRows.begin(), fwdRows.end());
     auto& bwdRows = bwdIndex[dstNodeOffset];
@@ -239,7 +239,8 @@ row_idx_t LocalRelTable::findMatchingRow(offset_t srcNodeOffset, offset_t dstNod
     for (auto i = 0u; i < intersectRows.size(); i++) {
         scanState->rowIdxVector->setValue<row_idx_t>(i, intersectRows[i]);
     }
-    localNodeGroup->lookup(&DUMMY_TRANSACTION, *scanState);
+    auto dummyTrx = Transaction::getDummyTransactionFromExistingOne(*transaction);
+    localNodeGroup->lookup(&dummyTrx, *scanState);
     const auto scannedRelIDVector = scanState->outputVectors[0];
     KU_ASSERT(scannedRelIDVector->state->getSelVector().getSelSize() == intersectRows.size());
     row_idx_t matchedRow = INVALID_ROW_IDX;

--- a/src/storage/store/node_group.cpp
+++ b/src/storage/store/node_group.cpp
@@ -203,6 +203,7 @@ void NodeGroup::update(Transaction* transaction, row_idx_t rowIdxInGroup, column
         const auto lock = chunkedGroups.lock();
         chunkedGroupToUpdate = findChunkedGroupFromRowIdx(lock, rowIdxInGroup);
     }
+    KU_ASSERT(chunkedGroupToUpdate);
     const auto rowIdxInChunkedGroup = rowIdxInGroup - chunkedGroupToUpdate->getStartRowIdx();
     chunkedGroupToUpdate->update(transaction, rowIdxInChunkedGroup, columnID, propertyVector);
 }
@@ -438,7 +439,7 @@ ChunkedNodeGroup* NodeGroup::findChunkedGroupFromRowIdx(const UniqLock& lock, ro
     }
     rowIdx -= numRowsInFirstGroup;
     const auto chunkedGroupIdx = rowIdx / ChunkedNodeGroup::CHUNK_CAPACITY + 1;
-    if (chunkedGroupIdx >= chunkedGroups.getNumGroupsNoLock()) {
+    if (chunkedGroupIdx >= chunkedGroups.getNumGroups(lock)) {
         return nullptr;
     }
     return chunkedGroups.getGroup(lock, chunkedGroupIdx);

--- a/test/test_files/dml_node/create/create_read_tinysnb.test
+++ b/test/test_files/dml_node/create/create_read_tinysnb.test
@@ -21,7 +21,7 @@
 80|22||1.100000
 -STATEMENT CREATE (a:organisation {ID:0, name:'test'}) RETURN a, a.history;
 ---- 1
-{_ID: 1:4611686018427387904, _LABEL: organisation, ID: 0, name: test}|
+{_ID: 1:3, _LABEL: organisation, ID: 0, name: test}|
 
 
 -CASE OptionalMatchAfterInsert

--- a/test/test_files/issue/issue.test
+++ b/test/test_files/issue/issue.test
@@ -106,7 +106,7 @@ Binder exception: iri is a reserved property name.
 ---- ok
 -STATEMENT CREATE (t:Test {content: "mycontent"}) RETURN t;
 ---- 1
-{_ID: 0:4611686018427387904, _LABEL: Test, id: 0, content: mycontent}
+{_ID: 0:0, _LABEL: Test, id: 0, content: mycontent}
 -STATEMENT MATCH (t:Test) RETURN t;
 ---- 1
 {_ID: 0:0, _LABEL: Test, id: 0, content: mycontent}

--- a/test/test_files/transaction/create_node/create_read_tinysnb_checkpoint.test
+++ b/test/test_files/transaction/create_node/create_read_tinysnb_checkpoint.test
@@ -25,7 +25,7 @@
 80|22||1.100000
 -STATEMENT CREATE (a:organisation {ID:0, name:'test'}) RETURN a, a.history;
 ---- 1
-{_ID: 1:4611686018427387904, _LABEL: organisation, ID: 0, name: test}|
+{_ID: 1:3, _LABEL: organisation, ID: 0, name: test}|
 
 
 -CASE OptionalMatchAfterInsert

--- a/test/test_files/transaction/delete_node/delete_node.test
+++ b/test/test_files/transaction/delete_node/delete_node.test
@@ -30,8 +30,8 @@
 ---- ok
 -STATEMENT MATCH (p1:person)-[r:knows]->(p2:person) RETURN ID(p1), p1.fName, ID(p2), p2.fName;
 ---- 2
-0:4611686018427387904|Alice|0:4611686018427387906|Charlie
-0:4611686018427387904|Alice|0:4611686018427387907|Dave
+0:0|Alice|0:2|Charlie
+0:0|Alice|0:3|Dave
 -STATEMENT COMMIT;
 ---- ok
 -STATEMENT MATCH (p:person) RETURN ID(p);


### PR DESCRIPTION
# Description

Change uncommitted transaction local node offsets to start with the max of committed node offset, instead of `MAX_NUM_ROWS_IN_TABLE`. The aim of this change is to simplify the mask on node tables for both committed and uncommitted data. #4421 relies on this change.

The key idea is to keep a map of min uncommitted node offsets (i.e., num of total rows) when the transaction starts. This may not be scalable for very small transactions when the database contains a lot of tables.

## TODO
- [ ] Change uncommitted local rel offsets to start with the max of committed rel offset.
- [ ] Apply semi mask to uncommitted transaction local nodes.