### PR TITLE
Cleanup and address warnings in storage

### DIFF
--- a/src/function/table/call/storage_info.cpp
+++ b/src/function/table/call/storage_info.cpp
@@ -277,7 +277,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
             auto& nodeTable = table->cast<NodeTable>();
             std::vector<Column*> columns;
             for (auto columnID = 0u; columnID < nodeTable.getNumColumns(); columnID++) {
-                collectColumns(nodeTable.getColumnPtr(columnID), columns);
+                collectColumns(&nodeTable.getColumn(columnID), columns);
             }
             outputData.columns = std::move(columns);
             numNodeGroups = nodeTable.getNumNodeGroups();

--- a/src/include/storage/store/column_chunk_data.h
+++ b/src/include/storage/store/column_chunk_data.h
@@ -248,7 +248,7 @@ protected:
     // constructor.
     void initializeBuffer(common::PhysicalTypeID physicalType, MemoryManager& mm,
         bool initializeToZero);
-    void initializeFunction(bool enableCompression);
+    void initializeFunction();
 
     // Note: This function is not setting child/null chunk data recursively.
     void setToOnDisk(const ColumnChunkMetadata& metadata);

--- a/src/include/storage/store/group_collection.h
+++ b/src/include/storage/store/group_collection.h
@@ -37,15 +37,11 @@ public:
     T* getGroup(const common::UniqLock& lock, common::idx_t groupIdx) const {
         KU_ASSERT(lock.isLocked());
         KU_UNUSED(lock);
-        if (groupIdx >= groups.size()) {
-            return nullptr;
-        }
+        KU_ASSERT(groupIdx < groups.size());
         return groups[groupIdx].get();
     }
     T* getGroupNoLock(common::idx_t groupIdx) const {
-        if (groupIdx >= groups.size()) {
-            return nullptr;
-        }
+        KU_ASSERT(groupIdx < groups.size());
         return groups[groupIdx].get();
     }
     void replaceGroup(const common::UniqLock& lock, common::idx_t groupIdx,
@@ -78,17 +74,12 @@ public:
         KU_UNUSED(lock);
         return groups.size();
     }
