### PR TITLE
Gds limit push down

### DIFF
--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -124,10 +124,10 @@ public:
         processor::NodeOffsetMaskMap* outputNodeMask)
         : DestinationsOutputWriter{context, rjOutputs, outputNodeMask} {}
 
-    void write(FactorizedTable &fTable, nodeID_t dstNodeID, processor::GDSOutputCounter* counter) override {
+    void write(FactorizedTable& fTable, nodeID_t dstNodeID,
+        processor::GDSOutputCounter* counter) override {
         auto outputs = rjOutputs->ptrCast<AllSPDestinationsOutputs>();
-        auto length = outputs->pathLengths->getMaskValueFromCurFrontierFixedMask(
-                dstNodeID.offset);
+        auto length = outputs->pathLengths->getMaskValueFromCurFrontierFixedMask(dstNodeID.offset);
         dstNodeIDVector->setValue<nodeID_t>(0, dstNodeID);
         lengthVector->setValue<uint16_t>(0, length);
         auto multiplicity = outputs->multiplicities.getTargetMultiplicity(dstNodeID.offset);

--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -124,19 +124,23 @@ public:
         processor::NodeOffsetMaskMap* outputNodeMask)
         : DestinationsOutputWriter{context, rjOutputs, outputNodeMask} {}
 
-    std::unique_ptr<RJOutputWriter> copy() override {
-        return std::make_unique<AllSPDestinationsOutputWriter>(context, rjOutputs, outputNodeMask);
-    }
-
-protected:
-    void writeMoreAndAppend(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID,
-        uint16_t) const override {
-        auto multiplicity =
-            rjOutputs->ptrCast<AllSPDestinationsOutputs>()->multiplicities.getTargetMultiplicity(
+    void write(FactorizedTable &fTable, nodeID_t dstNodeID, processor::GDSOutputCounter* counter) override {
+        auto outputs = rjOutputs->ptrCast<AllSPDestinationsOutputs>();
+        auto length = outputs->pathLengths->getMaskValueFromCurFrontierFixedMask(
                 dstNodeID.offset);
-        for (uint64_t i = 0; i < multiplicity; ++i) {
+        dstNodeIDVector->setValue<nodeID_t>(0, dstNodeID);
+        lengthVector->setValue<uint16_t>(0, length);
+        auto multiplicity = outputs->multiplicities.getTargetMultiplicity(dstNodeID.offset);
+        for (auto i = 0u; i < multiplicity; ++i) {
             fTable.append(vectors);
         }
+        if (counter != nullptr) {
+            counter->increase(multiplicity);
+        }
+    }
+
+    std::unique_ptr<RJOutputWriter> copy() override {
+        return std::make_unique<AllSPDestinationsOutputWriter>(context, rjOutputs, outputNodeMask);
     }
 };
 

--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -56,7 +56,6 @@ void VertexComputeTask::run() {
             localVc->vertexCompute(nodeID);
         }
     }
-    localVc->finalizeWorkerThread();
 }
 } // namespace function
 } // namespace kuzu

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -87,8 +87,8 @@ void GDSUtils::runVertexComputeIteration(processor::ExecutionContext* executionC
         if (!vc.beginOnTable(tableID)) {
             continue;
         }
-        sharedState->morselDispatcher.init(tableID,
-            graph->getNumNodes(clientContext->getTx(), tableID));
+        auto numNodes = graph->getNumNodes(clientContext->getTx(), tableID);
+        sharedState->morselDispatcher.init(tableID, numNodes);
         auto task = std::make_shared<VertexComputeTask>(maxThreads, info, sharedState);
         clientContext->getTaskScheduler()->scheduleTaskAndWaitOrError(task, executionContext,
             true /* launchNewWorkerThread */);

--- a/src/function/gds/output_writer.cpp
+++ b/src/function/gds/output_writer.cpp
@@ -81,7 +81,8 @@ static void setLength(ValueVector* vector, uint16_t length) {
     vector->setValue<uint16_t>(0, length);
 }
 
-void PathsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNodeID, GDSOutputCounter* counter) {
+void PathsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNodeID,
+    GDSOutputCounter* counter) {
     auto output = rjOutputs->ptrCast<PathsOutputs>();
     auto& bfsGraph = output->bfsGraph;
     auto sourceNodeID = output->sourceNodeID;
@@ -276,7 +277,8 @@ DestinationsOutputWriter::DestinationsOutputWriter(main::ClientContext* context,
     lengthVector = createVector(LogicalType::UINT16(), context->getMemoryManager());
 }
 
-void DestinationsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNodeID, GDSOutputCounter* counter) {
+void DestinationsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNodeID,
+    GDSOutputCounter* counter) {
     auto length =
         rjOutputs->ptrCast<SPOutputs>()->pathLengths->getMaskValueFromCurFrontierFixedMask(
             dstNodeID.offset);

--- a/src/function/gds/output_writer.cpp
+++ b/src/function/gds/output_writer.cpp
@@ -5,6 +5,7 @@
 #include "main/client_context.h"
 
 using namespace kuzu::common;
+using namespace kuzu::processor;
 
 namespace kuzu {
 namespace function {
@@ -80,7 +81,7 @@ static void setLength(ValueVector* vector, uint16_t length) {
     vector->setValue<uint16_t>(0, length);
 }
 
-void PathsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNodeID) const {
+void PathsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNodeID, GDSOutputCounter* counter) {
     auto output = rjOutputs->ptrCast<PathsOutputs>();
     auto& bfsGraph = output->bfsGraph;
     auto sourceNodeID = output->sourceNodeID;
@@ -96,6 +97,10 @@ void PathsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNo
                 beginWritePath(0);
             }
             fTable.append(vectors);
+            // No need to check against limit number since this is the first output.
+            if (counter != nullptr) {
+                counter->increase(1);
+            }
         }
         return;
     }
