### PR TITLE
set canParallel for clear_warnings() to false

### DIFF
--- a/src/function/table/call/clear_warnings.cpp
+++ b/src/function/table/call/clear_warnings.cpp
@@ -18,8 +18,10 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* /*contex
 
 function_set ClearWarningsFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(std::make_unique<TableFunction>(name, tableFunc, bindFunc,
-        initSharedState, initEmptyLocalState, std::vector<LogicalTypeID>{}));
+    auto func = std::make_unique<TableFunction>(name, tableFunc, bindFunc, initSharedState,
+        initEmptyLocalState, std::vector<LogicalTypeID>{});
+    func->canParallelFunc = []() { return false; };
+    functionSet.push_back(std::move(func));
     return functionSet;
 }
 

--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -124,8 +124,13 @@ void parseAndRegisterTestGroup(const std::string& path, bool generateTestList = 
                 __FILE__, __LINE__,
                 [datasetType, dataset, bufferPoolSize, checkpointWaitTimeout, connNames,
                     testStatements = std::move(testStatements)]() mutable -> DBTest* {
+                    decltype(testStatements) testStatementsCopy;
+                    for (const auto& testStatement : testStatements) {
+                        testStatementsCopy.emplace_back(
+                            std::make_unique<TestStatement>(*testStatement));
+                    }
                     return new EndToEndTest(datasetType, dataset, bufferPoolSize,
-                        checkpointWaitTimeout, connNames, std::move(testStatements));
+                        checkpointWaitTimeout, connNames, std::move(testStatementsCopy));
                 });
         }
     } else {


### PR DESCRIPTION
# Description

Parallel calls to `WarningContext::clearPopulatedWarnings()` was causing spurious test crashes. Also modified test runner so that tests could be repeatedly run with `--gtest_repeat` (previously since we moved the test statements all test runs after the 1st would run on an empty vector of statements).

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).