### PR TITLE
Fix duplicate quote char in JSON CASTING

### DIFF
--- a/extension/json/src/utils/json_utils.cpp
+++ b/extension/json/src/utils/json_utils.cpp
@@ -97,7 +97,7 @@ yyjson_mut_val* jsonify(JsonMutWrapper& wrapper, const common::ValueVector& vec,
             // check one more time in case this string a struct
             LogicalType detectedType = function::inferMinimalTypeFromString(strVal.getAsStringView()); 
             if (detectedType.getLogicalTypeID() == LogicalTypeID::STRUCT) {
-                ValueVector structValueVec(std::move(detectedType));
+                ValueVector structValueVec(std::move(detectedType),);
                 Value inferedStruct(std::move(detectedType), strVal.getAsString());
                 structValueVec.copyFromValue(0, inferedStruct);
                 jsonify(wrapper, structValueVec, pos);

--- a/extension/json/src/utils/json_utils.cpp
+++ b/extension/json/src/utils/json_utils.cpp
@@ -94,17 +94,7 @@ yyjson_mut_val* jsonify(JsonMutWrapper& wrapper, const common::ValueVector& vec,
             break;
         case LogicalTypeID::STRING: {
             auto strVal = vec.getValue<ku_string_t>(pos);
-            // check one more time in case this string a struct
-            // auto strContent = strVal.getAsStringView();
-            // LogicalType detectedType = function::inferMinimalTypeFromString(strContent); 
-            // if (detectedType.getLogicalTypeID() == LogicalTypeID::STRUCT) {
-            //     ValueVector structValueVec(std::move(detectedType));
-            //     Value inferedStruct(std::move(detectedType), strVal.getAsString());
-            //     structValueVec.copyFromValue(0, inferedStruct);
-            //     jsonify(wrapper, structValueVec, pos);
-            // } else {
             result = yyjson_mut_strncpy(wrapper.ptr, (const char*)strVal.getData(), strVal.len);
-            // }
         } break;
         case LogicalTypeID::LIST:
         case LogicalTypeID::ARRAY: {

--- a/extension/json/src/utils/json_utils.cpp
+++ b/extension/json/src/utils/json_utils.cpp
@@ -80,6 +80,8 @@ yyjson_mut_val* jsonify(JsonMutWrapper& wrapper, const common::ValueVector& vec,
             break;
         case LogicalTypeID::STRING: {
             auto strVal = vec.getValue<ku_string_t>(pos);
+            // check one more time in case this string a struct
+            LogicalType detectedType = inferMinimalTypeFromString(strVal.getAsStringView()); 
             result = yyjson_mut_strncpy(wrapper.ptr, (const char*)strVal.getData(), strVal.len);
         } break;
         case LogicalTypeID::LIST:

--- a/extension/json/src/utils/json_utils.cpp
+++ b/extension/json/src/utils/json_utils.cpp
@@ -149,8 +149,7 @@ JsonWrapper jsonify(const common::ValueVector& vec, uint64_t pos) {
         // check one more time in case this string a struct
         auto strContent = strVal.getAsStringView();
         LogicalType detectedType = function::inferMinimalTypeFromString(strContent);
-        if (detectedType.getLogicalTypeID() == LogicalTypeID::STRUCT) {
-            auto strVal = vec.getValue<ku_string_t>(pos);
+        if (detectedType.getLogicalTypeID() != LogicalTypeID::STRING) {
             auto strContent = strVal.getAsStringView();
             return stringToJson(std::string(strContent));
         }

--- a/extension/json/src/utils/json_utils.cpp
+++ b/extension/json/src/utils/json_utils.cpp
@@ -137,7 +137,6 @@ JsonWrapper jsonify(const common::ValueVector& vec, uint64_t pos) {
         auto strContent = strVal.getAsStringView();
         LogicalType detectedType = function::inferMinimalTypeFromString(strContent);
         if (detectedType.getLogicalTypeID() != LogicalTypeID::STRING) {
-            auto strContent = strVal.getAsStringView();
             return stringToJson(std::string(strContent));
         }
     }

--- a/extension/json/src/utils/json_utils.cpp
+++ b/extension/json/src/utils/json_utils.cpp
@@ -36,19 +36,6 @@ yyjson_mut_val* jsonifyAsString(JsonMutWrapper& wrapper, const common::ValueVect
     return yyjson_mut_strcpy(wrapper.ptr, strVal.c_str());
 }
 
-yyjson_mut_val* jsonifyAsStruct(JsonMutWrapper& wrapper, const common::ValueVector& vec,
-    uint64_t pos) {
-    yyjson_mut_val* result = yyjson_mut_obj(wrapper.ptr);
-    const auto& fieldVectors = StructVector::getFieldVectors(&vec);
-    const auto& fieldNames = StructType::getFieldNames(vec.dataType);
-    for (auto i = 0u; i < fieldVectors.size(); i++) {
-        auto key = yyjson_mut_strcpy(wrapper.ptr, fieldNames[i].c_str());
-        auto val = jsonify(wrapper, *fieldVectors[i], pos);
-        yyjson_mut_obj_add(result, key, val);
-    }
-    return result;
-}
-
 yyjson_mut_val* jsonify(JsonMutWrapper& wrapper, const common::ValueVector& vec, uint64_t pos) {
     // creates a mutable value linked to wrapper.ptr, but the responsibility to integrate it into
     // wrapper is placed upon the caller

--- a/extension/json/src/utils/json_utils.cpp
+++ b/extension/json/src/utils/json_utils.cpp
@@ -10,7 +10,6 @@
 #include "function/cast/functions/cast_from_string_functions.h"
 #include "function/cast/functions/cast_string_non_nested_functions.h"
 #include "function/cast/functions/numeric_limits.h"
-#include "function/cast/functions/cast_string_non_nested_functions.h"
 
 using namespace kuzu::common;
 

--- a/extension/json/test/json_cast.test
+++ b/extension/json/test/json_cast.test
@@ -39,3 +39,48 @@
 {int_array: [42,999,,,-42]}
 
 
+-STATEMENT return cast(cast(
+    '{
+        "float":3.4028235e+38
+    }'
+as json) as STRUCT(float DOUBLE));
+---- 1
+{float: 340282349999999991754788743781432688640.000000}
+
+-STATEMENT return cast(cast(
+    '{"uuid":"ffffffff-ffff-ffff-ffff-ffffffffffff"}'
+as json) as STRUCT(uuid UUID));
+---- 1
+{uuid: ffffffff-ffff-ffff-ffff-ffffffffffff}
+
+-STATEMENT return cast(cast(
+    '{
+        "timestamp":"2047-01-10 04:00:54.775806"
+    }'
+as json) as STRUCT(timestamp TIMESTAMP));
+---- 1
+{timestamp: 2047-01-10 04:00:54.775806}
+
+-STATEMENT return cast(cast(
+    '{
+        "bool": false
+    }'
+as json) as STRUCT(bool BOOL));
+---- 1
+{bool: False}
+
+-STATEMENT return cast(cast(
+    '{
+        "date":"2047-01-10"
+    }'
+as json) as STRUCT(date DATE));
+---- 1
+{date: 2047-01-10}
+
+-STATEMENT return cast(cast(
+    '{
+        "interval":"83 years 3 months 999 days 00:16:39.999999"
+    }'
+as json) as STRUCT(interval INTERVAL));
+---- 1
+{interval: 83 years 3 months 999 days 00:16:39.999999}

--- a/extension/json/test/json_cast.test
+++ b/extension/json/test/json_cast.test
@@ -36,4 +36,6 @@
 
 -STATEMENT RETURN cast(cast('{"int_array":[42,999,null,null,-42]}' as json) as struct (int_array INT64[]));
 ---- 1
-{int_array: [42,999,,,-42]}  
+{int_array: [42,999,,,-42]}
+
+

--- a/extension/json/test/json_cast.test
+++ b/extension/json/test/json_cast.test
@@ -1,0 +1,39 @@
+-DATASET CSV empty
+
+--
+
+-CASE JsonCastTest
+-STATEMENT LOAD EXTENSION "${KUZU_ROOT_DIRECTORY}/extension/json/build/libjson.kuzu_extension";
+---- ok
+-STATEMENT return cast ('{"duck": 42}' as json)
+---- 1
+{"duck":42}
+
+-STATEMENT return cast(cast ('2023-11-14' as DATE) as json);
+---- 1
+"2023-11-14"
+
+-STATEMENT return cast(cast ('"{\"duck\": 42}"' as json) as STRING);
+---- 1
+"\"{\"duck\": 42}\""
+
+-STATEMENT return cast (4 as json);
+---- 1
+4
+
+
+-STATEMENT return cast ('4' as json);
+---- 1
+4
+
+-STATEMENT return cast(cast ('{"duck": 42}' as json) as struct(duck int64));
+---- 1
+{duck: 42}
+
+-STATEMENT RETURN cast('{"int_array":[42,999,null,null,-42]}' as json);
+---- 1
+{"int_array":[42,999,null,null,-42]}
+
+-STATEMENT RETURN cast(cast('{"int_array":[42,999,null,null,-42]}' as json) as struct (int_array INT64[]));
+---- 1
+{int_array: [42,999,,,-42]}  

--- a/extension/json/test/json_utils.test
+++ b/extension/json/test/json_utils.test
@@ -111,8 +111,6 @@ True
 "ab"
 
 -CASE JsonStructureTest2
-#-SKIP
-#TODO(Ziyi): We should fix our sniffing before enabling the test.
 -STATEMENT LOAD EXTENSION "${KUZU_ROOT_DIRECTORY}/extension/json/build/libjson.kuzu_extension";
 ---- ok
 -STATEMENT return json_structure(

--- a/extension/json/test/json_utils.test
+++ b/extension/json/test/json_utils.test
@@ -109,6 +109,11 @@ True
 [{"a":[1],"b":2,"c":1},1,5,9]
 [1,2,3]
 "ab"
+-STATEMENT UNWIND ['[        {"a":  [1],     "b": 2,"c": 1}, 1,    5, 9]', '[1, 2, 3]', '"ab"'] AS ARR RETURN json_array_length(json(ARR));
+---- 3
+4
+3
+0
 
 -CASE JsonStructureTest2
 -STATEMENT LOAD EXTENSION "${KUZU_ROOT_DIRECTORY}/extension/json/build/libjson.kuzu_extension";
@@ -131,6 +136,7 @@ STRUCT(name STRING, length UINT8, note STRING, description STRUCT(rating DOUBLE,
 #TODO(sterling): the INF may be need to be supported by database.
 -STATEMENT LOAD EXTENSION "${KUZU_ROOT_DIRECTORY}/extension/json/build/libjson.kuzu_extension";
 ---- ok
+
 -STATEMENT return json_structure(
 '{
     "int_array":[42,999,null,null,-42],
@@ -156,6 +162,30 @@ STRUCT(name STRING, length UINT8, note STRING, description STRUCT(rating DOUBLE,
 ---- 1
 STRUCT(int_array INT32[], double_array DOUBLE[], date_array DATE[], timestamp_array TIMESTAMP[], varchar_array STRING[], nested_int_array INT32[][], struct STRUCT(a UINT8, b STRING), struct_of_arrays STRUCT(a INT32[], b STRING[]), array_of_structs STRUCT(a UINT8, b STRING)[], map STRUCT(key1 STRING, key2 STRING), union STRING, fixed_int_array UINT8[], fixed_varchar_array STRING[], fixed_nested_int_array UINT8[][], fixed_nested_varchar_array STRING[][], fixed_struct_array STRUCT(a UINT8, b STRING)[], struct_of_fixed_array STRUCT(a UINT8[], b STRING[]), fixed_array_of_int_list INT32[][], list_of_fixed_int_array UINT8[][])
 
+-STATEMENT return json_keys('{
+    "int_array":[42,999,null,null,-42],
+    "double_array":[42.0,null,null,null,null,-42.0],
+    "date_array":["1970-01-01",null,null,null,"2022-05-12"],
+    "timestamp_array":["1970-01-01 00:00:00",null,null,null,"2022-05-12 16:23:45"],
+    "varchar_array":["🦆🦆🦆🦆🦆🦆","goose",null,null],
+    "nested_int_array":[[],[42,999,null,null,-42],null,[],[42,999,null,null,-42]],
+    "struct":{"a":42,"b":"🦆🦆🦆🦆🦆🦆"},
+    "struct_of_arrays":{"a":[42,999,null,null,-42],"b":["🦆🦆🦆🦆🦆🦆","goose",null,null]},
+    "array_of_structs":[{"a":null,"b":null},{"a":42,"b":"🦆🦆🦆🦆🦆🦆"},null],
+    "map":{"key1":"🦆🦆🦆🦆🦆🦆","key2":"goose"},
+    "union":"5",
+    "fixed_int_array":[4,5,6],
+    "fixed_varchar_array":["d","e","f"],
+    "fixed_nested_int_array":[[4,5,6],[null,2,3],[4,5,6]],
+    "fixed_nested_varchar_array":[["d","e","f"],["a",null,"c"],["d","e","f"]],
+    "fixed_struct_array":[{"a":42,"b":"🦆🦆🦆🦆🦆🦆"},{"a":null,"b":null},{"a":42,"b":"🦆🦆🦆🦆🦆🦆"}],
+    "struct_of_fixed_array":{"a":[4,5,6],"b":["d","e","f"]},
+    "fixed_array_of_int_list":[[42,999,null,null,-42],[],[42,999,null,null,-42]],
+    "list_of_fixed_int_array":[[4,5,6],[null,2,3],[4,5,6]]
+    }'
+);
+---- 1
+[int_array,double_array,date_array,timestamp_array,varchar_array,nested_int_array,struct,struct_of_arrays,array_of_structs,map,union,fixed_int_array,fixed_varchar_array,fixed_nested_int_array,fixed_nested_varchar_array,fixed_struct_array,struct_of_fixed_array,fixed_array_of_int_list,list_of_fixed_int_array]
 
 #"blob":"\\x00\\x00\\x00a"
 

--- a/extension/json/test/test_json_extract.test
+++ b/extension/json/test/test_json_extract.test
@@ -16,11 +16,12 @@ null
 -STATEMENT RETURN json_extract('{"foo": null}', '$.foo.bar')
 ---- ok
 
--STATEMENT RETURN json_extract(null, '$')
+-STATEMENT RETURN json_extract(null, '0')
 ---- ok
 
--STATEMENT RETURN json_extract('[null]', '$[0]')
----- ok
+-STATEMENT RETURN json_extract('[null]', '0')
+---- 1
+null
 
 -STATEMENT RETURN json_extract('{"my_field": {"my_nested_field": ["goose", "kuzu"]}}', 'my_field/my_nested_field/1')
 ---- 1

--- a/extension/json/test/test_json_extract.test
+++ b/extension/json/test/test_json_extract.test
@@ -1,0 +1,69 @@
+-DATASET CSV empty
+
+--
+
+-CASE JsonExtractTestFromDuckDB
+
+-STATEMENT LOAD EXTENSION "${KUZU_ROOT_DIRECTORY}/extension/json/build/libjson.kuzu_extension";
+---- ok
+
+# should go to our NULL
+
+-STATEMENT RETURN json_extract('{"foo": null}', '$.foo')
+---- 1
+null
+
+-STATEMENT RETURN json_extract('{"foo": null}', '$.foo.bar')
+---- ok
+
+-STATEMENT RETURN json_extract(null, '$')
+---- ok
+
+-STATEMENT RETURN json_extract('[null]', '$[0]')
+---- ok
+
+-STATEMENT RETURN json_extract('{"my_field": {"my_nested_field": ["goose", "kuzu"]}}', 'my_field/my_nested_field/1')
+---- 1
+"kuzu"
+
+-STATEMENT RETURN json_extract('{"my_field": {"my_nested_field": ["goose", "kuzukuzukuzukuzu"]}}', 'my_field/my_nested_field/1')
+---- 1
+"kuzukuzukuzukuzu"
+
+-STATEMENT RETURN json_extract('[1, 2, 42]', 2)
+---- 1
+42
+
+# some sqlite tests
+
+-STATEMENT RETURN json_extract('{"a":2,"c":[4,5,{"f":7}]}', '$');
+---- 1
+{"a":2,"c":[4,5,{"f":7}]}
+
+
+-STATEMENT RETURN json_extract('{"a":2,"c":[4,5,{"f":7}]}', '$.c');
+---- 1
+[4,5,{"f":7}]
+
+
+-STATEMENT RETURN json_extract('{"a":2,"c":[4,5,{"f":7}]}', '$.c/2');
+---- 1
+{"f":7}
+
+
+-STATEMENT RETURN json_extract('{"a":2,"c":[4,5,{"f":7}]}', '$.c/2/f');
+---- 1
+7
+
+
+-STATEMENT RETURN json_extract('{"a":2,"c":[4,5,{"f":7}]}', '$.x');
+---- ok
+
+-STATEMENT RETURN json_extract('{"a":2,"c":[4,5],"f":7}', ['$.c','$.a']);
+---- 1
+[[4,5],2]
+
+
+-STATEMENT RETURN json_extract('{"a":2,"c":[4,5,{"f":7}]}', ['$.x', '$.a']);
+---- 1
+[,2]

--- a/extension/json/test/test_json_valid.test
+++ b/extension/json/test/test_json_valid.test
@@ -1,0 +1,594 @@
+-DATASET CSV empty
+
+--
+
+-CASE JsonValidTestFromDuckDB
+
+-STATEMENT LOAD EXTENSION "${KUZU_ROOT_DIRECTORY}/extension/json/build/libjson.kuzu_extension";
+---- ok
+
+-STATEMENT RETURN json_valid('{"a":55,"b":72,}');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('{"a":55,"b":72}');
+---- 1
+True
+
+
+-STATEMENT RETURN json_valid('["a",55,"b",72,]');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('["a",55,"b",72]');
+---- 1
+True
+
+-STATEMENT RETURN json_valid('{"x":01}')
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('{"x":-01}')
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('{"x":0}')
+---- 1
+True
+
+
+-STATEMENT RETURN json_valid('{"x":-0}')
+---- 1
+True
+
+
+-STATEMENT RETURN json_valid('{"x":0.1}')
+---- 1
+True
+
+
+-STATEMENT RETURN json_valid('{"x":-0.1}')
+---- 1
+True
+
+
+-STATEMENT RETURN json_valid('{"x":0.0000}')
+---- 1
+True
+
+
+-STATEMENT RETURN json_valid('{"x":-0.0000}')
+---- 1
+True
+
+
+-STATEMENT RETURN json_valid('{"x":01.5}')
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('{"x":-01.5}')
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('{"x":00}')
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('{"x":-00}')
+---- 1
+False
+
+-CASE JsonValidWithSingleChar
+-SKIP
+# our parser cannot recognize them
+
+-STATEMENT RETURN json_valid('" \  "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \! "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \" "');
+---- 1
+1
+
+
+-STATEMENT RETURN json_valid('" \# "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \$ "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \% "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \& "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \'' "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \( "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \) "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \* "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \+ "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \, "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \- "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \. "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \/ "');
+---- 1
+1
+
+
+-STATEMENT RETURN json_valid('" \0 "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \1 "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \2 "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \3 "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \4 "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \5 "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \6 "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \7 "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \8 "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \9 "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \: "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \; "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \< "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \= "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \> "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \? "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \@ "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \A "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \B "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \C "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \D "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \E "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \F "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \G "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \H "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \I "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \J "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \K "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \L "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \M "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \N "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \O "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \P "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \Q "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \R "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \S "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \T "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \U "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \V "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \W "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \X "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \Y "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \Z "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \[ "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \\ "');
+---- 1
+1
+
+
+-STATEMENT RETURN json_valid('" \] "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \^ "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \_ "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \` "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \a "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \b "');
+---- 1
+1
+
+
+-STATEMENT RETURN json_valid('" \c "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \d "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \e "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \f "');
+---- 1
+1
+
+
+-STATEMENT RETURN json_valid('" \g "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \h "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \i "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \j "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \k "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \l "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \m "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \n "');
+---- 1
+1
+
+
+-STATEMENT RETURN json_valid('" \o "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \p "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \q "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \r "');
+---- 1
+1
+
+
+-STATEMENT RETURN json_valid('" \s "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \t "');
+---- 1
+1
+
+
+-STATEMENT RETURN json_valid('" \u "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \ua "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \uab "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \uabc "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \uabcd "');
+---- 1
+1
+
+
+-STATEMENT RETURN json_valid('" \uFEDC "');
+---- 1
+1
+
+
+-STATEMENT RETURN json_valid('" \u1234 "');
+---- 1
+1
+
+
+-STATEMENT RETURN json_valid('" \v "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \w "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \x "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \y "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \z "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \{ "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \| "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \} "');
+---- 1
+False
+
+
+-STATEMENT RETURN json_valid('" \~ "');
+---- 1
+False

--- a/extension/json/test/to_json.test
+++ b/extension/json/test/to_json.test
@@ -7,9 +7,9 @@
 ---- ok
 -STATEMENT UNWIND ['1', '2', '3'] AS STR RETURN to_json(STR)
 ---- 3
-"1"
-"2"
-"3"
+1
+2
+3
 
 -STATEMENT UNWIND [{a: 1, b: {x: "a"}}, {a: 2, b: {x: "b"}}, {a: 3, b: {x: "c"}}] AS NSTD RETURN to_json(NSTD)
 ---- 3

--- a/src/common/string_utils.cpp
+++ b/src/common/string_utils.cpp
@@ -61,7 +61,8 @@ std::vector<std::string_view> StringUtils::smartSplit(std::string_view input, ch
                 result.push_back(input.substr(currentItem, i - currentItem));
                 currentItem = i + 1;
             }
-        } else if (c == '{' || c == '(' || c == '[' || (c == '\"' && (stk.size() == 0u || stk.back() != '\"'))) {
+        } else if (c == '{' || c == '(' || c == '[' ||
+                   (c == '\"' && (stk.size() == 0u || stk.back() != '\"'))) {
             stk.push_back(c);
         } else if (stk.size() > 0 && openingBracket(c) == stk.back()) {
             stk.pop_back();

--- a/src/common/string_utils.cpp
+++ b/src/common/string_utils.cpp
@@ -50,7 +50,7 @@ std::vector<std::string_view> StringUtils::smartSplit(std::string_view input, ch
     for (auto i = 0u; i < input.size(); i++) {
         char c = input[i];
 
-        if (c == '\'' && (stk.size() == 0u || stk.back() != '\'')) {
+        if (c == '\'' && (stk.size() == 0 || stk.back() != '\'')) {
             // Entering/Exiting a single-quoted block.
             insideSingleQuote = !insideSingleQuote;
         } else if (c == splitChar && stk.size() == 0u && !insideSingleQuote) {
@@ -63,7 +63,7 @@ std::vector<std::string_view> StringUtils::smartSplit(std::string_view input, ch
             }
         } else if (c == '{' || c == '(' || c == '[' || (c == '\"' && (stk.size() == 0u || stk.back() != '\"'))) {
             stk.push_back(c);
-        } else if (stk.size() > 0u && openingBracket(c) == stk.back()) {
+        } else if (stk.size() > 0 && openingBracket(c) == stk.back()) {
             stk.pop_back();
         }
     }

--- a/src/common/string_utils.cpp
+++ b/src/common/string_utils.cpp
@@ -61,7 +61,7 @@ std::vector<std::string_view> StringUtils::smartSplit(std::string_view input, ch
                 result.push_back(input.substr(currentItem, i - currentItem));
                 currentItem = i + 1;
             }
-        } else if (c == '{' || c == '(' || c == '[' || c == '\"') {
+        } else if (c == '{' || c == '(' || c == '[' || (c == '\"' && (stk.size() == 0u || stk.back() != '\"'))) {
             stk.push_back(c);
         } else if (stk.size() > 0u && openingBracket(c) == stk.back()) {
             stk.pop_back();

--- a/src/function/cast_from_string_functions.cpp
+++ b/src/function/cast_from_string_functions.cpp
@@ -614,6 +614,7 @@ static bool tryCastStringToStruct(const char* input, uint64_t len, ValueVector* 
         }
         auto valEnd = input;
         trimRightWhitespace(valStart, valEnd);
+        trimQuotes(valStart, valEnd);
         skipWhitespace(++input, end);
 
         auto fieldVector = StructVector::getFieldVector(vector, fieldIdx).get();


### PR DESCRIPTION
# Description

The BUG happened because we don't parse string in our `jsonify` function, by adding a check to detect the type might be in the string in `jsonify` and use `stringToJson` , we can now handle this case.

Will be adding more test cases for JSON casting

Fixes #4462  

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).