### PR TITLE
Add shortest path early stop

### DIFF
--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -23,7 +23,7 @@ void FrontierTask::run() {
     while (sharedState->frontierPair.getNextRangeMorsel(frontierMorsel)) {
         while (frontierMorsel.hasNextOffset()) {
             common::nodeID_t nodeID = frontierMorsel.getNextNodeID();
-            if (sharedState->frontierPair.curFrontier->isActive(nodeID)) {
+            if (sharedState->frontierPair.curFrontier->isActive(nodeID.offset)) {
                 switch (info.direction) {
                 case ExtendDirection::FWD: {
                     for (auto chunk : graph->scanFwd(nodeID, *scanState)) {

--- a/src/function/gds/single_shortest_paths.cpp
+++ b/src/function/gds/single_shortest_paths.cpp
@@ -30,10 +30,10 @@ struct SingleSPDestinationsOutputs : public SPOutputs {
     }
 };
 
-class SingleSPDestinationsEdgeCompute : public EdgeCompute {
+class SingleSPDestinationsEdgeCompute : public SPEdgeCompute {
 public:
     explicit SingleSPDestinationsEdgeCompute(SinglePathLengthsFrontierPair* frontierPair)
-        : frontierPair{frontierPair} {};
+        : SPEdgeCompute{frontierPair} {};
 
     std::vector<nodeID_t> edgeCompute(common::nodeID_t, GraphScanState::Chunk& resultChunk,
         bool) override {
@@ -50,15 +50,12 @@ public:
     std::unique_ptr<EdgeCompute> copy() override {
         return std::make_unique<SingleSPDestinationsEdgeCompute>(frontierPair);
     }
-
-private:
-    SinglePathLengthsFrontierPair* frontierPair;
 };
 
-class SingleSPPathsEdgeCompute : public EdgeCompute {
+class SingleSPPathsEdgeCompute : public SPEdgeCompute {
 public:
     SingleSPPathsEdgeCompute(SinglePathLengthsFrontierPair* frontierPair, BFSGraph* bfsGraph)
-        : frontierPair{frontierPair}, bfsGraph{bfsGraph} {
+        : SPEdgeCompute{frontierPair}, bfsGraph{bfsGraph} {
         parentListBlock = bfsGraph->addNewBlock();
     }
 
@@ -86,7 +83,6 @@ public:
     }
 
 private:
-    SinglePathLengthsFrontierPair* frontierPair;
     BFSGraph* bfsGraph;
     ObjectBlock<ParentList>* parentListBlock = nullptr;
 };

--- a/src/include/common/mask.h
+++ b/src/include/common/mask.h
@@ -20,6 +20,8 @@ public:
 
     virtual bool isMasked(common::offset_t startNodeOffset) = 0;
 
+    virtual common::offset_t getNumMaskedNodes() = 0;
+
     // include&exclude
     virtual std::vector<common::offset_t> range(uint32_t start, uint32_t end) = 0;
 
@@ -48,6 +50,8 @@ public:
     bool isMasked(common::offset_t startNodeOffset) override {
         return roaring->contains(startNodeOffset);
     }
+
+    common::offset_t getNumMaskedNodes() override { return roaring->cardinality(); }
 
     // include&exclude
     std::vector<common::offset_t> range(uint32_t start, uint32_t end) override {
@@ -80,6 +84,8 @@ public:
     bool isMasked(common::offset_t startNodeOffset) override {
         return roaring->contains(startNodeOffset);
     }
+
+    common::offset_t getNumMaskedNodes() override { return roaring->cardinality(); }
 
     // include&exclude
     std::vector<common::offset_t> range(uint32_t start, uint32_t end) override {

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -5,8 +5,8 @@
 
 #include "common/types/types.h"
 #include "graph/graph.h"
-#include "storage/buffer_manager/memory_manager.h"
 #include "processor/operator/gds_call_shared_state.h"
+#include "storage/buffer_manager/memory_manager.h"
 
 namespace kuzu {
 namespace function {
@@ -30,9 +30,7 @@ public:
 
     virtual void resetSingleThreadState() {}
 
-    virtual bool terminate(processor::NodeOffsetMaskMap&) {
-        return false;
-    }
+    virtual bool terminate(processor::NodeOffsetMaskMap&) { return false; }
 
     virtual std::unique_ptr<EdgeCompute> copy() = 0;
 };
@@ -350,14 +348,13 @@ public:
 
     void resetSingleThreadState() override { numNodesReached = 0; }
 
-    bool terminate(processor::NodeOffsetMaskMap &maskMap) override;
+    bool terminate(processor::NodeOffsetMaskMap& maskMap) override;
 
 protected:
     SinglePathLengthsFrontierPair* frontierPair;
     // States that should be only modified with single thread
     common::offset_t numNodesReached;
 };
-
 
 } // namespace function
 } // namespace kuzu

--- a/src/include/function/gds/output_writer.h
+++ b/src/include/function/gds/output_writer.h
@@ -64,6 +64,8 @@ public:
         processor::NodeOffsetMaskMap* outputNodeMask);
     virtual ~RJOutputWriter() = default;
 
+    processor::NodeOffsetMaskMap* getOutputNodeMask() const { return outputNodeMask; }
+
     void beginWritingForDstNodesInTable(common::table_id_t tableID);
 
     bool skip(common::nodeID_t dstNodeID) const;

--- a/src/processor/map/map_semi_masker.cpp
+++ b/src/processor/map/map_semi_masker.cpp
@@ -49,9 +49,11 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapSemiMasker(LogicalOperator* log
             switch (semiMasker.getTargetType()) {
             case SemiMaskTargetType::GDS_INPUT_NODE: {
                 initMask(masksPerTable, sharedState->getInputNodeMasks());
+                sharedState->enableInputNodeMask();
             } break;
             case SemiMaskTargetType::GDS_OUTPUT_NODE: {
                 initMask(masksPerTable, sharedState->getOutputNodeMasks());
+                sharedState->enableOutputNodeMask();
             } break;
             default:
                 KU_UNREACHABLE;

--- a/src/processor/operator/gds_call_shared_state.cpp
+++ b/src/processor/operator/gds_call_shared_state.cpp
@@ -5,6 +5,15 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace processor {
 
+offset_t NodeOffsetMaskMap::getNumMaskedNode() const {
+    KU_ASSERT(enabled_);
+    offset_t numNodes = 0;
+    for (auto& [tableID, mask] : maskMap) {
+        numNodes += mask->getNumMaskedNodes();
+    }
+    return numNodes;
+}
+
 FactorizedTable* GDSCallSharedState::claimLocalTable(storage::MemoryManager* mm) {
     std::unique_lock<std::mutex> lck{mtx};
     if (availableLocalTables.empty()) {


### PR DESCRIPTION
# Description

See title.

As a sanity check, on live journal
```
MATCH (a:N)-[e*SHORTEST 1..5]->(b:N) WHERE a.id=56174 AND b.id=952528 RETURN b.id, length(e) AS x ORDER BY x;
```
This query drops from 180ms to 80ms.

Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).