+    common::idx_t getNumGroupsNoLock() const { return groups.size(); }
 
     const std::vector<std::unique_ptr<T>>& getAllGroups(const common::UniqLock& lock) const {
         KU_ASSERT(lock.isLocked());
         KU_UNUSED(lock);
         return groups;
-    }
-    std::unique_ptr<T> moveGroup(const common::UniqLock& lock, common::idx_t groupIdx) {
-        KU_ASSERT(groupIdx < groups.size());
-        KU_ASSERT(lock.isLocked());
-        KU_UNUSED(lock);
-        return std::move(groups[groupIdx]);
     }
     T* getFirstGroup(const common::UniqLock& lock) const {
         KU_ASSERT(lock.isLocked());

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -154,7 +154,6 @@ public:
 
     virtual void checkpoint(MemoryManager& memoryManager, NodeGroupCheckpointState& state);
 
-    bool hasChanges();
     uint64_t getEstimatedMemoryUsage();
 
     virtual void serialize(common::Serializer& serializer);
@@ -203,9 +202,6 @@ private:
     std::unique_ptr<ChunkedNodeGroup> scanAllInsertedAndVersions(MemoryManager& memoryManager,
         const common::UniqLock& lock, const std::vector<common::column_id_t>& columnIDs,
         const std::vector<const Column*>& columns) const;
-
-    static void populateNodeID(common::ValueVector& nodeIDVector, common::table_id_t tableID,
-        common::offset_t startNodeOffset, common::row_idx_t numRows);
 
 protected:
     common::node_group_idx_t nodeGroupIdx;

--- a/src/include/storage/store/node_group_collection.h
+++ b/src/include/storage/store/node_group_collection.h
@@ -38,8 +38,12 @@ public:
     NodeGroup* getNodeGroupNoLock(const common::node_group_idx_t groupIdx) {
         return nodeGroups.getGroupNoLock(groupIdx);
     }
-    NodeGroup* getNodeGroup(const common::node_group_idx_t groupIdx) const {
+    NodeGroup* getNodeGroup(const common::node_group_idx_t groupIdx,
+        bool mayOutOfBound = false) const {
         const auto lock = nodeGroups.lock();
+        if (mayOutOfBound && groupIdx >= nodeGroups.getNumGroups(lock)) {
+            return nullptr;
+        }
         return nodeGroups.getGroup(lock, groupIdx);
     }
     NodeGroup* getOrCreateNodeGroup(common::node_group_idx_t groupIdx, NodeGroupDataFormat format);

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -130,10 +130,6 @@ public:
     common::column_id_t getPKColumnID() const { return pkColumnID; }
     PrimaryKeyIndex* getPKIndex() const { return pkIndex.get(); }
     common::column_id_t getNumColumns() const { return columns.size(); }
-    Column* getColumnPtr(common::column_id_t columnID) const {
-        KU_ASSERT(columnID < columns.size());
-        return columns[columnID].get();
-    }
     Column& getColumn(common::column_id_t columnID) {
         KU_ASSERT(columnID < columns.size());
         return *columns[columnID];

--- a/src/include/storage/store/rel_table_data.h
+++ b/src/include/storage/store/rel_table_data.h
@@ -42,16 +42,16 @@ public:
     common::column_id_t getNumColumns() const { return columns.size(); }
     Column* getColumn(common::column_id_t columnID) const { return columns[columnID].get(); }
     std::vector<const Column*> getColumns() const {
-        std::vector<const Column*> columns;
-        columns.reserve(this->columns.size());
-        for (const auto& column : this->columns) {
-            columns.push_back(column.get());
+        std::vector<const Column*> result;
+        result.reserve(columns.size());
+        for (const auto& column : columns) {
+            result.push_back(column.get());
         }
-        return columns;
+        return result;
     }
     common::node_group_idx_t getNumNodeGroups() const { return nodeGroups->getNumNodeGroups(); }
     NodeGroup* getNodeGroup(common::node_group_idx_t nodeGroupIdx) const {
-        return nodeGroups->getNodeGroup(nodeGroupIdx);
+        return nodeGroups->getNodeGroup(nodeGroupIdx, true /*mayOutOfBound*/);
     }
     NodeGroup* getOrCreateNodeGroup(common::node_group_idx_t nodeGroupIdx) const {
         return nodeGroups->getOrCreateNodeGroup(nodeGroupIdx, NodeGroupDataFormat::CSR);

--- a/src/storage/buffer_manager/buffer_manager.cpp
+++ b/src/storage/buffer_manager/buffer_manager.cpp
@@ -239,7 +239,7 @@ void BufferManager::optimisticRead(FileHandle& fileHandle, page_idx_t pageIdx,
             // If the page is marked, we try to switch to unlocked.
             pageState->tryClearMark(currStateAndVersion);
             continue;
-        } break;
+        }
         case PageState::EVICTED: {
             pin(fileHandle, pageIdx, PageReadPolicy::READ_PAGE);
             unpin(fileHandle, pageIdx);

--- a/src/storage/buffer_manager/memory_manager.cpp
+++ b/src/storage/buffer_manager/memory_manager.cpp
@@ -9,7 +9,6 @@
 #include "common/file_system/virtual_file_system.h"
 #include "storage/buffer_manager/buffer_manager.h"
 #include "storage/file_handle.h"
-#include "storage/store/chunked_node_group.h"
 
 using namespace kuzu::common;
 

--- a/src/storage/buffer_manager/spiller.cpp
+++ b/src/storage/buffer_manager/spiller.cpp
@@ -1,8 +1,6 @@
 #include "storage/buffer_manager/spiller.h"
 
 #include <cstdint>
-#include <cstring>
-#include <memory>
 
 #include "common/assert.h"
 #include "common/exception/io.h"

--- a/src/storage/compression/compression.cpp
+++ b/src/storage/compression/compression.cpp
@@ -495,7 +495,6 @@ void ConstantCompression::decompressValues(uint8_t* dstBuffer, uint64_t dstOffse
         [&](auto) {
             throw NotImplementedException("CONSTANT compression is not implemented for type " +
                                           PhysicalTypeUtils::toString(physicalType));
-            ;
         });
 }
 

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -217,7 +217,7 @@ void HashIndex<T>::reserve(const Transaction* transaction, uint64_t newEntries) 
         if (numRequiredSlots >= numSlotsOfCurrentLevel) {
             this->indexHeaderForWriteTrx.nextSplitSlotId =
                 numRequiredSlots - numSlotsOfCurrentLevel;
-        };
+        }
     } else {
         splitSlots(transaction, this->indexHeaderForWriteTrx,
             numRequiredSlots - pSlots->getNumElements(transaction->getType()));

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -10,7 +10,6 @@
 #include "storage/buffer_manager/memory_manager.h"
 #include "storage/compression/compression.h"
 #include "storage/file_handle.h"
-#include "storage/shadow_utils.h"
 #include "storage/storage_utils.h"
 #include "storage/store/column_chunk.h"
 #include "storage/store/column_chunk_data.h"

--- a/src/storage/store/csr_chunked_node_group.cpp
+++ b/src/storage/store/csr_chunked_node_group.cpp
@@ -240,8 +240,8 @@ std::unique_ptr<ChunkedNodeGroup> ChunkedCSRNodeGroup::flushAsNewChunkedNodeGrou
         flushedChunks[i] = std::make_unique<ColumnChunk>(getColumnChunk(i).isCompressionEnabled(),
             Column::flushChunkData(getColumnChunk(i).getData(), dataFH));
     }
-    ChunkedCSRHeader csrHeader{std::move(csrOffset), std::move(csrLength)};
-    auto flushedChunkedGroup = std::make_unique<ChunkedCSRNodeGroup>(std::move(csrHeader),
+    ChunkedCSRHeader newCSRHeader{std::move(csrOffset), std::move(csrLength)};
+    auto flushedChunkedGroup = std::make_unique<ChunkedCSRNodeGroup>(std::move(newCSRHeader),
         std::move(flushedChunks), 0 /*startRowIdx*/);
     flushedChunkedGroup->versionInfo = std::make_unique<VersionInfo>();
     KU_ASSERT(numRows == flushedChunkedGroup->getNumRows());

--- a/src/storage/store/node_group.cpp
+++ b/src/storage/store/node_group.cpp
@@ -108,19 +108,21 @@ void NodeGroup::initializeScanState(Transaction* transaction, TableScanState& st
 
 static void initializeScanStateForChunkedGroup(const TableScanState& state,
     ChunkedNodeGroup* chunkedGroup) {
-    if (chunkedGroup != nullptr && chunkedGroup->getResidencyState() == ResidencyState::ON_DISK) {
-        auto& nodeGroupScanState = *state.nodeGroupScanState;
-        for (auto i = 0u; i < state.columnIDs.size(); i++) {
-            KU_ASSERT(i < state.columnIDs.size());
-            KU_ASSERT(i < nodeGroupScanState.chunkStates.size());
-            const auto columnID = state.columnIDs[i];
-            if (columnID == INVALID_COLUMN_ID || columnID == ROW_IDX_COLUMN_ID) {
-                continue;
-            }
-            auto& chunk = chunkedGroup->getColumnChunk(columnID);
-            auto& chunkState = nodeGroupScanState.chunkStates[i];
-            chunk.initializeScanState(chunkState, state.columns[i]);
+    KU_ASSERT(chunkedGroup);
+    if (chunkedGroup->getResidencyState() != ResidencyState::ON_DISK) {
+        return;
+    }
+    auto& nodeGroupScanState = *state.nodeGroupScanState;
+    for (auto i = 0u; i < state.columnIDs.size(); i++) {
+        KU_ASSERT(i < state.columnIDs.size());
+        KU_ASSERT(i < nodeGroupScanState.chunkStates.size());
+        const auto columnID = state.columnIDs[i];
+        if (columnID == INVALID_COLUMN_ID || columnID == ROW_IDX_COLUMN_ID) {
+            continue;
         }
+        auto& chunk = chunkedGroup->getColumnChunk(columnID);
+        auto& chunkState = nodeGroupScanState.chunkStates[i];
+        chunk.initializeScanState(chunkState, state.columns[i]);
     }
 }
 
@@ -142,12 +144,12 @@ NodeGroupScanResult NodeGroup::scan(Transaction* transaction, TableScanState& st
     if (chunkedGroup && nodeGroupScanState.numScannedRows >=
                             chunkedGroup->getNumRows() + chunkedGroup->getStartRowIdx()) {
         nodeGroupScanState.chunkedGroupIdx++;
+        if (nodeGroupScanState.chunkedGroupIdx >= chunkedGroups.getNumGroups(lock)) {
+            return NODE_GROUP_SCAN_EMMPTY_RESULT;
+        }
         ChunkedNodeGroup* currentChunkedGroup =
             chunkedGroups.getGroup(lock, nodeGroupScanState.chunkedGroupIdx);
         initializeScanStateForChunkedGroup(state, currentChunkedGroup);
-    }
-    if (nodeGroupScanState.chunkedGroupIdx >= chunkedGroups.getNumGroups(lock)) {
-        return NODE_GROUP_SCAN_EMMPTY_RESULT;
     }
     const auto& chunkedGroupToScan =
         *chunkedGroups.getGroup(lock, nodeGroupScanState.chunkedGroupIdx);
@@ -447,47 +449,55 @@ std::unique_ptr<NodeGroup> NodeGroup::deserialize(MemoryManager& memoryManager,
 
 ChunkedNodeGroup* NodeGroup::findChunkedGroupFromRowIdx(const UniqLock& lock, row_idx_t rowIdx) {
     KU_ASSERT(!chunkedGroups.isEmpty(lock));
-    const auto numRowsInFirstGroup = chunkedGroups.getFirstGroup(lock)->getNumRows();
+    auto firstGroup = chunkedGroups.getFirstGroup(lock);
+    const auto numRowsInFirstGroup = firstGroup->getNumRows();
     if (rowIdx < numRowsInFirstGroup) {
-        return chunkedGroups.getFirstGroup(lock);
+        return firstGroup;
     }
     rowIdx -= numRowsInFirstGroup;
     const auto chunkedGroupIdx = rowIdx / ChunkedNodeGroup::CHUNK_CAPACITY + 1;
+    if (chunkedGroupIdx >= chunkedGroups.getNumGroups(lock)) {
+        return nullptr;
+    }
     return chunkedGroups.getGroup(lock, chunkedGroupIdx);
 }
 
 ChunkedNodeGroup* NodeGroup::findChunkedGroupFromRowIdxNoLock(row_idx_t rowIdx) {
-    const auto numRowsInFirstGroup = chunkedGroups.getFirstGroupNoLock()->getNumRows();
+    auto firstGroup = chunkedGroups.getFirstGroupNoLock();
+    const auto numRowsInFirstGroup = firstGroup->getNumRows();
     if (rowIdx < numRowsInFirstGroup) {
-        return chunkedGroups.getFirstGroupNoLock();
+        return firstGroup;
     }
     rowIdx -= numRowsInFirstGroup;
     const auto chunkedGroupIdx = rowIdx / ChunkedNodeGroup::CHUNK_CAPACITY + 1;
+    if (chunkedGroupIdx >= chunkedGroups.getNumGroupsNoLock()) {
+        return nullptr;
+    }
     return chunkedGroups.getGroupNoLock(chunkedGroupIdx);
 }
 
 template<ResidencyState RESIDENCY_STATE>
 row_idx_t NodeGroup::getNumResidentRows(const UniqLock& lock) const {
-    row_idx_t numRows = 0u;
+    row_idx_t numResidentRows = 0u;
     for (auto& chunkedGroup : chunkedGroups.getAllGroups(lock)) {
         if (chunkedGroup->getResidencyState() == RESIDENCY_STATE) {
-            numRows += chunkedGroup->getNumRows();
+            numResidentRows += chunkedGroup->getNumRows();
         }
     }
-    return numRows;
+    return numResidentRows;
 }
 
 template<ResidencyState RESIDENCY_STATE>
 std::unique_ptr<ChunkedNodeGroup> NodeGroup::scanAllInsertedAndVersions(
     MemoryManager& memoryManager, const UniqLock& lock, const std::vector<column_id_t>& columnIDs,
     const std::vector<const Column*>& columns) const {
-    auto numRows = getNumResidentRows<RESIDENCY_STATE>(lock);
+    auto numResidentRows = getNumResidentRows<RESIDENCY_STATE>(lock);
     std::vector<LogicalType> columnTypes;
     for (const auto* column : columns) {
         columnTypes.push_back(column->getDataType().copy());
     }
     auto mergedInMemGroup = std::make_unique<ChunkedNodeGroup>(memoryManager, columnTypes,
-        enableCompression, numRows, 0, ResidencyState::IN_MEMORY);
+        enableCompression, numResidentRows, 0, ResidencyState::IN_MEMORY);
     auto scanState = std::make_unique<TableScanState>(INVALID_TABLE_ID, columnIDs, columns);
     scanState->nodeGroupScanState = std::make_unique<NodeGroupScanState>(columnIDs.size());
     initializeScanState(&DUMMY_CHECKPOINT_TRANSACTION, lock, *scanState);
@@ -497,10 +507,10 @@ std::unique_ptr<ChunkedNodeGroup> NodeGroup::scanAllInsertedAndVersions(
     }
     for (auto i = 0u; i < columnIDs.size(); i++) {
         if (columnIDs[i] != 0) {
-            KU_ASSERT(numRows == mergedInMemGroup->getColumnChunk(i).getNumValues());
+            KU_ASSERT(numResidentRows == mergedInMemGroup->getColumnChunk(i).getNumValues());
         }
     }
-    mergedInMemGroup->setNumRows(numRows);
+    mergedInMemGroup->setNumRows(numResidentRows);
     return mergedInMemGroup;
 }
 

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -3,11 +3,10 @@
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "common/exception/runtime.h"
 #include "main/client_context.h"
+#include "main/db_config.h"
 #include "storage/local_storage/local_storage.h"
-#include "storage/store/version_info.h"
 #include "storage/undo_buffer.h"
 #include "storage/wal/wal.h"
-#include <main/db_config.h>
 
 using namespace kuzu::catalog;
 
@@ -30,6 +29,7 @@ Transaction::Transaction(TransactionType transactionType) noexcept
       forceCheckpoint{false} {
     currentTS = common::Timestamp::getCurrentTimestamp().value;
 }
+
 Transaction::Transaction(TransactionType transactionType, common::transaction_t ID,
     common::transaction_t startTS) noexcept
     : type{transactionType}, ID{ID}, startTS{startTS}, commitTS{common::INVALID_TRANSACTION},


### PR DESCRIPTION
# Description

This is a minor refactoring PR.
Address some shadowing and empty statement warnings in storage. Also, change `GroupCollection::getGroup` and `GroupCollection::getGroupNoLock` to not return nullptr when access with out-of-bound idx, instead, it will assert false or throw exception.