@@ -111,6 +116,12 @@ void PathsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNo
             if (checkPathNodeMask(curPath) && checkSemantic(curPath)) {
                 writePath(curPath);
                 fTable.append(vectors);
+                if (counter != nullptr) {
+                    counter->increase(1);
+                    if (counter->exceedLimit()) {
+                        return;
+                    }
+                }
             }
             backtracking = true;
         }
@@ -148,6 +159,7 @@ void PathsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNo
             backtracking = false;
         }
     }
+    return;
 }
 
 bool PathsOutputWriter::checkPathNodeMask(const std::vector<ParentList*>& path) const {
@@ -264,13 +276,17 @@ DestinationsOutputWriter::DestinationsOutputWriter(main::ClientContext* context,
     lengthVector = createVector(LogicalType::UINT16(), context->getMemoryManager());
 }
 
-void DestinationsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNodeID) const {
+void DestinationsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNodeID, GDSOutputCounter* counter) {
     auto length =
         rjOutputs->ptrCast<SPOutputs>()->pathLengths->getMaskValueFromCurFrontierFixedMask(
             dstNodeID.offset);
     dstNodeIDVector->setValue<nodeID_t>(0, dstNodeID);
     setLength(lengthVector.get(), length);
-    writeMoreAndAppend(fTable, dstNodeID, length);
+    fTable.append(vectors);
+    if (counter != nullptr) {
+        counter->increase(1);
+    }
+    return;
 }
 
 bool DestinationsOutputWriter::skipInternal(common::nodeID_t dstNodeID) const {
@@ -278,11 +294,6 @@ bool DestinationsOutputWriter::skipInternal(common::nodeID_t dstNodeID) const {
     return dstNodeID == outputs->sourceNodeID ||
            PathLengths::UNVISITED ==
                outputs->pathLengths->getMaskValueFromCurFrontierFixedMask(dstNodeID.offset);
-}
-
-void DestinationsOutputWriter::writeMoreAndAppend(processor::FactorizedTable& fTable, nodeID_t,
-    uint16_t) const {
-    fTable.append(vectors);
 }
 
 } // namespace function

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -54,10 +54,6 @@ public:
     // the function on each node in a graph.
     virtual void vertexCompute(common::nodeID_t curNodeID) = 0;
 
-    // This function is called by each worker thread T once at the end of
-    // GDSUtils::runVertexComputeIteration().
-    virtual void finalizeWorkerThread() {}
-
     virtual std::unique_ptr<VertexCompute> copy() = 0;
 };
 

--- a/src/include/function/gds/output_writer.h
+++ b/src/include/function/gds/output_writer.h
@@ -70,7 +70,8 @@ public:
 
     bool skip(common::nodeID_t dstNodeID) const;
 
