### PR TITLE
Fix rollback during Node Table COPY

### DIFF
--- a/scripts/headers.txt
+++ b/scripts/headers.txt
@@ -71,6 +71,5 @@ src/include/processor/result/flat_tuple.h
 src/include/processor/warning_context.h
 src/include/processor/operator/persistent/reader/copy_from_error.h
 src/include/storage/storage_version_info.h
-src/include/storage/enums/csr_node_group_scan_source.h
 src/include/transaction/transaction.h
 src/include/transaction/transaction_context.h

--- a/scripts/headers.txt
+++ b/scripts/headers.txt
@@ -71,5 +71,6 @@ src/include/processor/result/flat_tuple.h
 src/include/processor/warning_context.h
 src/include/processor/operator/persistent/reader/copy_from_error.h
 src/include/storage/storage_version_info.h
+src/include/storage/enums/csr_node_group_scan_source.h
 src/include/transaction/transaction.h
 src/include/transaction/transaction_context.h

--- a/src/include/common/mask.h
+++ b/src/include/common/mask.h
@@ -17,6 +17,7 @@ public:
     virtual ~RoaringBitmapSemiMask() = default;
 
     virtual void mask(common::offset_t nodeOffset) = 0;
+    virtual void maskRange(common::offset_t startNodeOffset, common::offset_t endNodeOffset) = 0;
 
     virtual bool isMasked(common::offset_t startNodeOffset) = 0;
 
@@ -44,6 +45,9 @@ public:
     }
 
     void mask(common::offset_t nodeOffset) override { roaring->add(nodeOffset); }
