### PR TITLE
GDS dst node pruning optimization

### DIFF
--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -276,8 +276,8 @@ private:
         auto output = std::make_unique<AllSPDestinationsOutputs>(
             sharedState->graph->getNumNodesMap(clientContext->getTx()), sourceNodeID,
             clientContext->getMemoryManager());
-        auto outputWriter =
-            std::make_unique<AllSPDestinationsOutputWriter>(clientContext, output.get(), sharedState->getOutputNodeMaskMap());
+        auto outputWriter = std::make_unique<AllSPDestinationsOutputWriter>(clientContext,
+            output.get(), sharedState->getOutputNodeMaskMap());
         auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,
             clientContext->getMaxNumThreadForExec());
         auto edgeCompute = std::make_unique<AllSPDestinationsEdgeCompute>(frontierPair.get(),

--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -122,11 +122,12 @@ public:
 
 class AllSPDestinationsOutputWriter : public DestinationsOutputWriter {
 public:
-    AllSPDestinationsOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs)
-        : DestinationsOutputWriter(context, rjOutputs) {}
+    AllSPDestinationsOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs,
+        processor::NodeOffsetMaskMap* outputNodeMask)
+        : DestinationsOutputWriter{context, rjOutputs, outputNodeMask} {}
 
     std::unique_ptr<RJOutputWriter> copy() override {
-        return std::make_unique<AllSPDestinationsOutputWriter>(context, rjOutputs);
+        return std::make_unique<AllSPDestinationsOutputWriter>(context, rjOutputs, outputNodeMask);
     }
 
 protected:
@@ -141,13 +142,13 @@ protected:
     }
 };
 
-class VarLenPathsOutputWriter : public PathsOutputWriter {
+class VarLenPathsOutputWriter final : public PathsOutputWriter {
 public:
     VarLenPathsOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs,
-        PathsOutputWriterInfo info)
-        : PathsOutputWriter{context, rjOutputs, info} {}
+        processor::NodeOffsetMaskMap* outputNodeMask, PathsOutputWriterInfo info)
+        : PathsOutputWriter{context, rjOutputs, outputNodeMask, info} {}
 
-    bool skipWriting(common::nodeID_t dstNodeID) const override {
+    bool skipInternal(common::nodeID_t dstNodeID) const override {
         auto pathsOutputs = rjOutputs->ptrCast<PathsOutputs>();
         auto firstParent = pathsOutputs->bfsGraph.getCurFixedParentPtrs()[dstNodeID.offset].load(
             std::memory_order_relaxed);
@@ -164,7 +165,7 @@ public:
     }
 
     std::unique_ptr<RJOutputWriter> copy() override {
-        return std::make_unique<VarLenPathsOutputWriter>(context, rjOutputs, info);
+        return std::make_unique<VarLenPathsOutputWriter>(context, rjOutputs, outputNodeMask, info);
     }
 };
 
@@ -276,7 +277,7 @@ private:
             sharedState->graph->getNumNodesMap(clientContext->getTx()), sourceNodeID,
             clientContext->getMemoryManager());
         auto outputWriter =
-            std::make_unique<AllSPDestinationsOutputWriter>(clientContext, output.get());
+            std::make_unique<AllSPDestinationsOutputWriter>(clientContext, output.get(), sharedState->getOutputNodeMaskMap());
         auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,
             clientContext->getMaxNumThreadForExec());
         auto edgeCompute = std::make_unique<AllSPDestinationsEdgeCompute>(frontierPair.get(),
@@ -313,7 +314,7 @@ private:
         auto writerInfo = rjBindData->getPathWriterInfo();
         writerInfo.pathNodeMask = sharedState->getPathNodeMaskMap();
         auto outputWriter = std::make_unique<SPPathsOutputWriter>(clientContext, output.get(),
-            std::move(writerInfo));
+            sharedState->getOutputNodeMaskMap(), std::move(writerInfo));
         auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,
             clientContext->getMaxNumThreadForExec());
         auto edgeCompute =
@@ -413,7 +414,7 @@ private:
         auto writerInfo = rjBindData->getPathWriterInfo();
         writerInfo.pathNodeMask = sharedState->getPathNodeMaskMap();
         auto outputWriter = std::make_unique<VarLenPathsOutputWriter>(clientContext, output.get(),
-            std::move(writerInfo));
+            sharedState->getOutputNodeMaskMap(), std::move(writerInfo));
         auto frontierPair = std::make_unique<DoublePathLengthsFrontierPair>(nodeTableToNumNodes,
             clientContext->getMaxNumThreadForExec(), mm);
         auto edgeCompute =

