### PR TITLE
Store just one OnDiskGraph scan state for both fwd and backward

### DIFF
--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -1,6 +1,8 @@
 #include "function/gds/gds_utils.h"
 
+#include "common/enums/extend_direction.h"
 #include "common/task_system/task_scheduler.h"
+#include "common/types/types.h"
 #include "function/gds/gds_frontier.h"
 #include "function/gds/gds_task.h"
 #include "function/gds/rec_joins.h"
@@ -13,15 +15,9 @@ using namespace kuzu::function;
 namespace kuzu {
 namespace function {
 
-static void scheduleFrontierTask(table_id_t relTableID, graph::Graph* graph,
-    ExtendDirection extendDirection, RJCompState& rjCompState,
+static void scheduleFrontierTask(std::shared_ptr<FrontierTask> task,
     processor::ExecutionContext* context) {
     auto clientContext = context->clientContext;
-    auto info = FrontierTaskInfo(relTableID, graph, extendDirection, *rjCompState.edgeCompute);
-    auto sharedState = std::make_shared<FrontierTaskSharedState>(*rjCompState.frontierPair);
-    auto maxThreads =
-        clientContext->getCurrentSetting(main::ThreadsSetting::name).getValue<uint64_t>();
-    auto task = std::make_shared<FrontierTask>(maxThreads, info, sharedState);
     // GDSUtils::runFrontiersUntilConvergence is called from a GDSCall operator, which is
     // already executed by a worker thread Tm of the task scheduler. So this function is
     // executed by Tm. Because this function will monitor the task and wait for it to
@@ -30,6 +26,7 @@ static void scheduleFrontierTask(table_id_t relTableID, graph::Graph* graph,
     // more generally decrease the number of worker threads by 1. Therefore, we instruct
     // scheduleTaskAndWaitOrError to start a new thread by passing true as the last
     // argument.
+    task->resetState();
     clientContext->getTaskScheduler()->scheduleTaskAndWaitOrError(task, context,
         true /* launchNewWorkerThread */);
 }
@@ -37,6 +34,12 @@ static void scheduleFrontierTask(table_id_t relTableID, graph::Graph* graph,
 void GDSUtils::runFrontiersUntilConvergence(processor::ExecutionContext* context,
     RJCompState& rjCompState, graph::Graph* graph, ExtendDirection extendDirection,
     uint64_t maxIters) {
+    auto maxThreads =
+        context->clientContext->getCurrentSetting(main::ThreadsSetting::name).getValue<uint64_t>();
+    auto info =
+        FrontierTaskInfo(INVALID_TABLE_ID, graph, extendDirection, *rjCompState.edgeCompute);
+    auto sharedState = std::make_shared<FrontierTaskSharedState>(*rjCompState.frontierPair);
+    auto task = std::make_shared<FrontierTask>(maxThreads, info, sharedState);
     auto frontierPair = rjCompState.frontierPair.get();
     auto outputNodeMask = rjCompState.outputWriter->getOutputNodeMask();
     rjCompState.edgeCompute->resetSingleThreadState();
@@ -46,28 +49,30 @@ void GDSUtils::runFrontiersUntilConvergence(processor::ExecutionContext* context
             break;
         }
         for (auto& relTableIDInfo : graph->getRelTableIDInfos()) {
+            info.relTableIDToScan = relTableIDInfo.relTableID;
+
             switch (extendDirection) {
             case ExtendDirection::FWD: {
+                info.direction = ExtendDirection::FWD;
                 rjCompState.beginFrontierComputeBetweenTables(relTableIDInfo.fromNodeTableID,
                     relTableIDInfo.toNodeTableID);
-                scheduleFrontierTask(relTableIDInfo.relTableID, graph, ExtendDirection::FWD,
-                    rjCompState, context);
+                scheduleFrontierTask(task, context);
             } break;
             case ExtendDirection::BWD: {
+                info.direction = ExtendDirection::BWD;
                 rjCompState.beginFrontierComputeBetweenTables(relTableIDInfo.toNodeTableID,
                     relTableIDInfo.fromNodeTableID);
-                scheduleFrontierTask(relTableIDInfo.relTableID, graph, ExtendDirection::BWD,
-                    rjCompState, context);
+                scheduleFrontierTask(task, context);
             } break;
             case ExtendDirection::BOTH: {
+                info.direction = ExtendDirection::FWD;
                 rjCompState.beginFrontierComputeBetweenTables(relTableIDInfo.fromNodeTableID,
                     relTableIDInfo.toNodeTableID);
-                scheduleFrontierTask(relTableIDInfo.relTableID, graph, ExtendDirection::FWD,
-                    rjCompState, context);
+                scheduleFrontierTask(task, context);
+                info.direction = ExtendDirection::BWD;
                 rjCompState.beginFrontierComputeBetweenTables(relTableIDInfo.toNodeTableID,
                     relTableIDInfo.fromNodeTableID);
-                scheduleFrontierTask(relTableIDInfo.relTableID, graph, ExtendDirection::BWD,
-                    rjCompState, context);
+                scheduleFrontierTask(task, context);
             } break;
             default:
                 KU_UNREACHABLE;

--- a/src/include/common/task_system/task.h
+++ b/src/include/common/task_system/task.h
@@ -72,6 +72,12 @@ public:
         return exceptionsPtr;
     }
 
+    // Resets a task so that it can be re-used and run again
+    virtual void resetState() {
+        numThreadsFinished = 0;
+        numThreadsRegistered = 0;
+    }
+
 private:
     bool canRegisterNoLock() const {
         return 0 == numThreadsFinished && maxNumThreads > numThreadsRegistered;

--- a/src/include/function/gds/gds_task.h
+++ b/src/include/function/gds/gds_task.h
@@ -32,13 +32,12 @@ struct FrontierTaskSharedState {
 class FrontierTask : public common::Task {
 public:
     FrontierTask(uint64_t maxNumThreads, const FrontierTaskInfo& info,
-        std::shared_ptr<FrontierTaskSharedState> sharedState)
-        : common::Task{maxNumThreads}, info{info}, sharedState{std::move(sharedState)} {}
+        std::shared_ptr<FrontierTaskSharedState> sharedState);
 
     void run() override;
 
 private:
-    FrontierTaskInfo info;
+    const FrontierTaskInfo& info;
     std::shared_ptr<FrontierTaskSharedState> sharedState;
 };
 

--- a/src/include/graph/graph.h
+++ b/src/include/graph/graph.h
@@ -163,8 +163,11 @@ public:
     // Get all possible "forward" (fromNodeTableID, relTableID, toNodeTableID) combinations.
     virtual std::vector<RelTableIDInfo> getRelTableIDInfos() = 0;
 
-    // Prepares scan on the specified relationship table (works for backwards and forwards scans)
-    virtual std::unique_ptr<GraphScanState> prepareScan(common::table_id_t relTableID,
+    // Prepares scan on the specified relationship table
+    virtual std::unique_ptr<GraphScanState> prepareScanFwd(common::table_id_t relTableID,
+        std::optional<common::idx_t> edgePropertyIndex = std::nullopt) = 0;
+    // Prepares scan on the specified relationship table
+    virtual std::unique_ptr<GraphScanState> prepareScanBwd(common::table_id_t relTableID,
         std::optional<common::idx_t> edgePropertyIndex = std::nullopt) = 0;
     // Prepares scan on all connected relationship tables using forward adjList.
     virtual std::unique_ptr<GraphScanState> prepareMultiTableScanFwd(

--- a/src/include/graph/on_disk_graph.h
+++ b/src/include/graph/on_disk_graph.h
@@ -21,59 +21,45 @@ class MemoryManager;
 namespace graph {
 
 struct OnDiskGraphScanState {
-    class InnerIterator {
-    public:
-        InnerIterator(const main::ClientContext* context, storage::RelTable* relTable,
-            std::unique_ptr<storage::RelTableScanState> tableScanState);
+public:
+    OnDiskGraphScanState(const main::ClientContext* context, storage::RelTable* relTable,
+        std::unique_ptr<storage::RelTableScanState> tableScanState);
 
-        DELETE_COPY_DEFAULT_MOVE(InnerIterator);
+    DELETE_COPY_DEFAULT_MOVE(OnDiskGraphScanState);
 
-        std::span<const common::nodeID_t> getNbrNodes() const {
-            RUNTIME_CHECK(for (size_t i = 0; i < getSelVector().getSelSize(); i++) {
-                KU_ASSERT(
-                    getSelVector().getSelectedPositions()[i] < common::DEFAULT_VECTOR_CAPACITY);
-            });
-            return std::span<const common::nodeID_t>(
-                &dstVector().getValue<const common::nodeID_t>(0), common::DEFAULT_VECTOR_CAPACITY);
-        }
-        std::span<const common::nodeID_t> getEdges() const {
-            RUNTIME_CHECK(for (size_t i = 0; i < getSelVector().getSelSize(); i++) {
-                KU_ASSERT(
-                    getSelVector().getSelectedPositions()[i] < common::DEFAULT_VECTOR_CAPACITY);
-            });
-            return std::span<const common::nodeID_t>(
-                &relIDVector().getValue<const common::nodeID_t>(0),
-                common::DEFAULT_VECTOR_CAPACITY);
-        }
+    std::span<const common::nodeID_t> getNbrNodes() const {
+        RUNTIME_CHECK(for (size_t i = 0; i < getSelVector().getSelSize(); i++) {
+            KU_ASSERT(getSelVector().getSelectedPositions()[i] < common::DEFAULT_VECTOR_CAPACITY);
+        });
+        return std::span<const common::nodeID_t>(&dstVector().getValue<const common::nodeID_t>(0),
+            common::DEFAULT_VECTOR_CAPACITY);
+    }
+    std::span<const common::nodeID_t> getEdges() const {
+        RUNTIME_CHECK(for (size_t i = 0; i < getSelVector().getSelSize(); i++) {
+            KU_ASSERT(getSelVector().getSelectedPositions()[i] < common::DEFAULT_VECTOR_CAPACITY);
+        });
+        return std::span<const common::nodeID_t>(&relIDVector().getValue<const common::nodeID_t>(0),
+            common::DEFAULT_VECTOR_CAPACITY);
+    }
 
-        common::SelectionVector& getSelVectorUnsafe() {
-            return tableScanState->outState->getSelVectorUnsafe();
-        }
+    common::SelectionVector& getSelVectorUnsafe() {
+        return tableScanState->outState->getSelVectorUnsafe();
+    }
 
-        const common::SelectionVector& getSelVector() const {
-            return tableScanState->outState->getSelVector();
-        }
+    const common::SelectionVector& getSelVector() const {
+        return tableScanState->outState->getSelVector();
+    }
 
-        bool next(evaluator::ExpressionEvaluator* predicate);
-        void initScan();
+    bool next(evaluator::ExpressionEvaluator* predicate);
+    void initScan();
 
-    private:
-        common::ValueVector& dstVector() const { return *tableScanState->outputVectors[0]; }
-        common::ValueVector& relIDVector() const { return *tableScanState->outputVectors[1]; }
+private:
+    common::ValueVector& dstVector() const { return *tableScanState->outputVectors[0]; }
+    common::ValueVector& relIDVector() const { return *tableScanState->outputVectors[1]; }
 
-        const main::ClientContext* context;
-        storage::RelTable* relTable;
-        std::unique_ptr<storage::RelTableScanState> tableScanState;
-    };
-
-    InnerIterator fwdIterator;
-    InnerIterator bwdIterator;
-
-    OnDiskGraphScanState(main::ClientContext* context, storage::RelTable& table,
-        std::unique_ptr<storage::RelTableScanState> fwdState,
-        std::unique_ptr<storage::RelTableScanState> bwdState)
-        : fwdIterator{context, &table, std::move(fwdState)},
-          bwdIterator{context, &table, std::move(bwdState)} {}
+    const main::ClientContext* context;
+    storage::RelTable* relTable;
+    std::unique_ptr<storage::RelTableScanState> tableScanState;
 };
 
 class OnDiskGraphScanStates : public GraphScanState {
@@ -81,8 +67,8 @@ class OnDiskGraphScanStates : public GraphScanState {
 
 public:
     GraphScanState::Chunk getChunk() override {
-        auto& iter = getInnerIterator();
-        return createChunk(iter.getNbrNodes(), iter.getEdges(), iter.getSelVectorUnsafe(),
+        auto& state = getCurrentScanState();
+        return createChunk(state.getNbrNodes(), state.getEdges(), state.getSelVectorUnsafe(),
             propertyVector.get());
     }
     bool next() override;
@@ -93,18 +79,14 @@ public:
     }
 
 private:
-    const OnDiskGraphScanState::InnerIterator& getInnerIterator() const {
+    const OnDiskGraphScanState& getCurrentScanState() const {
         KU_ASSERT(iteratorIndex < scanStates.size());
-        if (direction == common::RelDataDirection::FWD) {
-            return scanStates[iteratorIndex].second.fwdIterator;
-        } else {
-            return scanStates[iteratorIndex].second.bwdIterator;
-        }
+        return scanStates[iteratorIndex].second;
     }
 
-    OnDiskGraphScanState::InnerIterator& getInnerIterator() {
-        return const_cast<OnDiskGraphScanState::InnerIterator&>(
-            const_cast<const OnDiskGraphScanStates*>(this)->getInnerIterator());
+    OnDiskGraphScanState& getCurrentScanState() {
+        return const_cast<OnDiskGraphScanState&>(
+            const_cast<const OnDiskGraphScanStates*>(this)->getCurrentScanState());
     }
 
 private:
@@ -119,7 +101,7 @@ private:
 
     explicit OnDiskGraphScanStates(main::ClientContext* context,
         std::span<storage::RelTable*> tableIDs, const GraphEntry& graphEntry,
-        std::optional<common::idx_t> edgePropertyIndex = std::nullopt);
+        std::optional<common::idx_t> edgePropertyIndex, common::RelDataDirection direction);
     std::vector<std::pair<common::table_id_t, OnDiskGraphScanState>> scanStates;
 };
 
@@ -139,7 +121,9 @@ public:
 
     std::vector<RelTableIDInfo> getRelTableIDInfos() override;
 
-    std::unique_ptr<GraphScanState> prepareScan(common::table_id_t relTableID,
+    std::unique_ptr<GraphScanState> prepareScanFwd(common::table_id_t relTableID,
+        std::optional<common::idx_t> edgePropertyIndex = std::nullopt) override;
+    std::unique_ptr<GraphScanState> prepareScanBwd(common::table_id_t relTableID,
         std::optional<common::idx_t> edgePropertyIndex = std::nullopt) override;
     std::unique_ptr<GraphScanState> prepareMultiTableScanFwd(
         std::span<common::table_id_t> nodeTableIDs) override;

--- a/test/storage/rel_scan_test.cpp
+++ b/test/storage/rel_scan_test.cpp
@@ -1,5 +1,4 @@
 #include <cstdint>
-#include <random>
 #include <vector>
 
 #include "catalog/catalog.h"
@@ -7,7 +6,6 @@
 #include "common/types/types.h"
 #include "graph/graph_entry.h"
 #include "graph/on_disk_graph.h"
-#include "graph_test/base_graph_test.h"
 #include "main/client_context.h"
 #include "main_test_helper/private_main_test_helper.h"
 
@@ -54,7 +52,8 @@ TEST_F(RelScanTest, ScanFwd) {
     auto relTableID = catalog->getTableID(context->getTx(), "knows");
     auto datePropertyIndex =
         catalog->getTableCatalogEntry(context->getTx(), relTableID)->getPropertyIdx("date");
-    auto scanState = graph->prepareScan(relTableID, datePropertyIndex);
+    auto fwdScanState = graph->prepareScanFwd(relTableID, datePropertyIndex);
+    auto bwdScanState = graph->prepareScanBwd(relTableID, datePropertyIndex);
 
     std::unordered_map<offset_t, common::date_t> expectedDates = {
         {0, Date::fromDate(2021, 6, 30)},
@@ -82,7 +81,7 @@ TEST_F(RelScanTest, ScanFwd) {
 
         std::vector<offset_t> resultRelOffsets;
         std::vector<common::date_t> resultDates;
-        for (const auto chunk : graph->scanFwd(nodeID_t{node, tableID}, *scanState)) {
+        for (const auto chunk : graph->scanFwd(nodeID_t{node, tableID}, *fwdScanState)) {
             chunk.forEach<common::date_t>([&](auto nbr, auto edgeID, auto date) {
                 EXPECT_EQ(nbr.tableID, tableID);
                 resultNodeOffsets.push_back(nbr.offset);
@@ -99,14 +98,14 @@ TEST_F(RelScanTest, ScanFwd) {
                 << Date::toString(resultDates[i]) << " but we expected "
                 << Date::toString(expectedDates[resultRelOffsets[i]]);
         }
-        EXPECT_EQ(graph->scanFwd(nodeID_t{node, tableID}, *scanState).collectNbrNodes(),
+        EXPECT_EQ(graph->scanFwd(nodeID_t{node, tableID}, *fwdScanState).collectNbrNodes(),
             expectedNodes);
 
         resultNodeOffsets.clear();
         resultRelOffsets.clear();
         resultDates.clear();
 
-        for (const auto chunk : graph->scanBwd(nodeID_t{node, tableID}, *scanState)) {
+        for (const auto chunk : graph->scanBwd(nodeID_t{node, tableID}, *bwdScanState)) {
             chunk.forEach<common::date_t>([&](auto nbr, auto edgeID, auto date) {
                 EXPECT_EQ(nbr.tableID, tableID);
                 resultNodeOffsets.push_back(nbr.offset);
@@ -123,7 +122,7 @@ TEST_F(RelScanTest, ScanFwd) {
                 << Date::toString(resultDates[i]) << " but we expected "
                 << Date::toString(expectedDates[resultRelOffsets[i]]);
         }
-        EXPECT_EQ(graph->scanFwd(nodeID_t{node, tableID}, *scanState).collectNbrNodes(),
+        EXPECT_EQ(graph->scanFwd(nodeID_t{node, tableID}, *fwdScanState).collectNbrNodes(),
             expectedNodes);
     };
     compare(0, {1, 2, 3}, {0, 1, 2}, {3, 6, 9});


### PR DESCRIPTION
Only one is used at a time, and we should always know which at the point that the state is created.

This halves the setup cost of preparing OnDiskGraph scans, even when scanning in both directions (since in gds_utils.cpp where the tasks are created we're creating a task for each direction anyway).