+    void maskRange(common::offset_t startNodeOffset, common::offset_t endNodeOffset) override {
+        roaring->addRange(startNodeOffset, endNodeOffset);
+    }
 
     bool isMasked(common::offset_t startNodeOffset) override {
         return roaring->contains(startNodeOffset);
@@ -76,6 +80,9 @@ public:
           roaring(std::make_shared<roaring::Roaring64Map>()) {}
 
     void mask(common::offset_t nodeOffset) override { roaring->add(nodeOffset); }
+    void maskRange(common::offset_t startNodeOffset, common::offset_t endNodeOffset) override {
+        roaring->addRange(startNodeOffset, endNodeOffset);
+    }
 
     bool isMasked(common::offset_t startNodeOffset) override {
         return roaring->contains(startNodeOffset);

--- a/src/include/main/database.h
+++ b/src/include/main/database.h
@@ -142,8 +142,8 @@ private:
     void initMembers(std::string_view dbPath, construct_bm_func_t initBmFunc = initBufferManager);
 
     // factory method only to be used for tests
-    static std::unique_ptr<Database> construct(std::string_view databasePath,
-        SystemConfig systemConfig, construct_bm_func_t constructFunc);
+    Database(std::string_view databasePath, SystemConfig systemConfig,
+        construct_bm_func_t constructBMFunc);
 
     void openLockFile();
     void initAndLockDBDir();

--- a/src/include/storage/buffer_manager/buffer_manager.h
+++ b/src/include/storage/buffer_manager/buffer_manager.h
@@ -20,8 +20,9 @@ namespace common {
 class VirtualFileSystem;
 };
 namespace testing {
-class EmptyBufferManagerTest;
-};
+class FlakyBufferManager;
+class CopyTestHelper;
+}; // namespace testing
 namespace storage {
 class ChunkedNodeGroup;
 class Spiller;
@@ -179,6 +180,9 @@ private:
  * https://github.com/fabubaker/kuzu/blob/umbra-bm/final_project_report.pdf.
  */
 class BufferManager {
+    friend class testing::FlakyBufferManager;
+    friend class testing::CopyTestHelper;
+
     friend class FileHandle;
     friend class MemoryManager;
 

--- a/src/include/storage/enums/csr_node_group_scan_source.h
+++ b/src/include/storage/enums/csr_node_group_scan_source.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+
+namespace kuzu::storage {
+enum class CSRNodeGroupScanSource : uint8_t {
+    COMMITTED_PERSISTENT = 0,
+    COMMITTED_IN_MEMORY = 1,
+    UNCOMMITTED = 2,
+    NONE = 10
+};
+} // namespace kuzu::storage

--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -343,7 +343,7 @@ public:
         KU_ASSERT(keyDataTypeID == common::TypeUtils::getPhysicalTypeIDForType<T>());
         return getTypedHashIndex(key)->insertInternal(transaction, key, value, isVisible);
     }
-    bool insert(const transaction::Transaction* transaction, common::ValueVector* keyVector,
+    bool insert(const transaction::Transaction* transaction, const common::ValueVector* keyVector,
         uint64_t vectorPos, common::offset_t value, visible_func isVisible);
 
     // Appends the buffer to the index. Returns the number of values successfully inserted.

--- a/src/include/storage/index/in_mem_hash_index.h
+++ b/src/include/storage/index/in_mem_hash_index.h
@@ -188,6 +188,11 @@ public:
             } else {
                 iter.slot->header.setEntryInvalid(*deletedPos);
             }
+
+            if (newIter.slot->header.numEntries() == 0) {
+                reclaimOverflowSlots(SlotIterator(slotId, this));
+            }
+
             return true;
         }
         return false;
@@ -196,18 +201,9 @@ public:
 private:
     SlotIterator getLastValidEntry(const SlotIterator& startIter) {
         auto curIter = startIter;
-        auto newIter = startIter;
-        while (nextChainedSlot(curIter)) {
-            if (curIter.slotInfo.slotId == SlotHeader::INVALID_OVERFLOW_SLOT_ID) {
-                break;
-            }
-            if (curIter.slot->header.numEntries() == 0) {
-                // if the current overflow slot is empty if last valid entry is in the previous slot
-                break;
-            }
-            newIter = curIter;
-        }
-        return newIter;
+        while (curIter.slot->header.nextOvfSlotId != SlotHeader::INVALID_OVERFLOW_SLOT_ID &&
+               nextChainedSlot(curIter)) {}
+        return curIter;
     }
 
     // Assumes that space has already been allocated for the entry

--- a/src/include/storage/store/chunked_group_undo_iterator.h
+++ b/src/include/storage/store/chunked_group_undo_iterator.h
@@ -18,9 +18,8 @@ class ChunkedGroupUndoIterator;
 using chunked_group_undo_op_t = void (
     ChunkedNodeGroup::*)(common::row_idx_t, common::row_idx_t, common::transaction_t);
 
-using chunked_group_iterator_construct_t =
-    std::function<std::unique_ptr<ChunkedGroupUndoIterator>(common::row_idx_t, common::row_idx_t,
-        common::node_group_idx_t, common::transaction_t commitTS)>;
+using chunked_group_iterator_construct_t = std::function<std::unique_ptr<ChunkedGroupUndoIterator>(
+    common::row_idx_t, common::row_idx_t, common::node_group_idx_t, common::transaction_t)>;
 
 // Note: these iterators are not necessarily thread-safe when used on their own
 class ChunkedGroupUndoIterator {

--- a/src/include/storage/store/chunked_group_undo_iterator.h
+++ b/src/include/storage/store/chunked_group_undo_iterator.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <functional>
+
+#include "common/types/types.h"
+
+namespace kuzu {
+
+namespace transaction {
+class Transaction;
+}
+
+namespace storage {
+class ChunkedNodeGroup;
+class NodeGroupCollection;
+class ChunkedGroupUndoIterator;
+
+using chunked_group_undo_op_t = void (
+    ChunkedNodeGroup::*)(common::row_idx_t, common::row_idx_t, common::transaction_t);
+
+using chunked_group_iterator_construct_t =
+    std::function<std::unique_ptr<ChunkedGroupUndoIterator>(common::row_idx_t, common::row_idx_t,
+        common::node_group_idx_t, common::transaction_t commitTS)>;
+
+// Note: these iterators are not necessarily thread-safe when used on their own
+class ChunkedGroupUndoIterator {
+public:
+    ChunkedGroupUndoIterator(NodeGroupCollection* nodeGroups, common::row_idx_t startRow,
+        common::row_idx_t numRows, common::transaction_t commitTS)
+        : startRow(startRow), numRows(numRows), commitTS(commitTS), nodeGroups(nodeGroups) {}
+
+    virtual ~ChunkedGroupUndoIterator() = default;
+
+    virtual void initRollbackInsert(const transaction::Transaction* /*transaction*/) {}
+    virtual void finalizeRollbackInsert() {};
+    virtual void iterate(chunked_group_undo_op_t undoFunc) = 0;
+
+protected:
+    common::row_idx_t startRow;
+    common::row_idx_t numRows;
+    common::transaction_t commitTS;
+
+    NodeGroupCollection* nodeGroups;
+};
+
+} // namespace storage
+} // namespace kuzu

--- a/src/include/storage/store/chunked_group_undo_iterator.h
+++ b/src/include/storage/store/chunked_group_undo_iterator.h
@@ -13,26 +13,26 @@ class Transaction;
 namespace storage {
 class ChunkedNodeGroup;
 class NodeGroupCollection;
-class ChunkedGroupUndoIterator;
+class VersionRecordHandler;
 
-using chunked_group_undo_op_t = void (
+using version_record_handler_op_t = void (
     ChunkedNodeGroup::*)(common::row_idx_t, common::row_idx_t, common::transaction_t);
 
-using chunked_group_iterator_construct_t = std::function<std::unique_ptr<ChunkedGroupUndoIterator>(
+using version_record_handler_construct_t = std::function<std::unique_ptr<VersionRecordHandler>(
     common::row_idx_t, common::row_idx_t, common::node_group_idx_t, common::transaction_t)>;
 
 // Note: these iterators are not necessarily thread-safe when used on their own
-class ChunkedGroupUndoIterator {
+class VersionRecordHandler {
 public:
-    ChunkedGroupUndoIterator(NodeGroupCollection* nodeGroups, common::row_idx_t startRow,
+    VersionRecordHandler(NodeGroupCollection* nodeGroups, common::row_idx_t startRow,
         common::row_idx_t numRows, common::transaction_t commitTS)
         : startRow(startRow), numRows(numRows), commitTS(commitTS), nodeGroups(nodeGroups) {}
 
-    virtual ~ChunkedGroupUndoIterator() = default;
+    virtual ~VersionRecordHandler() = default;
 
     virtual void initRollbackInsert(const transaction::Transaction* /*transaction*/) {}
-    virtual void finalizeRollbackInsert() {};
-    virtual void iterate(chunked_group_undo_op_t undoFunc) = 0;
+    virtual void finalizeRollbackInsert(){};
+    virtual void applyFuncToChunkedGroups(version_record_handler_op_t func) = 0;
 
 protected:
     common::row_idx_t startRow;
@@ -40,6 +40,15 @@ protected:
     common::transaction_t commitTS;
 
     NodeGroupCollection* nodeGroups;
+};
+
+class VersionRecordHandlerData {
+public:
+    virtual ~VersionRecordHandlerData() = default;
+
+    virtual std::unique_ptr<VersionRecordHandler> constructVersionRecordHandler(
+        common::row_idx_t startRow, common::row_idx_t numRows, common::transaction_t commitTS,
+        common::node_group_idx_t nodeGroupIdx) const = 0;
 };
 
 } // namespace storage

--- a/src/include/storage/store/chunked_node_group.h
+++ b/src/include/storage/store/chunked_node_group.h
@@ -103,7 +103,7 @@ public:
     std::pair<std::unique_ptr<ColumnChunk>, std::unique_ptr<ColumnChunk>> scanUpdates(
         transaction::Transaction* transaction, common::column_id_t columnID);
 
-    bool lookup(transaction::Transaction* transaction, const TableScanState& state,
+    bool lookup(const transaction::Transaction* transaction, const TableScanState& state,
         NodeGroupScanState& nodeGroupScanState, common::offset_t rowIdxInChunk,
         common::sel_t posInOutput) const;
 
@@ -139,10 +139,12 @@ public:
 
     void commitInsert(common::row_idx_t startRow, common::row_idx_t numRows_,
         common::transaction_t commitTS);
-    void rollbackInsert(common::row_idx_t startRow, common::row_idx_t numRows_);
+    void rollbackInsert(common::row_idx_t startRow, common::row_idx_t numRows_,
+        common::transaction_t commitTS);
     void commitDelete(common::row_idx_t startRow, common::row_idx_t numRows_,
         common::transaction_t commitTS);
-    void rollbackDelete(common::row_idx_t startRow, common::row_idx_t numRows_);
+    void rollbackDelete(common::row_idx_t startRow, common::row_idx_t numRows_,
+        common::transaction_t commitTS);
 
     uint64_t getEstimatedMemoryUsage() const;
 

--- a/src/include/storage/store/column.h
+++ b/src/include/storage/store/column.h
@@ -52,15 +52,15 @@ public:
     virtual void scan(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInChunk, common::row_idx_t numValuesToScan,
         common::ValueVector* resultVector) const;
-    virtual void lookupValue(transaction::Transaction* transaction, const ChunkState& state,
+    virtual void lookupValue(const transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t nodeOffset, common::ValueVector* resultVector, uint32_t posInVector) const;
 
     // Scan from [startOffsetInGroup, endOffsetInGroup).
-    virtual void scan(transaction::Transaction* transaction, const ChunkState& state,
+    virtual void scan(const transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
         common::ValueVector* resultVector, uint64_t offsetInVector) const;
     // Scan from [startOffsetInGroup, endOffsetInGroup).
-    virtual void scan(transaction::Transaction* transaction, const ChunkState& state,
+    virtual void scan(const transaction::Transaction* transaction, const ChunkState& state,
         ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET) const;
 
@@ -71,7 +71,7 @@ public:
 
     std::string getName() const { return name; }
 
-    virtual void scan(transaction::Transaction* transaction, const ChunkState& state,
+    virtual void scan(const transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup, uint8_t* result);
 
     // Batch write to a set of sequential pages.
@@ -99,8 +99,9 @@ protected:
         common::offset_t startOffsetInChunk, common::row_idx_t numValuesToScan,
         common::ValueVector* resultVector) const;
 
-    virtual void lookupInternal(transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t nodeOffset, common::ValueVector* resultVector, uint32_t posInVector) const;
+    virtual void lookupInternal(const transaction::Transaction* transaction,
+        const ChunkState& state, common::offset_t nodeOffset, common::ValueVector* resultVector,
+        uint32_t posInVector) const;
 
     void writeValues(ChunkState& state, common::offset_t dstOffset, const uint8_t* data,
         const common::NullMask* nullChunkData, common::offset_t srcOffset = 0,
@@ -162,7 +163,7 @@ public:
         populateCommonTableID(resultVector);
     }
 
-    void scan(transaction::Transaction* transaction, const ChunkState& state,
+    void scan(const transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
         common::ValueVector* resultVector, uint64_t offsetInVector) const override {
         Column::scan(transaction, state, startOffsetInGroup, endOffsetInGroup, resultVector,
@@ -170,7 +171,7 @@ public:
         populateCommonTableID(resultVector);
     }
 
-    void lookupInternal(transaction::Transaction* transaction, const ChunkState& state,
+    void lookupInternal(const transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t nodeOffset, common::ValueVector* resultVector,
         uint32_t posInVector) const override {
         Column::lookupInternal(transaction, state, nodeOffset, resultVector, posInVector);

--- a/src/include/storage/store/column_chunk.h
+++ b/src/include/storage/store/column_chunk.h
@@ -51,10 +51,10 @@ public:
     void scan(const transaction::Transaction* transaction, const ChunkState& state,
         common::ValueVector& output, common::offset_t offsetInChunk, common::length_t length) const;
     template<ResidencyState SCAN_RESIDENCY_STATE>
-    void scanCommitted(transaction::Transaction* transaction, ChunkState& chunkState,
+    void scanCommitted(const transaction::Transaction* transaction, ChunkState& chunkState,
         ColumnChunk& output, common::row_idx_t startRow = 0,
         common::row_idx_t numRows = common::INVALID_ROW_IDX) const;
-    void lookup(transaction::Transaction* transaction, const ChunkState& state,
+    void lookup(const transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t rowInChunk, common::ValueVector& output,
         common::sel_t posInOutputVector) const;
     void update(const transaction::Transaction* transaction, common::offset_t offsetInChunk,

--- a/src/include/storage/store/column_reader_writer.h
+++ b/src/include/storage/store/column_reader_writer.h
@@ -49,22 +49,22 @@ public:
 
     virtual ~ColumnReadWriter() = default;
 
-    virtual void readCompressedValueToPage(transaction::Transaction* transaction,
+    virtual void readCompressedValueToPage(const transaction::Transaction* transaction,
         const ChunkState& state, common::offset_t nodeOffset, uint8_t* result,
         uint32_t offsetInResult, const read_value_from_page_func_t<uint8_t*>& readFunc) = 0;
 
-    virtual void readCompressedValueToVector(transaction::Transaction* transaction,
+    virtual void readCompressedValueToVector(const transaction::Transaction* transaction,
         const ChunkState& state, common::offset_t nodeOffset, common::ValueVector* result,
         uint32_t offsetInResult,
         const read_value_from_page_func_t<common::ValueVector*>& readFunc) = 0;
 
-    virtual uint64_t readCompressedValuesToPage(transaction::Transaction* transaction,
+    virtual uint64_t readCompressedValuesToPage(const transaction::Transaction* transaction,
         const ChunkState& state, uint8_t* result, uint32_t startOffsetInResult,
         uint64_t startNodeOffset, uint64_t endNodeOffset,
         const read_values_from_page_func_t<uint8_t*>& readFunc,
         const std::optional<filter_func_t>& filterFunc = {}) = 0;
 
-    virtual uint64_t readCompressedValuesToVector(transaction::Transaction* transaction,
+    virtual uint64_t readCompressedValuesToVector(const transaction::Transaction* transaction,
         const ChunkState& state, common::ValueVector* result, uint32_t startOffsetInResult,
         uint64_t startNodeOffset, uint64_t endNodeOffset,
         const read_values_from_page_func_t<common::ValueVector*>& readFunc,
@@ -78,7 +78,7 @@ public:
         const uint8_t* data, const common::NullMask* nullChunkData, common::offset_t srcOffset,
         common::offset_t numValues, const write_values_func_t& writeFunc) = 0;
 
-    void readFromPage(transaction::Transaction* transaction, common::page_idx_t pageIdx,
+    void readFromPage(const transaction::Transaction* transaction, common::page_idx_t pageIdx,
         const std::function<void(uint8_t*)>& readFunc);
 
     void updatePageWithCursor(PageCursor cursor,

--- a/src/include/storage/store/csr_node_group.h
+++ b/src/include/storage/store/csr_node_group.h
@@ -165,12 +165,12 @@ static constexpr common::column_id_t REL_ID_COLUMN_ID = 1;
 struct RelTableScanState;
 class CSRNodeGroup final : public NodeGroup {
 public:
-    class PersistentIterator : public ChunkedGroupUndoIterator {
+    class PersistentIterator : public VersionRecordHandler {
     public:
         PersistentIterator(NodeGroupCollection* nodeGroups, common::node_group_idx_t nodeGroupIdx,
             common::row_idx_t startRow, common::row_idx_t numRows, common::transaction_t commitTS);
 
-        void iterate(chunked_group_undo_op_t undoFunc) override;
+        void applyFuncToChunkedGroups(version_record_handler_op_t func) override;
         void finalizeRollbackInsert() override;
 
     private:

--- a/src/include/storage/store/csr_node_group.h
+++ b/src/include/storage/store/csr_node_group.h
@@ -171,7 +171,7 @@ public:
             common::row_idx_t startRow, common::row_idx_t numRows, common::transaction_t commitTS);
 
         void applyFuncToChunkedGroups(version_record_handler_op_t func) override;
-        void finalizeRollbackInsert() override;
+        void rollbackInsert(const transaction::Transaction* transaction) override;
 
     private:
         CSRNodeGroup* nodeGroup;

--- a/src/include/storage/store/csr_node_group.h
+++ b/src/include/storage/store/csr_node_group.h
@@ -217,7 +217,6 @@ public:
 
     bool isEmpty() const override { return !persistentChunkGroup && NodeGroup::isEmpty(); }
 
-    common::row_idx_t getNumPersistentRows() const;
     ChunkedNodeGroup* getPersistentChunkedGroup() const { return persistentChunkGroup.get(); }
     void setPersistentChunkedGroup(std::unique_ptr<ChunkedNodeGroup> chunkedNodeGroup) {
         KU_ASSERT(chunkedNodeGroup->getFormat() == NodeGroupDataFormat::CSR);

--- a/src/include/storage/store/csr_node_group.h
+++ b/src/include/storage/store/csr_node_group.h
@@ -165,18 +165,6 @@ static constexpr common::column_id_t REL_ID_COLUMN_ID = 1;
 struct RelTableScanState;
 class CSRNodeGroup final : public NodeGroup {
 public:
-    class PersistentIterator : public VersionRecordHandler {
-    public:
-        PersistentIterator(NodeGroupCollection* nodeGroups, common::node_group_idx_t nodeGroupIdx,
-            common::row_idx_t startRow, common::row_idx_t numRows, common::transaction_t commitTS);
-
-        void applyFuncToChunkedGroups(version_record_handler_op_t func) override;
-        void rollbackInsert(const transaction::Transaction* transaction) override;
-
-    private:
-        CSRNodeGroup* nodeGroup;
-    };
-
     static constexpr PackedCSRInfo DEFAULT_PACKED_CSR_INFO{};
 
     CSRNodeGroup(const common::node_group_idx_t nodeGroupIdx, const bool enableCompression,

--- a/src/include/storage/store/dictionary_column.h
+++ b/src/include/storage/store/dictionary_column.h
@@ -12,12 +12,12 @@ public:
     DictionaryColumn(const std::string& name, FileHandle* dataFH, MemoryManager* mm,
         ShadowFile* shadowFile, bool enableCompression);
 
-    void scan(transaction::Transaction* transaction, const ChunkState& state,
+    void scan(const transaction::Transaction* transaction, const ChunkState& state,
         DictionaryChunk& dictChunk) const;
     // Offsets to scan should be a sorted list of pairs mapping the index of the entry in the string
     // dictionary (as read from the index column) to the output index in the result vector to store
     // the string.
-    void scan(transaction::Transaction* transaction, const ChunkState& offsetState,
+    void scan(const transaction::Transaction* transaction, const ChunkState& offsetState,
         const ChunkState& dataState,
         std::vector<std::pair<DictionaryChunk::string_index_t, uint64_t>>& offsetsToScan,
         common::ValueVector* resultVector, const ColumnChunkMetadata& indexMeta) const;
@@ -32,10 +32,10 @@ public:
     Column* getOffsetColumn() const { return offsetColumn.get(); }
 
 private:
-    void scanOffsets(transaction::Transaction* transaction, const ChunkState& state,
+    void scanOffsets(const transaction::Transaction* transaction, const ChunkState& state,
         DictionaryChunk::string_offset_t* offsets, uint64_t index, uint64_t numValues,
         uint64_t dataSize) const;
-    void scanValueToVector(transaction::Transaction* transaction, const ChunkState& dataState,
+    void scanValueToVector(const transaction::Transaction* transaction, const ChunkState& dataState,
         uint64_t startOffset, uint64_t endOffset, common::ValueVector* resultVector,
         uint64_t offsetInVector) const;
 

--- a/src/include/storage/store/group_collection.h
+++ b/src/include/storage/store/group_collection.h
@@ -6,6 +6,7 @@
 #include "common/serializer/serializer.h"
 #include "common/types/types.h"
 #include "common/uniq_lock.h"
+#include "common/utils.h"
 
 namespace kuzu {
 namespace storage {
@@ -114,6 +115,14 @@ public:
         KU_ASSERT(lock.isLocked());
         KU_UNUSED(lock);
         groups.clear();
+    }
+
+    common::idx_t getNumEmptyTrailingGroups(const common::UniqLock& lock) {
+        const auto& groupsVector = getAllGroups(lock);
+        return common::safeIntegerConversion<common::idx_t>(
+            std::find_if(groupsVector.rbegin(), groupsVector.rend(),
+                [](const auto& group) { return (group->getNumRows() != 0); }) -
+            groupsVector.rbegin());
     }
 
 private:

--- a/src/include/storage/store/group_collection.h
+++ b/src/include/storage/store/group_collection.h
@@ -24,6 +24,11 @@ public:
             [&](common::Deserializer& deser) { return T::deserialize(memoryManager, deser); });
     }
 
+    void removeTrailingGroups(const common::UniqLock&, common::idx_t numGroupsToRemove) {
+        KU_ASSERT(numGroupsToRemove <= groups.size());
+        groups.erase(groups.end() - numGroupsToRemove, groups.end());
+    }
+
     void serializeGroups(common::Serializer& ser) {
         auto lockGuard = lock();
         ser.serializeVectorOfPtrs<T>(groups);

--- a/src/include/storage/store/group_collection.h
+++ b/src/include/storage/store/group_collection.h
@@ -25,7 +25,9 @@ public:
             [&](common::Deserializer& deser) { return T::deserialize(memoryManager, deser); });
     }
 
-    void removeTrailingGroups(const common::UniqLock&, common::idx_t numGroupsToRemove) {
+    void removeTrailingGroups([[maybe_unused]] const common::UniqLock& lock,
+        common::idx_t numGroupsToRemove) {
+        KU_ASSERT(lock.isLocked());
         KU_ASSERT(numGroupsToRemove <= groups.size());
         groups.erase(groups.end() - numGroupsToRemove, groups.end());
     }

--- a/src/include/storage/store/list_column.h
+++ b/src/include/storage/store/list_column.h
@@ -56,10 +56,10 @@ public:
     static std::unique_ptr<ColumnChunkData> flushChunkData(const ColumnChunkData& chunk,
         FileHandle& dataFH);
 
-    void scan(transaction::Transaction* transaction, const ChunkState& state,
+    void scan(const transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
         common::ValueVector* resultVector, uint64_t offsetInVector = 0) const override;
-    void scan(transaction::Transaction* transaction, const ChunkState& state,
+    void scan(const transaction::Transaction* transaction, const ChunkState& state,
         ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET) const override;
 
@@ -74,7 +74,7 @@ protected:
         common::offset_t startOffsetInChunk, common::row_idx_t numValuesToScan,
         common::ValueVector* resultVector) const override;
 
-    void lookupInternal(transaction::Transaction* transaction, const ChunkState& state,
+    void lookupInternal(const transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t nodeOffset, common::ValueVector* resultVector,
         uint32_t posInVector) const override;
 
@@ -85,12 +85,12 @@ private:
     void scanFiltered(transaction::Transaction* transaction, const ChunkState& state,
         common::ValueVector* offsetVector, const ListOffsetSizeInfo& listOffsetInfoInStorage) const;
 
-    common::offset_t readOffset(transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t offsetInNodeGroup) const;
-    common::list_size_t readSize(transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t offsetInNodeGroup) const;
+    common::offset_t readOffset(const transaction::Transaction* transaction,
+        const ChunkState& state, common::offset_t offsetInNodeGroup) const;
+    common::list_size_t readSize(const transaction::Transaction* transaction,
+        const ChunkState& state, common::offset_t offsetInNodeGroup) const;
 
-    ListOffsetSizeInfo getListOffsetSizeInfo(transaction::Transaction* transaction,
+    ListOffsetSizeInfo getListOffsetSizeInfo(const transaction::Transaction* transaction,
         const ChunkState& state, common::offset_t startOffsetInNodeGroup,
         common::offset_t endOffsetInNodeGroup) const;
 

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -4,9 +4,9 @@
 
 #include "common/uniq_lock.h"
 #include "storage/enums/residency_state.h"
-#include "storage/store/chunked_group_undo_iterator.h"
 #include "storage/store/chunked_node_group.h"
 #include "storage/store/group_collection.h"
+#include "storage/store/version_record_handler.h"
 
 namespace kuzu {
 namespace transaction {
@@ -82,16 +82,15 @@ static auto NODE_GROUP_SCAN_EMMPTY_RESULT = NodeGroupScanResult{};
 struct TableScanState;
 class NodeGroup {
 public:
-    class ChunkedGroupIterator : public VersionRecordHandler {
+    class NodeGroupVersionRecordHandler : public VersionRecordHandler {
     public:
-        ChunkedGroupIterator(NodeGroupCollection* nodeGroups, common::node_group_idx_t nodeGroupIdx,
-            common::row_idx_t startRow, common::row_idx_t numRows, common::transaction_t commitTS);
+        NodeGroupVersionRecordHandler(NodeGroupCollection* nodeGroups,
+            common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
+            common::row_idx_t numRows, common::transaction_t commitTS);
         void applyFuncToChunkedGroups(version_record_handler_op_t func) override;
-        void finalizeRollbackInsert() override;
 
     protected:
         NodeGroup* nodeGroup;
-        common::row_idx_t numRowsToRollback;
     };
 
     NodeGroup(const common::node_group_idx_t nodeGroupIdx, const bool enableCompression,

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -82,11 +82,10 @@ static auto NODE_GROUP_SCAN_EMMPTY_RESULT = NodeGroupScanResult{};
 struct TableScanState;
 class NodeGroup {
 public:
-    class NodeGroupBaseIterator : public ChunkedGroupUndoIterator {
+    class ChunkedGroupIterator : public ChunkedGroupUndoIterator {
     public:
-        NodeGroupBaseIterator(NodeGroupCollection* nodeGroups,
-            common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
-            common::row_idx_t numRows, common::transaction_t commitTS);
+        ChunkedGroupIterator(NodeGroupCollection* nodeGroups, common::node_group_idx_t nodeGroupIdx,
+            common::row_idx_t startRow, common::row_idx_t numRows, common::transaction_t commitTS);
         void iterate(chunked_group_undo_op_t undoFunc) override;
         void finalizeRollbackInsert() override;
 

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -82,11 +82,11 @@ static auto NODE_GROUP_SCAN_EMMPTY_RESULT = NodeGroupScanResult{};
 struct TableScanState;
 class NodeGroup {
 public:
-    class ChunkedGroupIterator : public ChunkedGroupUndoIterator {
+    class ChunkedGroupIterator : public VersionRecordHandler {
     public:
         ChunkedGroupIterator(NodeGroupCollection* nodeGroups, common::node_group_idx_t nodeGroupIdx,
             common::row_idx_t startRow, common::row_idx_t numRows, common::transaction_t commitTS);
-        void iterate(chunked_group_undo_op_t undoFunc) override;
+        void applyFuncToChunkedGroups(version_record_handler_op_t func) override;
         void finalizeRollbackInsert() override;
 
     protected:

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -18,7 +18,6 @@ class MemoryManager;
 
 struct TableAddColumnState;
 class NodeGroup;
-class NodeGroupCollection;
 
 struct NodeGroupScanState {
     // Index of committed but not yet checkpointed chunked group to scan.

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -82,17 +82,6 @@ static auto NODE_GROUP_SCAN_EMMPTY_RESULT = NodeGroupScanResult{};
 struct TableScanState;
 class NodeGroup {
 public:
-    class NodeGroupVersionRecordHandler : public VersionRecordHandler {
-    public:
-        NodeGroupVersionRecordHandler(NodeGroupCollection* nodeGroups,
-            common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
-            common::row_idx_t numRows, common::transaction_t commitTS);
-        void applyFuncToChunkedGroups(version_record_handler_op_t func) override;
-
-    protected:
-        NodeGroup* nodeGroup;
-    };
-
     NodeGroup(const common::node_group_idx_t nodeGroupIdx, const bool enableCompression,
         std::vector<common::LogicalType> dataTypes,
         common::row_idx_t capacity = common::StorageConstants::NODE_GROUP_SIZE,
@@ -163,6 +152,8 @@ public:
 
     void flush(transaction::Transaction* transaction, FileHandle& dataFH);
 
+    void applyFuncToChunkedGroups(version_record_handler_op_t func, common::row_idx_t startRow,
+        common::row_idx_t numRows, common::transaction_t commitTS) const;
     void rollbackInsert(common::row_idx_t startRow);
 
     virtual void checkpoint(MemoryManager& memoryManager, NodeGroupCheckpointState& state);

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -3,7 +3,6 @@
 #include <cstdint>
 
 #include "common/uniq_lock.h"
-#include "storage/enums/csr_node_group_scan_source.h"
 #include "storage/enums/residency_state.h"
 #include "storage/store/chunked_group_undo_iterator.h"
 #include "storage/store/chunked_node_group.h"
@@ -93,6 +92,7 @@ public:
 
     protected:
         NodeGroup* nodeGroup;
+        common::row_idx_t numRowsToRollback;
     };
 
     NodeGroup(const common::node_group_idx_t nodeGroupIdx, const bool enableCompression,

--- a/src/include/storage/store/node_group_collection.h
+++ b/src/include/storage/store/node_group_collection.h
@@ -50,8 +50,7 @@ public:
         return nodeGroups.getGroup(lock, groupIdx);
     }
     NodeGroup* getOrCreateNodeGroup(transaction::Transaction* transaction,
-        common::node_group_idx_t groupIdx, NodeGroupDataFormat format,
-        const VersionRecordHandler* versionRecordHandler);
+        common::node_group_idx_t groupIdx, NodeGroupDataFormat format);
 
     void setNodeGroup(const common::node_group_idx_t nodeGroupIdx,
         std::unique_ptr<NodeGroup> group) {
@@ -81,12 +80,12 @@ public:
 
     void pushInsertInfo(const transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
-        common::row_idx_t numRows, const VersionRecordHandler* overridedVersionRecordHandler);
+        common::row_idx_t numRows, const VersionRecordHandler* versionRecordHandler,
+        bool incrementNumTotalRows);
 
 private:
     void pushInsertInfo(const transaction::Transaction* transaction, NodeGroup* nodeGroup,
-        common::row_idx_t numRows,
-        const VersionRecordHandler* overridedVersionRecordHandler = nullptr);
+        common::row_idx_t numRows);
 
     bool enableCompression;
     // Num rows in the collection regardless of deletions.

--- a/src/include/storage/store/node_group_collection.h
+++ b/src/include/storage/store/node_group_collection.h
@@ -16,7 +16,7 @@ class NodeGroupCollection {
 public:
     NodeGroupCollection(MemoryManager& memoryManager, const std::vector<common::LogicalType>& types,
         bool enableCompression, FileHandle* dataFH = nullptr, common::Deserializer* deSer = nullptr,
-        const chunked_group_iterator_construct_t* iteratorConstructFunc = nullptr);
+        const VersionRecordHandlerData* versionRecordHandlerData = nullptr);
 
     void append(const transaction::Transaction* transaction,
         const std::vector<common::ValueVector*>& vectors);
@@ -51,7 +51,7 @@ public:
     }
     NodeGroup* getOrCreateNodeGroup(transaction::Transaction* transaction,
         common::node_group_idx_t groupIdx, NodeGroupDataFormat format,
-        const chunked_group_iterator_construct_t* constructIteratorFunc_);
+        const VersionRecordHandlerData* versionRecordHandlerData);
 
     void setNodeGroup(const common::node_group_idx_t nodeGroupIdx,
         std::unique_ptr<NodeGroup> group) {
@@ -82,12 +82,12 @@ public:
     void pushInsertInfo(const transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
         common::row_idx_t numRows,
-        const chunked_group_iterator_construct_t* constructIteratorFunc_);
+        const VersionRecordHandlerData* overridedVersionRecordHandlerData);
 
 private:
     void pushInsertInfo(const transaction::Transaction* transaction, NodeGroup* nodeGroup,
         common::row_idx_t numRows,
-        const chunked_group_iterator_construct_t* constructIteratorOverrideFunc = nullptr);
+        const VersionRecordHandlerData* overridedVersionRecordHandlerData = nullptr);
 
     bool enableCompression;
     // Num rows in the collection regardless of deletions.
@@ -96,7 +96,7 @@ private:
     GroupCollection<NodeGroup> nodeGroups;
     FileHandle* dataFH;
     TableStats stats;
-    const chunked_group_iterator_construct_t* iteratorConstructFunc;
+    const VersionRecordHandlerData* versionRecordHandlerData;
 };
 
 } // namespace storage

--- a/src/include/storage/store/node_group_collection.h
+++ b/src/include/storage/store/node_group_collection.h
@@ -87,7 +87,7 @@ public:
 private:
     void pushInsertInfo(const transaction::Transaction* transaction, NodeGroup* nodeGroup,
         common::row_idx_t numRows,
-        const chunked_group_iterator_construct_t* constructIteratorFunc_ = nullptr);
+        const chunked_group_iterator_construct_t* constructIteratorOverrideFunc = nullptr);
 
     bool enableCompression;
     // Num rows in the collection regardless of deletions.

--- a/src/include/storage/store/node_group_collection.h
+++ b/src/include/storage/store/node_group_collection.h
@@ -16,7 +16,7 @@ class NodeGroupCollection {
 public:
     NodeGroupCollection(MemoryManager& memoryManager, const std::vector<common::LogicalType>& types,
         bool enableCompression, FileHandle* dataFH = nullptr, common::Deserializer* deSer = nullptr,
-        const VersionRecordHandlerData* versionRecordHandlerData = nullptr);
+        const VersionRecordHandlerSelector* versionRecordHandlerSelector = nullptr);
 
     void append(const transaction::Transaction* transaction,
         const std::vector<common::ValueVector*>& vectors);
@@ -51,7 +51,7 @@ public:
     }
     NodeGroup* getOrCreateNodeGroup(transaction::Transaction* transaction,
         common::node_group_idx_t groupIdx, NodeGroupDataFormat format,
-        const VersionRecordHandlerData* versionRecordHandlerData);
+        const VersionRecordHandlerSelector* versionRecordHandlerSelector);
 
     void setNodeGroup(const common::node_group_idx_t nodeGroupIdx,
         std::unique_ptr<NodeGroup> group) {
@@ -82,12 +82,12 @@ public:
     void pushInsertInfo(const transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
         common::row_idx_t numRows,
-        const VersionRecordHandlerData* overridedVersionRecordHandlerData);
+        const VersionRecordHandlerSelector* overridedVersionRecordHandlerSelector);
 
 private:
     void pushInsertInfo(const transaction::Transaction* transaction, NodeGroup* nodeGroup,
         common::row_idx_t numRows,
-        const VersionRecordHandlerData* overridedVersionRecordHandlerData = nullptr);
+        const VersionRecordHandlerSelector* overridedVersionRecordHandlerSelector = nullptr);
 
     bool enableCompression;
     // Num rows in the collection regardless of deletions.
@@ -96,7 +96,7 @@ private:
     GroupCollection<NodeGroup> nodeGroups;
     FileHandle* dataFH;
     TableStats stats;
-    const VersionRecordHandlerData* versionRecordHandlerData;
+    const VersionRecordHandlerSelector* versionRecordHandlerSelector;
 };
 
 } // namespace storage

--- a/src/include/storage/store/node_group_collection.h
+++ b/src/include/storage/store/node_group_collection.h
@@ -16,8 +16,8 @@ class MemoryManager;
 class NodeGroupCollection {
 public:
     NodeGroupCollection(MemoryManager& memoryManager, const std::vector<common::LogicalType>& types,
-        bool enableCompression, FileHandle* dataFH = nullptr,
-        common::Deserializer* deSer = nullptr);
+        bool enableCompression, FileHandle* dataFH = nullptr, common::Deserializer* deSer = nullptr,
+        const transaction::rollback_insert_func_t* rollbackInsertFunc = nullptr);
 
     void append(const transaction::Transaction* transaction,
         const std::vector<common::ValueVector*>& vectors);
@@ -106,6 +106,7 @@ private:
     GroupCollection<NodeGroup> nodeGroups;
     FileHandle* dataFH;
     TableStats stats;
+    const transaction::rollback_insert_func_t* rollbackInsertFunc;
 };
 
 } // namespace storage

--- a/src/include/storage/store/node_group_collection.h
+++ b/src/include/storage/store/node_group_collection.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "storage/enums/csr_node_group_scan_source.h"
 #include "storage/stats/table_stats.h"
 #include "storage/store/group_collection.h"
 #include "storage/store/node_group.h"

--- a/src/include/storage/store/node_group_collection.h
+++ b/src/include/storage/store/node_group_collection.h
@@ -16,7 +16,7 @@ class NodeGroupCollection {
 public:
     NodeGroupCollection(MemoryManager& memoryManager, const std::vector<common::LogicalType>& types,
         bool enableCompression, FileHandle* dataFH = nullptr, common::Deserializer* deSer = nullptr,
-        const VersionRecordHandlerSelector* versionRecordHandlerSelector = nullptr);
+        const VersionRecordHandler* versionRecordHandler = nullptr);
 
     void append(const transaction::Transaction* transaction,
         const std::vector<common::ValueVector*>& vectors);
@@ -51,7 +51,7 @@ public:
     }
     NodeGroup* getOrCreateNodeGroup(transaction::Transaction* transaction,
         common::node_group_idx_t groupIdx, NodeGroupDataFormat format,
-        const VersionRecordHandlerSelector* versionRecordHandlerSelector);
+        const VersionRecordHandler* versionRecordHandler);
 
     void setNodeGroup(const common::node_group_idx_t nodeGroupIdx,
         std::unique_ptr<NodeGroup> group) {
@@ -81,13 +81,12 @@ public:
 
     void pushInsertInfo(const transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
-        common::row_idx_t numRows,
-        const VersionRecordHandlerSelector* overridedVersionRecordHandlerSelector);
+        common::row_idx_t numRows, const VersionRecordHandler* overridedVersionRecordHandler);
 
 private:
     void pushInsertInfo(const transaction::Transaction* transaction, NodeGroup* nodeGroup,
         common::row_idx_t numRows,
-        const VersionRecordHandlerSelector* overridedVersionRecordHandlerSelector = nullptr);
+        const VersionRecordHandler* overridedVersionRecordHandler = nullptr);
 
     bool enableCompression;
     // Num rows in the collection regardless of deletions.
@@ -96,7 +95,7 @@ private:
     GroupCollection<NodeGroup> nodeGroups;
     FileHandle* dataFH;
     TableStats stats;
-    const VersionRecordHandlerSelector* versionRecordHandlerSelector;
+    const VersionRecordHandler* versionRecordHandler;
 };
 
 } // namespace storage

--- a/src/include/storage/store/node_group_collection.h
+++ b/src/include/storage/store/node_group_collection.h
@@ -95,7 +95,7 @@ public:
         common::row_idx_t numRows, storage::CSRNodeGroupScanSource source);
 
 private:
-    void appendToUndoBuffer(const transaction::Transaction* transaction, NodeGroup* nodeGroup,
+    void pushInsertInfo(const transaction::Transaction* transaction, NodeGroup* nodeGroup,
         common::row_idx_t numRows, CSRNodeGroupScanSource source = CSRNodeGroupScanSource::NONE);
 
     bool enableCompression;

--- a/src/include/storage/store/node_group_collection.h
+++ b/src/include/storage/store/node_group_collection.h
@@ -4,6 +4,7 @@
 #include "storage/stats/table_stats.h"
 #include "storage/store/group_collection.h"
 #include "storage/store/node_group.h"
+#include "transaction/transaction.h"
 
 namespace kuzu {
 namespace transaction {

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -178,6 +178,10 @@ public:
 
     TableStats getStats(const transaction::Transaction* transaction) const;
 
+    const pre_rollback_insert_func_t& getPreRollbackInsertFunc() const {
+        return preRollbackInsertFunc;
+    }
+
 private:
     void insertPK(const transaction::Transaction* transaction,
         const common::ValueVector& nodeIDVector, const common::ValueVector& pkVector) const;
@@ -197,6 +201,7 @@ private:
     std::unique_ptr<NodeGroupCollection> nodeGroups;
     common::column_id_t pkColumnID;
     std::unique_ptr<PrimaryKeyIndex> pkIndex;
+    pre_rollback_insert_func_t preRollbackInsertFunc;
 };
 
 } // namespace storage

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -176,8 +176,8 @@ public:
 
     TableStats getStats(const transaction::Transaction* transaction) const;
 
-    const pre_rollback_insert_func_t& getPreRollbackInsertFunc() const {
-        return preRollbackInsertFunc;
+    const transaction::rollback_insert_func_t& getRollbackInsertFunc() const {
+        return rollbackInsertFunc;
     }
 
 private:
@@ -199,7 +199,7 @@ private:
     std::unique_ptr<NodeGroupCollection> nodeGroups;
     common::column_id_t pkColumnID;
     std::unique_ptr<PrimaryKeyIndex> pkIndex;
-    pre_rollback_insert_func_t preRollbackInsertFunc;
+    transaction::rollback_insert_func_t rollbackInsertFunc;
 };
 
 } // namespace storage

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -98,9 +98,9 @@ struct PKColumnScanHelper {
 class StorageManager;
 class NodeTable final : public Table {
 public:
-    class NodeGroupIterator : public NodeGroup::NodeGroupBaseIterator {
+    class ChunkedGroupIterator : public NodeGroup::ChunkedGroupIterator {
     public:
-        NodeGroupIterator(NodeTable* table, common::node_group_idx_t nodeGroupIdx,
+        ChunkedGroupIterator(NodeTable* table, common::node_group_idx_t nodeGroupIdx,
             common::row_idx_t startRow, common::row_idx_t numRows, common::transaction_t commitTS);
 
         void initRollbackInsert(const transaction::Transaction* transaction) override;

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -213,7 +213,8 @@ private:
 
     visible_func getVisibleFunc(const transaction::Transaction* transaction) const;
     common::DataChunk constructDataChunkForPKColumn() const;
-    void scanPKColumn(const transaction::Transaction* transaction, PKColumnScanHelper& scanHelper);
+    void scanPKColumn(const transaction::Transaction* transaction, PKColumnScanHelper& scanHelper,
+        NodeGroupCollection& nodeGroups_);
 
 private:
     std::vector<std::unique_ptr<Column>> columns;

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -96,9 +96,9 @@ struct PKColumnScanHelper {
     PrimaryKeyIndex* pkIndex;
 };
 
-class NodeTableVersionRecordHandlerData : public VersionRecordHandlerData {
+class NodeTableVersionRecordHandlerSelector : public VersionRecordHandlerSelector {
 public:
-    explicit NodeTableVersionRecordHandlerData(NodeTable* nodeTable) : nodeTable(nodeTable) {}
+    explicit NodeTableVersionRecordHandlerSelector(NodeTable* nodeTable) : nodeTable(nodeTable) {}
 
     std::unique_ptr<VersionRecordHandler> constructVersionRecordHandler(common::row_idx_t startRow,
         common::row_idx_t numRows, common::transaction_t commitTS,
@@ -111,12 +111,12 @@ private:
 class StorageManager;
 class NodeTable final : public Table {
 public:
-    class ChunkedGroupIterator : public NodeGroup::ChunkedGroupIterator {
+    class ChunkedGroupIterator : public NodeGroup::NodeGroupVersionRecordHandler {
     public:
         ChunkedGroupIterator(NodeTable* table, common::node_group_idx_t nodeGroupIdx,
             common::row_idx_t startRow, common::row_idx_t numRows, common::transaction_t commitTS);
 
-        void initRollbackInsert(const transaction::Transaction* transaction) override;
+        void rollbackInsert(const transaction::Transaction* transaction) override;
 
     private:
         NodeTable* table;
@@ -230,7 +230,7 @@ private:
     std::unique_ptr<NodeGroupCollection> nodeGroups;
     common::column_id_t pkColumnID;
     std::unique_ptr<PrimaryKeyIndex> pkIndex;
-    NodeTableVersionRecordHandlerData versionRecordHandlerData;
+    NodeTableVersionRecordHandlerSelector versionRecordHandlerSelector;
 };
 
 } // namespace storage

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -174,8 +174,6 @@ public:
         return nodeGroups->getNodeGroupNoLock(nodeGroupIdx);
     }
 
-    NodeGroupCollection* getNodeGroups() { return nodeGroups.get(); }
-
     TableStats getStats(const transaction::Transaction* transaction) const;
 
     const pre_rollback_insert_func_t& getPreRollbackInsertFunc() const {

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -156,6 +156,9 @@ public:
     void commit(transaction::Transaction* transaction, LocalTable* localTable) override;
     void checkpoint(common::Serializer& ser, catalog::TableCatalogEntry* tableEntry) override;
 
+    void rollbackInsert(const transaction::Transaction* transaction, common::row_idx_t startRow,
+        common::row_idx_t numRows_, common::node_group_idx_t nodeGroupIdx);
+
     common::node_group_idx_t getNumCommittedNodeGroups() const {
         return nodeGroups->getNumNodeGroups();
     }
@@ -171,6 +174,8 @@ public:
         return nodeGroups->getNodeGroupNoLock(nodeGroupIdx);
     }
 
+    NodeGroupCollection* getNodeGroups() { return nodeGroups.get(); }
+
     TableStats getStats(const transaction::Transaction* transaction) const;
 
 private:
@@ -180,6 +185,12 @@ private:
         common::ValueVector* pkVector);
 
     void serialize(common::Serializer& serializer) const override;
+
+    std::unique_ptr<NodeTableScanState> initPKScanState(common::DataChunk& dataChunk,
+        TableScanSource source) const;
+
+    visible_func getVisibleFunc(const transaction::Transaction* transaction) const;
+    common::DataChunk constructDataChunkForPKColumn() const;
 
 private:
     std::vector<std::unique_ptr<Column>> columns;

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -84,6 +84,17 @@ struct NodeTableDeleteState final : TableDeleteState {
 class StorageManager;
 class NodeTable final : public Table {
 public:
+    class NodeGroupIterator : public NodeGroup::NodeGroupBaseIterator {
+    public:
+        NodeGroupIterator(NodeTable* table, common::node_group_idx_t nodeGroupIdx,
+            common::row_idx_t startRow, common::row_idx_t numRows, common::transaction_t commitTS);
+
+        void initRollbackInsert(const transaction::Transaction* transaction) override;
+
+    private:
+        NodeTable* table;
+    };
+
     static std::vector<common::LogicalType> getNodeTableColumnTypes(const NodeTable& table) {
         std::vector<common::LogicalType> types;
         for (auto i = 0u; i < table.getNumColumns(); i++) {
@@ -176,8 +187,8 @@ public:
 
     TableStats getStats(const transaction::Transaction* transaction) const;
 
-    const transaction::rollback_insert_func_t& getRollbackInsertFunc() const {
-        return rollbackInsertFunc;
+    const chunked_group_iterator_construct_t& getIteratorConstructFunc() const {
+        return iteratorConstructFunc;
     }
 
 private:
@@ -199,7 +210,7 @@ private:
     std::unique_ptr<NodeGroupCollection> nodeGroups;
     common::column_id_t pkColumnID;
     std::unique_ptr<PrimaryKeyIndex> pkIndex;
-    transaction::rollback_insert_func_t rollbackInsertFunc;
+    chunked_group_iterator_construct_t iteratorConstructFunc;
 };
 
 } // namespace storage

--- a/src/include/storage/store/null_column.h
+++ b/src/include/storage/store/null_column.h
@@ -21,10 +21,10 @@ public:
     void scan(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInChunk, common::row_idx_t numValuesToScan,
         common::ValueVector* resultVector) const override;
-    void scan(transaction::Transaction* transaction, const ChunkState& state,
+    void scan(const transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
         common::ValueVector* resultVector, uint64_t offsetInVector) const override;
-    void scan(transaction::Transaction* transaction, const ChunkState& state,
+    void scan(const transaction::Transaction* transaction, const ChunkState& state,
         ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET) const override;
 

--- a/src/include/storage/store/rel_table.h
+++ b/src/include/storage/store/rel_table.h
@@ -186,6 +186,9 @@ public:
         return currentRelOffset;
     }
 
+    void pushInsertInfo(transaction::Transaction* transaction, common::RelDataDirection direction,
+        const CSRNodeGroup& nodeGroup, common::row_idx_t numRows_, CSRNodeGroupScanSource source);
+
 private:
     static void prepareCommitForNodeGroup(const transaction::Transaction* transaction,
         NodeGroup& localNodeGroup, CSRNodeGroup& csrNodeGroup, common::offset_t boundOffsetInGroup,
@@ -198,9 +201,9 @@ private:
     static common::offset_t getCommittedOffset(common::offset_t uncommittedOffset,
         common::offset_t maxCommittedOffset);
 
-    void detachDeleteForCSRRels(transaction::Transaction* transaction,
-        const RelTableData* tableData, const RelTableData* reverseTableData,
-        RelTableScanState* relDataReadState, RelTableDeleteState* deleteState);
+    void detachDeleteForCSRRels(transaction::Transaction* transaction, RelTableData* tableData,
+        RelTableData* reverseTableData, RelTableScanState* relDataReadState,
+        RelTableDeleteState* deleteState);
 
     void checkRelMultiplicityConstraint(transaction::Transaction* transaction,
         const TableInsertState& state) const;

--- a/src/include/storage/store/rel_table.h
+++ b/src/include/storage/store/rel_table.h
@@ -208,6 +208,8 @@ private:
     void checkRelMultiplicityConstraint(transaction::Transaction* transaction,
         const TableInsertState& state) const;
 
+    RelTableData* getRelTableData(common::RelDataDirection direction) const;
+
 private:
     common::table_id_t fromNodeTableID;
     common::table_id_t toNodeTableID;

--- a/src/include/storage/store/rel_table.h
+++ b/src/include/storage/store/rel_table.h
@@ -166,8 +166,8 @@ public:
                                                             bwdRelTableData->getColumn(columnID);
     }
 
-    NodeGroup* getOrCreateNodeGroup(common::node_group_idx_t nodeGroupIdx,
-        common::RelDataDirection direction) const;
+    NodeGroup* getOrCreateNodeGroup(transaction::Transaction* transaction,
+        common::node_group_idx_t nodeGroupIdx, common::RelDataDirection direction) const;
 
     void commit(transaction::Transaction* transaction, LocalTable* localTable) override;
     void checkpoint(common::Serializer& ser, catalog::TableCatalogEntry* tableEntry) override;

--- a/src/include/storage/store/rel_table_data.h
+++ b/src/include/storage/store/rel_table_data.h
@@ -53,8 +53,10 @@ public:
     NodeGroup* getNodeGroup(common::node_group_idx_t nodeGroupIdx) const {
         return nodeGroups->getNodeGroup(nodeGroupIdx, true /*mayOutOfBound*/);
     }
-    NodeGroup* getOrCreateNodeGroup(common::node_group_idx_t nodeGroupIdx) const {
-        return nodeGroups->getOrCreateNodeGroup(nodeGroupIdx, NodeGroupDataFormat::CSR);
+    NodeGroup* getOrCreateNodeGroup(transaction::Transaction* transaction,
+        common::node_group_idx_t nodeGroupIdx) const {
+        return nodeGroups->getOrCreateNodeGroup(transaction, nodeGroupIdx,
+            NodeGroupDataFormat::CSR);
     }
 
     common::RelMultiplicity getMultiplicity() const { return multiplicity; }

--- a/src/include/storage/store/rel_table_data.h
+++ b/src/include/storage/store/rel_table_data.h
@@ -21,9 +21,9 @@ struct CSRHeaderColumns {
     std::unique_ptr<Column> length;
 };
 
-class RelTableVersionRecordHandlerData : public VersionRecordHandlerData {
+class RelTableVersionRecordHandlerSelector : public VersionRecordHandlerSelector {
 public:
-    RelTableVersionRecordHandlerData(RelTableData* relTableData, CSRNodeGroupScanSource source)
+    RelTableVersionRecordHandlerSelector(RelTableData* relTableData, CSRNodeGroupScanSource source)
         : relTableData(relTableData), source(source) {}
 
     std::unique_ptr<VersionRecordHandler> constructVersionRecordHandler(common::row_idx_t startRow,
@@ -71,7 +71,7 @@ public:
     NodeGroup* getOrCreateNodeGroup(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx) const {
         return nodeGroups->getOrCreateNodeGroup(transaction, nodeGroupIdx, NodeGroupDataFormat::CSR,
-            &persistentVersionRecordHandlerData);
+            &persistentVersionRecordHandlerSelector);
     }
 
     common::RelMultiplicity getMultiplicity() const { return multiplicity; }
@@ -118,7 +118,7 @@ private:
         return types;
     }
 
-    const RelTableVersionRecordHandlerData* getVersionRecordHandlerData(
+    const RelTableVersionRecordHandlerSelector* getVersionRecordHandlerSelector(
         CSRNodeGroupScanSource source);
 
 private:
@@ -137,8 +137,8 @@ private:
     CSRHeaderColumns csrHeaderColumns;
     std::vector<std::unique_ptr<Column>> columns;
 
-    RelTableVersionRecordHandlerData persistentVersionRecordHandlerData;
-    RelTableVersionRecordHandlerData inMemoryVersionRecordHandlerData;
+    RelTableVersionRecordHandlerSelector persistentVersionRecordHandlerSelector;
+    RelTableVersionRecordHandlerSelector inMemoryVersionRecordHandlerSelector;
 };
 
 } // namespace storage

--- a/src/include/storage/store/rel_table_data.h
+++ b/src/include/storage/store/rel_table_data.h
@@ -55,8 +55,8 @@ public:
     }
     NodeGroup* getOrCreateNodeGroup(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx) const {
-        return nodeGroups->getOrCreateNodeGroup(transaction, nodeGroupIdx,
-            NodeGroupDataFormat::CSR);
+        return nodeGroups->getOrCreateNodeGroup(transaction, nodeGroupIdx, NodeGroupDataFormat::CSR,
+            &persistentIteratorConstructFunc);
     }
 
     common::RelMultiplicity getMultiplicity() const { return multiplicity; }
@@ -113,6 +113,9 @@ private:
 
     CSRHeaderColumns csrHeaderColumns;
     std::vector<std::unique_ptr<Column>> columns;
+
+    chunked_group_iterator_construct_t inMemIteratorConstructFunc;
+    chunked_group_iterator_construct_t persistentIteratorConstructFunc;
 };
 
 } // namespace storage

--- a/src/include/storage/store/rel_table_data.h
+++ b/src/include/storage/store/rel_table_data.h
@@ -30,7 +30,7 @@ public:
         const common::ValueVector& relIDVector, common::column_id_t columnID,
         const common::ValueVector& dataVector) const;
     bool delete_(transaction::Transaction* transaction, common::ValueVector& boundNodeIDVector,
-        const common::ValueVector& relIDVector) const;
+        const common::ValueVector& relIDVector);
     void addColumn(transaction::Transaction* transaction, TableAddColumnState& addColumnState);
 
     bool checkIfNodeHasRels(transaction::Transaction* transaction,
@@ -57,20 +57,16 @@ public:
         return nodeGroups->getOrCreateNodeGroup(nodeGroupIdx, NodeGroupDataFormat::CSR);
     }
 
-    common::row_idx_t getNumRows() const {
-        common::row_idx_t numRows = 0;
-        const auto numGroups = nodeGroups->getNumNodeGroups();
-        for (auto nodeGroupIdx = 0u; nodeGroupIdx < numGroups; nodeGroupIdx++) {
-            numRows += nodeGroups->getNodeGroup(nodeGroupIdx)->getNumRows();
-        }
-        return numRows;
-    }
+    NodeGroupCollection* getNodeGroups() { return nodeGroups.get(); }
 
     common::RelMultiplicity getMultiplicity() const { return multiplicity; }
 
     TableStats getStats() const { return nodeGroups->getStats(); }
 
     void checkpoint(const std::vector<common::column_id_t>& columnIDs);
+
+    void pushInsertInfo(transaction::Transaction* transaction, const CSRNodeGroup& nodeGroup,
+        common::row_idx_t numRows_, CSRNodeGroupScanSource source);
 
     void serialize(common::Serializer& serializer) const;
 

--- a/src/include/storage/store/rel_table_data.h
+++ b/src/include/storage/store/rel_table_data.h
@@ -57,8 +57,6 @@ public:
         return nodeGroups->getOrCreateNodeGroup(nodeGroupIdx, NodeGroupDataFormat::CSR);
     }
 
-    NodeGroupCollection* getNodeGroups() { return nodeGroups.get(); }
-
     common::RelMultiplicity getMultiplicity() const { return multiplicity; }
 
     TableStats getStats() const { return nodeGroups->getStats(); }

--- a/src/include/storage/store/rel_table_data.h
+++ b/src/include/storage/store/rel_table_data.h
@@ -86,8 +86,8 @@ public:
     }
     NodeGroup* getOrCreateNodeGroup(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx) const {
-        return nodeGroups->getOrCreateNodeGroup(transaction, nodeGroupIdx, NodeGroupDataFormat::CSR,
-            &persistentVersionRecordHandler);
+        return nodeGroups->getOrCreateNodeGroup(transaction, nodeGroupIdx,
+            NodeGroupDataFormat::CSR);
     }
 
     common::RelMultiplicity getMultiplicity() const { return multiplicity; }

--- a/src/include/storage/store/string_column.h
+++ b/src/include/storage/store/string_column.h
@@ -17,10 +17,10 @@ public:
     static std::unique_ptr<ColumnChunkData> flushChunkData(const ColumnChunkData& chunkData,
         FileHandle& dataFH);
 
-    void scan(transaction::Transaction* transaction, const ChunkState& state,
+    void scan(const transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
         common::ValueVector* resultVector, uint64_t offsetInVector = 0) const override;
-    void scan(transaction::Transaction* transaction, const ChunkState& state,
+    void scan(const transaction::Transaction* transaction, const ChunkState& state,
         ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET) const override;
 
@@ -39,13 +39,13 @@ protected:
     void scanInternal(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInChunk, common::row_idx_t numValuesToScan,
         common::ValueVector* resultVector) const override;
-    void scanUnfiltered(transaction::Transaction* transaction, const ChunkState& state,
+    void scanUnfiltered(const transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInChunk, common::offset_t numValuesToRead,
         common::ValueVector* resultVector, common::sel_t startPosInVector = 0) const;
     void scanFiltered(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInChunk, common::ValueVector* resultVector) const;
 
-    void lookupInternal(transaction::Transaction* transaction, const ChunkState& state,
+    void lookupInternal(const transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t nodeOffset, common::ValueVector* resultVector,
         uint32_t posInVector) const override;
 

--- a/src/include/storage/store/struct_column.h
+++ b/src/include/storage/store/struct_column.h
@@ -14,10 +14,10 @@ public:
     static std::unique_ptr<ColumnChunkData> flushChunkData(const ColumnChunkData& chunk,
         FileHandle& dataFH);
 
-    void scan(transaction::Transaction* transaction, const ChunkState& state,
+    void scan(const transaction::Transaction* transaction, const ChunkState& state,
         ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET) const override;
-    void scan(transaction::Transaction* transaction, const ChunkState& state,
+    void scan(const transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
         common::ValueVector* resultVector, uint64_t offsetInVector) const override;
 
@@ -35,7 +35,7 @@ protected:
         common::offset_t startOffsetInChunk, common::row_idx_t numValuesToScan,
         common::ValueVector* resultVector) const override;
 
-    void lookupInternal(transaction::Transaction* transaction, const ChunkState& state,
+    void lookupInternal(const transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t nodeOffset, common::ValueVector* resultVector,
         uint32_t posInVector) const override;
 

--- a/src/include/storage/store/table.h
+++ b/src/include/storage/store/table.h
@@ -13,9 +13,6 @@ class ExpressionEvaluator;
 namespace storage {
 class MemoryManager;
 
-using pre_rollback_insert_func_t = std::function<void(const transaction::Transaction*,
-    common::row_idx_t, common::row_idx_t, common::node_group_idx_t)>;
-
 enum class TableScanSource : uint8_t { COMMITTED = 0, UNCOMMITTED = 1, NONE = UINT8_MAX };
 
 struct TableScanState {

--- a/src/include/storage/store/table.h
+++ b/src/include/storage/store/table.h
@@ -13,6 +13,9 @@ class ExpressionEvaluator;
 namespace storage {
 class MemoryManager;
 
+using pre_rollback_insert_func_t = std::function<void(const transaction::Transaction*,
+    common::row_idx_t, common::row_idx_t, common::node_group_idx_t)>;
+
 enum class TableScanSource : uint8_t { COMMITTED = 0, UNCOMMITTED = 1, NONE = UINT8_MAX };
 
 struct TableScanState {

--- a/src/include/storage/store/version_info.h
+++ b/src/include/storage/store/version_info.h
@@ -86,9 +86,9 @@ class VersionInfo {
 public:
     VersionInfo() {}
 
-    void append(const transaction::Transaction* transaction, common::row_idx_t startRow,
+    void append(common::transaction_t transactionID, common::row_idx_t startRow,
         common::row_idx_t numRows);
-    bool delete_(const transaction::Transaction* transaction, common::row_idx_t rowIdx);
+    bool delete_(common::transaction_t transactionID, common::row_idx_t rowIdx);
 
     void getSelVectorToScan(common::transaction_t startTS, common::transaction_t transactionID,
         common::SelectionVector& selVector, common::row_idx_t startRow,

--- a/src/include/storage/store/version_info.h
+++ b/src/include/storage/store/version_info.h
@@ -86,10 +86,9 @@ class VersionInfo {
 public:
     VersionInfo() {}
 
-    void append(const transaction::Transaction* transaction, ChunkedNodeGroup* chunkedNodeGroup,
-        common::row_idx_t startRow, common::row_idx_t numRows);
-    bool delete_(const transaction::Transaction* transaction, ChunkedNodeGroup* chunkedNodeGroup,
-        common::row_idx_t rowIdx);
+    void append(const transaction::Transaction* transaction, common::row_idx_t startRow,
+        common::row_idx_t numRows);
+    bool delete_(const transaction::Transaction* transaction, common::row_idx_t rowIdx);
 
     void getSelVectorToScan(common::transaction_t startTS, common::transaction_t transactionID,
         common::SelectionVector& selVector, common::row_idx_t startRow,

--- a/src/include/storage/store/version_record_handler.h
+++ b/src/include/storage/store/version_record_handler.h
@@ -7,8 +7,6 @@
 namespace kuzu {
 
 namespace storage {
-class NodeGroupCollection;
-class VersionRecordHandler;
 
 using version_record_handler_op_t = void (
     ChunkedNodeGroup::*)(common::row_idx_t, common::row_idx_t, common::transaction_t);

--- a/src/include/storage/store/version_record_handler.h
+++ b/src/include/storage/store/version_record_handler.h
@@ -2,12 +2,9 @@
 
 #include "common/types/types.h"
 #include "storage/store/chunked_node_group.h"
+#include "transaction/transaction.h"
 
 namespace kuzu {
-
-namespace transaction {
-class Transaction;
-}
 
 namespace storage {
 class NodeGroupCollection;
@@ -19,35 +16,15 @@ using version_record_handler_op_t = void (
 // Note: these iterators are not necessarily thread-safe when used on their own
 class VersionRecordHandler {
 public:
-    VersionRecordHandler(NodeGroupCollection* nodeGroups, common::row_idx_t startRow,
-        common::row_idx_t numRows, common::transaction_t commitTS)
-        : startRow(startRow), numRows(numRows), commitTS(commitTS), nodeGroups(nodeGroups) {}
-
     virtual ~VersionRecordHandler() = default;
 
-    virtual void applyFuncToChunkedGroups(version_record_handler_op_t func) = 0;
+    virtual void applyFuncToChunkedGroups(version_record_handler_op_t func,
+        common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
+        common::row_idx_t numRows, common::transaction_t commitTS) const = 0;
 
-    virtual void rollbackInsert(const transaction::Transaction* /*transaction*/) {
-        applyFuncToChunkedGroups(&ChunkedNodeGroup::rollbackInsert);
-    }
-
-protected:
-    common::row_idx_t startRow;
-    common::row_idx_t numRows;
-    common::transaction_t commitTS;
-
-    NodeGroupCollection* nodeGroups;
-};
-
-// Contains pointer to a table + any information needed by the table to construct a
-// VersionRecordHandler
-class VersionRecordHandlerSelector {
-public:
-    virtual ~VersionRecordHandlerSelector() = default;
-
-    virtual std::unique_ptr<VersionRecordHandler> constructVersionRecordHandler(
-        common::row_idx_t startRow, common::row_idx_t numRows, common::transaction_t commitTS,
-        common::node_group_idx_t nodeGroupIdx) const = 0;
+    virtual void rollbackInsert(const transaction::Transaction* transaction,
+        common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
+        common::row_idx_t numRows) const;
 };
 
 } // namespace storage

--- a/src/include/storage/store/version_record_handler.h
+++ b/src/include/storage/store/version_record_handler.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include "common/types/types.h"
-#include "storage/store/chunked_node_group.h"
 #include "transaction/transaction.h"
 
 namespace kuzu {
 
 namespace storage {
+
+class ChunkedNodeGroup;
 
 using version_record_handler_op_t = void (
     ChunkedNodeGroup::*)(common::row_idx_t, common::row_idx_t, common::transaction_t);

--- a/src/include/storage/undo_buffer.h
+++ b/src/include/storage/undo_buffer.h
@@ -66,8 +66,6 @@ private:
 class UpdateInfo;
 class VersionInfo;
 struct VectorUpdateInfo;
-class RelTableData;
-class NodeTable;
 class WAL;
 // This class is not thread safe, as it is supposed to be accessed by a single thread.
 class UndoBuffer {

--- a/src/include/storage/undo_buffer.h
+++ b/src/include/storage/undo_buffer.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <functional>
 #include <mutex>
 
 #include "common/constants.h"
 #include "common/types/types.h"
 #include "storage/enums/csr_node_group_scan_source.h"
+#include "storage/store/table.h"
 
 namespace kuzu {
 namespace catalog {
@@ -22,9 +22,6 @@ namespace main {
 class ClientContext;
 }
 namespace storage {
-
-using pre_rollback_callback_t = std::function<void(const transaction::Transaction*,
-    common::row_idx_t, common::row_idx_t, common::node_group_idx_t)>;
 
 // TODO(Guodong): This should be reworked to use MemoryManager for memory allocaiton.
 //                For now, we use malloc to get around the limitation of 256KB from MM.
@@ -114,9 +111,10 @@ private:
     uint8_t* createUndoRecord(uint64_t size);
 
     void createVersionInfo(UndoRecordType recordType, NodeGroupCollection* nodeGroupCollection,
-        pre_rollback_callback_t preRollbackCallback, common::row_idx_t startRow,
-        common::row_idx_t numRows, common::node_group_idx_t nodeGroupIdx = 0,
-        storage::CSRNodeGroupScanSource source = CSRNodeGroupScanSource::NONE);
+        common::row_idx_t startRow, common::row_idx_t numRows,
+        common::node_group_idx_t nodeGroupIdx = 0,
+        storage::CSRNodeGroupScanSource source = CSRNodeGroupScanSource::NONE,
+        const pre_rollback_insert_func_t* preRollbackCallback = nullptr);
 
     void commitRecord(UndoRecordType recordType, const uint8_t* record,
         common::transaction_t commitTS) const;

--- a/src/include/storage/undo_buffer.h
+++ b/src/include/storage/undo_buffer.h
@@ -88,9 +88,11 @@ public:
     void createSequenceChange(catalog::SequenceCatalogEntry& sequenceEntry,
         const catalog::SequenceRollbackData& data);
     void createInsertInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
-        common::row_idx_t numRows, const chunked_group_iterator_construct_t* iteratorConstructFunc);
+        common::row_idx_t numRows,
+        const storage::VersionRecordHandlerData* versionRecordHandlerData);
     void createDeleteInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
-        common::row_idx_t numRows, const chunked_group_iterator_construct_t* iteratorConstructFunc);
+        common::row_idx_t numRows,
+        const storage::VersionRecordHandlerData* versionRecordHandlerData);
     void createVectorUpdateInfo(UpdateInfo* updateInfo, common::idx_t vectorIdx,
         VectorUpdateInfo* vectorUpdateInfo);
 
@@ -103,7 +105,8 @@ private:
     uint8_t* createUndoRecord(uint64_t size);
 
     void createVersionInfo(UndoRecordType recordType, common::row_idx_t startRow,
-        common::row_idx_t numRows, const chunked_group_iterator_construct_t* iteratorConstructFunc,
+        common::row_idx_t numRows,
+        const storage::VersionRecordHandlerData* versionRecordHandlerData,
         common::node_group_idx_t nodeGroupIdx = 0);
 
     void commitRecord(UndoRecordType recordType, const uint8_t* record,

--- a/src/include/storage/undo_buffer.h
+++ b/src/include/storage/undo_buffer.h
@@ -95,7 +95,7 @@ public:
         VectorUpdateInfo* vectorUpdateInfo);
 
     void commit(common::transaction_t commitTS) const;
-    void rollback(const transaction::Transaction* transaction);
+    void rollback();
 
     uint64_t getMemUsage() const;
 

--- a/src/include/storage/undo_buffer.h
+++ b/src/include/storage/undo_buffer.h
@@ -4,8 +4,7 @@
 
 #include "common/constants.h"
 #include "common/types/types.h"
-#include "storage/enums/csr_node_group_scan_source.h"
-#include "transaction/transaction.h"
+#include "storage/store/node_group.h"
 
 namespace kuzu {
 namespace catalog {
@@ -88,13 +87,10 @@ public:
     void createCatalogEntry(catalog::CatalogSet& catalogSet, catalog::CatalogEntry& catalogEntry);
     void createSequenceChange(catalog::SequenceCatalogEntry& sequenceEntry,
         const catalog::SequenceRollbackData& data);
-    void createInsertInfo(NodeGroupCollection* nodeGroups, common::node_group_idx_t nodeGroupIdx,
-        common::row_idx_t startRow, common::row_idx_t numRows,
-        storage::CSRNodeGroupScanSource source = CSRNodeGroupScanSource::NONE,
-        const transaction::rollback_insert_func_t* rollbackInsertFunc = nullptr);
-    void createDeleteInfo(NodeGroupCollection* nodeGroups, common::node_group_idx_t nodeGroupIdx,
-        common::row_idx_t startRow, common::row_idx_t numRows,
-        storage::CSRNodeGroupScanSource source);
+    void createInsertInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
+        common::row_idx_t numRows, const chunked_group_iterator_construct_t* iteratorConstructFunc);
+    void createDeleteInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
+        common::row_idx_t numRows, const chunked_group_iterator_construct_t* iteratorConstructFunc);
     void createVectorUpdateInfo(UpdateInfo* updateInfo, common::idx_t vectorIdx,
         VectorUpdateInfo* vectorUpdateInfo);
 
@@ -106,11 +102,9 @@ public:
 private:
     uint8_t* createUndoRecord(uint64_t size);
 
-    void createVersionInfo(UndoRecordType recordType, NodeGroupCollection* nodeGroupCollection,
-        common::row_idx_t startRow, common::row_idx_t numRows,
-        common::node_group_idx_t nodeGroupIdx = 0,
-        storage::CSRNodeGroupScanSource source = CSRNodeGroupScanSource::NONE,
-        const transaction::rollback_insert_func_t* rollbackInsertFunc = nullptr);
+    void createVersionInfo(UndoRecordType recordType, common::row_idx_t startRow,
+        common::row_idx_t numRows, const chunked_group_iterator_construct_t* iteratorConstructFunc,
+        common::node_group_idx_t nodeGroupIdx = 0);
 
     void commitRecord(UndoRecordType recordType, const uint8_t* record,
         common::transaction_t commitTS) const;

--- a/src/include/storage/undo_buffer.h
+++ b/src/include/storage/undo_buffer.h
@@ -5,7 +5,7 @@
 #include "common/constants.h"
 #include "common/types/types.h"
 #include "storage/enums/csr_node_group_scan_source.h"
-#include "storage/store/table.h"
+#include "transaction/transaction.h"
 
 namespace kuzu {
 namespace catalog {
@@ -69,7 +69,6 @@ class VersionInfo;
 struct VectorUpdateInfo;
 class RelTableData;
 class NodeTable;
-class NodeGroupCollection;
 class WAL;
 // This class is not thread safe, as it is supposed to be accessed by a single thread.
 class UndoBuffer {
@@ -91,9 +90,8 @@ public:
         const catalog::SequenceRollbackData& data);
     void createInsertInfo(NodeGroupCollection* nodeGroups, common::node_group_idx_t nodeGroupIdx,
         common::row_idx_t startRow, common::row_idx_t numRows,
-        storage::CSRNodeGroupScanSource source = CSRNodeGroupScanSource::NONE);
-    void createInsertInfo(NodeTable* nodeTable, common::node_group_idx_t nodeGroupIdx,
-        common::row_idx_t startRow, common::row_idx_t numRows);
+        storage::CSRNodeGroupScanSource source = CSRNodeGroupScanSource::NONE,
+        const transaction::rollback_insert_func_t* rollbackInsertFunc = nullptr);
     void createDeleteInfo(NodeGroupCollection* nodeGroups, common::node_group_idx_t nodeGroupIdx,
         common::row_idx_t startRow, common::row_idx_t numRows,
         storage::CSRNodeGroupScanSource source);
@@ -112,7 +110,7 @@ private:
         common::row_idx_t startRow, common::row_idx_t numRows,
         common::node_group_idx_t nodeGroupIdx = 0,
         storage::CSRNodeGroupScanSource source = CSRNodeGroupScanSource::NONE,
-        const pre_rollback_insert_func_t* preRollbackCallback = nullptr);
+        const transaction::rollback_insert_func_t* rollbackInsertFunc = nullptr);
 
     void commitRecord(UndoRecordType recordType, const uint8_t* record,
         common::transaction_t commitTS) const;

--- a/src/include/storage/undo_buffer.h
+++ b/src/include/storage/undo_buffer.h
@@ -89,10 +89,10 @@ public:
         const catalog::SequenceRollbackData& data);
     void createInsertInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
         common::row_idx_t numRows,
-        const storage::VersionRecordHandlerData* versionRecordHandlerData);
+        const storage::VersionRecordHandlerSelector* versionRecordHandlerSelector);
     void createDeleteInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
         common::row_idx_t numRows,
-        const storage::VersionRecordHandlerData* versionRecordHandlerData);
+        const storage::VersionRecordHandlerSelector* versionRecordHandlerSelector);
     void createVectorUpdateInfo(UpdateInfo* updateInfo, common::idx_t vectorIdx,
         VectorUpdateInfo* vectorUpdateInfo);
 
@@ -106,7 +106,7 @@ private:
 
     void createVersionInfo(UndoRecordType recordType, common::row_idx_t startRow,
         common::row_idx_t numRows,
-        const storage::VersionRecordHandlerData* versionRecordHandlerData,
+        const storage::VersionRecordHandlerSelector* versionRecordHandlerSelector,
         common::node_group_idx_t nodeGroupIdx = 0);
 
     void commitRecord(UndoRecordType recordType, const uint8_t* record,

--- a/src/include/storage/undo_buffer.h
+++ b/src/include/storage/undo_buffer.h
@@ -88,11 +88,9 @@ public:
     void createSequenceChange(catalog::SequenceCatalogEntry& sequenceEntry,
         const catalog::SequenceRollbackData& data);
     void createInsertInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
-        common::row_idx_t numRows,
-        const storage::VersionRecordHandlerSelector* versionRecordHandlerSelector);
+        common::row_idx_t numRows, const storage::VersionRecordHandler* versionRecordHandler);
     void createDeleteInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
-        common::row_idx_t numRows,
-        const storage::VersionRecordHandlerSelector* versionRecordHandlerSelector);
+        common::row_idx_t numRows, const storage::VersionRecordHandler* versionRecordHandler);
     void createVectorUpdateInfo(UpdateInfo* updateInfo, common::idx_t vectorIdx,
         VectorUpdateInfo* vectorUpdateInfo);
 
@@ -105,8 +103,7 @@ private:
     uint8_t* createUndoRecord(uint64_t size);
 
     void createVersionInfo(UndoRecordType recordType, common::row_idx_t startRow,
-        common::row_idx_t numRows,
-        const storage::VersionRecordHandlerSelector* versionRecordHandlerSelector,
+        common::row_idx_t numRows, const storage::VersionRecordHandler* versionRecordHandler,
         common::node_group_idx_t nodeGroupIdx = 0);
 
     void commitRecord(UndoRecordType recordType, const uint8_t* record,

--- a/src/include/storage/undo_buffer.h
+++ b/src/include/storage/undo_buffer.h
@@ -89,14 +89,12 @@ public:
     void createCatalogEntry(catalog::CatalogSet& catalogSet, catalog::CatalogEntry& catalogEntry);
     void createSequenceChange(catalog::SequenceCatalogEntry& sequenceEntry,
         const catalog::SequenceRollbackData& data);
-    void createInsertInfo(RelTableData* relTableData, common::node_group_idx_t nodeGroupIdx,
+    void createInsertInfo(NodeGroupCollection* nodeGroups, common::node_group_idx_t nodeGroupIdx,
         common::row_idx_t startRow, common::row_idx_t numRows,
-        storage::CSRNodeGroupScanSource source);
+        storage::CSRNodeGroupScanSource source = CSRNodeGroupScanSource::NONE);
     void createInsertInfo(NodeTable* nodeTable, common::node_group_idx_t nodeGroupIdx,
         common::row_idx_t startRow, common::row_idx_t numRows);
-    void createDeleteInfo(NodeTable* nodeTable, common::node_group_idx_t nodeGroupIdx,
-        common::row_idx_t startRow, common::row_idx_t numRows);
-    void createDeleteInfo(RelTableData* relTableData, common::node_group_idx_t nodeGroupIdx,
+    void createDeleteInfo(NodeGroupCollection* nodeGroups, common::node_group_idx_t nodeGroupIdx,
         common::row_idx_t startRow, common::row_idx_t numRows,
         storage::CSRNodeGroupScanSource source);
     void createVectorUpdateInfo(UpdateInfo* updateInfo, common::idx_t vectorIdx,

--- a/src/include/storage/undo_buffer.h
+++ b/src/include/storage/undo_buffer.h
@@ -4,7 +4,6 @@
 
 #include "common/constants.h"
 #include "common/types/types.h"
-#include "storage/store/node_group.h"
 
 namespace kuzu {
 namespace catalog {
@@ -21,6 +20,7 @@ namespace main {
 class ClientContext;
 }
 namespace storage {
+class VersionRecordHandler;
 
 // TODO(Guodong): This should be reworked to use MemoryManager for memory allocaiton.
 //                For now, we use malloc to get around the limitation of 256KB from MM.
@@ -86,9 +86,9 @@ public:
     void createSequenceChange(catalog::SequenceCatalogEntry& sequenceEntry,
         const catalog::SequenceRollbackData& data);
     void createInsertInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
-        common::row_idx_t numRows, const storage::VersionRecordHandler* versionRecordHandler);
+        common::row_idx_t numRows, const VersionRecordHandler* versionRecordHandler);
     void createDeleteInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
-        common::row_idx_t numRows, const storage::VersionRecordHandler* versionRecordHandler);
+        common::row_idx_t numRows, const VersionRecordHandler* versionRecordHandler);
     void createVectorUpdateInfo(UpdateInfo* updateInfo, common::idx_t vectorIdx,
         VectorUpdateInfo* vectorUpdateInfo);
 
@@ -101,7 +101,7 @@ private:
     uint8_t* createUndoRecord(uint64_t size);
 
     void createVersionInfo(UndoRecordType recordType, common::row_idx_t startRow,
-        common::row_idx_t numRows, const storage::VersionRecordHandler* versionRecordHandler,
+        common::row_idx_t numRows, const VersionRecordHandler* versionRecordHandler,
         common::node_group_idx_t nodeGroupIdx = 0);
 
     void commitRecord(UndoRecordType recordType, const uint8_t* record,

--- a/src/include/transaction/transaction.h
+++ b/src/include/transaction/transaction.h
@@ -22,11 +22,9 @@ class UpdateInfo;
 struct VectorUpdateInfo;
 class ChunkedNodeGroup;
 class VersionRecordHandler;
-class VersionRecordHandlerSelector;
 } // namespace storage
 namespace transaction {
 class TransactionManager;
-class Transaction;
 
 enum class TransactionType : uint8_t { READ_ONLY, WRITE, CHECKPOINT, DUMMY, RECOVERY };
 

--- a/src/include/transaction/transaction.h
+++ b/src/include/transaction/transaction.h
@@ -23,15 +23,12 @@ class VersionInfo;
 class UpdateInfo;
 struct VectorUpdateInfo;
 class ChunkedNodeGroup;
-class ChunkedGroupUndoIterator;
+class VersionRecordHandler;
+class VersionRecordHandlerData;
 } // namespace storage
 namespace transaction {
 class TransactionManager;
 class Transaction;
-
-using chunked_group_iterator_construct_t =
-    std::function<std::unique_ptr<storage::ChunkedGroupUndoIterator>(common::row_idx_t,
-        common::row_idx_t, common::node_group_idx_t, common::transaction_t commitTS)>;
 
 enum class TransactionType : uint8_t { READ_ONLY, WRITE, CHECKPOINT, DUMMY, RECOVERY };
 
@@ -123,10 +120,10 @@ public:
         const catalog::SequenceRollbackData& data) const;
     void pushInsertInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
         common::row_idx_t numRows,
-        const chunked_group_iterator_construct_t* constructIteratorFunc = nullptr) const;
+        const storage::VersionRecordHandlerData* versionRecordHandlerData) const;
     void pushDeleteInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
         common::row_idx_t numRows,
-        const chunked_group_iterator_construct_t* constructIteratorFunc) const;
+        const storage::VersionRecordHandlerData* versionRecordHandlerData) const;
     void pushVectorUpdateInfo(storage::UpdateInfo& updateInfo, common::idx_t vectorIdx,
         storage::VectorUpdateInfo& vectorUpdateInfo) const;
 

--- a/src/include/transaction/transaction.h
+++ b/src/include/transaction/transaction.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <functional>
-
 #include "common/enums/statement_type.h"
 #include "common/types/types.h"
 
@@ -119,11 +117,9 @@ public:
     void pushSequenceChange(catalog::SequenceCatalogEntry* sequenceEntry, int64_t kCount,
         const catalog::SequenceRollbackData& data) const;
     void pushInsertInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
-        common::row_idx_t numRows,
-        const storage::VersionRecordHandlerSelector* versionRecordHandlerSelector) const;
+        common::row_idx_t numRows, const storage::VersionRecordHandler* versionRecordHandler) const;
     void pushDeleteInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
-        common::row_idx_t numRows,
-        const storage::VersionRecordHandlerSelector* versionRecordHandlerSelector) const;
+        common::row_idx_t numRows, const storage::VersionRecordHandler* versionRecordHandler) const;
     void pushVectorUpdateInfo(storage::UpdateInfo& updateInfo, common::idx_t vectorIdx,
         storage::VectorUpdateInfo& vectorUpdateInfo) const;
 

--- a/src/include/transaction/transaction.h
+++ b/src/include/transaction/transaction.h
@@ -24,7 +24,7 @@ class UpdateInfo;
 struct VectorUpdateInfo;
 class ChunkedNodeGroup;
 class VersionRecordHandler;
-class VersionRecordHandlerData;
+class VersionRecordHandlerSelector;
 } // namespace storage
 namespace transaction {
 class TransactionManager;
@@ -120,10 +120,10 @@ public:
         const catalog::SequenceRollbackData& data) const;
     void pushInsertInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
         common::row_idx_t numRows,
-        const storage::VersionRecordHandlerData* versionRecordHandlerData) const;
+        const storage::VersionRecordHandlerSelector* versionRecordHandlerSelector) const;
     void pushDeleteInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
         common::row_idx_t numRows,
-        const storage::VersionRecordHandlerData* versionRecordHandlerData) const;
+        const storage::VersionRecordHandlerSelector* versionRecordHandlerSelector) const;
     void pushVectorUpdateInfo(storage::UpdateInfo& updateInfo, common::idx_t vectorIdx,
         storage::VectorUpdateInfo& vectorUpdateInfo) const;
 

--- a/src/include/transaction/transaction.h
+++ b/src/include/transaction/transaction.h
@@ -2,6 +2,7 @@
 
 #include "common/enums/statement_type.h"
 #include "common/types/types.h"
+#include "storage/enums/csr_node_group_scan_source.h"
 
 namespace kuzu {
 namespace catalog {
@@ -20,10 +21,13 @@ class WAL;
 class VersionInfo;
 class UpdateInfo;
 struct VectorUpdateInfo;
+class RelTableData;
+class NodeTable;
 class ChunkedNodeGroup;
 } // namespace storage
 namespace transaction {
 class TransactionManager;
+class Transaction;
 
 enum class TransactionType : uint8_t { READ_ONLY, WRITE, CHECKPOINT, DUMMY, RECOVERY };
 
@@ -113,10 +117,16 @@ public:
         bool skipLoggingToWAL = false) const;
     void pushSequenceChange(catalog::SequenceCatalogEntry* sequenceEntry, int64_t kCount,
         const catalog::SequenceRollbackData& data) const;
-    void pushInsertInfo(storage::ChunkedNodeGroup* chunkedNodeGroup, common::row_idx_t startRow,
-        common::row_idx_t numRows) const;
-    void pushDeleteInfo(storage::ChunkedNodeGroup* chunkedNodeGroup, common::row_idx_t startRow,
-        common::row_idx_t numRows) const;
+    void pushInsertInfo(storage::RelTableData* relTableData, common::node_group_idx_t nodeGroupIdx,
+        common::row_idx_t startRow, common::row_idx_t numRows,
+        storage::CSRNodeGroupScanSource source) const;
+    void pushInsertInfo(storage::NodeTable* nodeTable, common::node_group_idx_t nodeGroupIdx,
+        common::row_idx_t startRow, common::row_idx_t numRows) const;
+    void pushDeleteInfo(storage::RelTableData* relTableData, common::node_group_idx_t nodeGroupIdx,
+        common::row_idx_t startRow, common::row_idx_t numRows,
+        storage::CSRNodeGroupScanSource source) const;
+    void pushDeleteInfo(storage::NodeTable* nodeTable, common::node_group_idx_t nodeGroupIdx,
+        common::row_idx_t startRow, common::row_idx_t numRows) const;
     void pushVectorUpdateInfo(storage::UpdateInfo& updateInfo, common::idx_t vectorIdx,
         storage::VectorUpdateInfo& vectorUpdateInfo) const;
 

--- a/src/include/transaction/transaction.h
+++ b/src/include/transaction/transaction.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "common/enums/statement_type.h"
 #include "common/types/types.h"
 #include "storage/enums/csr_node_group_scan_source.h"
@@ -27,6 +29,10 @@ class ChunkedNodeGroup;
 namespace transaction {
 class TransactionManager;
 class Transaction;
+
+using rollback_insert_func_t =
+    std::function<void(const transaction::Transaction*, common::row_idx_t, common::row_idx_t,
+        common::node_group_idx_t, storage::CSRNodeGroupScanSource)>;
 
 enum class TransactionType : uint8_t { READ_ONLY, WRITE, CHECKPOINT, DUMMY, RECOVERY };
 
@@ -119,7 +125,8 @@ public:
     void pushInsertInfo(storage::NodeGroupCollection* nodeGroups,
         common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
         common::row_idx_t numRows,
-        storage::CSRNodeGroupScanSource source = storage::CSRNodeGroupScanSource::NONE) const;
+        storage::CSRNodeGroupScanSource source = storage::CSRNodeGroupScanSource::NONE,
+        const transaction::rollback_insert_func_t* rollbackInsertCallback = nullptr) const;
     void pushDeleteInfo(storage::NodeGroupCollection* nodeGroups,
         common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
         common::row_idx_t numRows,

--- a/src/include/transaction/transaction.h
+++ b/src/include/transaction/transaction.h
@@ -21,8 +21,7 @@ class WAL;
 class VersionInfo;
 class UpdateInfo;
 struct VectorUpdateInfo;
-class RelTableData;
-class NodeTable;
+class NodeGroupCollection;
 class ChunkedNodeGroup;
 } // namespace storage
 namespace transaction {
@@ -117,16 +116,14 @@ public:
         bool skipLoggingToWAL = false) const;
     void pushSequenceChange(catalog::SequenceCatalogEntry* sequenceEntry, int64_t kCount,
         const catalog::SequenceRollbackData& data) const;
-    void pushInsertInfo(storage::RelTableData* relTableData, common::node_group_idx_t nodeGroupIdx,
-        common::row_idx_t startRow, common::row_idx_t numRows,
-        storage::CSRNodeGroupScanSource source) const;
-    void pushInsertInfo(storage::NodeTable* nodeTable, common::node_group_idx_t nodeGroupIdx,
-        common::row_idx_t startRow, common::row_idx_t numRows) const;
-    void pushDeleteInfo(storage::RelTableData* relTableData, common::node_group_idx_t nodeGroupIdx,
-        common::row_idx_t startRow, common::row_idx_t numRows,
-        storage::CSRNodeGroupScanSource source) const;
-    void pushDeleteInfo(storage::NodeTable* nodeTable, common::node_group_idx_t nodeGroupIdx,
-        common::row_idx_t startRow, common::row_idx_t numRows) const;
+    void pushInsertInfo(storage::NodeGroupCollection* nodeGroups,
+        common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
+        common::row_idx_t numRows,
+        storage::CSRNodeGroupScanSource source = storage::CSRNodeGroupScanSource::NONE) const;
+    void pushDeleteInfo(storage::NodeGroupCollection* nodeGroups,
+        common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
+        common::row_idx_t numRows,
+        storage::CSRNodeGroupScanSource source = storage::CSRNodeGroupScanSource::NONE) const;
     void pushVectorUpdateInfo(storage::UpdateInfo& updateInfo, common::idx_t vectorIdx,
         storage::VectorUpdateInfo& vectorUpdateInfo) const;
 

--- a/src/include/transaction/transaction.h
+++ b/src/include/transaction/transaction.h
@@ -22,7 +22,6 @@ class WAL;
 class VersionInfo;
 class UpdateInfo;
 struct VectorUpdateInfo;
-class NodeGroupCollection;
 class ChunkedNodeGroup;
 class ChunkedGroupUndoIterator;
 } // namespace storage

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -15,12 +15,14 @@ class ClientContext;
 
 namespace testing {
 class DBTest;
+class FlakyBufferManager;
 } // namespace testing
 
 namespace transaction {
 
 class TransactionManager {
     friend class testing::DBTest;
+    friend class testing::FlakyBufferManager;
 
 public:
     // Timestamp starts from 1. 0 is reserved for the dummy system transaction.

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -79,6 +79,12 @@ Database::Database(std::string_view databasePath, SystemConfig systemConfig)
     initMembers(databasePath);
 }
 
+Database::Database(std::string_view databasePath, SystemConfig systemConfig,
+    construct_bm_func_t constructBMFunc)
+    : dbConfig(systemConfig) {
+    initMembers(databasePath, constructBMFunc);
+}
+
 std::unique_ptr<storage::BufferManager> Database::initBufferManager(const Database& db) {
     return std::make_unique<BufferManager>(db.databasePath,
         db.vfs->joinPath(db.databasePath, StorageConstants::TEMP_SPILLING_FILE_NAME),

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -85,7 +85,9 @@ static void appendNewChunkedGroup(transaction::Transaction* transaction,
     const CSRNodeGroupScanSource source = isNewNodeGroup ?
                                               CSRNodeGroupScanSource::COMMITTED_PERSISTENT :
                                               CSRNodeGroupScanSource::COMMITTED_IN_MEMORY;
-    // TODO this may need to be atomic
+    // since each thread operates on distinct node groups
+    // We don't need a lock here (to ensure the insert info and append agree on the number of rows
+    // in the node group)
     relTable.pushInsertInfo(transaction, direction, nodeGroup, chunkedGroup.getNumRows(), source);
     if (isNewNodeGroup) {
         auto flushedChunkedGroup =

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -68,15 +68,10 @@ void RelBatchInsert::executeInternal(ExecutionContext* context) {
         }
         // TODO(Guodong): We need to handle the concurrency between COPY and other insertions
         // into the same node group.
-        auto& nodeGroup =
-            relTable->getOrCreateNodeGroup(relLocalState->nodeGroupIdx, relInfo->direction)
-                ->cast<CSRNodeGroup>();
-        if (nodeGroup.isEmpty()) {
-            // push an insert of size 0 so that we can rollback the creation of this node group if
-            // needed
-            relTable->pushInsertInfo(context->clientContext->getTx(), relInfo->direction, nodeGroup,
-                0, CSRNodeGroupScanSource::COMMITTED_PERSISTENT);
-        }
+        auto& nodeGroup = relTable
+                              ->getOrCreateNodeGroup(context->clientContext->getTx(),
+                                  relLocalState->nodeGroupIdx, relInfo->direction)
+                              ->cast<CSRNodeGroup>();
         appendNodeGroup(context->clientContext->getTx(), nodeGroup, *relInfo, *relLocalState,
             *sharedState, *partitionerSharedState);
         updateProgress(context);

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -85,6 +85,7 @@ static void appendNewChunkedGroup(transaction::Transaction* transaction,
     const CSRNodeGroupScanSource source = isNewNodeGroup ?
                                               CSRNodeGroupScanSource::COMMITTED_PERSISTENT :
                                               CSRNodeGroupScanSource::COMMITTED_IN_MEMORY;
+    // TODO this may need to be atomic
     relTable.pushInsertInfo(transaction, direction, nodeGroup, chunkedGroup.getNumRows(), source);
     if (isNewNodeGroup) {
         auto flushedChunkedGroup =

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -500,7 +500,7 @@ bool PrimaryKeyIndex::lookup(const Transaction* trx, ValueVector* keyVector, uin
     return retVal;
 }
 
-bool PrimaryKeyIndex::insert(const Transaction* transaction, ValueVector* keyVector,
+bool PrimaryKeyIndex::insert(const Transaction* transaction, const ValueVector* keyVector,
     uint64_t vectorPos, offset_t value, visible_func isVisible) {
     bool result = false;
     TypeUtils::visit(

--- a/src/storage/index/in_mem_hash_index.cpp
+++ b/src/storage/index/in_mem_hash_index.cpp
@@ -141,6 +141,7 @@ void InMemHashIndex<T>::reclaimOverflowSlots(SlotIterator iter) {
         while (iter.slot->header.numEntries() > 0 || iter.slotInfo.slotType == SlotType::PRIMARY) {
             lastNonEmptySlot = iter.slot;
             if (!nextChainedSlot(iter)) {
+                iter.slotInfo = HashIndexUtils::INVALID_OVF_INFO;
                 break;
             }
         }

--- a/src/storage/index/in_mem_hash_index.cpp
+++ b/src/storage/index/in_mem_hash_index.cpp
@@ -99,7 +99,10 @@ void InMemHashIndex<T>::splitSlot(HashIndexHeader& header) {
                 if (newSlotPos >= getSlotCapacity<T>()) {
                     auto newOvfSlotId = allocateAOSlot();
                     newSlot.slot->header.nextOvfSlotId = newOvfSlotId;
-                    nextChainedSlot(newSlot);
+                    if (newSlot.slot->header.nextOvfSlotId !=
+                        SlotHeader::INVALID_OVERFLOW_SLOT_ID) {
+                        nextChainedSlot(newSlot);
+                    }
                     newSlotPos = 0;
                 }
                 newSlot.slot->entries[newSlotPos] = entry;
@@ -114,7 +117,10 @@ void InMemHashIndex<T>::splitSlot(HashIndexHeader& header) {
                     entryPosToInsert++;
                     if (entryPosToInsert >= getSlotCapacity<T>()) {
                         entryPosToInsert = 0;
-                        nextChainedSlot(originalSlotForInsert);
+                        if (originalSlotForInsert.slot->header.nextOvfSlotId !=
+                            SlotHeader::INVALID_OVERFLOW_SLOT_ID) {
+                            nextChainedSlot(originalSlotForInsert);
+                        }
                     }
                 }
                 originalSlotForInsert.slot->entries[entryPosToInsert] = entry;

--- a/src/storage/store/CMakeLists.txt
+++ b/src/storage/store/CMakeLists.txt
@@ -29,7 +29,9 @@ add_library(kuzu_storage_store
         struct_column.cpp
         table.cpp
         update_info.cpp
-        version_info.cpp)
+        version_info.cpp
+        version_record_handler.cpp
+)
 
 set(ALL_OBJECT_FILES
         ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_storage_store>

--- a/src/storage/store/chunked_node_group.cpp
+++ b/src/storage/store/chunked_node_group.cpp
@@ -429,7 +429,12 @@ bool ChunkedNodeGroup::hasUpdates() const {
     return false;
 }
 
-void ChunkedNodeGroup::rollbackInsert(common::row_idx_t startRow, common::row_idx_t numRows_,
+void ChunkedNodeGroup::commitInsert(row_idx_t startRow, row_idx_t numRowsToCommit,
+    transaction_t commitTS) {
+    versionInfo->commitInsert(startRow, numRowsToCommit, commitTS);
+}
+
+void ChunkedNodeGroup::rollbackInsert(row_idx_t startRow, row_idx_t numRows_,
     common::transaction_t) {
     if (startRow == 0) {
         setNumRows(0);
@@ -442,11 +447,6 @@ void ChunkedNodeGroup::rollbackInsert(common::row_idx_t startRow, common::row_id
     }
     versionInfo->rollbackInsert(startRow, numRows_);
     numRows = startRow;
-}
-
-void ChunkedNodeGroup::commitInsert(row_idx_t startRow, row_idx_t numRowsToCommit,
-    transaction_t commitTS) {
-    versionInfo->commitInsert(startRow, numRowsToCommit, commitTS);
 }
 
 void ChunkedNodeGroup::commitDelete(row_idx_t startRow, row_idx_t numRows_,

--- a/src/storage/store/chunked_node_group.cpp
+++ b/src/storage/store/chunked_node_group.cpp
@@ -137,7 +137,7 @@ uint64_t ChunkedNodeGroup::append(const Transaction* transaction,
         if (!versionInfo) {
             versionInfo = std::make_unique<VersionInfo>();
         }
-        versionInfo->append(transaction, numRows, numRowsToAppendInChunk);
+        versionInfo->append(transaction->getID(), numRows, numRowsToAppendInChunk);
     }
     numRows += numRowsToAppendInChunk;
     return numRowsToAppendInChunk;
@@ -168,7 +168,7 @@ offset_t ChunkedNodeGroup::append(const Transaction* transaction,
         if (!versionInfo) {
             versionInfo = std::make_unique<VersionInfo>();
         }
-        versionInfo->append(transaction, numRows, numToAppendInChunkedGroup);
+        versionInfo->append(transaction->getID(), numRows, numToAppendInChunkedGroup);
     }
     numRows += numToAppendInChunkedGroup;
     return numToAppendInChunkedGroup;
@@ -334,7 +334,7 @@ bool ChunkedNodeGroup::delete_(const Transaction* transaction, row_idx_t rowIdxI
     if (!versionInfo) {
         versionInfo = std::make_unique<VersionInfo>();
     }
-    return versionInfo->delete_(transaction, rowIdxInChunk);
+    return versionInfo->delete_(transaction->getID(), rowIdxInChunk);
 }
 
 void ChunkedNodeGroup::addColumn(Transaction* transaction,
@@ -396,7 +396,7 @@ std::unique_ptr<ChunkedNodeGroup> ChunkedNodeGroup::flushAsNewChunkedNodeGroup(
         std::make_unique<ChunkedNodeGroup>(std::move(flushedChunks), 0 /*startRowIdx*/);
     flushedChunkedGroup->versionInfo = std::make_unique<VersionInfo>();
     KU_ASSERT(flushedChunkedGroup->getNumRows() == numRows);
-    flushedChunkedGroup->versionInfo->append(transaction, 0, numRows);
+    flushedChunkedGroup->versionInfo->append(transaction->getID(), 0, numRows);
     return flushedChunkedGroup;
 }
 

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -196,8 +196,9 @@ void Column::scan(Transaction* transaction, const ChunkState& state, offset_t st
     scanInternal(transaction, state, startOffsetInChunk, numValuesToScan, resultVector);
 }
 
-void Column::scan(Transaction* transaction, const ChunkState& state, offset_t startOffsetInGroup,
-    offset_t endOffsetInGroup, ValueVector* resultVector, uint64_t offsetInVector) const {
+void Column::scan(const Transaction* transaction, const ChunkState& state,
+    offset_t startOffsetInGroup, offset_t endOffsetInGroup, ValueVector* resultVector,
+    uint64_t offsetInVector) const {
     if (nullColumn) {
         KU_ASSERT(state.nullState);
         nullColumn->scan(transaction, *state.nullState, startOffsetInGroup, endOffsetInGroup,
@@ -207,8 +208,8 @@ void Column::scan(Transaction* transaction, const ChunkState& state, offset_t st
         startOffsetInGroup, endOffsetInGroup, readToVectorFunc);
 }
 
-void Column::scan(Transaction* transaction, const ChunkState& state, ColumnChunkData* columnChunk,
-    offset_t startOffset, offset_t endOffset) const {
+void Column::scan(const Transaction* transaction, const ChunkState& state,
+    ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) const {
     if (nullColumn) {
         nullColumn->scan(transaction, *state.nullState, columnChunk->getNullData(), startOffset,
             endOffset);
@@ -233,8 +234,8 @@ void Column::scan(Transaction* transaction, const ChunkState& state, ColumnChunk
     columnChunk->setNumValues(numValuesScanned);
 }
 
-void Column::scan(Transaction* transaction, const ChunkState& state, offset_t startOffsetInGroup,
-    offset_t endOffsetInGroup, uint8_t* result) {
+void Column::scan(const Transaction* transaction, const ChunkState& state,
+    offset_t startOffsetInGroup, offset_t endOffsetInGroup, uint8_t* result) {
     columnReadWriter->readCompressedValuesToPage(transaction, state, result, 0, startOffsetInGroup,
         endOffsetInGroup, readToPageFunc);
 }
@@ -267,8 +268,8 @@ void Column::scanInternal(Transaction* transaction, const ChunkState& state,
     }
 }
 
-void Column::lookupValue(Transaction* transaction, const ChunkState& state, offset_t nodeOffset,
-    ValueVector* resultVector, uint32_t posInVector) const {
+void Column::lookupValue(const Transaction* transaction, const ChunkState& state,
+    offset_t nodeOffset, ValueVector* resultVector, uint32_t posInVector) const {
     if (nullColumn) {
         nullColumn->lookupValue(transaction, *state.nullState, nodeOffset, resultVector,
             posInVector);
@@ -279,8 +280,8 @@ void Column::lookupValue(Transaction* transaction, const ChunkState& state, offs
     lookupInternal(transaction, state, nodeOffset, resultVector, posInVector);
 }
 
-void Column::lookupInternal(Transaction* transaction, const ChunkState& state, offset_t nodeOffset,
-    ValueVector* resultVector, uint32_t posInVector) const {
+void Column::lookupInternal(const Transaction* transaction, const ChunkState& state,
+    offset_t nodeOffset, ValueVector* resultVector, uint32_t posInVector) const {
     columnReadWriter->readCompressedValueToVector(transaction, state, nodeOffset, resultVector,
         posInVector, readToVectorFunc);
 }

--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -83,7 +83,7 @@ void ColumnChunk::scan(const Transaction* transaction, const ChunkState& state, 
 }
 
 template<ResidencyState SCAN_RESIDENCY_STATE>
-void ColumnChunk::scanCommitted(Transaction* transaction, ChunkState& chunkState,
+void ColumnChunk::scanCommitted(const Transaction* transaction, ChunkState& chunkState,
     ColumnChunk& output, row_idx_t startRow, row_idx_t numRows) const {
     if (numRows == INVALID_ROW_IDX) {
         numRows = getNumValues();
@@ -111,9 +111,9 @@ void ColumnChunk::scanCommitted(Transaction* transaction, ChunkState& chunkState
     }
 }
 
-template void ColumnChunk::scanCommitted<ResidencyState::ON_DISK>(Transaction* transaction,
+template void ColumnChunk::scanCommitted<ResidencyState::ON_DISK>(const Transaction* transaction,
     ChunkState& chunkState, ColumnChunk& output, row_idx_t startRow, row_idx_t numRows) const;
-template void ColumnChunk::scanCommitted<ResidencyState::IN_MEMORY>(Transaction* transaction,
+template void ColumnChunk::scanCommitted<ResidencyState::IN_MEMORY>(const Transaction* transaction,
     ChunkState& chunkState, ColumnChunk& output, row_idx_t startRow, row_idx_t numRows) const;
 
 bool ColumnChunk::hasUpdates(const Transaction* transaction, row_idx_t startRow,
@@ -160,8 +160,8 @@ void ColumnChunk::scanCommittedUpdates(const Transaction* transaction, ColumnChu
     }
 }
 
-void ColumnChunk::lookup(Transaction* transaction, const ChunkState& state, offset_t rowInChunk,
-    ValueVector& output, sel_t posInOutputVector) const {
+void ColumnChunk::lookup(const Transaction* transaction, const ChunkState& state,
+    offset_t rowInChunk, ValueVector& output, sel_t posInOutputVector) const {
     switch (getResidencyState()) {
     case ResidencyState::IN_MEMORY: {
         data->lookup(rowInChunk, output, posInOutputVector);

--- a/src/storage/store/column_reader_writer.cpp
+++ b/src/storage/store/column_reader_writer.cpp
@@ -79,23 +79,24 @@ public:
         ShadowFile* shadowFile)
         : ColumnReadWriter(dbFileID, dataFH, bufferManager, shadowFile) {}
 
-    void readCompressedValueToPage(transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t nodeOffset, uint8_t* result, uint32_t offsetInResult,
-        const read_value_from_page_func_t<uint8_t*>& readFunc) override {
+    void readCompressedValueToPage(const transaction::Transaction* transaction,
+        const ChunkState& state, common::offset_t nodeOffset, uint8_t* result,
+        uint32_t offsetInResult, const read_value_from_page_func_t<uint8_t*>& readFunc) override {
         auto [offsetInChunk, cursor] = getOffsetAndCursor(nodeOffset, state);
         readCompressedValue<uint8_t*>(transaction, state.metadata, cursor, offsetInChunk, result,
             offsetInResult, readFunc);
     }
 
-    void readCompressedValueToVector(transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t nodeOffset, common::ValueVector* result, uint32_t offsetInResult,
+    void readCompressedValueToVector(const transaction::Transaction* transaction,
+        const ChunkState& state, common::offset_t nodeOffset, common::ValueVector* result,
+        uint32_t offsetInResult,
         const read_value_from_page_func_t<common::ValueVector*>& readFunc) override {
         auto [offsetInChunk, cursor] = getOffsetAndCursor(nodeOffset, state);
         readCompressedValue<ValueVector*>(transaction, state.metadata, cursor, offsetInChunk,
             result, offsetInResult, readFunc);
     }
 
-    uint64_t readCompressedValuesToPage(transaction::Transaction* transaction,
+    uint64_t readCompressedValuesToPage(const transaction::Transaction* transaction,
         const ChunkState& state, uint8_t* result, uint32_t startOffsetInResult,
         uint64_t startNodeOffset, uint64_t endNodeOffset,
         const read_values_from_page_func_t<uint8_t*>& readFunc,
@@ -104,7 +105,7 @@ public:
             startNodeOffset, endNodeOffset, readFunc, filterFunc);
     }
 
-    uint64_t readCompressedValuesToVector(transaction::Transaction* transaction,
+    uint64_t readCompressedValuesToVector(const transaction::Transaction* transaction,
         const ChunkState& state, common::ValueVector* result, uint32_t startOffsetInResult,
         uint64_t startNodeOffset, uint64_t endNodeOffset,
         const read_values_from_page_func_t<common::ValueVector*>& readFunc,
@@ -152,7 +153,7 @@ public:
     }
 
     template<typename OutputType>
-    void readCompressedValue(transaction::Transaction* transaction,
+    void readCompressedValue(const transaction::Transaction* transaction,
         const ColumnChunkMetadata& metadata, PageCursor cursor, common::offset_t /*offsetInChunk*/,
         OutputType result, uint32_t offsetInResult,
         const read_value_from_page_func_t<OutputType>& readFunc) {
@@ -164,7 +165,7 @@ public:
     }
 
     template<typename OutputType>
-    uint64_t readCompressedValues(Transaction* transaction, const ChunkState& state,
+    uint64_t readCompressedValues(const Transaction* transaction, const ChunkState& state,
         OutputType result, uint32_t startOffsetInResult, uint64_t startNodeOffset,
         uint64_t endNodeOffset, const read_values_from_page_func_t<OutputType>& readFunc,
         const std::optional<filter_func_t>& filterFunc) {
@@ -210,23 +211,24 @@ public:
           defaultReader(std::make_unique<DefaultColumnReadWriter>(dbFileID, dataFH, bufferManager,
               shadowFile)) {}
 
-    void readCompressedValueToPage(transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t nodeOffset, uint8_t* result, uint32_t offsetInResult,
-        const read_value_from_page_func_t<uint8_t*>& readFunc) override {
+    void readCompressedValueToPage(const transaction::Transaction* transaction,
+        const ChunkState& state, common::offset_t nodeOffset, uint8_t* result,
+        uint32_t offsetInResult, const read_value_from_page_func_t<uint8_t*>& readFunc) override {
         auto [offsetInChunk, cursor] = getOffsetAndCursor(nodeOffset, state);
         readCompressedValue<uint8_t*>(transaction, state, offsetInChunk, result, offsetInResult,
             readFunc);
     }
 
-    void readCompressedValueToVector(transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t nodeOffset, common::ValueVector* result, uint32_t offsetInResult,
+    void readCompressedValueToVector(const transaction::Transaction* transaction,
+        const ChunkState& state, common::offset_t nodeOffset, common::ValueVector* result,
+        uint32_t offsetInResult,
         const read_value_from_page_func_t<common::ValueVector*>& readFunc) override {
         auto [offsetInChunk, cursor] = getOffsetAndCursor(nodeOffset, state);
         readCompressedValue<ValueVector*>(transaction, state, offsetInChunk, result, offsetInResult,
             readFunc);
     }
 
-    uint64_t readCompressedValuesToPage(transaction::Transaction* transaction,
+    uint64_t readCompressedValuesToPage(const transaction::Transaction* transaction,
         const ChunkState& state, uint8_t* result, uint32_t startOffsetInResult,
         uint64_t startNodeOffset, uint64_t endNodeOffset,
         const read_values_from_page_func_t<uint8_t*>& readFunc,
@@ -235,7 +237,7 @@ public:
             startNodeOffset, endNodeOffset, readFunc, filterFunc);
     }
 
-    uint64_t readCompressedValuesToVector(transaction::Transaction* transaction,
+    uint64_t readCompressedValuesToVector(const transaction::Transaction* transaction,
         const ChunkState& state, common::ValueVector* result, uint32_t startOffsetInResult,
         uint64_t startNodeOffset, uint64_t endNodeOffset,
         const read_values_from_page_func_t<common::ValueVector*>& readFunc,
@@ -298,7 +300,7 @@ private:
     }
 
     template<typename OutputType>
-    void readCompressedValue(transaction::Transaction* transaction, const ChunkState& state,
+    void readCompressedValue(const transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t offsetInChunk, OutputType result, uint32_t offsetInResult,
         const read_value_from_page_func_t<OutputType>& readFunc) {
         RUNTIME_CHECK(const ColumnChunkMetadata& metadata = state.metadata);
@@ -311,7 +313,7 @@ private:
     }
 
     template<typename OutputType>
-    uint64_t readCompressedValues(Transaction* transaction, const ChunkState& state,
+    uint64_t readCompressedValues(const Transaction* transaction, const ChunkState& state,
         OutputType result, uint32_t startOffsetInResult, uint64_t startNodeOffset,
         uint64_t endNodeOffset, const read_values_from_page_func_t<OutputType>& readFunc,
         const std::optional<filter_func_t>& filterFunc) {
@@ -429,7 +431,7 @@ ColumnReadWriter::ColumnReadWriter(DBFileID dbFileID, FileHandle* dataFH,
     BufferManager* bufferManager, ShadowFile* shadowFile)
     : dbFileID(dbFileID), dataFH(dataFH), bufferManager(bufferManager), shadowFile(shadowFile) {}
 
-void ColumnReadWriter::readFromPage(Transaction* transaction, page_idx_t pageIdx,
+void ColumnReadWriter::readFromPage(const Transaction* transaction, page_idx_t pageIdx,
     const std::function<void(uint8_t*)>& readFunc) {
     // For constant compression, call read on a nullptr since there is no data on disk and
     // decompression only requires metadata

--- a/src/storage/store/csr_chunked_node_group.cpp
+++ b/src/storage/store/csr_chunked_node_group.cpp
@@ -245,7 +245,7 @@ std::unique_ptr<ChunkedNodeGroup> ChunkedCSRNodeGroup::flushAsNewChunkedNodeGrou
         std::move(flushedChunks), 0 /*startRowIdx*/);
     flushedChunkedGroup->versionInfo = std::make_unique<VersionInfo>();
     KU_ASSERT(numRows == flushedChunkedGroup->getNumRows());
-    flushedChunkedGroup->versionInfo->append(transaction, flushedChunkedGroup.get(), 0, numRows);
+    flushedChunkedGroup->versionInfo->append(transaction, 0, numRows);
     return flushedChunkedGroup;
 }
 

--- a/src/storage/store/csr_chunked_node_group.cpp
+++ b/src/storage/store/csr_chunked_node_group.cpp
@@ -245,7 +245,7 @@ std::unique_ptr<ChunkedNodeGroup> ChunkedCSRNodeGroup::flushAsNewChunkedNodeGrou
         std::move(flushedChunks), 0 /*startRowIdx*/);
     flushedChunkedGroup->versionInfo = std::make_unique<VersionInfo>();
     KU_ASSERT(numRows == flushedChunkedGroup->getNumRows());
-    flushedChunkedGroup->versionInfo->append(transaction, 0, numRows);
+    flushedChunkedGroup->versionInfo->append(transaction->getID(), 0, numRows);
     return flushedChunkedGroup;
 }
 

--- a/src/storage/store/csr_node_group.cpp
+++ b/src/storage/store/csr_node_group.cpp
@@ -963,7 +963,7 @@ std::pair<idx_t, row_idx_t> CSRNodeGroup::actionOnChunkedGroups(const common::Un
         if (persistentChunkGroup) {
             std::invoke(operation, *persistentChunkGroup, startRow, numRows_, commitTS);
         }
-        return {UINT32_MAX, UINT32_MAX};
+        return {INVALID_CHUNKED_GROUP_IDX, INVALID_START_ROW_IDX};
     } else {
         KU_ASSERT(source == CSRNodeGroupScanSource::COMMITTED_IN_MEMORY);
         return NodeGroup::actionOnChunkedGroups(lock, startRow, numRows_, commitTS, source,

--- a/src/storage/store/csr_node_group.cpp
+++ b/src/storage/store/csr_node_group.cpp
@@ -974,12 +974,5 @@ void CSRNodeGroup::finalizeCheckpoint(const UniqLock& lock) {
     csrIndex.reset();
 }
 
-common::row_idx_t CSRNodeGroup::getNumPersistentRows() const {
-    if (!persistentChunkGroup) {
-        return 0;
-    }
-    return persistentChunkGroup->getNumRows();
-}
-
 } // namespace storage
 } // namespace kuzu

--- a/src/storage/store/csr_node_group.cpp
+++ b/src/storage/store/csr_node_group.cpp
@@ -27,7 +27,8 @@ void CSRNodeGroup::PersistentIterator::applyFuncToChunkedGroups(version_record_h
     }
 }
 
-void CSRNodeGroup::PersistentIterator::finalizeRollbackInsert() {
+void CSRNodeGroup::PersistentIterator::rollbackInsert(const transaction::Transaction* transaction) {
+    VersionRecordHandler::rollbackInsert(transaction);
     nodeGroups->rollbackInsert(numRows, false);
 }
 

--- a/src/storage/store/csr_node_group.cpp
+++ b/src/storage/store/csr_node_group.cpp
@@ -15,15 +15,15 @@ namespace storage {
 CSRNodeGroup::PersistentIterator::PersistentIterator(NodeGroupCollection* nodeGroups,
     common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow, common::row_idx_t numRows,
     common::transaction_t commitTS)
-    : ChunkedGroupUndoIterator(nodeGroups, startRow, numRows, commitTS), nodeGroup(nullptr) {
+    : VersionRecordHandler(nodeGroups, startRow, numRows, commitTS), nodeGroup(nullptr) {
     if (nodeGroupIdx < nodeGroups->getNumNodeGroups()) {
         nodeGroup = ku_dynamic_cast<CSRNodeGroup*>(nodeGroups->getNodeGroupNoLock(nodeGroupIdx));
     }
 }
 
-void CSRNodeGroup::PersistentIterator::iterate(chunked_group_undo_op_t undoFunc) {
+void CSRNodeGroup::PersistentIterator::applyFuncToChunkedGroups(version_record_handler_op_t func) {
     if (nodeGroup && nodeGroup->persistentChunkGroup) {
-        std::invoke(undoFunc, *nodeGroup->persistentChunkGroup, startRow, numRows, commitTS);
+        std::invoke(func, *nodeGroup->persistentChunkGroup, startRow, numRows, commitTS);
     }
 }
 

--- a/src/storage/store/csr_node_group.cpp
+++ b/src/storage/store/csr_node_group.cpp
@@ -12,26 +12,6 @@ using namespace kuzu::transaction;
 namespace kuzu {
 namespace storage {
 
-CSRNodeGroup::PersistentIterator::PersistentIterator(NodeGroupCollection* nodeGroups,
-    common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow, common::row_idx_t numRows,
-    common::transaction_t commitTS)
-    : VersionRecordHandler(nodeGroups, startRow, numRows, commitTS), nodeGroup(nullptr) {
-    if (nodeGroupIdx < nodeGroups->getNumNodeGroups()) {
-        nodeGroup = ku_dynamic_cast<CSRNodeGroup*>(nodeGroups->getNodeGroupNoLock(nodeGroupIdx));
-    }
-}
-
-void CSRNodeGroup::PersistentIterator::applyFuncToChunkedGroups(version_record_handler_op_t func) {
-    if (nodeGroup && nodeGroup->persistentChunkGroup) {
-        std::invoke(func, *nodeGroup->persistentChunkGroup, startRow, numRows, commitTS);
-    }
-}
-
-void CSRNodeGroup::PersistentIterator::rollbackInsert(const transaction::Transaction* transaction) {
-    VersionRecordHandler::rollbackInsert(transaction);
-    nodeGroups->rollbackInsert(numRows, false);
-}
-
 bool CSRNodeGroupScanState::tryScanCachedTuples(RelTableScanState& tableScanState) {
     if (numCachedRows == 0 ||
         tableScanState.currBoundNodeIdx >= tableScanState.cachedBoundNodeSelVector.getSelSize()) {

--- a/src/storage/store/dictionary_column.cpp
+++ b/src/storage/store/dictionary_column.cpp
@@ -28,7 +28,7 @@ DictionaryColumn::DictionaryColumn(const std::string& name, FileHandle* dataFH, 
         shadowFile, enableCompression, false /*requireNullColumn*/);
 }
 
-void DictionaryColumn::scan(Transaction* transaction, const ChunkState& state,
+void DictionaryColumn::scan(const Transaction* transaction, const ChunkState& state,
     DictionaryChunk& dictChunk) const {
     auto& dataMetadata =
         StringColumn::getChildState(state, StringColumn::ChildStateIndex::DATA).metadata;
@@ -51,7 +51,7 @@ void DictionaryColumn::scan(Transaction* transaction, const ChunkState& state,
         StringColumn::getChildState(state, StringColumn::ChildStateIndex::OFFSET), offsetChunk);
 }
 
-void DictionaryColumn::scan(Transaction* transaction, const ChunkState& offsetState,
+void DictionaryColumn::scan(const Transaction* transaction, const ChunkState& offsetState,
     const ChunkState& dataState, std::vector<std::pair<string_index_t, uint64_t>>& offsetsToScan,
     ValueVector* resultVector, const ColumnChunkMetadata& indexMeta) const {
     string_index_t firstOffsetToScan = 0, lastOffsetToScan = 0;
@@ -108,7 +108,7 @@ string_index_t DictionaryColumn::append(const DictionaryChunk& dictChunk, ChunkS
         reinterpret_cast<const uint8_t*>(&startOffset), nullptr /*nullChunkData*/, 1 /*numValues*/);
 }
 
-void DictionaryColumn::scanOffsets(Transaction* transaction, const ChunkState& state,
+void DictionaryColumn::scanOffsets(const Transaction* transaction, const ChunkState& state,
     DictionaryChunk::string_offset_t* offsets, uint64_t index, uint64_t numValues,
     uint64_t dataSize) const {
     // We either need to read the next value, or store the maximum string offset at the end.
@@ -121,9 +121,9 @@ void DictionaryColumn::scanOffsets(Transaction* transaction, const ChunkState& s
     }
 }
 
-void DictionaryColumn::scanValueToVector(Transaction* transaction, const ChunkState& dataState,
-    uint64_t startOffset, uint64_t endOffset, ValueVector* resultVector,
-    uint64_t offsetInVector) const {
+void DictionaryColumn::scanValueToVector(const Transaction* transaction,
+    const ChunkState& dataState, uint64_t startOffset, uint64_t endOffset,
+    ValueVector* resultVector, uint64_t offsetInVector) const {
     KU_ASSERT(endOffset >= startOffset);
     // Add string to vector first and read directly into the vector
     auto& kuString =

--- a/src/storage/store/list_column.cpp
+++ b/src/storage/store/list_column.cpp
@@ -85,7 +85,7 @@ std::unique_ptr<ColumnChunkData> ListColumn::flushChunkData(const ColumnChunkDat
     return flushedChunk;
 }
 
-void ListColumn::scan(Transaction* transaction, const ChunkState& state,
+void ListColumn::scan(const Transaction* transaction, const ChunkState& state,
     offset_t startOffsetInGroup, offset_t endOffsetInGroup, ValueVector* resultVector,
     uint64_t offsetInVector) const {
     nullColumn->scan(transaction, *state.nullState, startOffsetInGroup, endOffsetInGroup,
@@ -126,7 +126,7 @@ void ListColumn::scan(Transaction* transaction, const ChunkState& state,
     }
 }
 
-void ListColumn::scan(Transaction* transaction, const ChunkState& state,
+void ListColumn::scan(const Transaction* transaction, const ChunkState& state,
     ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) const {
     Column::scan(transaction, state, columnChunk, startOffset, endOffset);
     if (columnChunk->getNumValues() == 0) {
@@ -190,7 +190,7 @@ void ListColumn::scanInternal(Transaction* transaction, const ChunkState& state,
     }
 }
 
-void ListColumn::lookupInternal(Transaction* transaction, const ChunkState& state,
+void ListColumn::lookupInternal(const Transaction* transaction, const ChunkState& state,
     offset_t nodeOffset, ValueVector* resultVector, uint32_t posInVector) const {
     auto [nodeGroupIdx, offsetInChunk] = StorageUtils::getNodeGroupIdxAndOffsetInChunk(nodeOffset);
     const auto listEndOffset = readOffset(transaction, state, offsetInChunk);
@@ -271,7 +271,7 @@ void ListColumn::scanFiltered(Transaction* transaction, const ChunkState& state,
     }
 }
 
-offset_t ListColumn::readOffset(Transaction* transaction, const ChunkState& readState,
+offset_t ListColumn::readOffset(const Transaction* transaction, const ChunkState& readState,
     offset_t offsetInNodeGroup) const {
     offset_t ret = INVALID_OFFSET;
     const auto& offsetState = readState.childrenStates[OFFSET_COLUMN_CHILD_READ_STATE_IDX];
@@ -280,7 +280,7 @@ offset_t ListColumn::readOffset(Transaction* transaction, const ChunkState& read
     return ret;
 }
 
-list_size_t ListColumn::readSize(Transaction* transaction, const ChunkState& readState,
+list_size_t ListColumn::readSize(const Transaction* transaction, const ChunkState& readState,
     offset_t offsetInNodeGroup) const {
     const auto& sizeState = readState.childrenStates[SIZE_COLUMN_CHILD_READ_STATE_IDX];
     offset_t value = INVALID_OFFSET;
@@ -289,7 +289,7 @@ list_size_t ListColumn::readSize(Transaction* transaction, const ChunkState& rea
     return value;
 }
 
-ListOffsetSizeInfo ListColumn::getListOffsetSizeInfo(Transaction* transaction,
+ListOffsetSizeInfo ListColumn::getListOffsetSizeInfo(const Transaction* transaction,
     const ChunkState& state, offset_t startOffsetInNodeGroup, offset_t endOffsetInNodeGroup) const {
     const auto numOffsetsToRead = endOffsetInNodeGroup - startOffsetInNodeGroup;
     auto offsetColumnChunk = ColumnChunkFactory::createColumnChunkData(*mm, LogicalType::INT64(),

--- a/src/storage/store/node_group.cpp
+++ b/src/storage/store/node_group.cpp
@@ -488,7 +488,7 @@ std::unique_ptr<VersionInfo> NodeGroup::checkpointVersionInfo(const UniqLock& lo
             // TODO(Guodong): Optimize the for loop here to directly acess the version info.
             for (auto i = 0u; i < chunkedGroup->getNumRows(); i++) {
                 if (chunkedGroup->isDeleted(transaction, i)) {
-                    checkpointVersionInfo->delete_(transaction, currRow + i);
+                    checkpointVersionInfo->delete_(transaction->getID(), currRow + i);
                 }
             }
         }

--- a/src/storage/store/node_group.cpp
+++ b/src/storage/store/node_group.cpp
@@ -185,6 +185,7 @@ NodeGroupScanResult NodeGroup::scan(const Transaction* transaction, TableScanSta
     }
     const auto& chunkedGroupToScan =
         *chunkedGroups.getGroup(lock, nodeGroupScanState.chunkedGroupIdx);
+    KU_ASSERT(nodeGroupScanState.nextRowToScan >= chunkedGroupToScan.getStartRowIdx());
     const auto rowIdxInChunkToScan =
         nodeGroupScanState.nextRowToScan - chunkedGroupToScan.getStartRowIdx();
     const auto numRowsToScan =

--- a/src/storage/store/node_group_collection.cpp
+++ b/src/storage/store/node_group_collection.cpp
@@ -14,9 +14,9 @@ namespace storage {
 
 NodeGroupCollection::NodeGroupCollection(MemoryManager& memoryManager,
     const std::vector<LogicalType>& types, const bool enableCompression, FileHandle* dataFH,
-    Deserializer* deSer, const VersionRecordHandlerData* versionRecordHandlerData)
+    Deserializer* deSer, const VersionRecordHandlerSelector* versionRecordHandlerSelector)
     : enableCompression{enableCompression}, numTotalRows{0}, types{LogicalType::copy(types)},
-      dataFH{dataFH}, versionRecordHandlerData(versionRecordHandlerData) {
+      dataFH{dataFH}, versionRecordHandlerSelector(versionRecordHandlerSelector) {
     if (deSer) {
         deserialize(*deSer, memoryManager);
     }
@@ -155,7 +155,7 @@ row_idx_t NodeGroupCollection::getNumTotalRows() {
 
 NodeGroup* NodeGroupCollection::getOrCreateNodeGroup(transaction::Transaction* transaction,
     node_group_idx_t groupIdx, NodeGroupDataFormat format,
-    const VersionRecordHandlerData* versionRecordHandlerData) {
+    const VersionRecordHandlerSelector* versionRecordHandlerSelector) {
     const auto lock = nodeGroups.lock();
     while (groupIdx >= nodeGroups.getNumGroups(lock)) {
         const auto currentGroupIdx = nodeGroups.getNumGroups(lock);
@@ -166,7 +166,7 @@ NodeGroup* NodeGroupCollection::getOrCreateNodeGroup(transaction::Transaction* t
                                              enableCompression, LogicalType::copy(types)));
         // push an insert of size 0 so that we can rollback the creation of this node group if
         // needed
-        pushInsertInfo(transaction, nodeGroups.getLastGroup(lock), 0, versionRecordHandlerData);
+        pushInsertInfo(transaction, nodeGroups.getLastGroup(lock), 0, versionRecordHandlerSelector);
     }
     KU_ASSERT(groupIdx < nodeGroups.getNumGroups(lock));
     return nodeGroups.getGroup(lock, groupIdx);
@@ -213,19 +213,19 @@ void NodeGroupCollection::rollbackInsert(common::row_idx_t numRows_, bool update
 
 void NodeGroupCollection::pushInsertInfo(const transaction::Transaction* transaction,
     NodeGroup* nodeGroup, common::row_idx_t numRows,
-    const VersionRecordHandlerData* overridedVersionRecordHandlerData) {
+    const VersionRecordHandlerSelector* overridedVersionRecordHandlerSelector) {
     pushInsertInfo(transaction, nodeGroup->getNodeGroupIdx(), nodeGroup->getNumRows(), numRows,
-        overridedVersionRecordHandlerData ? overridedVersionRecordHandlerData :
-                                            versionRecordHandlerData);
+        overridedVersionRecordHandlerSelector ? overridedVersionRecordHandlerSelector :
+                                                versionRecordHandlerSelector);
 };
 
 void NodeGroupCollection::pushInsertInfo(const transaction::Transaction* transaction,
     common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow, common::row_idx_t numRows,
-    const VersionRecordHandlerData* overridedVersionRecordHandlerData) {
+    const VersionRecordHandlerSelector* overridedVersionRecordHandlerSelector) {
     // we only append to the undo buffer if the node group collection is persistent
     if (dataFH && transaction->shouldAppendToUndoBuffer()) {
         transaction->pushInsertInfo(nodeGroupIdx, startRow, numRows,
-            overridedVersionRecordHandlerData);
+            overridedVersionRecordHandlerSelector);
     }
 }
 

--- a/src/storage/store/node_group_collection.cpp
+++ b/src/storage/store/node_group_collection.cpp
@@ -53,8 +53,8 @@ void NodeGroupCollection::append(const Transaction* transaction,
             std::min(numRowsToAppend - numRowsAppended, lastNodeGroup->getNumRowsLeftToAppend());
         lastNodeGroup->moveNextRowToAppend(numToAppendInNodeGroup);
         pushInsertInfo(transaction, lastNodeGroup, numToAppendInNodeGroup);
-        lastNodeGroup->append(transaction, vectors, numRowsAppended, numToAppendInNodeGroup);
         numTotalRows += numToAppendInNodeGroup;
+        lastNodeGroup->append(transaction, vectors, numRowsAppended, numToAppendInNodeGroup);
         numRowsAppended += numToAppendInNodeGroup;
     }
     stats.incrementCardinality(numRowsAppended);
@@ -94,9 +94,9 @@ void NodeGroupCollection::append(const Transaction* transaction, NodeGroup& node
                     lastNodeGroup->getNumRowsLeftToAppend());
             lastNodeGroup->moveNextRowToAppend(numToAppendInBatch);
             pushInsertInfo(transaction, lastNodeGroup, numToAppendInBatch);
+            numTotalRows += numToAppendInBatch;
             lastNodeGroup->append(transaction, *chunkedGroupToAppend, numRowsAppendedInChunkedGroup,
                 numToAppendInBatch);
-            numTotalRows += numToAppendInBatch;
             numRowsAppendedInChunkedGroup += numToAppendInBatch;
         }
         numChunkedGroupsAppended++;
@@ -213,9 +213,9 @@ void NodeGroupCollection::rollbackInsert(common::row_idx_t numRows_, bool update
 
 void NodeGroupCollection::pushInsertInfo(const transaction::Transaction* transaction,
     NodeGroup* nodeGroup, common::row_idx_t numRows,
-    const chunked_group_iterator_construct_t* constructIteratorFunc_) {
+    const chunked_group_iterator_construct_t* constructIteratorOverrideFunc) {
     pushInsertInfo(transaction, nodeGroup->getNodeGroupIdx(), nodeGroup->getNumRows(), numRows,
-        constructIteratorFunc_ ? constructIteratorFunc_ : iteratorConstructFunc);
+        constructIteratorOverrideFunc ? constructIteratorOverrideFunc : iteratorConstructFunc);
 };
 
 void NodeGroupCollection::pushInsertInfo(const transaction::Transaction* transaction,

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -37,8 +37,8 @@ void NodeTableVersionRecordHandler::rollbackInsert(const transaction::Transactio
 
     VersionRecordHandler::rollbackInsert(transaction, nodeGroupIdx, startRow, numRows);
     auto* nodeGroup = table->getNodeGroupNoLock(nodeGroupIdx);
-    nodeGroup->rollbackInsert(startRow);
     const auto numRowsToRollback = std::min(numRows, nodeGroup->getNumRows() - startRow);
+    nodeGroup->rollbackInsert(startRow);
     table->rollbackGroupCollectionInsert(numRowsToRollback);
 }
 

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -37,6 +37,7 @@ void NodeTableVersionRecordHandler::rollbackInsert(const transaction::Transactio
 
     VersionRecordHandler::rollbackInsert(transaction, nodeGroupIdx, startRow, numRows);
     auto* nodeGroup = table->getNodeGroupNoLock(nodeGroupIdx);
+    nodeGroup->rollbackInsert(startRow);
     const auto numRowsToRollback = std::min(numRows, nodeGroup->getNumRows() - startRow);
     table->rollbackGroupCollectionInsert(numRowsToRollback);
 }

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -204,16 +204,6 @@ bool NodeTableScanState::scanNext(Transaction* transaction) {
     return true;
 }
 
-static decltype(auto) createAppendToUndoBufferFunc(NodeGroupCollection* nodeGroups) {
-    return [nodeGroups](const transaction::Transaction* transaction, NodeGroup* nodeGroup,
-               common::row_idx_t numRows) {
-        if (transaction->shouldAppendToUndoBuffer()) {
-            transaction->pushInsertInfo(nodeGroups, nodeGroup->getNodeGroupIdx(),
-                nodeGroup->getNumRows(), numRows);
-        }
-    };
-}
-
 NodeTable::NodeTable(const StorageManager* storageManager,
     const NodeTableCatalogEntry* nodeTableEntry, MemoryManager* memoryManager,
     VirtualFileSystem* vfs, main::ClientContext* context, Deserializer* deSer)
@@ -231,8 +221,7 @@ NodeTable::NodeTable(const StorageManager* storageManager,
     }
 
     nodeGroups = std::make_unique<NodeGroupCollection>(*memoryManager,
-        getNodeTableColumnTypes(*this), enableCompression, storageManager->getDataFH(), deSer,
-        createAppendToUndoBufferFunc(nodeGroups.get()));
+        getNodeTableColumnTypes(*this), enableCompression, storageManager->getDataFH(), deSer);
     initializePKIndex(storageManager->getDatabasePath(), nodeTableEntry,
         storageManager->isReadOnly(), vfs, context);
 

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -226,8 +226,9 @@ NodeTable::NodeTable(const StorageManager* storageManager,
         return rollbackInsert(transaction, startRow, numRows_, nodeGroupIdx_);
     };
 
-    nodeGroups = std::make_unique<NodeGroupCollection>(*memoryManager,
-        getNodeTableColumnTypes(*this), enableCompression, storageManager->getDataFH(), deSer);
+    nodeGroups =
+        std::make_unique<NodeGroupCollection>(*memoryManager, getNodeTableColumnTypes(*this),
+            enableCompression, storageManager->getDataFH(), deSer, &rollbackInsertFunc);
     initializePKIndex(storageManager->getDatabasePath(), nodeTableEntry,
         storageManager->isReadOnly(), vfs, context);
 }

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -220,16 +220,16 @@ NodeTable::NodeTable(const StorageManager* storageManager,
             dataFH, memoryManager, shadowFile, enableCompression);
     }
 
+    rollbackInsertFunc = [this](const transaction::Transaction* transaction,
+                             common::row_idx_t startRow, common::row_idx_t numRows_,
+                             common::node_group_idx_t nodeGroupIdx_, CSRNodeGroupScanSource) {
+        return rollbackInsert(transaction, startRow, numRows_, nodeGroupIdx_);
+    };
+
     nodeGroups = std::make_unique<NodeGroupCollection>(*memoryManager,
         getNodeTableColumnTypes(*this), enableCompression, storageManager->getDataFH(), deSer);
     initializePKIndex(storageManager->getDatabasePath(), nodeTableEntry,
         storageManager->isReadOnly(), vfs, context);
-
-    preRollbackInsertFunc = [this](const transaction::Transaction* transaction,
-                                common::row_idx_t startRow, common::row_idx_t numRows_,
-                                common::node_group_idx_t nodeGroupIdx_) {
-        return rollbackInsert(transaction, startRow, numRows_, nodeGroupIdx_);
-    };
 }
 
 std::unique_ptr<NodeTable> NodeTable::loadTable(Deserializer& deSer, const Catalog& catalog,

--- a/src/storage/store/null_column.cpp
+++ b/src/storage/store/null_column.cpp
@@ -42,14 +42,14 @@ void NullColumn::scan(Transaction* transaction, const ChunkState& state,
     scanInternal(transaction, state, startOffsetInChunk, numValuesToScan, resultVector);
 }
 
-void NullColumn::scan(Transaction* transaction, const ChunkState& state,
+void NullColumn::scan(const Transaction* transaction, const ChunkState& state,
     offset_t startOffsetInGroup, offset_t endOffsetInGroup, ValueVector* resultVector,
     uint64_t offsetInVector) const {
     Column::scan(transaction, state, startOffsetInGroup, endOffsetInGroup, resultVector,
         offsetInVector);
 }
 
-void NullColumn::scan(Transaction* transaction, const ChunkState& state,
+void NullColumn::scan(const Transaction* transaction, const ChunkState& state,
     ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) const {
     Column::scan(transaction, state, columnChunk, startOffset, endOffset);
 }

--- a/src/storage/store/rel_table_data.cpp
+++ b/src/storage/store/rel_table_data.cpp
@@ -53,8 +53,8 @@ void InMemoryVersionRecordHandler::rollbackInsert(const transaction::Transaction
     common::row_idx_t numRows) const {
     VersionRecordHandler::rollbackInsert(transaction, nodeGroupIdx, startRow, numRows);
     auto* nodeGroup = relTableData->getNodeGroupNoLock(nodeGroupIdx);
-    nodeGroup->rollbackInsert(startRow);
     const auto numRowsToRollback = std::min(numRows, nodeGroup->getNumRows() - startRow);
+    nodeGroup->rollbackInsert(startRow);
     relTableData->rollbackGroupCollectionInsert(numRowsToRollback, false);
 }
 

--- a/src/storage/store/rel_table_data.cpp
+++ b/src/storage/store/rel_table_data.cpp
@@ -98,7 +98,7 @@ bool RelTableData::delete_(Transaction* transaction, ValueVector& boundNodeIDVec
     auto& csrNodeGroup = getNodeGroup(nodeGroupIdx)->cast<CSRNodeGroup>();
     bool isDeleted = csrNodeGroup.delete_(transaction, source, rowIdx);
     if (isDeleted && transaction->shouldAppendToUndoBuffer()) {
-        transaction->pushDeleteInfo(this, nodeGroupIdx, rowIdx, 1, source);
+        transaction->pushDeleteInfo(nodeGroups.get(), nodeGroupIdx, rowIdx, 1, source);
     }
     return isDeleted;
 }
@@ -195,7 +195,8 @@ void RelTableData::pushInsertInfo(transaction::Transaction* transaction,
     const auto startRow = (source == CSRNodeGroupScanSource::COMMITTED_PERSISTENT) ?
                               nodeGroup.getNumPersistentRows() :
                               nodeGroup.getNumRows();
-    transaction->pushInsertInfo(this, nodeGroup.getNodeGroupIdx(), startRow, numRows_, source);
+    transaction->pushInsertInfo(nodeGroups.get(), nodeGroup.getNodeGroupIdx(), startRow, numRows_,
+        source);
 }
 
 void RelTableData::checkpoint(const std::vector<column_id_t>& columnIDs) {

--- a/src/storage/store/rel_table_data.cpp
+++ b/src/storage/store/rel_table_data.cpp
@@ -53,6 +53,7 @@ void InMemoryVersionRecordHandler::rollbackInsert(const transaction::Transaction
     common::row_idx_t numRows) const {
     VersionRecordHandler::rollbackInsert(transaction, nodeGroupIdx, startRow, numRows);
     auto* nodeGroup = relTableData->getNodeGroupNoLock(nodeGroupIdx);
+    nodeGroup->rollbackInsert(startRow);
     const auto numRowsToRollback = std::min(numRows, nodeGroup->getNumRows() - startRow);
     relTableData->rollbackGroupCollectionInsert(numRowsToRollback, false);
 }

--- a/src/storage/store/rel_table_data.cpp
+++ b/src/storage/store/rel_table_data.cpp
@@ -195,7 +195,7 @@ void RelTableData::pushInsertInfo(transaction::Transaction* transaction,
     const auto startRow = (source == CSRNodeGroupScanSource::COMMITTED_PERSISTENT) ?
                               nodeGroup.getNumPersistentRows() :
                               nodeGroup.getNumRows();
-    transaction->pushInsertInfo(nodeGroups.get(), nodeGroup.getNodeGroupIdx(), startRow, numRows_,
+    nodeGroups->pushInsertInfo(transaction, nodeGroup.getNodeGroupIdx(), startRow, numRows_,
         source);
 }
 

--- a/src/storage/store/string_column.cpp
+++ b/src/storage/store/string_column.cpp
@@ -59,7 +59,7 @@ std::unique_ptr<ColumnChunkData> StringColumn::flushChunkData(const ColumnChunkD
     return flushedChunkData;
 }
 
-void StringColumn::scan(Transaction* transaction, const ChunkState& state,
+void StringColumn::scan(const Transaction* transaction, const ChunkState& state,
     offset_t startOffsetInGroup, offset_t endOffsetInGroup, ValueVector* resultVector,
     uint64_t offsetInVector) const {
     nullColumn->scan(transaction, *state.nullState, startOffsetInGroup, endOffsetInGroup,
@@ -68,7 +68,7 @@ void StringColumn::scan(Transaction* transaction, const ChunkState& state,
         resultVector, offsetInVector);
 }
 
-void StringColumn::scan(Transaction* transaction, const ChunkState& state,
+void StringColumn::scan(const Transaction* transaction, const ChunkState& state,
     ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) const {
     KU_ASSERT(state.nullState);
     Column::scan(transaction, state, columnChunk, startOffset, endOffset);
@@ -82,7 +82,7 @@ void StringColumn::scan(Transaction* transaction, const ChunkState& state,
     dictionary.scan(transaction, state, stringColumnChunk.getDictionaryChunk());
 }
 
-void StringColumn::lookupInternal(Transaction* transaction, const ChunkState& state,
+void StringColumn::lookupInternal(const Transaction* transaction, const ChunkState& state,
     offset_t nodeOffset, ValueVector* resultVector, uint32_t posInVector) const {
     auto [nodeGroupIdx, offsetInChunk] = StorageUtils::getNodeGroupIdxAndOffsetInChunk(nodeOffset);
     string_index_t index = 0;
@@ -141,7 +141,7 @@ void StringColumn::scanInternal(Transaction* transaction, const ChunkState& stat
     }
 }
 
-void StringColumn::scanUnfiltered(Transaction* transaction, const ChunkState& state,
+void StringColumn::scanUnfiltered(const Transaction* transaction, const ChunkState& state,
     offset_t startOffsetInChunk, offset_t numValuesToRead, ValueVector* resultVector,
     sel_t startPosInVector) const {
     // TODO: Replace indices with ValueVector to avoid maintaining `scan` interface from

--- a/src/storage/store/struct_column.cpp
+++ b/src/storage/store/struct_column.cpp
@@ -39,7 +39,7 @@ std::unique_ptr<ColumnChunkData> StructColumn::flushChunkData(const ColumnChunkD
     return flushedChunk;
 }
 
-void StructColumn::scan(Transaction* transaction, const ChunkState& state,
+void StructColumn::scan(const Transaction* transaction, const ChunkState& state,
     ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) const {
     KU_ASSERT(columnChunk->getDataType().getPhysicalType() == PhysicalTypeID::STRUCT);
     Column::scan(transaction, state, columnChunk, startOffset, endOffset);
@@ -50,7 +50,7 @@ void StructColumn::scan(Transaction* transaction, const ChunkState& state,
     }
 }
 
-void StructColumn::scan(Transaction* transaction, const ChunkState& state,
+void StructColumn::scan(const Transaction* transaction, const ChunkState& state,
     offset_t startOffsetInGroup, offset_t endOffsetInGroup, ValueVector* resultVector,
     uint64_t offsetInVector) const {
     nullColumn->scan(transaction, *state.nullState, startOffsetInGroup, endOffsetInGroup,
@@ -71,7 +71,7 @@ void StructColumn::scanInternal(Transaction* transaction, const ChunkState& stat
     }
 }
 
-void StructColumn::lookupInternal(Transaction* transaction, const ChunkState& state,
+void StructColumn::lookupInternal(const Transaction* transaction, const ChunkState& state,
     offset_t nodeOffset, ValueVector* resultVector, uint32_t posInVector) const {
     for (auto i = 0u; i < childColumns.size(); i++) {
         const auto fieldVector = StructVector::getFieldVector(resultVector, i).get();

--- a/src/storage/store/version_info.cpp
+++ b/src/storage/store/version_info.cpp
@@ -352,7 +352,7 @@ VectorVersionInfo* VersionInfo::getVectorVersionInfo(idx_t vectorIdx) const {
     return vectorsInfo[vectorIdx].get();
 }
 
-void VersionInfo::append(const transaction::Transaction* transaction, const row_idx_t startRow,
+void VersionInfo::append(transaction_t transactionID, const row_idx_t startRow,
     const row_idx_t numRows) {
     if (numRows == 0) {
         return;
@@ -367,11 +367,11 @@ void VersionInfo::append(const transaction::Transaction* transaction, const row_
         const auto endRowIdx =
             vectorIdx == endVectorIdx ? endRowIdxInVector : DEFAULT_VECTOR_CAPACITY - 1;
         const auto numRowsInVector = endRowIdx - startRowIdx + 1;
-        vectorVersionInfo.append(transaction->getID(), startRowIdx, numRowsInVector);
+        vectorVersionInfo.append(transactionID, startRowIdx, numRowsInVector);
     }
 }
 
-bool VersionInfo::delete_(const transaction::Transaction* transaction, const row_idx_t rowIdx) {
+bool VersionInfo::delete_(transaction_t transactionID, const row_idx_t rowIdx) {
     auto [vectorIdx, rowIdxInVector] =
         StorageUtils::getQuotientRemainder(rowIdx, DEFAULT_VECTOR_CAPACITY);
     auto& vectorVersionInfo = getOrCreateVersionInfo(vectorIdx);
@@ -381,7 +381,7 @@ bool VersionInfo::delete_(const transaction::Transaction* transaction, const row
         // ALWAYS_INSERTED to avoid checking the version in the future.
         vectorVersionInfo.insertionStatus = VectorVersionInfo::InsertionStatus::ALWAYS_INSERTED;
     }
-    return vectorVersionInfo.delete_(transaction->getID(), rowIdxInVector);
+    return vectorVersionInfo.delete_(transactionID, rowIdxInVector);
 }
 
 void VersionInfo::getSelVectorToScan(const transaction_t startTS, const transaction_t transactionID,

--- a/src/storage/store/version_info.cpp
+++ b/src/storage/store/version_info.cpp
@@ -352,8 +352,8 @@ VectorVersionInfo* VersionInfo::getVectorVersionInfo(idx_t vectorIdx) const {
     return vectorsInfo[vectorIdx].get();
 }
 
-void VersionInfo::append(const transaction::Transaction* transaction,
-    ChunkedNodeGroup* chunkedNodeGroup, const row_idx_t startRow, const row_idx_t numRows) {
+void VersionInfo::append(const transaction::Transaction* transaction, const row_idx_t startRow,
+    const row_idx_t numRows) {
     if (numRows == 0) {
         return;
     }
@@ -369,13 +369,9 @@ void VersionInfo::append(const transaction::Transaction* transaction,
         const auto numRowsInVector = endRowIdx - startRowIdx + 1;
         vectorVersionInfo.append(transaction->getID(), startRowIdx, numRowsInVector);
     }
-    if (transaction->shouldAppendToUndoBuffer()) {
-        transaction->pushInsertInfo(chunkedNodeGroup, startRow, numRows);
-    }
 }
 
-bool VersionInfo::delete_(const transaction::Transaction* transaction,
-    ChunkedNodeGroup* chunkedNodeGroup, const row_idx_t rowIdx) {
+bool VersionInfo::delete_(const transaction::Transaction* transaction, const row_idx_t rowIdx) {
     auto [vectorIdx, rowIdxInVector] =
         StorageUtils::getQuotientRemainder(rowIdx, DEFAULT_VECTOR_CAPACITY);
     auto& vectorVersionInfo = getOrCreateVersionInfo(vectorIdx);
@@ -385,11 +381,7 @@ bool VersionInfo::delete_(const transaction::Transaction* transaction,
         // ALWAYS_INSERTED to avoid checking the version in the future.
         vectorVersionInfo.insertionStatus = VectorVersionInfo::InsertionStatus::ALWAYS_INSERTED;
     }
-    const auto deleted = vectorVersionInfo.delete_(transaction->getID(), rowIdxInVector);
-    if (deleted && transaction->shouldAppendToUndoBuffer()) {
-        transaction->pushDeleteInfo(chunkedNodeGroup, rowIdx, 1);
-    }
-    return deleted;
+    return vectorVersionInfo.delete_(transaction->getID(), rowIdxInVector);
 }
 
 void VersionInfo::getSelVectorToScan(const transaction_t startTS, const transaction_t transactionID,

--- a/src/storage/store/version_record_handler.cpp
+++ b/src/storage/store/version_record_handler.cpp
@@ -1,5 +1,7 @@
 #include "storage/store/version_record_handler.h"
 
+#include "storage/store/chunked_node_group.h"
+
 namespace kuzu::storage {
 void VersionRecordHandler::rollbackInsert(const transaction::Transaction* transaction,
     common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,

--- a/src/storage/store/version_record_handler.cpp
+++ b/src/storage/store/version_record_handler.cpp
@@ -1,0 +1,10 @@
+#include "storage/store/version_record_handler.h"
+
+namespace kuzu::storage {
+void VersionRecordHandler::rollbackInsert(const transaction::Transaction* transaction,
+    common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
+    common::row_idx_t numRows) const {
+    applyFuncToChunkedGroups(&ChunkedNodeGroup::rollbackInsert, nodeGroupIdx, startRow, numRows,
+        transaction->getCommitTS());
+}
+} // namespace kuzu::storage

--- a/src/storage/undo_buffer.cpp
+++ b/src/storage/undo_buffer.cpp
@@ -4,8 +4,6 @@
 #include "catalog/catalog_entry/sequence_catalog_entry.h"
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "catalog/catalog_set.h"
-#include "storage/store/node_table.h"
-#include "storage/store/rel_table_data.h"
 #include "storage/store/update_info.h"
 
 using namespace kuzu::catalog;

--- a/src/storage/undo_buffer.cpp
+++ b/src/storage/undo_buffer.cpp
@@ -166,7 +166,7 @@ void UndoBuffer::commit(transaction_t commitTS) const {
     });
 }
 
-void UndoBuffer::rollback(const transaction::Transaction* transaction) {
+void UndoBuffer::rollback() {
     UndoBufferIterator iterator{*this};
     iterator.reverseIterate([&](UndoRecordType entryType, uint8_t const* entry) {
         rollbackRecord(transaction, entryType, entry);

--- a/src/storage/undo_buffer.cpp
+++ b/src/storage/undo_buffer.cpp
@@ -4,7 +4,9 @@
 #include "catalog/catalog_entry/sequence_catalog_entry.h"
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "catalog/catalog_set.h"
+#include "storage/store/chunked_node_group.h"
 #include "storage/store/update_info.h"
+#include "storage/store/version_record_handler.h"
 #include "transaction/transaction.h"
 
 using namespace kuzu::catalog;

--- a/src/storage/undo_buffer.cpp
+++ b/src/storage/undo_buffer.cpp
@@ -113,28 +113,17 @@ void UndoBuffer::createSequenceChange(SequenceCatalogEntry& sequenceEntry,
     *reinterpret_cast<SequenceEntryRecord*>(buffer) = sequenceEntryRecord;
 }
 
-void UndoBuffer::createInsertInfo(NodeTable* nodeTable, common::node_group_idx_t nodeGroupIdx,
-    row_idx_t startRow, row_idx_t numRows) {
-    createVersionInfo(UndoRecordType::INSERT_INFO, nodeTable->getNodeGroups(), startRow, numRows,
-        nodeGroupIdx, CSRNodeGroupScanSource::NONE, &nodeTable->getPreRollbackInsertFunc());
-}
-
-void UndoBuffer::createInsertInfo(RelTableData* relTableData, node_group_idx_t nodeGroupIdx,
+void UndoBuffer::createInsertInfo(NodeGroupCollection* nodeGroups, node_group_idx_t nodeGroupIdx,
     row_idx_t startRow, row_idx_t numRows, storage::CSRNodeGroupScanSource source) {
-    createVersionInfo(UndoRecordType::INSERT_INFO, relTableData->getNodeGroups(), startRow, numRows,
-        nodeGroupIdx, source);
+    createVersionInfo(UndoRecordType::INSERT_INFO, nodeGroups, startRow, numRows, nodeGroupIdx,
+        source);
 }
 
-void UndoBuffer::createDeleteInfo(NodeTable* nodeTable, common::node_group_idx_t nodeGroupIdx,
-    common::row_idx_t startRow, common::row_idx_t numRows) {
-    createVersionInfo(UndoRecordType::DELETE_INFO, nodeTable->getNodeGroups(), startRow, numRows,
-        nodeGroupIdx);
-}
-
-void UndoBuffer::createDeleteInfo(RelTableData* relTableData, common::node_group_idx_t nodeGroupIdx,
-    common::row_idx_t startRow, common::row_idx_t numRows, storage::CSRNodeGroupScanSource source) {
-    createVersionInfo(UndoRecordType::DELETE_INFO, relTableData->getNodeGroups(), startRow, numRows,
-        nodeGroupIdx, source);
+void UndoBuffer::createDeleteInfo(NodeGroupCollection* nodeGroups,
+    common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow, common::row_idx_t numRows,
+    storage::CSRNodeGroupScanSource source) {
+    createVersionInfo(UndoRecordType::DELETE_INFO, nodeGroups, startRow, numRows, nodeGroupIdx,
+        source);
 }
 
 void UndoBuffer::createVersionInfo(const UndoRecordType recordType,

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -175,14 +175,14 @@ void Transaction::pushSequenceChange(SequenceCatalogEntry* sequenceEntry, int64_
 
 void Transaction::pushInsertInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
     common::row_idx_t numRows,
-    const storage::VersionRecordHandlerData* versionRecordHandlerData) const {
-    undoBuffer->createInsertInfo(nodeGroupIdx, startRow, numRows, versionRecordHandlerData);
+    const storage::VersionRecordHandlerSelector* versionRecordHandlerSelector) const {
+    undoBuffer->createInsertInfo(nodeGroupIdx, startRow, numRows, versionRecordHandlerSelector);
 }
 
 void Transaction::pushDeleteInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
     common::row_idx_t numRows,
-    const storage::VersionRecordHandlerData* versionRecordHandlerData) const {
-    undoBuffer->createDeleteInfo(nodeGroupIdx, startRow, numRows, versionRecordHandlerData);
+    const storage::VersionRecordHandlerSelector* versionRecordHandlerSelector) const {
+    undoBuffer->createDeleteInfo(nodeGroupIdx, startRow, numRows, versionRecordHandlerSelector);
 }
 
 void Transaction::pushVectorUpdateInfo(storage::UpdateInfo& updateInfo,

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -173,28 +173,16 @@ void Transaction::pushSequenceChange(SequenceCatalogEntry* sequenceEntry, int64_
     }
 }
 
-void Transaction::pushInsertInfo(storage::RelTableData* relTableData,
+void Transaction::pushInsertInfo(storage::NodeGroupCollection* nodeGroups,
     common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow, common::row_idx_t numRows,
     storage::CSRNodeGroupScanSource source) const {
-    undoBuffer->createInsertInfo(relTableData, nodeGroupIdx, startRow, numRows, source);
+    undoBuffer->createInsertInfo(nodeGroups, nodeGroupIdx, startRow, numRows, source);
 }
 
-void Transaction::pushInsertInfo(storage::NodeTable* nodeTable,
-    common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
-    common::row_idx_t numRows) const {
-    undoBuffer->createInsertInfo(nodeTable, nodeGroupIdx, startRow, numRows);
-}
-
-void Transaction::pushDeleteInfo(storage::NodeTable* nodeTable,
-    common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
-    common::row_idx_t numRows) const {
-    undoBuffer->createDeleteInfo(nodeTable, nodeGroupIdx, startRow, numRows);
-}
-
-void Transaction::pushDeleteInfo(storage::RelTableData* relTableData,
+void Transaction::pushDeleteInfo(storage::NodeGroupCollection* nodeGroups,
     common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow, common::row_idx_t numRows,
     storage::CSRNodeGroupScanSource source) const {
-    undoBuffer->createDeleteInfo(relTableData, nodeGroupIdx, startRow, numRows, source);
+    undoBuffer->createDeleteInfo(nodeGroups, nodeGroupIdx, startRow, numRows, source);
 }
 
 void Transaction::pushVectorUpdateInfo(storage::UpdateInfo& updateInfo,

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -63,7 +63,7 @@ void Transaction::commit(storage::WAL* wal) const {
 
 void Transaction::rollback(storage::WAL* wal) const {
     localStorage->rollback();
-    undoBuffer->rollback(this);
+    undoBuffer->rollback();
     if (isWriteTransaction() && shouldLogToWAL()) {
         KU_ASSERT(wal);
         wal->logRollback();

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -173,18 +173,16 @@ void Transaction::pushSequenceChange(SequenceCatalogEntry* sequenceEntry, int64_
     }
 }
 
-void Transaction::pushInsertInfo(storage::NodeGroupCollection* nodeGroups,
-    common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow, common::row_idx_t numRows,
-    storage::CSRNodeGroupScanSource source,
-    const transaction::rollback_insert_func_t* rollbackInsertCallback) const {
-    undoBuffer->createInsertInfo(nodeGroups, nodeGroupIdx, startRow, numRows, source,
-        rollbackInsertCallback);
+void Transaction::pushInsertInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
+    common::row_idx_t numRows,
+    const chunked_group_iterator_construct_t* constructIteratorFunc) const {
+    undoBuffer->createInsertInfo(nodeGroupIdx, startRow, numRows, constructIteratorFunc);
 }
 
-void Transaction::pushDeleteInfo(storage::NodeGroupCollection* nodeGroups,
-    common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow, common::row_idx_t numRows,
-    storage::CSRNodeGroupScanSource source) const {
-    undoBuffer->createDeleteInfo(nodeGroups, nodeGroupIdx, startRow, numRows, source);
+void Transaction::pushDeleteInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
+    common::row_idx_t numRows,
+    const chunked_group_iterator_construct_t* constructIteratorFunc) const {
+    undoBuffer->createDeleteInfo(nodeGroupIdx, startRow, numRows, constructIteratorFunc);
 }
 
 void Transaction::pushVectorUpdateInfo(storage::UpdateInfo& updateInfo,

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -175,8 +175,10 @@ void Transaction::pushSequenceChange(SequenceCatalogEntry* sequenceEntry, int64_
 
 void Transaction::pushInsertInfo(storage::NodeGroupCollection* nodeGroups,
     common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow, common::row_idx_t numRows,
-    storage::CSRNodeGroupScanSource source) const {
-    undoBuffer->createInsertInfo(nodeGroups, nodeGroupIdx, startRow, numRows, source);
+    storage::CSRNodeGroupScanSource source,
+    const transaction::rollback_insert_func_t* rollbackInsertCallback) const {
+    undoBuffer->createInsertInfo(nodeGroups, nodeGroupIdx, startRow, numRows, source,
+        rollbackInsertCallback);
 }
 
 void Transaction::pushDeleteInfo(storage::NodeGroupCollection* nodeGroups,

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -174,15 +174,13 @@ void Transaction::pushSequenceChange(SequenceCatalogEntry* sequenceEntry, int64_
 }
 
 void Transaction::pushInsertInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
-    common::row_idx_t numRows,
-    const storage::VersionRecordHandlerSelector* versionRecordHandlerSelector) const {
-    undoBuffer->createInsertInfo(nodeGroupIdx, startRow, numRows, versionRecordHandlerSelector);
+    common::row_idx_t numRows, const storage::VersionRecordHandler* versionRecordHandler) const {
+    undoBuffer->createInsertInfo(nodeGroupIdx, startRow, numRows, versionRecordHandler);
 }
 
 void Transaction::pushDeleteInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
-    common::row_idx_t numRows,
-    const storage::VersionRecordHandlerSelector* versionRecordHandlerSelector) const {
-    undoBuffer->createDeleteInfo(nodeGroupIdx, startRow, numRows, versionRecordHandlerSelector);
+    common::row_idx_t numRows, const storage::VersionRecordHandler* versionRecordHandler) const {
+    undoBuffer->createDeleteInfo(nodeGroupIdx, startRow, numRows, versionRecordHandler);
 }
 
 void Transaction::pushVectorUpdateInfo(storage::UpdateInfo& updateInfo,

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -175,14 +175,14 @@ void Transaction::pushSequenceChange(SequenceCatalogEntry* sequenceEntry, int64_
 
 void Transaction::pushInsertInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
     common::row_idx_t numRows,
-    const chunked_group_iterator_construct_t* constructIteratorFunc) const {
-    undoBuffer->createInsertInfo(nodeGroupIdx, startRow, numRows, constructIteratorFunc);
+    const storage::VersionRecordHandlerData* versionRecordHandlerData) const {
+    undoBuffer->createInsertInfo(nodeGroupIdx, startRow, numRows, versionRecordHandlerData);
 }
 
 void Transaction::pushDeleteInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
     common::row_idx_t numRows,
-    const chunked_group_iterator_construct_t* constructIteratorFunc) const {
-    undoBuffer->createDeleteInfo(nodeGroupIdx, startRow, numRows, constructIteratorFunc);
+    const storage::VersionRecordHandlerData* versionRecordHandlerData) const {
+    undoBuffer->createDeleteInfo(nodeGroupIdx, startRow, numRows, versionRecordHandlerData);
 }
 
 void Transaction::pushVectorUpdateInfo(storage::UpdateInfo& updateInfo,

--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -218,7 +218,7 @@ TEST_F(CopyTest, RelInsertBMExceptionDuringCommitRecovery) {
         .canFailDuringCheckpoint = false,
         .initFunc =
             [this](main::Connection* conn) {
-                failureFrequency = 128;
+                failureFrequency = 32;
                 conn->query("CREATE NODE TABLE account(ID INT64, PRIMARY KEY(ID))");
                 conn->query("CREATE REL TABLE follows(FROM account TO account);");
                 const auto queryString = common::stringFormat(

--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -119,8 +119,6 @@ void CopyTest::BMExceptionRecoveryTest(BMExceptionRecoveryTestConfig cfg) {
                                                  "memory! The buffer pool is full and no "
                                                  "memory could be freed!");
         } else {
-            // the copy shouldn't succeed first try
-            ASSERT_GT(i, 0);
             break;
         }
     }
@@ -183,8 +181,9 @@ TEST_F(CopyTest, RelCopyBMExceptionRecoverySameConnection) {
         .earlyExitOnFailureFunc =
             [this](main::QueryResult*) {
                 // clear the BM so that the failure frequency isn't messed with by cached pages
-                while (0 != currentBM->evictPages())
-                    ;
+                for (auto& fh : currentBM->fileHandles) {
+                    currentBM->removeFilePagesFromFrames(*fh);
+                }
                 return false;
             },
         .checkFunc =

--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -3,13 +3,19 @@
 #include "graph_test/base_graph_test.h"
 #include "graph_test/graph_test.h"
 #include "main/database.h"
-
-#define private public
 #include "storage/buffer_manager/buffer_manager.h"
 #include "transaction/transaction_manager.h"
 
 namespace kuzu {
 namespace testing {
+
+class CopyTestHelper {
+public:
+    static std::vector<std::unique_ptr<storage::FileHandle>>& getBMFileHandles(
+        storage::BufferManager* bm) {
+        return bm->fileHandles;
+    }
+};
 
 class FlakyBufferManager : public storage::BufferManager {
 public:
@@ -176,7 +182,7 @@ TEST_F(CopyTest, RelCopyBMExceptionRecoverySameConnection) {
         .earlyExitOnFailureFunc =
             [this](main::QueryResult*) {
                 // clear the BM so that the failure frequency isn't messed with by cached pages
-                for (auto& fh : currentBM->fileHandles) {
+                for (auto& fh : CopyTestHelper::getBMFileHandles(currentBM)) {
                     currentBM->removeFilePagesFromFrames(*fh);
                 }
                 return false;

--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -3,32 +3,56 @@
 #include "graph_test/base_graph_test.h"
 #include "graph_test/graph_test.h"
 #include "main/database.h"
+
+#define private public
 #include "storage/buffer_manager/buffer_manager.h"
+#include "transaction/transaction_manager.h"
 
 namespace kuzu {
 namespace testing {
 
-// TODO(Royi) add tests that use this once enough issues are fixed so that the tests can pass
 class FlakyBufferManager : public storage::BufferManager {
 public:
     FlakyBufferManager(const std::string& databasePath, const std::string& spillToDiskPath,
         uint64_t bufferPoolSize, uint64_t maxDBSize, common::VirtualFileSystem* vfs, bool readOnly,
-        uint64_t& failureFrequency)
+        uint64_t& failureFrequency, bool canFailDuringExecute, bool canFailDuringCheckpoint)
         : storage::BufferManager(databasePath, spillToDiskPath, bufferPoolSize, maxDBSize, vfs,
               readOnly),
-          failureFrequency(failureFrequency) {}
+          failureFrequency(failureFrequency), canFailDuringCheckpoint(canFailDuringCheckpoint),
+          canFailDuringExecute(canFailDuringExecute) {}
 
     bool reserve(uint64_t sizeToReserve) override {
+        const bool inCheckpoint =
+            ctx && !ctx->getTransactionManagerUnsafe()->hasActiveWriteTransactionNoLock();
+        const bool inCommit =
+            !inCheckpoint && ctx && ctx->getTx()->getCommitTS() != common::INVALID_TRANSACTION;
+        const bool inExecute = (!inCommit && !inCheckpoint);
         reserveCount = (reserveCount + 1) % failureFrequency;
-        if (reserveCount == 0) {
+        if ((canFailDuringCheckpoint || !inCheckpoint) && (canFailDuringExecute || !inExecute) &&
+            reserveCount == 0) {
             failureFrequency *= 2;
             return false;
         }
         return storage::BufferManager::reserve(sizeToReserve);
     }
 
+    void setClientContext(main::ClientContext* newCtx) { ctx = newCtx; }
+
     uint64_t& failureFrequency;
+    main::ClientContext* ctx{nullptr};
+    bool canFailDuringCheckpoint;
+    bool canFailDuringExecute;
     uint64_t reserveCount = 0;
+};
+
+struct BMExceptionRecoveryTestConfig {
+    bool canFailDuringExecute;
+    bool canFailDuringCheckpoint;
+    std::function<void(main::Connection*)> initFunc;
+    std::function<std::unique_ptr<main::QueryResult>(main::Connection*, int)> executeFunc;
+    std::function<bool(main::QueryResult*)> earlyExitOnFailureFunc;
+    std::function<std::unique_ptr<main::QueryResult>(main::Connection*)> checkFunc;
+    uint64_t checkResult;
 };
 
 class CopyTest : public BaseGraphTest {
@@ -40,29 +64,161 @@ public:
 
     void resetDB(uint64_t bufferPoolSize) {
         systemConfig->bufferPoolSize = bufferPoolSize;
-        conn.reset();
         database.reset();
+        conn.reset();
         createDBAndConn();
     }
-
-    void resetDBFlaky() {
+    void resetDBFlaky(bool canFailDuringExecute = true, bool canFailDuringCheckpoint = true) {
         database.reset();
         conn.reset();
         systemConfig->bufferPoolSize = main::SystemConfig{}.bufferPoolSize;
         auto constructBMFunc = [&](const main::Database& db) {
-            return std::unique_ptr<storage::BufferManager>(new FlakyBufferManager(databasePath,
+            auto bm = std::unique_ptr<FlakyBufferManager>(new FlakyBufferManager(databasePath,
                 getFileSystem(db)->joinPath(databasePath, "copy.tmp"), systemConfig->bufferPoolSize,
                 systemConfig->maxDBSize, getFileSystem(db), systemConfig->readOnly,
-                failureFrequency));
+                failureFrequency, canFailDuringExecute, canFailDuringCheckpoint));
+            currentBM = bm.get();
+            return bm;
         };
         database = BaseGraphTest::constructDB(databasePath, *systemConfig, constructBMFunc);
         conn = std::make_unique<main::Connection>(database.get());
+        currentBM->setClientContext(conn->getClientContext());
     }
     std::string getInputDir() override { KU_UNREACHABLE; }
+    void BMExceptionRecoveryTest(BMExceptionRecoveryTestConfig cfg);
     uint64_t failureFrequency;
+    FlakyBufferManager* currentBM;
 };
 
-TEST_F(CopyTest, DISABLED_OutOfMemoryRecovery) {
+void CopyTest::BMExceptionRecoveryTest(BMExceptionRecoveryTestConfig cfg) {
+    if (inMemMode) {
+        GTEST_SKIP();
+    }
+    static constexpr uint64_t dbSize = 64 * 1024 * 1024;
+    resetDB(dbSize);
+    cfg.initFunc(conn.get());
+
+    // this test only checks robustness during the transaction
+    // we don't want to trigger BM exceptions during checkpoint
+    // TODO(Royi) fix checkpointing so this test passes even if BM fails during checkpoint
+    resetDBFlaky(cfg.canFailDuringExecute, cfg.canFailDuringCheckpoint);
+
+    for (int i = 0;; i++) {
+        ASSERT_LT(i, 20);
+
+        const auto queryString = common::stringFormat(
+            "COPY account FROM \"{}/dataset/snap/twitter/csv/twitter-nodes.csv\"",
+            KUZU_ROOT_DIRECTORY);
+
+        auto result = cfg.executeFunc(conn.get(), i);
+        if (!result->isSuccess()) {
+            if (cfg.earlyExitOnFailureFunc(result.get())) {
+                break;
+            }
+            ASSERT_EQ(result->getErrorMessage(), "Buffer manager exception: Unable to allocate "
+                                                 "memory! The buffer pool is full and no "
+                                                 "memory could be freed!");
+        } else {
+            // the copy shouldn't succeed first try
+            ASSERT_GT(i, 0);
+            break;
+        }
+    }
+
+    // Reopen the DB so no spurious errors occur during the query
+    resetDB(dbSize);
+    {
+        // Test that the table copied as expected after the query
+        auto result = cfg.checkFunc(conn.get());
+        ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+        ASSERT_TRUE(result->hasNext());
+        ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), cfg.checkResult);
+    }
+}
+
+TEST_F(CopyTest, NodeCopyBMExceptionRecoverySameConnection) {
+    BMExceptionRecoveryTestConfig cfg{.canFailDuringExecute = true,
+        .canFailDuringCheckpoint = false,
+        .initFunc =
+            [](main::Connection* conn) {
+                conn->query("CREATE NODE TABLE account(ID INT64, PRIMARY KEY(ID))");
+            },
+        .executeFunc =
+            [](main::Connection* conn, int) {
+                const auto queryString = common::stringFormat(
+                    "COPY account FROM \"{}/dataset/snap/twitter/csv/twitter-nodes.csv\"",
+                    KUZU_ROOT_DIRECTORY);
+
+                return conn->query(queryString);
+            },
+        .earlyExitOnFailureFunc = [](main::QueryResult*) { return false; },
+        .checkFunc =
+            [](main::Connection* conn) { return conn->query("MATCH (a:account) RETURN COUNT(*)"); },
+        .checkResult = 81306};
+    BMExceptionRecoveryTest(cfg);
+}
+
+TEST_F(CopyTest, RelCopyBMExceptionRecoverySameConnection) {
+    BMExceptionRecoveryTestConfig cfg{.canFailDuringExecute = true,
+        .canFailDuringCheckpoint = false,
+        .initFunc =
+            [](main::Connection* conn) {
+                conn->query("CREATE NODE TABLE account(ID INT64, PRIMARY KEY(ID))");
+                conn->query("CREATE REL TABLE follows(FROM account TO account);");
+                ASSERT_TRUE(conn->query(common::stringFormat(
+                    "COPY account FROM \"{}/dataset/snap/twitter/csv/twitter-nodes.csv\"",
+                    KUZU_ROOT_DIRECTORY)));
+            },
+        .executeFunc =
+            [this](main::Connection* conn, int i) {
+                // there are many allocations in the partitioning phase
+                // we scale the failure frequency linearly so that we trigger at least one
+                // allocation failure in the batch insert phase
+                failureFrequency = 512 * (i + 15);
+
+                return conn->query(common::stringFormat(
+                    "COPY follows FROM '{}/dataset/snap/twitter/csv/twitter-edges.csv' (DELIM=' ')",
+                    KUZU_ROOT_DIRECTORY));
+            },
+        .earlyExitOnFailureFunc =
+            [this](main::QueryResult*) {
+                // clear the BM so that the failure frequency isn't messed with by cached pages
+                while (0 != currentBM->evictPages())
+                    ;
+                return false;
+            },
+        .checkFunc =
+            [](main::Connection* conn) {
+                return conn->query("MATCH (a:account)-[:follows]->(b:account) RETURN COUNT(*)");
+            },
+        .checkResult = 2420766};
+    BMExceptionRecoveryTest(cfg);
+}
+
+TEST_F(CopyTest, NodeInsertBMExceptionDuringCommitRecovery) {
+    static constexpr uint64_t numValues = 200000;
+    BMExceptionRecoveryTestConfig cfg{.canFailDuringExecute = false,
+        .canFailDuringCheckpoint = false,
+        .initFunc =
+            [this](main::Connection* conn) {
+                failureFrequency = 128;
+                conn->query("CREATE NODE TABLE account(ID INT64, PRIMARY KEY(ID))");
+            },
+        .executeFunc =
+            [](main::Connection* conn, int) {
+                const auto queryString = common::stringFormat(
+                    "UNWIND RANGE(1,{}) AS i CREATE (a:account {ID:i})", numValues);
+
+                return conn->query(queryString);
+            },
+        .earlyExitOnFailureFunc = [](main::QueryResult*) { return false; },
+        .checkFunc =
+            [](main::Connection* conn) { return conn->query("MATCH (a:account) RETURN COUNT(*)"); },
+        .checkResult = numValues};
+    BMExceptionRecoveryTest(cfg);
+}
+
+TEST_F(CopyTest, OutOfMemoryRecovery) {
     if (inMemMode) {
         GTEST_SKIP();
     }

--- a/test/include/graph_test/base_graph_test.h
+++ b/test/include/graph_test/base_graph_test.h
@@ -65,7 +65,8 @@ protected:
     // Static functions to access Database's non-public properties/interfaces.
     static std::unique_ptr<main::Database> constructDB(std::string_view databasePath,
         main::SystemConfig systemConfig, main::Database::construct_bm_func_t constructFunc) {
-        return main::Database::construct(databasePath, systemConfig, constructFunc);
+        return std::unique_ptr<main::Database>(
+            new main::Database(databasePath, systemConfig, constructFunc));
     }
 
     static storage::BufferManager* getBufferManager(const main::Database& database) {

--- a/test/storage/local_hash_index_test.cpp
+++ b/test/storage/local_hash_index_test.cpp
@@ -17,17 +17,17 @@ TEST(LocalHashIndexTests, LocalInserts) {
     auto hashIndex =
         std::make_unique<LocalHashIndex>(PhysicalTypeID::INT64, overflowFileHandle.get());
 
-    for (int64_t i = 0u; i < 100; i++) {
+    for (int64_t i = 0u; i < 100000; i++) {
         ASSERT_TRUE(hashIndex->insert(i, i * 2, isVisible));
     }
-    for (int64_t i = 0u; i < 100; i++) {
+    for (int64_t i = 0u; i < 100000; i++) {
         ASSERT_FALSE(hashIndex->insert(i, i, isVisible));
     }
 
-    for (int64_t i = 0u; i < 100; i++) {
+    for (int64_t i = 0u; i < 100000; i++) {
         hashIndex->delete_(i);
     }
-    for (int64_t i = 0u; i < 100; i++) {
+    for (int64_t i = 0u; i < 100000; i++) {
         ASSERT_TRUE(hashIndex->insert(i, i, isVisible));
     }
 }

--- a/test/test_files/transaction/copy/copy_node.test
+++ b/test/test_files/transaction/copy/copy_node.test
@@ -1,12 +1,26 @@
 -DATASET CSV empty
 --
 
+-CASE CopyNodeAfterPKErrorRollbackFlushedGroups
+-STATEMENT create node table Comment (id int64, creationDate INT64, locationIP STRING, browserUsed STRING, content STRING, length INT32, PRIMARY KEY (id));
+---- ok
+# COPY will trigger duplicate PK once the 2nd file is hit
+-STATEMENT COPY Comment FROM ['${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Comment.csv', '${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Comment.csv'] (delim="|", header=true, parallel=false);
+---- error(regex)
+Copy exception: Found duplicated primary key value \w+, which violates the uniqueness constraint of the primary key column.
+# The failed COPY should revert all of its insertions and the 2nd COPY should succeed
+-STATEMENT COPY Comment FROM '${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Comment.csv' (DELIM="|", header=true);
+---- ok
+-STATEMENT MATCH (c:Comment) WHERE c.ID = 962073046352 RETURN c.locationIP
+---- 1
+36.95.74.186
+
 -CASE CopyNodeManualTransactionCheck
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
 ---- ok
--STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv" 
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv"
 ---- error
 Connection exception: COPY FROM is only supported in auto transaction mode.
 
@@ -16,7 +30,7 @@ Connection exception: COPY FROM is only supported in auto transaction mode.
 ---- ok
 -STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
 ---- ok
--STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv" 
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv"
 ---- ok
 -STATEMENT COMMIT;
 ---- ok
@@ -37,7 +51,7 @@ Connection exception: COPY FROM is only supported in auto transaction mode.
 ---- ok
 -STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
 ---- ok
--STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv" 
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv"
 ---- ok
 -STATEMENT COMMIT;
 ---- ok
@@ -56,7 +70,7 @@ Connection exception: COPY FROM is only supported in auto transaction mode.
 -CASE CopyNodeRollbackDueToError
 -STATEMENT CREATE NODE TABLE person (ID INT64, name STRING, PRIMARY KEY (ID));
 ---- ok
--STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-test/copy-error/person.csv" 
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-test/copy-error/person.csv"
 ---- error
 Copy exception: Found duplicated primary key value 10, which violates the uniqueness constraint of the primary key column.
 -STATEMENT MATCH (p:person) return count(*);
@@ -66,7 +80,7 @@ Copy exception: Found duplicated primary key value 10, which violates the unique
 -CASE CopyNodeRollbackAndManualCheckpoint
 -STATEMENT CREATE NODE TABLE person (ID INT64, name STRING, PRIMARY KEY (ID));
 ---- ok
--STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-test/copy-error/person.csv" 
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-test/copy-error/person.csv"
 ---- error
 Copy exception: Found duplicated primary key value 10, which violates the uniqueness constraint of the primary key column.
 -STATEMENT MATCH (p:person) return count(*);
@@ -81,7 +95,7 @@ Copy exception: Found duplicated primary key value 10, which violates the unique
 -CASE CopyNodeRollbackAndManualCheckpointAndReloadDB
 -STATEMENT CREATE NODE TABLE person (ID INT64, name STRING, PRIMARY KEY (ID));
 ---- ok
--STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-test/copy-error/person.csv" 
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-test/copy-error/person.csv"
 ---- error
 Copy exception: Found duplicated primary key value 10, which violates the uniqueness constraint of the primary key column.
 -STATEMENT MATCH (p:person) return count(*);
@@ -100,9 +114,9 @@ Copy exception: Found duplicated primary key value 10, which violates the unique
 -CASE CopyNodeRollbackAndManualCheckpoint2
 -STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
 ---- ok
--STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv" 
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv"
 ---- ok
--STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv" 
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv"
 ---- error
 Copy exception: Found duplicated primary key value 0, which violates the uniqueness constraint of the primary key column.
 -STATEMENT MATCH (p:person) return count(*);
@@ -181,7 +195,7 @@ Copy exception: Found duplicated primary key value 0, which violates the uniquen
 -CASE CopyNodeAndDeleteAndManualCheckpoint
 -STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
 ---- ok
--STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv" 
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv"
 ---- ok
 -STATEMENT MATCH (p:person) return count(*);
 ---- 1
@@ -200,7 +214,7 @@ Copy exception: Found duplicated primary key value 0, which violates the uniquen
 -CASE CopyNodeAndDeleteAndManualCheckpointAndReloadDB
 -STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
 ---- ok
--STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv" 
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv"
 ---- ok
 -STATEMENT MATCH (p:person) return count(*);
 ---- 1

--- a/test/test_files/transaction/create_node/create_node.test
+++ b/test/test_files/transaction/create_node/create_node.test
@@ -36,6 +36,24 @@
 ---- 1
 0|A|True|2019-01-01
 
+-CASE CreateRollbackThenRetry
+-STATEMENT CREATE NODE TABLE test(id INT64, name STRING, isTrue BOOLEAN, birthday DATE, PRIMARY KEY(id));
+---- ok
+-STATEMENT BEGIN TRANSACTION
+---- ok
+-STATEMENT CREATE (a:test {id:0, name:'A', isTrue:True, birthday:Date('2019-01-01')})
+---- ok
+-STATEMENT MATCH (a:test) RETURN a.id, a.name, a.isTrue, a.birthday
+---- 1
+0|A|True|2019-01-01
+-STATEMENT ROLLBACK
+---- ok
+-STATEMENT CREATE (a:test {id:0, name:'A', isTrue:True, birthday:Date('2019-01-01')})
+---- ok
+-STATEMENT MATCH (a:test) RETURN a.id, a.name, a.isTrue, a.birthday
+---- 1
+0|A|True|2019-01-01
+
 -CASE Create3
 -STATEMENT CALL auto_checkpoint=false;
 ---- ok

--- a/test/test_files/transaction/create_rel/create_tinysnb.test
+++ b/test/test_files/transaction/create_rel/create_tinysnb.test
@@ -34,6 +34,21 @@
 ---- error
 Runtime exception: Node(nodeOffset: 7) has more than one neighbour in table marries in the bwd direction, which violates the rel multiplicity constraint.
 
+# Retry
+-STATEMENT MATCH (a:person)-[m:marries]->(b:person) RETURN a.ID, b.ID
+---- 3
+0|2
+3|5
+7|8
+-STATEMENT MATCH (a:person), (b:person) WHERE a.ID = 9 AND b.ID = 10 CREATE (a)-[:marries]->(b)
+---- ok
+-STATEMENT MATCH (a:person)-[m:marries]->(b:person) RETURN a.ID, b.ID
+---- 4
+0|2
+3|5
+7|8
+9|10
+
 -LOG Bwd
 -STATEMENT BEGIN TRANSACTION
 ---- ok

--- a/test/test_files/transaction/set_node/set_empty.test
+++ b/test/test_files/transaction/set_node/set_empty.test
@@ -2,6 +2,24 @@
 
 --
 
+-CASE ExceptionDuringHashIndexCommitRecovery
+-STATEMENT CREATE NODE TABLE account(ID INT64, PRIMARY KEY(ID))
+---- ok
+-STATEMENT BEGIN TRANSACTION
+---- ok
+-STATEMENT UNWIND RANGE(1,200000) AS i CREATE (a:account {ID:i})
+---- ok
+-STATEMENT MATCH (a:account) WHERE a.ID = 199000 SET a.ID = 1
+---- ok
+-STATEMENT COMMIT
+---- error(regex)
+Runtime exception: Found duplicated primary key value \d+, which violates the uniqueness constraint of the primary key column.
+-STATEMENT UNWIND RANGE(1,200000) AS i CREATE (a:account {ID:i})
+---- ok
+-STATEMENT MATCH (a:account) RETURN COUNT(*)
+---- 1
+200000
+
 -CASE DoubleColumnInsertionsAndUpdatesLarge
 -STATEMENT CALL auto_checkpoint=false;
 ---- ok


### PR DESCRIPTION
# Description

- Implement in-memory hash index rollback for insertions
- Inserts/deletes are now pushed to the undo buffer at the table level (instead of in `ChunkedNodeGroup`). This also prevents changes to temporary chunked node groups from being pushed to the undo buffer (which is a potential cause of use-after-frees). 
- New iterators are added that allow us to iterate over `ChunkedNodeGroups` in `NodeGroups` which we use to perform undo buffer commit/rollback
- Empty node groups/chunked node groups are deleted during rollback
- Fix in-memory hash index delete to properly find the last valid entry

Fixes #4338

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).