-    virtual void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID, processor::GDSOutputCounter* counter) = 0;
+    virtual void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID,
+        processor::GDSOutputCounter* counter) = 0;
 
     virtual std::unique_ptr<RJOutputWriter> copy() = 0;
 
@@ -94,7 +95,8 @@ public:
     DestinationsOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs,
         processor::NodeOffsetMaskMap* outputNodeMask);
 
-    void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID, processor::GDSOutputCounter* counter) override;
+    void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID,
+        processor::GDSOutputCounter* counter) override;
 
     std::unique_ptr<RJOutputWriter> copy() override {
         return std::make_unique<DestinationsOutputWriter>(context, rjOutputs, outputNodeMask);
@@ -127,7 +129,8 @@ public:
     PathsOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs,
         processor::NodeOffsetMaskMap* outputNodeMask, PathsOutputWriterInfo info);
 
-    void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID, processor::GDSOutputCounter* counter) override;
+    void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID,
+        processor::GDSOutputCounter* counter) override;
 
 private:
     bool checkPathNodeMask(const std::vector<ParentList*>& path) const;

--- a/src/include/function/gds/output_writer.h
+++ b/src/include/function/gds/output_writer.h
@@ -70,7 +70,7 @@ public:
 
     bool skip(common::nodeID_t dstNodeID) const;
 
-    virtual void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID) const = 0;
+    virtual void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID, processor::GDSOutputCounter* counter) = 0;
 
     virtual std::unique_ptr<RJOutputWriter> copy() = 0;
 
@@ -94,7 +94,7 @@ public:
     DestinationsOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs,
         processor::NodeOffsetMaskMap* outputNodeMask);
 
-    void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID) const override;
+    void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID, processor::GDSOutputCounter* counter) override;
 
     std::unique_ptr<RJOutputWriter> copy() override {
         return std::make_unique<DestinationsOutputWriter>(context, rjOutputs, outputNodeMask);
@@ -102,8 +102,6 @@ public:
 
 protected:
     bool skipInternal(common::nodeID_t dstNodeID) const override;
-    virtual void writeMoreAndAppend(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID,
-        uint16_t length) const;
 
 protected:
     std::unique_ptr<common::ValueVector> lengthVector;
@@ -129,7 +127,7 @@ public:
     PathsOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs,
         processor::NodeOffsetMaskMap* outputNodeMask, PathsOutputWriterInfo info);
 
-    void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID) const override;
+    void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID, processor::GDSOutputCounter* counter) override;
 
 private:
     bool checkPathNodeMask(const std::vector<ParentList*>& path) const;