--- a/src/function/gds/rec_joins.cpp
+++ b/src/function/gds/rec_joins.cpp
@@ -144,7 +144,7 @@ public:
     }
 
     void vertexCompute(nodeID_t nodeID) override {
-        if (writer->skipWriting(nodeID)) {
+        if (writer->skip(nodeID)) {
             return;
         }
         writer->write(*localFT, nodeID);

--- a/src/function/gds/single_shortest_paths.cpp
+++ b/src/function/gds/single_shortest_paths.cpp
@@ -115,7 +115,8 @@ private:
         auto output = std::make_unique<SingleSPDestinationsOutputs>(
             sharedState->graph->getNumNodesMap(clientContext->getTx()), sourceNodeID,
             clientContext->getMemoryManager());
-        auto outputWriter = std::make_unique<DestinationsOutputWriter>(clientContext, output.get(), sharedState->getOutputNodeMaskMap());
+        auto outputWriter = std::make_unique<DestinationsOutputWriter>(clientContext, output.get(),
+            sharedState->getOutputNodeMaskMap());
         auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,
             clientContext->getMaxNumThreadForExec());
         auto edgeCompute = std::make_unique<SingleSPDestinationsEdgeCompute>(frontierPair.get());

--- a/src/function/gds/single_shortest_paths.cpp
+++ b/src/function/gds/single_shortest_paths.cpp
@@ -115,7 +115,7 @@ private:
         auto output = std::make_unique<SingleSPDestinationsOutputs>(
             sharedState->graph->getNumNodesMap(clientContext->getTx()), sourceNodeID,
             clientContext->getMemoryManager());
-        auto outputWriter = std::make_unique<DestinationsOutputWriter>(clientContext, output.get());
+        auto outputWriter = std::make_unique<DestinationsOutputWriter>(clientContext, output.get(), sharedState->getOutputNodeMaskMap());
         auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,
             clientContext->getMaxNumThreadForExec());
         auto edgeCompute = std::make_unique<SingleSPDestinationsEdgeCompute>(frontierPair.get());
@@ -151,7 +151,7 @@ private:
         auto writerInfo = rjBindData->getPathWriterInfo();
         writerInfo.pathNodeMask = sharedState->getPathNodeMaskMap();
         auto outputWriter = std::make_unique<SPPathsOutputWriter>(clientContext, output.get(),
-            std::move(writerInfo));
+            sharedState->getOutputNodeMaskMap(), std::move(writerInfo));
         auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,
             clientContext->getMaxNumThreadForExec());
         auto edgeCompute =

--- a/src/include/function/gds/gds.h
+++ b/src/include/function/gds/gds.h
@@ -32,6 +32,8 @@ struct GDSBindData {
 
     virtual std::shared_ptr<binder::Expression> getNodeInput() const { return nullptr; }
 
+    virtual bool hasNodeOutput() const { return false; }
+
     virtual std::shared_ptr<binder::Expression> getNodeOutput() const {
         KU_ASSERT(nodeOutput != nullptr);
         return nodeOutput;

--- a/src/include/function/gds/output_writer.h
+++ b/src/include/function/gds/output_writer.h
@@ -37,7 +37,6 @@ public:
         storage::MemoryManager* mm);
 
 public:
-    // TODO: I don't think
     std::shared_ptr<PathLengths> pathLengths;
 };
 
@@ -61,26 +60,28 @@ public:
 
 class RJOutputWriter {
 public:
-    RJOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs);
+    RJOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs,
+        processor::NodeOffsetMaskMap* outputNodeMask);
     virtual ~RJOutputWriter() = default;
 
-    void beginWritingForDstNodesInTable(common::table_id_t tableID) {
-        rjOutputs->beginWritingOutputsForDstNodesInTable(tableID);
-    }
+    void beginWritingForDstNodesInTable(common::table_id_t tableID);
 
-    virtual bool skipWriting(common::nodeID_t dstNodeID) const = 0;
+    bool skip(common::nodeID_t dstNodeID) const;
 
     virtual void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID) const = 0;
 
     virtual std::unique_ptr<RJOutputWriter> copy() = 0;
 
 protected:
+    virtual bool skipInternal(common::nodeID_t dstNodeID) const = 0;
     std::unique_ptr<common::ValueVector> createVector(const common::LogicalType& type,
         storage::MemoryManager* mm);
 
 protected:
     main::ClientContext* context;
     RJOutputs* rjOutputs;
+    processor::NodeOffsetMaskMap* outputNodeMask;
+
     std::unique_ptr<common::ValueVector> srcNodeIDVector;
     std::unique_ptr<common::ValueVector> dstNodeIDVector;
     std::vector<common::ValueVector*> vectors;
@@ -88,17 +89,17 @@ protected:
 
 class DestinationsOutputWriter : public RJOutputWriter {
 public:
-    DestinationsOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs);
+    DestinationsOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs,
+        processor::NodeOffsetMaskMap* outputNodeMask);
 
     void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID) const override;
 
