### PR TITLE
Bug in Testing framework OK followed by EOF raise seg fault

### DIFF
--- a/test/include/test_runner/test_parser.h
+++ b/test/include/test_runner/test_parser.h
@@ -118,7 +118,6 @@ private:
     void replaceVariables(std::string& str) const;
     static void extractConnName(std::string& query, TestStatement* statement);
 
-    bool endOfFile() const { return fileStream.eof(); }
     void setCursorToPreviousLine() { fileStream.seekg(previousFilePosition); }
 
     bool nextLine() {

--- a/test/test_files/common/comment.test
+++ b/test/test_files/common/comment.test
@@ -1,4 +1,4 @@
--DATASET CSV empty
+-DATASET CSV tinysnb
 
 --
 
@@ -20,3 +20,10 @@
            RETURN 1;
 ---- 1
 1
+
+-CASE OkWithEOFTest
+
+-STATEMENT RETURN 5
+
+-STATEMENT CALL show_tables() RETURN *
+---- ok

--- a/test/test_files/common/okwitheof.test
+++ b/test/test_files/common/okwitheof.test
@@ -1,0 +1,9 @@
+-DATASET CSV tinysnb
+
+--
+
+-CASE OkWithEOFTest
+
+
+-STATEMENT CALL show_tables() RETURN *
+---- ok

--- a/test/test_files/common/okwitheof.test
+++ b/test/test_files/common/okwitheof.test
@@ -1,9 +1,0 @@
--DATASET CSV tinysnb
-
---
-
--CASE OkWithEOFTest
-
-
--STATEMENT CALL show_tables() RETURN *
----- ok

--- a/test/test_runner/test_parser.cpp
+++ b/test/test_runner/test_parser.cpp
@@ -226,9 +226,6 @@ std::string TestParser::extractTextBeforeNextStatement(bool ignoreLineBreak) {
 
 TestStatement* TestParser::extractStatement(TestStatement* statement,
     const std::string& testCaseName) {
-    if (endOfFile()) {
-        return statement;
-    }
     tokenize();
     switch (currentToken.type) {
     case TokenType::LOG: {


### PR DESCRIPTION
# Description

Bug raised in https://github.com/kuzudb/kuzu/issues/4432

Where in the testing framework, if the expected result is `----ok`, but the line wasn't followed by a newline, a segfault is raised. 

I think that this was because when `TestParser::extractStatement` is ran, the currentToken has already parsed the line `---- ok`, and is currently pointing to eof. Checking eof will return true, which returns without assigning the proper QueryResult to the statement class. (This is why the program is segfaulting - it was trying to access `statement->result[i]`, but `result` was an empty vector)

We haven't encountered this problem before because:
1. None of the tests ended with `----ok` as the last line
2. For testcases where the expected result was followed by lines of the expected value, our code has separate logic for dealing with the expected value. 

Removed eof checking within `extractStatement`, and added test covering the case described above.

**A potential bug discovered while debugging:**
I was trying to put cout statements / spdlog statements in `test_parser.cpp` to print out values of variables such as `query`, which interesting make the testing framework only run a subset of ~300 tests with the cout/spdlog statements. Is this a potential bug or is it to just protect variables from printing their value?

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).