### PR TITLE
Lazily create the copy.tmp file when used

### DIFF
--- a/src/include/main/settings.h
+++ b/src/include/main/settings.h
@@ -223,10 +223,7 @@ struct ForceCheckpointClosingDBSetting {
 struct SpillToDiskFileSetting {
     static constexpr auto name = "spill_to_disk_tmp_file";
     static constexpr auto inputType = common::LogicalTypeID::STRING;
-    static void setContext(ClientContext* context, const common::Value& parameter) {
-        parameter.validateType(inputType);
-        context->getDBConfigUnsafe()->spillToDiskTmpFile = parameter.getValue<std::string>();
-    }
+    static void setContext(ClientContext* context, const common::Value& parameter);
     static common::Value getSetting(const ClientContext* context) {
         return common::Value::createValue(context->getDBConfig()->spillToDiskTmpFile);
     }

--- a/src/include/storage/buffer_manager/buffer_manager.h
+++ b/src/include/storage/buffer_manager/buffer_manager.h
@@ -11,6 +11,9 @@
 #include "storage/file_handle.h"
 
 namespace kuzu {
+namespace main {
+struct DBConfig;
+};
 namespace common {
 class VirtualFileSystem;
 };
@@ -203,6 +206,8 @@ public:
             return func(*spiller);
         }
     }
+
+    void resetSpiller(const main::DBConfig& dbConfig);
 
 protected:
     // Reclaims used memory until the given size to reserve is available

--- a/src/include/storage/buffer_manager/spiller.h
+++ b/src/include/storage/buffer_manager/spiller.h
@@ -13,10 +13,11 @@ class ChunkedNodeGroup;
 
 class BufferManager;
 class ColumnChunkData;
+
+// This should only be used with a LocalFileSystem
 class Spiller {
 public:
-    Spiller(const std::string& tmpFilePath, BufferManager& bufferManager,
-        common::VirtualFileSystem* vfs);
+    Spiller(std::string tmpFilePath, BufferManager& bufferManager, common::VirtualFileSystem* vfs);
     void addUnusedChunk(ChunkedNodeGroup* nodeGroup);
     void clearUnusedChunk(ChunkedNodeGroup* nodeGroup);
     uint64_t spillToDisk(ColumnChunkData& chunk) const;
@@ -30,9 +31,16 @@ public:
     ~Spiller();
 
 private:
-    std::mutex partitionerGroupsMtx;
+    FileHandle* getDataFH() const;
+
+private:
+    std::string tmpFilePath;
+    BufferManager& bufferManager;
+    common::VirtualFileSystem* vfs;
     std::unordered_set<ChunkedNodeGroup*> fullPartitionerGroups;
     FileHandle* dataFH;
+    std::mutex partitionerGroupsMtx;
+    mutable std::mutex fileCreationMutex;
 };
 
 } // namespace storage

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -11,7 +11,8 @@ add_library(kuzu_main
         query_summary.cpp
         storage_driver.cpp
         version.cpp
-        db_config.cpp)
+        db_config.cpp
+        settings.cpp)
 
 set(ALL_OBJECT_FILES
         ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_main>

--- a/src/main/settings.cpp
+++ b/src/main/settings.cpp
@@ -1,0 +1,17 @@
+#include "main/settings.h"
+
+#include "main/client_context.h"
+#include "storage/buffer_manager/buffer_manager.h"
+#include "storage/buffer_manager/memory_manager.h"
+
+namespace kuzu {
+namespace main {
+void SpillToDiskFileSetting::setContext(ClientContext* context, const common::Value& parameter) {
+    parameter.validateType(inputType);
+    context->getDBConfigUnsafe()->spillToDiskTmpFile = parameter.getValue<std::string>();
+    const auto& dbConfig = *context->getDBConfig();
+    context->getMemoryManager()->getBufferManager()->resetSpiller(dbConfig);
+}
+
+} // namespace main
+} // namespace kuzu

--- a/src/storage/buffer_manager/buffer_manager.cpp
+++ b/src/storage/buffer_manager/buffer_manager.cpp
@@ -343,7 +343,7 @@ bool BufferManager::reserve(uint64_t sizeToReserve) {
         uint64_t memoryClaimed = 0;
         // Avoid reducing the evictable memory below 1/2 at first to reduce thrashing if most of the
         // memory is non-evictable
-        if (usedMemory - nonEvictableMemory > bufferPoolSize / 2) {
+        if (!spiller || usedMemory - nonEvictableMemory > bufferPoolSize / 2) {
             memoryClaimed = evictPages();
         } else {
             memoryClaimed = spiller->claimNextGroup();

--- a/src/storage/buffer_manager/buffer_manager.cpp
+++ b/src/storage/buffer_manager/buffer_manager.cpp
@@ -458,6 +458,19 @@ uint64_t BufferManager::freeUsedMemory(uint64_t size) {
     return usedMemory.fetch_sub(size);
 }
 
+void BufferManager::resetSpiller(const main::DBConfig& dbConfig) {
+    KU_ASSERT(dbConfig.spillToDiskTmpFile.has_value());
+    if (dbConfig.readOnly) {
+        throw BufferManagerException("Cannot set spill_to_disk_tmp_file for a read only database!");
+    }
+    if (dbConfig.spillToDiskTmpFile->empty()) {
+        // Disable spilling to disk when the string is empty
+        spiller = nullptr;
+    } else {
+        spiller = std::make_unique<Spiller>(*dbConfig.spillToDiskTmpFile, *this, vfs);
+    }
+}
+
 BufferManager::~BufferManager() = default;
 
 } // namespace storage

--- a/test/main/system_config_test.cpp
+++ b/test/main/system_config_test.cpp
@@ -35,6 +35,11 @@ TEST_F(SystemConfigTest, testAccessMode) {
     EXPECT_NO_THROW(con2 = std::make_unique<Connection>(db2.get()));
     ASSERT_FALSE(con2->query("DROP TABLE Person")->isSuccess());
     EXPECT_NO_THROW(con2->query("MATCH (:Person) RETURN COUNT(*)"));
+
+    auto result = con2->query("CALL spill_to_disk_tmp_file='/tmp/foo';");
+    ASSERT_FALSE(result->isSuccess());
+    ASSERT_EQ(result->toString(),
+        "Buffer manager exception: Cannot set spill_to_disk_tmp_file for a read only database!");
 }
 
 TEST_F(SystemConfigTest, testMaxDBSize) {

--- a/test/test_files/copy/spill_to_disk.test
+++ b/test/test_files/copy/spill_to_disk.test
@@ -1,0 +1,29 @@
+-DATASET CSV empty
+-BUFFER_POOL_SIZE 134217728
+
+--
+-CASE DisableSpillToDisk
+-STATEMENT CREATE NODE TABLE account(ID INT64, PRIMARY KEY(ID));
+---- ok
+-STATEMENT CREATE REL TABLE follows(FROM account TO account);
+---- ok
+-STATEMENT COPY account FROM "${KUZU_ROOT_DIRECTORY}/dataset/snap/twitter/csv/twitter-nodes.csv";
+---- ok
+-STATEMENT CALL spill_to_disk_tmp_file="";
+---- ok
+-STATEMENT COPY follows FROM "${KUZU_ROOT_DIRECTORY}/dataset/snap/twitter/csv/twitter-edges.csv" (DELIM=' ');
+---- error
+Buffer manager exception: Unable to allocate memory! The buffer pool is full and no memory could be freed!
+
+-CASE CustomSpillToDiskPath
+-SKIP_IN_MEM
+-STATEMENT CREATE NODE TABLE account(ID INT64, PRIMARY KEY(ID));
+---- ok
+-STATEMENT CREATE REL TABLE follows(FROM account TO account);
+---- ok
+-STATEMENT COPY account FROM "${KUZU_ROOT_DIRECTORY}/dataset/snap/twitter/csv/twitter-nodes.csv";
+---- ok
+-STATEMENT CALL spill_to_disk_tmp_file="${DATABASE_PATH}/foo.tmp";
+---- ok
+-STATEMENT COPY follows FROM "${KUZU_ROOT_DIRECTORY}/dataset/snap/twitter/csv/twitter-edges.csv" (DELIM=' ');
+---- ok


### PR DESCRIPTION
Fixes #4468

The copy.tmp file will be created the first time we attempt to spill data to the disk. Since spilling occurs concurrently some synchronization is necessary, but to minimize this it checks the pointer before acquiring the mutex so that we can avoid synchronization after the file has been created.