### PR TITLE
Add filter pushdown with extend

### DIFF
--- a/src/include/optimizer/filter_push_down_optimizer.h
+++ b/src/include/optimizer/filter_push_down_optimizer.h
@@ -74,9 +74,6 @@ private:
         const binder::expression_vector& predicates,
         std::shared_ptr<planner::LogicalOperator> child);
 
-    std::shared_ptr<planner::LogicalOperator> appendScanNodeTable(
-        std::shared_ptr<binder::Expression> nodeID, std::vector<common::table_id_t> nodeTableIDs,
-        binder::expression_vector properties, std::shared_ptr<planner::LogicalOperator> child);
     std::shared_ptr<planner::LogicalOperator> appendFilter(
         std::shared_ptr<binder::Expression> predicate,
         std::shared_ptr<planner::LogicalOperator> child);


### PR DESCRIPTION
# Description

This enables index scan on Scan of node table as chid of Extend.

An example query:
```
MATCH (p1:person)-[e:knows]->(b:person) WHERE p1.ID=1 RETURN *;
```
The optimizer will turn `SCAN(p1)` into `INDEX_SCAN(p1)`.