### PR TITLE
Rework limit push down optimizer

### DIFF
--- a/src/include/optimizer/limit_push_down_optimizer.h
+++ b/src/include/optimizer/limit_push_down_optimizer.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "planner/operator/logical_limit.h"
 #include "planner/operator/logical_plan.h"
 
 namespace kuzu {
@@ -11,21 +10,16 @@ namespace optimizer {
 
 class LimitPushDownOptimizer {
 public:
-    explicit LimitPushDownOptimizer(main::ClientContext* context)
-        : limitOperator{nullptr}, context{context} {}
+    LimitPushDownOptimizer() : skipNumber{0}, limitNumber{common::INVALID_LIMIT} {}
 
     void rewrite(planner::LogicalPlan* plan);
 
 private:
-    std::shared_ptr<planner::LogicalOperator> visitOperator(
-        std::shared_ptr<planner::LogicalOperator> op);
-
-    std::shared_ptr<planner::LogicalOperator> finishPushDown(
-        std::shared_ptr<planner::LogicalOperator> op);
+    void visitOperator(planner::LogicalOperator* op);
 
 private:
-    planner::LogicalLimit* limitOperator;
-    main::ClientContext* context;
+    common::offset_t skipNumber;
+    common::offset_t limitNumber;
 };
 
 } // namespace optimizer

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -39,7 +39,7 @@ void Optimizer::optimize(planner::LogicalPlan* plan, main::ClientContext* contex
         hashJoinSIPOptimizer.rewrite(plan);
     }
 
-    auto limitPushDownOptimizer = LimitPushDownOptimizer(context);
+    auto limitPushDownOptimizer = LimitPushDownOptimizer();
     limitPushDownOptimizer.rewrite(plan);
 
     auto topKOptimizer = TopKOptimizer();

--- a/test/test_files/projection/skip_limit.test
+++ b/test/test_files/projection/skip_limit.test
@@ -4,6 +4,10 @@
 
 -CASE ProjectionSkipLimit
 
+-STATEMENT UNWIND [1,2] AS x MATCH (a:person) RETURN DISTINCT a.fName LIMIT 1
+---- 1
+Alice
+
 -LOG BasicSkipTest1
 -STATEMENT MATCH (a:person) RETURN a.fName Skip 5
 ---- 3


### PR DESCRIPTION
# Description

Rework limit push down optimizer so that we don't remove LIMIT operator. Instead we just document skip and limit number and push them into other operators (DISTINCT for now).

Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).