### PR TITLE
Fix primary key scan not working

### DIFF
--- a/src/include/common/mask.h
+++ b/src/include/common/mask.h
@@ -20,12 +20,10 @@ public:
 
     virtual bool isMasked(common::offset_t startNodeOffset) = 0;
 
-    virtual common::offset_t getNumMaskedNodes() = 0;
-
     // include&exclude
     virtual std::vector<common::offset_t> range(uint32_t start, uint32_t end) = 0;
 
-    virtual uint64_t size() const = 0;
+    virtual uint64_t getNumMaskedNodes() const = 0;
 
     common::table_id_t getTableID() const { return tableID; }
     common::offset_t getMaxOffset() const { return maxOffset; }
@@ -51,7 +49,7 @@ public:
         return roaring->contains(startNodeOffset);
     }
 
-    common::offset_t getNumMaskedNodes() override { return roaring->cardinality(); }
+    uint64_t getNumMaskedNodes() const override { return roaring->cardinality(); }
 
     // include&exclude
     std::vector<common::offset_t> range(uint32_t start, uint32_t end) override {
@@ -68,8 +66,6 @@ public:
         return ans;
     };
 
-    uint64_t size() const override { return roaring->cardinality(); }
-
     std::shared_ptr<roaring::Roaring> roaring;
 };
 
@@ -85,7 +81,7 @@ public:
         return roaring->contains(startNodeOffset);
     }
 
-    common::offset_t getNumMaskedNodes() override { return roaring->cardinality(); }
+    uint64_t getNumMaskedNodes() const override { return roaring->cardinality(); }
 
     // include&exclude
     std::vector<common::offset_t> range(uint32_t start, uint32_t end) override {
@@ -101,8 +97,6 @@ public:
         }
         return ans;
     };
-
-    uint64_t size() const override { return roaring->cardinality(); }
 
     std::shared_ptr<roaring::Roaring64Map> roaring;
 };

--- a/src/include/optimizer/filter_push_down_optimizer.h
+++ b/src/include/optimizer/filter_push_down_optimizer.h
@@ -81,6 +81,9 @@ private:
         std::shared_ptr<binder::Expression> predicate,
         std::shared_ptr<planner::LogicalOperator> child);
 
+    std::shared_ptr<planner::LogicalOperator> visitChildren(
+        const std::shared_ptr<planner::LogicalOperator>& op);
+
 private:
     PredicateSet predicateSet;
     main::ClientContext* context;

--- a/src/processor/operator/semi_masker.cpp
+++ b/src/processor/operator/semi_masker.cpp
@@ -90,7 +90,7 @@ bool PathSingleTableSemiMasker::getNextTuplesInternal(ExecutionContext* context)
             }
         }
     }
-    metrics->numOutputTuple.increase(masker->size());
+    metrics->numOutputTuple.increase(masker->getNumMaskedNodes());
     return true;
 }
 
@@ -115,7 +115,7 @@ bool PathMultipleTableSemiMasker::getNextTuplesInternal(ExecutionContext* contex
     }
     uint64_t num = 0;
     for (const auto& [_, masker] : localInfo->localMasksPerTable) {
-        num += masker->size();
+        num += masker->getNumMaskedNodes();
     }
     metrics->numOutputTuple.increase(num);
     return true;

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -104,5 +104,11 @@ TEST_F(OptimizerTest, RemoveUnnecessaryJoinTest) {
     ASSERT_STREQ(getEncodedPlan(q1).c_str(), "E(b)S(a)");
 }
 
+TEST_F(OptimizerTest, PkScanTest) {
+    auto q1 = "MATCH (a:person {ID:24189255811663})-[f]->(b) RETURN b;";
+    auto ans = getEncodedPlan(q1);
+    ASSERT_STREQ(ans.c_str(), "HJ(b._ID){S(b)}{E(b)IndexScan(a)}");
+}
+
 } // namespace testing
 } // namespace kuzu


### PR DESCRIPTION
# Description

This enables index scan on Scan of node table as child of Extend.

An example query:

`MATCH (p1:person)-[e:knows]->(b:person) WHERE p1.ID=1 RETURN *;`

The optimizer will turn SCAN(p1) into INDEX_SCAN(p1).

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).