-    bool skipWriting(common::nodeID_t dstNodeID) const override;
-
     std::unique_ptr<RJOutputWriter> copy() override {
-        return std::make_unique<DestinationsOutputWriter>(context, rjOutputs);
+        return std::make_unique<DestinationsOutputWriter>(context, rjOutputs, outputNodeMask);
     }
 
 protected:
+    bool skipInternal(common::nodeID_t dstNodeID) const override;
     virtual void writeMoreAndAppend(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID,
         uint16_t length) const;
 
@@ -124,7 +125,7 @@ struct PathsOutputWriterInfo {
 class PathsOutputWriter : public RJOutputWriter {
 public:
     PathsOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs,
-        PathsOutputWriterInfo info);
+        processor::NodeOffsetMaskMap* outputNodeMask, PathsOutputWriterInfo info);
 
     void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID) const override;
 
@@ -154,20 +155,21 @@ protected:
 class SPPathsOutputWriter : public PathsOutputWriter {
 public:
     SPPathsOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs,
-        PathsOutputWriterInfo info)
-        : PathsOutputWriter(context, rjOutputs, std::move(info)) {}
+        processor::NodeOffsetMaskMap* outputNodeMask, PathsOutputWriterInfo info)
+        : PathsOutputWriter{context, rjOutputs, outputNodeMask, std::move(info)} {}
 
-    bool skipWriting(common::nodeID_t dstNodeID) const override {
+    std::unique_ptr<RJOutputWriter> copy() override {
+        return std::make_unique<SPPathsOutputWriter>(context, rjOutputs, outputNodeMask, info);
+    }
+
+protected:
+    bool skipInternal(common::nodeID_t dstNodeID) const override {
         auto pathsOutputs = rjOutputs->ptrCast<PathsOutputs>();
         // For single/all shortest path computations, we do not output any results from source to
         // source. We also do not output any results if a destination node has not been reached.
         return dstNodeID == pathsOutputs->sourceNodeID ||
                nullptr == pathsOutputs->bfsGraph.getCurFixedParentPtrs()[dstNodeID.offset].load(
                               std::memory_order_relaxed);
-    }
-
-    std::unique_ptr<RJOutputWriter> copy() override {
-        return std::make_unique<SPPathsOutputWriter>(context, rjOutputs, info);
     }
 };
 

--- a/src/include/function/gds/rec_joins.h
+++ b/src/include/function/gds/rec_joins.h
@@ -48,6 +48,7 @@ struct RJBindData final : public GDSBindData {
 
     bool hasNodeInput() const override { return true; }
     std::shared_ptr<binder::Expression> getNodeInput() const override { return nodeInput; }
+    bool hasNodeOutput() const override { return true; }
 
     PathsOutputWriterInfo getPathWriterInfo() const;
 

--- a/src/include/optimizer/acc_hash_join_optimizer.h
+++ b/src/include/optimizer/acc_hash_join_optimizer.h
@@ -35,8 +35,10 @@ private:
     // most one match because rel table is scanned exactly once.
     std::vector<planner::LogicalOperator*> getRecursiveJoinCandidates(
         const binder::Expression& nodeID, planner::LogicalOperator* root);
-    std::vector<planner::LogicalOperator*> getGDSCallCandidates(const binder::Expression& nodeID,
-        planner::LogicalOperator* root);
+    std::vector<planner::LogicalOperator*> getGDSCallInputNodeCandidates(
+        const binder::Expression& nodeID, planner::LogicalOperator* root);
+    std::vector<planner::LogicalOperator*> getGDSCallOutputNodeCandidates(
+        const binder::Expression& nodeID, planner::LogicalOperator* root);
 };
 
 } // namespace optimizer

