### PR TITLE
Fix cost model for Extend

### DIFF
--- a/benchmark/queries/ldbc-sf100/join/selective-join.benchmark
+++ b/benchmark/queries/ldbc-sf100/join/selective-join.benchmark
@@ -2,4 +2,4 @@
 -COMPARE_RESULT 1
 -QUERY MATCH (a:Person)-[:knows]->(b:Person)-[:knows]->(c:person) WHERE a.ID=933 RETURN MIN(a.birthday), MIN(b.birthday), MIN(c.birthday)
 ---- 1
-1980-02-01|1980-02-01|1980-02-01
+1989-12-03|1980-03-31|1980-02-01

--- a/benchmark/queries/ldbc-sf100/join/selective-join.benchmark
+++ b/benchmark/queries/ldbc-sf100/join/selective-join.benchmark
@@ -1,0 +1,5 @@
+-NAME SelectiveTwoHopJoin
+-COMPARE_RESULT 1
+-QUERY MATCH (a:Person)-[:knows]->(b:Person)-[:knows]->(c:person) WHERE a.ID=933 RETURN MIN(a.birthday), MIN(b.birthday), MIN(c.birthday)
+---- 1
+1980-02-01|1980-02-01|1980-02-01

--- a/src/planner/join_order/cost_model.cpp
+++ b/src/planner/join_order/cost_model.cpp
@@ -9,8 +9,7 @@ namespace kuzu {
 namespace planner {
 
 uint64_t CostModel::computeExtendCost(const LogicalPlan& childPlan) {
-    KU_ASSERT(childPlan.estCardinality >= 1);
-    return childPlan.estCardinality;
+    return childPlan.getCost() + childPlan.estCardinality;
 }
 
 uint64_t CostModel::computeRecursiveExtendCost(uint8_t upperBound, double extensionRate,

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -91,10 +91,11 @@ void Planner::appendNonRecursiveExtend(const std::shared_ptr<NodeExpression>& bo
     auto extend = make_shared<LogicalExtend>(boundNode, nbrNode, rel, direction, extendFromSource,
         properties_, plan.getLastOperator());
     extend->computeFactorizedSchema();
-    plan.setCost(CostModel::computeExtendCost(plan));
-    auto extensionRate =
+    // Update cost & cardinality. Note that extend does not change cardinality.
+    const auto extensionRate =
         cardinalityEstimator.getExtensionRate(*rel, *boundNode, clientContext->getTx());
     extend->setCardinality(cardinalityEstimator.estimateExtend(extensionRate, plan));
+    plan.setCost(CostModel::computeExtendCost(plan));
     auto group = extend->getSchema()->getGroup(nbrNode->getInternalID());
     group->setMultiplier(extensionRate);
     plan.setCardinality(extend->getCardinality());

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -123,7 +123,7 @@ TEST_F(OptimizerTest, SingleNodeTwoHopJoins) {
     auto q1 =
         "MATCH (a:person)-[e:knows]->(b:person)-[e2:knows]->(c:person) WHERE b.ID=0 RETURN a,b,c;";
     ASSERT_STREQ(getEncodedPlan(q1).c_str(),
-        "HJ(c._ID){Filter()S(c)}{HJ(a._ID){S(a)}{E(c)E(a)IndexScan(b)}}");
+        "HJ(c._ID){S(c)}{HJ(a._ID){S(a)}{E(c)E(a)IndexScan(b)}}");
     auto q2 = "MATCH (a:person)-[e:knows]->(b:person)-[e2:knows]->(c:person) WHERE a.ID=0 "
               "RETURN a,b,c;";
     ASSERT_STREQ(getEncodedPlan(q2).c_str(),


### PR DESCRIPTION
# Description

Fix the bug that `Extend` is not keeping its child's cost.
Also, update the cost of `Extend` itself to be aligned with num of rels scanned, instead of num of bound nodes, which is not reflecting where the main cost comes from. 

The change can fix the plan for the following query to start scan from `c1`, instead of `c2`.
```
match (c1:person)-[e1:knows]-(c2:person)-[e2:knows]-(c3:person) where c1.ID=30786325638641 return min(c1.ID), min(c2.ID), min(c3.ID);
```

@andyfengHKU let me know if there are other tests I should add for this change.