### PR TITLE
Revert unintentional change to maxThreads

### DIFF
--- a/test/include/test_helper/test_helper.h
+++ b/test/include/test_helper/test_helper.h
@@ -59,8 +59,7 @@ public:
             bufferPoolSizeEnv.empty() ?
                 common::BufferPoolConstants::DEFAULT_BUFFER_POOL_SIZE_FOR_TESTING :
                 std::stoull(bufferPoolSizeEnv);
-        systemConfig->maxNumThreads =
-            2; // maxNumThreadsEnv.empty() ? 2 : std::stoull(maxNumThreadsEnv);
+        systemConfig->maxNumThreads = maxNumThreadsEnv.empty() ? 2 : std::stoull(maxNumThreadsEnv);
         if (!enableCompressionEnv.empty()) {
             systemConfig->enableCompression = enableCompressionEnv == "true";
         }


### PR DESCRIPTION
Accidentally changed in a recent PR. This generally defaults to 2 anyway, and I think is only ever overridden manually; none of the jobs change it by default.