--- a/src/include/planner/operator/sip/logical_semi_masker.h
+++ b/src/include/planner/operator/sip/logical_semi_masker.h
@@ -28,6 +28,7 @@ enum class SemiMaskTargetType : uint8_t {
     RECURSIVE_JOIN_TARGET_NODE = 1,
     GDS_INPUT_NODE = 2,
     GDS_PATH_NODE = 3,
+    GDS_OUTPUT_NODE = 4,
 };
 
 class LogicalSemiMasker : public LogicalOperator {

--- a/src/processor/map/map_gds.cpp
+++ b/src/processor/map/map_gds.cpp
@@ -53,7 +53,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapGDSCall(LogicalOperator* logica
     }
     if (bindData->hasNodeOutput()) {
         auto& node = bindData->getNodeOutput()->constCast<NodeExpression>();
-        sharedState->setOutputNodeMask(getNodeOffsetMaskMap(clientContext, node.getTableIDs(), storageManager));
+        sharedState->setOutputNodeMask(
+            getNodeOffsetMaskMap(clientContext, node.getTableIDs(), storageManager));
     }
     auto printInfo = std::make_unique<GDSCallPrintInfo>(call.getInfo().func.name);
     auto gdsAlgorithm = call.getInfo().getGDS()->copy();

--- a/src/processor/map/map_gds.cpp
+++ b/src/processor/map/map_gds.cpp
@@ -29,9 +29,10 @@ static std::unique_ptr<NodeOffsetMaskMap> getNodeOffsetMaskMap(main::ClientConte
 
 std::unique_ptr<PhysicalOperator> PlanMapper::mapGDSCall(LogicalOperator* logicalOperator) {
     auto& call = logicalOperator->constCast<LogicalGDSCall>();
+    auto& logicalInfo = call.getInfo();
     auto outSchema = call.getSchema();
     auto tableSchema = std::make_unique<FactorizedTableSchema>();
-    auto columns = call.getInfo().outExprs;
+    auto columns = logicalInfo.outExprs;
     for (auto& expr : columns) {
         auto dataPos = getDataPos(*expr, *outSchema);
         auto columnSchema = ColumnSchema(false /* isUnFlat */, dataPos.dataChunkPos,
@@ -40,18 +41,20 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapGDSCall(LogicalOperator* logica
     }
     auto table =
         std::make_shared<FactorizedTable>(clientContext->getMemoryManager(), tableSchema->copy());
-    auto graph = std::make_unique<OnDiskGraph>(clientContext, call.getInfo().graphEntry);
+    auto graph = std::make_unique<OnDiskGraph>(clientContext, logicalInfo.graphEntry);
     auto storageManager = clientContext->getStorageManager();
     auto sharedState = std::make_shared<GDSCallSharedState>(table, std::move(graph));
     common::table_id_map_t<std::unique_ptr<NodeOffsetLevelSemiMask>> masks;
-    if (call.getInfo().getBindData()->hasNodeInput()) {
-        // Generate an empty semi mask which later on picked by SemiMaker.
-        auto& node =
-            call.getInfo().getBindData()->getNodeInput()->constCast<binder::NodeExpression>();
+    auto bindData = call.getInfo().getBindData();
+    if (bindData->hasNodeInput()) {
+        auto& node = bindData->getNodeInput()->constCast<NodeExpression>();
         sharedState->setInputNodeMask(
             getNodeOffsetMaskMap(clientContext, node.getTableIDs(), storageManager));
     }
-
+    if (bindData->hasNodeOutput()) {
+        auto& node = bindData->getNodeOutput()->constCast<NodeExpression>();
+        sharedState->setOutputNodeMask(getNodeOffsetMaskMap(clientContext, node.getTableIDs(), storageManager));
+    }
     auto printInfo = std::make_unique<GDSCallPrintInfo>(call.getInfo().func.name);
     auto gdsAlgorithm = call.getInfo().getGDS()->copy();
     auto descriptor = std::make_unique<ResultSetDescriptor>();

--- a/src/processor/map/map_semi_masker.cpp
+++ b/src/processor/map/map_semi_masker.cpp
@@ -44,10 +44,18 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapSemiMasker(LogicalOperator* log
             initMaskIdx(masksPerTable, recursiveJoin.getSemiMask());
         } break;
         case PhysicalOperatorType::TABLE_FUNCTION_CALL: {
-            KU_ASSERT(semiMasker.getTargetType() == SemiMaskTargetType::GDS_INPUT_NODE);
             KU_ASSERT(physicalOp->getChild(0)->getOperatorType() == PhysicalOperatorType::GDS_CALL);
             auto sharedState = physicalOp->getChild(0)->ptrCast<GDSCall>()->getSharedState();
-            initMaskIdx(masksPerTable, sharedState->getInputNodeMasks());
+            switch (semiMasker.getTargetType()) {
+            case SemiMaskTargetType::GDS_INPUT_NODE: {
+                initMaskIdx(masksPerTable, sharedState->getInputNodeMasks());
+            } break;
+            case SemiMaskTargetType::GDS_OUTPUT_NODE: {
+                initMaskIdx(masksPerTable, sharedState->getOutputNodeMasks());
+            } break;
+            default:
+                KU_UNREACHABLE;
+            }
         } break;
         case PhysicalOperatorType::GDS_CALL: {
             KU_ASSERT(semiMasker.getTargetType() == SemiMaskTargetType::GDS_PATH_NODE);


### PR DESCRIPTION
# Description

This PR pass a semi masker to GDS if the number of destination nodes is small. So we end up writing a much smaller intermediate result.

A quick sanity check benchmark. On LDBC10 person knows person
```
MATCH (a:Person)-[e:Knows* 1..4]->(b:Person) WHERE a.ID = 933 AND b.ID = 15393162795677 RETURN e;
```
Query time improves from 400ms -> 18ms

Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).