--- a/src/include/optimizer/limit_push_down_optimizer.h
+++ b/src/include/optimizer/limit_push_down_optimizer.h
@@ -3,9 +3,6 @@
 #include "planner/operator/logical_plan.h"
 
 namespace kuzu {
-namespace main {
-class ClientContext;
-}
 namespace optimizer {
 
 class LimitPushDownOptimizer {

--- a/src/include/planner/operator/logical_distinct.h
+++ b/src/include/planner/operator/logical_distinct.h
@@ -27,12 +27,12 @@ public:
     binder::expression_vector getPayloads() const { return payloads; }
     void setPayloads(binder::expression_vector expressions) { payloads = std::move(expressions); }
 
-    void setSkipNum(uint64_t num) { skipNum = num; }
-    bool hasSkipNum() const { return skipNum != UINT64_MAX; }
-    uint64_t getSkipNum() const { return skipNum; }
-    void setLimitNum(uint64_t num) { limitNum = num; }
-    bool hasLimitNum() const { return limitNum != UINT64_MAX; }
-    uint64_t getLimitNum() const { return limitNum; }
+    void setSkipNum(common::offset_t num) { skipNum = num; }
+    bool hasSkipNum() const { return skipNum != common::INVALID_LIMIT; }
+    common::offset_t getSkipNum() const { return skipNum; }
+    void setLimitNum(common::offset_t num) { limitNum = num; }
+    bool hasLimitNum() const { return limitNum != common::INVALID_LIMIT; }
+    common::offset_t getLimitNum() const { return limitNum; }
 
     std::unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalDistinct>(operatorType, keys, payloads, children[0]->copy());
@@ -47,8 +47,8 @@ protected:
     binder::expression_vector payloads;
 
 private:
-    uint64_t skipNum;
-    uint64_t limitNum;
+    common::offset_t skipNum;
+    common::offset_t limitNum;
 };
 
 } // namespace planner

--- a/src/include/planner/operator/logical_gds_call.h
+++ b/src/include/planner/operator/logical_gds_call.h
@@ -11,11 +11,11 @@ class LogicalGDSCall final : public LogicalOperator {
 
 public:
     explicit LogicalGDSCall(binder::BoundGDSCallInfo info)
-        : LogicalOperator{operatorType_}, info{std::move(info)} {}
+        : LogicalOperator{operatorType_}, info{std::move(info)}, limitNum{common::INVALID_LIMIT} {}
     LogicalGDSCall(binder::BoundGDSCallInfo info, common::table_id_set_t nbrTableIDSet,
         std::shared_ptr<LogicalOperator> nodePredicateRoot)
         : LogicalOperator{operatorType_}, info{std::move(info)}, nbrTableIDSet{nbrTableIDSet},
-          nodePredicateRoot{std::move(nodePredicateRoot)} {}
+          nodePredicateRoot{std::move(nodePredicateRoot)}, limitNum{common::INVALID_LIMIT} {}
 
     void computeFlatSchema() override;
     void computeFactorizedSchema() override;
@@ -33,6 +33,9 @@ public:
     bool hasNodePredicate() const { return nodePredicateRoot != nullptr; }
     std::shared_ptr<LogicalOperator> getNodePredicateRoot() const { return nodePredicateRoot; }
 
+    void setLimitNum(common::offset_t num) { limitNum = num; }
+    common::offset_t getLimitNum() const { return limitNum; }
+
     std::string getExpressionsForPrinting() const override { return info.func.name; }
 
     std::unique_ptr<LogicalOperator> copy() override {
@@ -43,6 +46,7 @@ private:
     binder::BoundGDSCallInfo info;
     common::table_id_set_t nbrTableIDSet;
     std::shared_ptr<LogicalOperator> nodePredicateRoot;
+    common::offset_t limitNum;
 };
 
 } // namespace planner

--- a/src/include/processor/operator/gds_call.h
+++ b/src/include/processor/operator/gds_call.h
@@ -41,7 +41,7 @@ public:
 
     bool isParallel() const override { return false; }
 
-    void initLocalStateInternal(ResultSet* /*resultSet_*/, ExecutionContext* /*context*/) override {
+    void initLocalStateInternal(ResultSet*, ExecutionContext*) override {
         gds->setSharedState(sharedState);
     }
 

--- a/src/include/processor/operator/gds_call_shared_state.h
+++ b/src/include/processor/operator/gds_call_shared_state.h
@@ -65,18 +65,13 @@ private:
 
 class GDSOutputCounter {
 public:
-    explicit GDSOutputCounter(common::offset_t limitNumber)
-        : limitNumber{limitNumber} {
+    explicit GDSOutputCounter(common::offset_t limitNumber) : limitNumber{limitNumber} {
         counter.store(0);
     }
 
-    void increase(common::offset_t number) {
-        counter.fetch_add(number);
-    }
+    void increase(common::offset_t number) { counter.fetch_add(number); }
 
-    bool exceedLimit() const {
-        return counter.load() >= limitNumber;
-    }
+    bool exceedLimit() const { return counter.load() >= limitNumber; }
 
 private:
     common::offset_t limitNumber;
@@ -89,7 +84,8 @@ struct GDSCallSharedState {
     std::unique_ptr<graph::Graph> graph;
     std::unique_ptr<GDSOutputCounter> counter = nullptr;
 
-    GDSCallSharedState(std::shared_ptr<FactorizedTable> fTable, std::unique_ptr<graph::Graph> graph, common::offset_t limitNumber)
+    GDSCallSharedState(std::shared_ptr<FactorizedTable> fTable, std::unique_ptr<graph::Graph> graph,
+        common::offset_t limitNumber)
         : fTable{fTable}, graph{std::move(graph)} {
         if (limitNumber != common::INVALID_LIMIT) {
             counter = std::make_unique<GDSOutputCounter>(limitNumber);
@@ -127,9 +123,7 @@ struct GDSCallSharedState {
     FactorizedTable* claimLocalTable(storage::MemoryManager* mm);
     void returnLocalTable(FactorizedTable* table);
     void mergeLocalTables();
-    bool exceedLimit() const {
-        return !(counter == nullptr) && counter->exceedLimit();
-    }
+    bool exceedLimit() const { return !(counter == nullptr) && counter->exceedLimit(); }
 
     void setNbrTableIDSet(common::table_id_set_t set) { nbrTableIDSet = set; }
     bool inNbrTableIDs(common::table_id_t tableID) const {

--- a/src/include/processor/operator/gds_call_shared_state.h
+++ b/src/include/processor/operator/gds_call_shared_state.h
@@ -63,13 +63,38 @@ private:
     bool enabled_;
 };
 
+class GDSOutputCounter {
+public:
+    explicit GDSOutputCounter(common::offset_t limitNumber)
+        : limitNumber{limitNumber} {
+        counter.store(0);
+    }
+
+    void increase(common::offset_t number) {
+        counter.fetch_add(number);
+    }
+
+    bool exceedLimit() const {
+        return counter.load() >= limitNumber;
+    }
+
+private:
+    common::offset_t limitNumber;
+    std::atomic<common::offset_t> counter;
+};
+
 struct GDSCallSharedState {
     std::mutex mtx;
     std::shared_ptr<FactorizedTable> fTable;
     std::unique_ptr<graph::Graph> graph;
+    std::unique_ptr<GDSOutputCounter> counter = nullptr;
 
-    GDSCallSharedState(std::shared_ptr<FactorizedTable> fTable, std::unique_ptr<graph::Graph> graph)
-        : fTable{fTable}, graph{std::move(graph)} {}
+    GDSCallSharedState(std::shared_ptr<FactorizedTable> fTable, std::unique_ptr<graph::Graph> graph, common::offset_t limitNumber)
+        : fTable{fTable}, graph{std::move(graph)} {
+        if (limitNumber != common::INVALID_LIMIT) {
+            counter = std::make_unique<GDSOutputCounter>(limitNumber);
+        }
+    }
     DELETE_COPY_AND_MOVE(GDSCallSharedState);
 
     void setInputNodeMask(std::unique_ptr<NodeOffsetMaskMap> maskMap) {
@@ -102,6 +127,9 @@ struct GDSCallSharedState {
     FactorizedTable* claimLocalTable(storage::MemoryManager* mm);
     void returnLocalTable(FactorizedTable* table);
     void mergeLocalTables();
+    bool exceedLimit() const {
+        return !(counter == nullptr) && counter->exceedLimit();
+    }
 
     void setNbrTableIDSet(common::table_id_set_t set) { nbrTableIDSet = set; }
     bool inNbrTableIDs(common::table_id_t tableID) const {

--- a/src/optimizer/limit_push_down_optimizer.cpp
+++ b/src/optimizer/limit_push_down_optimizer.cpp
@@ -1,7 +1,7 @@
 #include "optimizer/limit_push_down_optimizer.h"
-
 #include "planner/operator/logical_distinct.h"
 #include "planner/operator/logical_limit.h"
+#include "planner/operator/logical_gds_call.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -18,15 +18,18 @@ void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op) {
     switch (op->getOperatorType()) {
     case LogicalOperatorType::LIMIT: {
         auto& limit = op->constCast<LogicalLimit>();
-        skipNumber = limit.getSkipNum();
-        limitNumber = limit.getLimitNum();
+        if (limit.hasSkipNum()) {
+            skipNumber = limit.getSkipNum();
+        }
+        if (limit.hasLimitNum()) {
+            limitNumber = limit.getLimitNum();
+        }
         visitOperator(limit.getChild(0).get());
         return;
     }
     case LogicalOperatorType::MULTIPLICITY_REDUCER:
     case LogicalOperatorType::EXPLAIN:
     case LogicalOperatorType::ACCUMULATE:
-    case LogicalOperatorType::PATH_PROPERTY_PROBE:
     case LogicalOperatorType::PROJECTION: {
         visitOperator(op->getChild(0).get());
         return;
@@ -38,6 +41,21 @@ void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op) {
         auto& distinctOp = op->cast<LogicalDistinct>();
         distinctOp.setLimitNum(limitNumber);
         distinctOp.setSkipNum(skipNumber);
+        return;
+    }
+    case LogicalOperatorType::HASH_JOIN: {
+        if (limitNumber == INVALID_LIMIT && skipNumber == 0) {
+            return;
+        }
+        if (op->getChild(0)->getOperatorType() == LogicalOperatorType::HASH_JOIN) {
+            // OP is the hash join reading destination node property. Continue push limit down.
+            op = op->getChild(0).get();
+        }
+        if (op->getChild(0)->getOperatorType() == LogicalOperatorType::PATH_PROPERTY_PROBE) {
+            KU_ASSERT(op->getChild(0)->getChild(0)->getOperatorType() == LogicalOperatorType::GDS_CALL);
+            auto& gds = op->getChild(0)->getChild(0)->cast<LogicalGDSCall>();
+            gds.setLimitNum(skipNumber + limitNumber);
+        }
         return;
     }
     case LogicalOperatorType::UNION_ALL: {

--- a/src/optimizer/limit_push_down_optimizer.cpp
+++ b/src/optimizer/limit_push_down_optimizer.cpp
@@ -1,7 +1,8 @@
 #include "optimizer/limit_push_down_optimizer.h"
+
 #include "planner/operator/logical_distinct.h"
-#include "planner/operator/logical_limit.h"
 #include "planner/operator/logical_gds_call.h"
+#include "planner/operator/logical_limit.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -52,7 +53,8 @@ void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op) {
             op = op->getChild(0).get();
         }
         if (op->getChild(0)->getOperatorType() == LogicalOperatorType::PATH_PROPERTY_PROBE) {
-            KU_ASSERT(op->getChild(0)->getChild(0)->getOperatorType() == LogicalOperatorType::GDS_CALL);
+            KU_ASSERT(
+                op->getChild(0)->getChild(0)->getOperatorType() == LogicalOperatorType::GDS_CALL);
             auto& gds = op->getChild(0)->getChild(0)->cast<LogicalGDSCall>();
             gds.setLimitNum(skipNumber + limitNumber);
         }

--- a/src/planner/join_order/cardinality_estimator.cpp
+++ b/src/planner/join_order/cardinality_estimator.cpp
@@ -138,7 +138,10 @@ double CardinalityEstimator::getExtensionRate(const RelExpression& rel,
     }
     case QueryRelType::VARIABLE_LENGTH_WALK:
     case QueryRelType::VARIABLE_LENGTH_TRAIL:
-    case QueryRelType::VARIABLE_LENGTH_ACYCLIC:
+    case QueryRelType::VARIABLE_LENGTH_ACYCLIC: {
+        auto rate = oneHopExtensionRate * rel.getUpperBound();
+        return rate * context->getClientConfig()->recursivePatternCardinalityScaleFactor;
+    }
     case QueryRelType::SHORTEST:
     case QueryRelType::ALL_SHORTEST: {
         auto rate = std::min<double>(oneHopExtensionRate * rel.getUpperBound(), numRels);

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -199,13 +199,14 @@ void Planner::appendRecursiveExtendAsGDS(const std::shared_ptr<NodeExpression>& 
     pathPropertyProbe->getSIPInfoUnsafe().position = SemiMaskPosition::PROHIBIT;
     pathPropertyProbe->computeFactorizedSchema();
     probePlan.setLastOperator(pathPropertyProbe);
-    auto extensionRate =
-        cardinalityEstimator.getExtensionRate(*rel, *boundNode, clientContext->getTx());
     probePlan.setCost(plan.getCardinality());
-    probePlan.setCardinality(plan.getCardinality() * extensionRate);
+    auto cardinality = UINT32_MAX;
+    probePlan.setCardinality(cardinality);
     // Join with input node
     auto joinConditions = expression_vector{boundNode->getInternalID()};
     appendHashJoin(joinConditions, JoinType::INNER, probePlan, plan, plan);
+    // Hash join above should not change the cardinality of probe plan.
+    plan.setCardinality(probePlan.getCardinality());
 }
 
 void Planner::appendRecursiveExtend(const std::shared_ptr<NodeExpression>& boundNode,

--- a/src/processor/map/map_gds.cpp
+++ b/src/processor/map/map_gds.cpp
@@ -43,7 +43,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapGDSCall(LogicalOperator* logica
         std::make_shared<FactorizedTable>(clientContext->getMemoryManager(), tableSchema->copy());
     auto graph = std::make_unique<OnDiskGraph>(clientContext, logicalInfo.graphEntry);
     auto storageManager = clientContext->getStorageManager();
-    auto sharedState = std::make_shared<GDSCallSharedState>(table, std::move(graph));
+    auto sharedState = std::make_shared<GDSCallSharedState>(table, std::move(graph), call.getLimitNum());
     if (call.hasNbrTableIDSet()) {
         sharedState->setNbrTableIDSet(call.getNbrTableIDSet());
     }

--- a/src/processor/map/map_gds.cpp
+++ b/src/processor/map/map_gds.cpp
@@ -43,7 +43,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapGDSCall(LogicalOperator* logica
         std::make_shared<FactorizedTable>(clientContext->getMemoryManager(), tableSchema->copy());
     auto graph = std::make_unique<OnDiskGraph>(clientContext, logicalInfo.graphEntry);
     auto storageManager = clientContext->getStorageManager();
-    auto sharedState = std::make_shared<GDSCallSharedState>(table, std::move(graph), call.getLimitNum());
+    auto sharedState =
+        std::make_shared<GDSCallSharedState>(table, std::move(graph), call.getLimitNum());
     if (call.hasNbrTableIDSet()) {
         sharedState->setNbrTableIDSet(call.getNbrTableIDSet());
     }

--- a/test/test_files/ldbc/ldbc_interactive/interactive_complex.test
+++ b/test/test_files/ldbc/ldbc_interactive/interactive_complex.test
@@ -4,6 +4,7 @@
 --
 
 -CASE LDBCInteractiveComplex
+-SKIP_WASM
 
 -LOG IC2
 -STATEMENT MATCH (:Person {id: 32985348834100 })-[:knows]-(friend:Person)<-[:Post_hasCreator|:Comment_hasCreator]-(message:Comment:Post)

--- a/test/test_files/ldbc/ldbc_interactive/interactive_short.test
+++ b/test/test_files/ldbc/ldbc_interactive/interactive_short.test
@@ -4,6 +4,7 @@
 --
 
 -CASE LDBCInteractiveShort
+-SKIP_WASM
 
 -LOG IS1
 -STATEMENT MATCH (n:Person {id: 933})-[:Person_isLocatedIn]->(p:Place)

--- a/test/test_files/ldbc/ldbc_interactive/interactive_short_parquet.test
+++ b/test/test_files/ldbc/ldbc_interactive/interactive_short_parquet.test
@@ -3,6 +3,7 @@
 --
 
 -CASE LDBCInteractiveShortParquet
+-SKIP_WASM
 
 -LOG IS1
 -STATEMENT MATCH (n:Person {id: 933})-[:Person_isLocatedIn]->(p:Place)

--- a/test/test_files/var_length_extend/n_n.test
+++ b/test/test_files/var_length_extend/n_n.test
@@ -143,3 +143,15 @@ Greg
 ---- 2
 [Alice,Dan,Alice]|[2021-06-30,2021-06-30]
 [Alice,Dan,Carol]|[2021-06-30,2000-01-01]
+-STATEMENT MATCH p = (a:person)-[e:knows*2..2 (r, n | WHERE n.fName = 'Alice')]->(b:person) WITH properties(nodes(p), 'fName') AS x LIMIT 3 RETURN COUNT(*)
+---- 1
+3
+-STATEMENT MATCH p = (a:person)-[e:knows*2..2 (r, n | WHERE n.fName = 'Alice')]->(b:person) WITH properties(nodes(p), 'fName') AS x SKIP 3 LIMIT 3 RETURN COUNT(*)
+---- 1
+3
+-STATEMENT MATCH p = (a:person)-[e:knows*2..2 (r, n | WHERE n.fName = 'Alice')]->(b:person) WITH b.fName AS x LIMIT 1 RETURN COUNT(*)
+---- 1
+1
+-STATEMENT MATCH p = (a:person)-[e:knows*2..2 (r, n | WHERE n.fName = 'Alice')]->(b:person) WITH b.fName AS x SKIP 6 LIMIT 2 RETURN COUNT(*)
+---- 1
+2


### PR DESCRIPTION
# Description

This PR adds limit push down to GDS which can be quite expensive if we are generating a large number of path.

Some sanity check on LiveJournal
```
MATCH p=(a)-[e* 2..2]-(b) WHERE a.id=0 RETURN p LIMIT 10;
```
Goes from 680ms -> 280ms

And
```
MATCH p=(a)-[e* 3..3]-(b) WHERE a.id=0 RETURN p LIMIT 10;
```
Goes from more than 2 mins-> 380ms

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).