### PR TITLE
Add GDS support for vertex property scanning

### DIFF
--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -14,7 +14,8 @@
 namespace kuzu {
 namespace common {
 
-ValueVector::ValueVector(LogicalType dataType, storage::MemoryManager* memoryManager)
+ValueVector::ValueVector(LogicalType dataType, storage::MemoryManager* memoryManager,
+    std::shared_ptr<DataChunkState> dataChunkState)
     : dataType{std::move(dataType)}, nullMask{DEFAULT_VECTOR_CAPACITY} {
     if (this->dataType.getLogicalTypeID() == LogicalTypeID::ANY) {
         // LCOV_EXCL_START
@@ -26,6 +27,9 @@ ValueVector::ValueVector(LogicalType dataType, storage::MemoryManager* memoryMan
     numBytesPerValue = getDataTypeSize(this->dataType);
     initializeValueBuffer();
     auxiliaryBuffer = AuxiliaryBufferFactory::getAuxiliaryBuffer(this->dataType, memoryManager);
+    if (dataChunkState) {
+        setState(std::move(dataChunkState));
+    }
 }
 
 void ValueVector::setState(const std::shared_ptr<DataChunkState>& state_) {

--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -150,7 +150,7 @@ public:
         PathMultiplicities* multiplicities)
         : SPEdgeCompute{frontierPair}, multiplicities{multiplicities} {};
 
-    std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, GraphScanState::Chunk& resultChunk,
+    std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, NbrScanState::Chunk& resultChunk,
         bool) override {
         std::vector<nodeID_t> activeNodes;
         resultChunk.forEach([&](auto nbrNodeID, auto /*edgeID*/) {
@@ -190,7 +190,7 @@ public:
         parentListBlock = bfsGraph->addNewBlock();
     }
 
-    std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, GraphScanState::Chunk& resultChunk,
+    std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, NbrScanState::Chunk& resultChunk,
         bool fwdEdge) override {
         std::vector<nodeID_t> activeNodes;
         resultChunk.forEach([&](auto nbrNodeID, auto edgeID) {

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -82,7 +82,7 @@ void GDSUtils::runVertexComputeIteration(processor::ExecutionContext* executionC
     auto maxThreads =
         clientContext->getCurrentSetting(main::ThreadsSetting::name).getValue<uint64_t>();
     auto info = VertexComputeTaskInfo(vc);
-    auto sharedState = std::make_shared<VertexComputeTaskSharedState>(maxThreads);
+    auto sharedState = std::make_shared<VertexComputeTaskSharedState>(maxThreads, graph);
     for (auto& tableID : graph->getNodeTableIDs()) {
         if (!vc.beginOnTable(tableID)) {
             continue;

--- a/src/function/gds/single_shortest_paths.cpp
+++ b/src/function/gds/single_shortest_paths.cpp
@@ -35,7 +35,7 @@ public:
     explicit SingleSPDestinationsEdgeCompute(SinglePathLengthsFrontierPair* frontierPair)
         : SPEdgeCompute{frontierPair} {};
 
-    std::vector<nodeID_t> edgeCompute(common::nodeID_t, GraphScanState::Chunk& resultChunk,
+    std::vector<nodeID_t> edgeCompute(common::nodeID_t, NbrScanState::Chunk& resultChunk,
         bool) override {
         std::vector<nodeID_t> activeNodes;
         resultChunk.forEach([&](auto nbrNode, auto) {
@@ -59,7 +59,7 @@ public:
         parentListBlock = bfsGraph->addNewBlock();
     }
 
-    std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, GraphScanState::Chunk& resultChunk,
+    std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, NbrScanState::Chunk& resultChunk,
         bool isFwd) override {
         std::vector<nodeID_t> activeNodes;
         resultChunk.forEach([&](auto nbrNodeID, auto edgeID) {

--- a/src/function/gds/variable_length_path.cpp
+++ b/src/function/gds/variable_length_path.cpp
@@ -51,7 +51,7 @@ struct VarLenJoinsEdgeCompute : public EdgeCompute {
         parentPtrsBlock = bfsGraph->addNewBlock();
     };
 
-    std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, graph::GraphScanState::Chunk& chunk,
+    std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, graph::NbrScanState::Chunk& chunk,
         bool isFwd) override {
         std::vector<nodeID_t> activeNodes;
         chunk.forEach([&](auto nbrNode, auto edgeID) {

--- a/src/function/gds/weakly_connected_components.cpp
+++ b/src/function/gds/weakly_connected_components.cpp
@@ -112,8 +112,7 @@ public:
     }
 
 private:
-    void findConnectedComponent(common::nodeID_t nodeID, int64_t groupID,
-        GraphScanState& scanState) {
+    void findConnectedComponent(common::nodeID_t nodeID, int64_t groupID, NbrScanState& scanState) {
         KU_ASSERT(!visitedMap.contains(nodeID));
         visitedMap.insert({nodeID, groupID});
         // Collect the nodes so that the recursive scan doesn't begin until this scan is done

--- a/src/include/common/vector/value_vector.h
+++ b/src/include/common/vector/value_vector.h
@@ -25,7 +25,8 @@ class KUZU_API ValueVector {
     friend class ArrowColumnVector;
 
 public:
-    explicit ValueVector(LogicalType dataType, storage::MemoryManager* memoryManager = nullptr);
+    explicit ValueVector(LogicalType dataType, storage::MemoryManager* memoryManager = nullptr,
+        std::shared_ptr<DataChunkState> dataChunkState = nullptr);
     explicit ValueVector(LogicalTypeID dataTypeID, storage::MemoryManager* memoryManager = nullptr)
         : ValueVector(LogicalType(dataTypeID), memoryManager) {
         KU_ASSERT(dataTypeID != LogicalTypeID::LIST);

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -26,7 +26,7 @@ public:
     // So if the implementing class has access to the next frontier as a field,
     // **do not** call setActive. Helper functions in GDSUtils will do that work.
     virtual std::vector<common::nodeID_t> edgeCompute(common::nodeID_t boundNodeID,
-        graph::GraphScanState::Chunk& results, bool fwdEdge) = 0;
+        graph::NbrScanState::Chunk& results, bool fwdEdge) = 0;
 
     virtual void resetSingleThreadState() {}
 
@@ -52,7 +52,7 @@ public:
     // GDSUtils helper functions call isActive on nodes to check if any work should be done for
     // the edges of a node. Instead, here GDSUtils helper functions for VertexCompute blindly run
     // the function on each node in a graph.
-    virtual void vertexCompute(common::nodeID_t curNodeID) = 0;
+    virtual void vertexCompute(const graph::VertexScanState::Chunk& chunk) = 0;
 
     virtual std::unique_ptr<VertexCompute> copy() = 0;
 };
@@ -66,6 +66,9 @@ public:
     bool hasNextOffset() const { return nextOffset < endOffsetExclusive; }
 
     common::nodeID_t getNextNodeID() { return {nextOffset++, tableID}; }
+
+    common::offset_t getBeginOffset() const { return beginOffset; }
+    common::offset_t getEndOffsetExclusive() const { return endOffsetExclusive; }
 
 protected:
     void initMorsel(common::table_id_t _tableID, common::offset_t _beginOffset,
@@ -96,6 +99,8 @@ public:
     void init(common::table_id_t _tableID, common::offset_t _numOffsets);
 
     bool getNextRangeMorsel(FrontierMorsel& frontierMorsel);
+
+    common::table_id_t getTableID() const { return tableID; }
 
 private:
     std::atomic<uint64_t> maxThreadsForExec;

--- a/src/include/function/gds/gds_task.h
+++ b/src/include/function/gds/gds_task.h
@@ -44,9 +44,10 @@ private:
 
 struct VertexComputeTaskSharedState {
     FrontierMorselDispatcher morselDispatcher;
+    graph::Graph* graph;
 
-    explicit VertexComputeTaskSharedState(uint64_t maxThreadsForExecution)
-        : morselDispatcher{maxThreadsForExecution} {}
+    explicit VertexComputeTaskSharedState(uint64_t maxThreadsForExecution, graph::Graph* graph)
+        : morselDispatcher{maxThreadsForExecution}, graph{graph} {}
 };
 
 struct VertexComputeTaskInfo {

--- a/src/include/storage/store/column_chunk_data.h
+++ b/src/include/storage/store/column_chunk_data.h
@@ -64,17 +64,6 @@ struct ChunkState {
         return childrenStates[childIdx];
     }
 
-    void resetState() {
-        numValuesPerPage = UINT64_MAX;
-        metadata = ColumnChunkMetadata{};
-        if (nullState) {
-            nullState->resetState();
-        }
-        for (auto& childState : childrenStates) {
-            childState.resetState();
-        }
-    }
-
     template<std::floating_point T>
     InMemoryExceptionChunk<T>* getExceptionChunk() {
         using GetType = std::unique_ptr<InMemoryExceptionChunk<T>>;

--- a/src/include/storage/store/csr_node_group.h
+++ b/src/include/storage/store/csr_node_group.h
@@ -127,34 +127,22 @@ struct CSRNodeGroupScanState final : NodeGroupScanState {
     common::row_idx_t nextCachedRowToScan;
 
     // States at the csr list level. Cached during scan over a single csr list.
-    common::row_idx_t nextRowToScan;
     NodeCSRIndex inMemCSRList;
 
     CSRNodeGroupScanSource source;
 
     explicit CSRNodeGroupScanState(common::idx_t numChunks)
         : NodeGroupScanState{numChunks}, header{nullptr}, numTotalRows{0}, numCachedRows{0},
-          nextCachedRowToScan{0}, nextRowToScan{0},
-          source{CSRNodeGroupScanSource::COMMITTED_PERSISTENT} {}
+          nextCachedRowToScan{0}, source{CSRNodeGroupScanSource::COMMITTED_PERSISTENT} {}
     CSRNodeGroupScanState(MemoryManager& mm, common::idx_t numChunks)
         : NodeGroupScanState{numChunks}, numTotalRows{0}, numCachedRows{0}, nextCachedRowToScan{0},
-          nextRowToScan{0}, source{CSRNodeGroupScanSource::COMMITTED_PERSISTENT} {
+          source{CSRNodeGroupScanSource::COMMITTED_PERSISTENT} {
         header = std::make_unique<ChunkedCSRHeader>(mm, false,
             common::StorageConstants::NODE_GROUP_SIZE, ResidencyState::IN_MEMORY);
         cachedScannedVectorsSelBitset.set();
     }
 
     bool tryScanCachedTuples(RelTableScanState& tableScanState);
-
-    void resetState() override {
-        NodeGroupScanState::resetState();
-        numTotalRows = 0;
-        numCachedRows = 0;
-        nextCachedRowToScan = 0;
-        nextRowToScan = 0;
-        inMemCSRList = NodeCSRIndex{};
-        source = CSRNodeGroupScanSource::COMMITTED_PERSISTENT;
-    }
 };
 
 struct CSRNodeGroupCheckpointState final : NodeGroupCheckpointState {

--- a/src/include/storage/store/rel_table.h
+++ b/src/include/storage/store/rel_table.h
@@ -50,11 +50,6 @@ struct RelTableScanState : TableScanState {
 
     bool scanNext(transaction::Transaction* transaction) override;
 
-    void resetState() override {
-        TableScanState::resetState();
-        currBoundNodeIdx = 0;
-    }
-
     void setNodeIDVectorToFlat(common::sel_t selPos) const;
 
 private:

--- a/src/main/storage_driver.cpp
+++ b/src/main/storage_driver.cpp
@@ -128,12 +128,10 @@ uint64_t StorageDriver::getNumRels(const std::string& relName) {
 void StorageDriver::scanColumn(storage::Table* table, column_id_t columnID, offset_t* offsets,
     size_t size, uint8_t* result) {
     // Create scan state.
-    auto columnIDs = std::vector<column_id_t>{columnID};
     auto nodeTable = table->ptrCast<NodeTable>();
     auto column = &nodeTable->getColumn(columnID);
-    std::vector<const Column*> columns;
-    columns.push_back(column);
-    auto scanState = std::make_unique<NodeTableScanState>(table->getTableID(), columnIDs, columns);
+    auto scanState = std::make_unique<NodeTableScanState>(table->getTableID(),
+        std::vector<column_id_t>{columnID}, std::vector<const Column*>{column});
     // Create value vectors
     auto idVector = std::make_unique<ValueVector>(LogicalType::INTERNAL_ID());
     auto columnVector = std::make_unique<ValueVector>(column->getDataType().copy(),

--- a/src/processor/operator/scan/offset_scan_node_table.cpp
+++ b/src/processor/operator/scan/offset_scan_node_table.cpp
@@ -34,15 +34,8 @@ bool OffsetScanNodeTable::getNextTuplesInternal(ExecutionContext* context) {
     auto nodeID = nodeIDVector->getValue<nodeID_t>(0);
     KU_ASSERT(tableIDToNodeInfo.contains(nodeID.tableID));
     auto& nodeInfo = tableIDToNodeInfo.at(nodeID.tableID);
-    if (transaction->isUnCommitted(nodeID.tableID, nodeID.offset)) {
-        nodeInfo.localScanState->source = TableScanSource::UNCOMMITTED;
-        nodeInfo.localScanState->nodeGroupIdx = StorageUtils::getNodeGroupIdx(
-            transaction->getLocalRowIdx(nodeID.tableID, nodeID.offset));
-    } else {
-        nodeInfo.localScanState->source = TableScanSource::COMMITTED;
-        nodeInfo.localScanState->nodeGroupIdx = StorageUtils::getNodeGroupIdx(nodeID.offset);
-    }
-    nodeInfo.table->initScanState(transaction, *nodeInfo.localScanState);
+    nodeInfo.table->initScanState(transaction, *nodeInfo.localScanState, nodeID.tableID,
+        nodeID.offset);
     if (!nodeInfo.table->lookup(transaction, *nodeInfo.localScanState)) {
         // LCOV_EXCL_START
         throw RuntimeException(stringFormat("Cannot perform lookup on {}. This should not happen.",

--- a/src/processor/operator/scan/primary_key_scan_node_table.cpp
+++ b/src/processor/operator/scan/primary_key_scan_node_table.cpp
@@ -79,15 +79,8 @@ bool PrimaryKeyScanNodeTable::getNextTuplesInternal(ExecutionContext* context) {
     }
     auto nodeID = nodeID_t{nodeOffset, nodeInfo.table->getTableID()};
     nodeInfo.localScanState->nodeIDVector->setValue<nodeID_t>(pos, nodeID);
-    if (transaction->isUnCommitted(nodeID.tableID, nodeOffset)) {
-        nodeInfo.localScanState->source = TableScanSource::UNCOMMITTED;
-        nodeInfo.localScanState->nodeGroupIdx =
-            StorageUtils::getNodeGroupIdx(transaction->getLocalRowIdx(nodeID.tableID, nodeOffset));
-    } else {
-        nodeInfo.localScanState->source = TableScanSource::COMMITTED;
-        nodeInfo.localScanState->nodeGroupIdx = StorageUtils::getNodeGroupIdx(nodeOffset);
-    }
-    nodeInfo.table->initScanState(transaction, *nodeInfo.localScanState);
+    nodeInfo.table->initScanState(transaction, *nodeInfo.localScanState, nodeID.tableID,
+        nodeOffset);
     metrics->numOutputTuple.incrementByOne();
     return nodeInfo.table->lookup(transaction, *nodeInfo.localScanState);
 }

--- a/src/storage/store/csr_node_group.cpp
+++ b/src/storage/store/csr_node_group.cpp
@@ -22,15 +22,15 @@ bool CSRNodeGroupScanState::tryScanCachedTuples(RelTableScanState& tableScanStat
     const auto startCSROffset = header->getStartCSROffset(boundNodeOffsetInGroup);
     const auto csrLength = header->getCSRLength(boundNodeOffsetInGroup);
     nextCachedRowToScan = std::max(nextCachedRowToScan, startCSROffset);
-    if (nextCachedRowToScan >= numScannedRows ||
-        nextCachedRowToScan < numScannedRows - numCachedRows) {
+    if (nextCachedRowToScan >= nextRowToScan ||
+        nextCachedRowToScan < nextRowToScan - numCachedRows) {
         // Out of the bound of cached rows.
         return false;
     }
-    KU_ASSERT(nextCachedRowToScan >= numScannedRows - numCachedRows);
+    KU_ASSERT(nextCachedRowToScan >= nextRowToScan - numCachedRows);
     const auto numRowsToScan =
-        std::min(numScannedRows, startCSROffset + csrLength) - nextCachedRowToScan;
-    const auto startCachedRow = nextCachedRowToScan - (numScannedRows - numCachedRows);
+        std::min(nextRowToScan, startCSROffset + csrLength) - nextCachedRowToScan;
+    const auto startCachedRow = nextCachedRowToScan - (nextRowToScan - numCachedRows);
     auto numSelected = 0u;
     tableScanState.outState->getSelVectorUnsafe().setToFiltered();
     for (auto i = 0u; i < numRowsToScan; i++) {
@@ -54,7 +54,6 @@ void CSRNodeGroup::initializeScanState(Transaction* transaction, TableScanState&
     KU_ASSERT(relScanState.nodeGroupScanState);
     auto& nodeGroupScanState = relScanState.nodeGroupScanState->cast<CSRNodeGroupScanState>();
     if (relScanState.nodeGroupIdx != nodeGroupIdx) {
-        relScanState.nodeGroupScanState->resetState();
         relScanState.nodeGroupIdx = nodeGroupIdx;
         if (persistentChunkGroup) {
             initScanForCommittedPersistent(transaction, relScanState, nodeGroupScanState);
@@ -62,15 +61,14 @@ void CSRNodeGroup::initializeScanState(Transaction* transaction, TableScanState&
     }
     // Switch to a new Vector of bound nodes (i.e., new csr lists) in the node group.
     if (persistentChunkGroup) {
-        nodeGroupScanState.numScannedRows = 0;
-        nodeGroupScanState.numCachedRows = 0;
         nodeGroupScanState.nextRowToScan = 0;
+        nodeGroupScanState.numCachedRows = 0;
         nodeGroupScanState.source = CSRNodeGroupScanSource::COMMITTED_PERSISTENT;
     } else if (csrIndex) {
         initScanForCommittedInMem(relScanState, nodeGroupScanState);
     } else {
         nodeGroupScanState.source = CSRNodeGroupScanSource::NONE;
-        nodeGroupScanState.numScannedRows = 0;
+        nodeGroupScanState.nextRowToScan = 0;
     }
 }
 
@@ -106,9 +104,8 @@ void CSRNodeGroup::initScanForCommittedInMem(RelTableScanState& relScanState,
     CSRNodeGroupScanState& nodeGroupScanState) const {
     relScanState.currBoundNodeIdx = 0;
     nodeGroupScanState.source = CSRNodeGroupScanSource::COMMITTED_IN_MEMORY;
-    nodeGroupScanState.numScannedRows = 0;
-    nodeGroupScanState.numCachedRows = 0;
     nodeGroupScanState.nextRowToScan = 0;
+    nodeGroupScanState.numCachedRows = 0;
     nodeGroupScanState.inMemCSRList.clear();
 }
 
@@ -160,11 +157,11 @@ NodeGroupScanResult CSRNodeGroup::scanCommittedPersistentWithCache(const Transac
         while (nodeGroupScanState.tryScanCachedTuples(tableState)) {
             if (tableState.outState->getSelVector().getSelSize() > 0) {
                 // Note: This is a dummy return value.
-                return NodeGroupScanResult{nodeGroupScanState.numScannedRows,
+                return NodeGroupScanResult{nodeGroupScanState.nextRowToScan,
                     tableState.outState->getSelVector().getSelSize()};
             }
         }
-        if (nodeGroupScanState.numScannedRows == nodeGroupScanState.numTotalRows ||
+        if (nodeGroupScanState.nextRowToScan == nodeGroupScanState.numTotalRows ||
             tableState.currBoundNodeIdx >= tableState.cachedBoundNodeSelVector.getSelSize()) {
             return NODE_GROUP_SCAN_EMMPTY_RESULT;
         }
@@ -172,17 +169,17 @@ NodeGroupScanResult CSRNodeGroup::scanCommittedPersistentWithCache(const Transac
             tableState.cachedBoundNodeSelVector[tableState.currBoundNodeIdx]);
         const auto offsetInGroup = currNodeOffset % StorageConstants::NODE_GROUP_SIZE;
         const auto startCSROffset = nodeGroupScanState.header->getStartCSROffset(offsetInGroup);
-        if (startCSROffset > nodeGroupScanState.numScannedRows) {
-            nodeGroupScanState.numScannedRows = startCSROffset;
+        if (startCSROffset > nodeGroupScanState.nextRowToScan) {
+            nodeGroupScanState.nextRowToScan = startCSROffset;
         }
-        KU_ASSERT(nodeGroupScanState.numScannedRows <= nodeGroupScanState.numTotalRows);
+        KU_ASSERT(nodeGroupScanState.nextRowToScan <= nodeGroupScanState.numTotalRows);
         const auto numToScan =
-            std::min(nodeGroupScanState.numTotalRows - nodeGroupScanState.numScannedRows,
+            std::min(nodeGroupScanState.numTotalRows - nodeGroupScanState.nextRowToScan,
                 DEFAULT_VECTOR_CAPACITY);
         persistentChunkGroup->scan(transaction, tableState, nodeGroupScanState,
-            nodeGroupScanState.numScannedRows, numToScan);
+            nodeGroupScanState.nextRowToScan, numToScan);
         nodeGroupScanState.numCachedRows = numToScan;
-        nodeGroupScanState.numScannedRows += numToScan;
+        nodeGroupScanState.nextRowToScan += numToScan;
         if (tableState.outState->getSelVector().isUnfiltered()) {
             nodeGroupScanState.cachedScannedVectorsSelBitset.set();
         } else {

--- a/src/storage/store/table.cpp
+++ b/src/storage/store/table.cpp
@@ -60,11 +60,11 @@ void Table::serialize(Serializer& serializer) const {
     serializer.write<table_id_t>(tableID);
 }
 
-std::unique_ptr<DataChunk> Table::constructDataChunk(const std::vector<LogicalType>& types) {
-    auto dataChunk = std::make_unique<DataChunk>(types.size());
+DataChunk Table::constructDataChunk(std::vector<LogicalType> types) const {
+    DataChunk dataChunk(types.size());
     for (auto i = 0u; i < types.size(); i++) {
-        auto valueVector = std::make_unique<ValueVector>(types[i].copy(), memoryManager);
-        dataChunk->insert(i, std::move(valueVector));
+        auto valueVector = std::make_unique<ValueVector>(std::move(types[i]), memoryManager);
+        dataChunk.insert(i, std::move(valueVector));
     }
     return dataChunk;
 }


### PR DESCRIPTION
I think the new `NodeGroup::scan` function may still be buggy. I have attempted to merge the two implementations, but have encountered issues with the result.

I renamed `NodeGroupScanState::numScannedRows` to `nextRowToScan` since they are functionally equivalent and nothing was ever using `numScannedRows` as a size, just as an indication of the next row to scan. There was also a field called `nextRowToScan` already in `CSRNodeGroupScanState`, so that was just removed and the other field is now used in its place.