### PR TITLE
Push down dst table id filter to GDS

### DIFF
--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -84,7 +84,9 @@ void GDSUtils::runVertexComputeIteration(processor::ExecutionContext* executionC
     auto info = VertexComputeTaskInfo(vc);
     auto sharedState = std::make_shared<VertexComputeTaskSharedState>(maxThreads);
     for (auto& tableID : graph->getNodeTableIDs()) {
-        vc.beginOnTable(tableID);
+        if (!vc.beginOnTable(tableID)) {
+            continue;
+        }
         sharedState->morselDispatcher.init(tableID,
             graph->getNumNodes(clientContext->getTx(), tableID));
         auto task = std::make_shared<VertexComputeTask>(maxThreads, info, sharedState);

--- a/src/function/gds/rec_joins.cpp
+++ b/src/function/gds/rec_joins.cpp
@@ -139,8 +139,12 @@ public:
     }
     ~RJVertexCompute() override { sharedState->returnLocalTable(localFT); }
 
-    void beginOnTable(table_id_t tableID) override {
+    bool beginOnTable(table_id_t tableID) override {
+        if (!sharedState->inNbrTableIDs(tableID)) {
+            return false;
+        }
         writer->beginWritingForDstNodesInTable(tableID);
+        return true;
     }
 
     void vertexCompute(nodeID_t nodeID) override {

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -43,7 +43,7 @@ public:
     // GDSUtils::runVertexComputeIteration function. runVertexComputeIteration loops through
     // each node table T on the graph on which vertexCompute should run and then before
     // parallelizing the computation on T calls this function.
-    virtual void beginOnTable(common::table_id_t) {}
+    virtual bool beginOnTable(common::table_id_t) { return true; }
 
     // This function is called by each worker thread T on each node in the morsel that T grabs.
     // Does any vertex-centric work that is needed while running on the curNodeID. This function

--- a/src/include/planner/operator/logical_gds_call.h
+++ b/src/include/planner/operator/logical_gds_call.h
@@ -12,9 +12,9 @@ class LogicalGDSCall final : public LogicalOperator {
 public:
     explicit LogicalGDSCall(binder::BoundGDSCallInfo info)
         : LogicalOperator{operatorType_}, info{std::move(info)} {}
-    LogicalGDSCall(binder::BoundGDSCallInfo info,
+    LogicalGDSCall(binder::BoundGDSCallInfo info, common::table_id_set_t nbrTableIDSet,
         std::shared_ptr<LogicalOperator> nodePredicateRoot)
-        : LogicalOperator{operatorType_}, info{std::move(info)},
+        : LogicalOperator{operatorType_}, info{std::move(info)}, nbrTableIDSet{nbrTableIDSet},
           nodePredicateRoot{std::move(nodePredicateRoot)} {}
 
     void computeFlatSchema() override;
@@ -22,6 +22,16 @@ public:
 
     const binder::BoundGDSCallInfo& getInfo() const { return info; }
     binder::BoundGDSCallInfo& getInfoUnsafe() { return info; }
+
+    void setNbrTableIDSet(common::table_id_set_t set) {
+        nbrTableIDSet = set;
+    }
+    bool hasNbrTableIDSet() const {
+        return !nbrTableIDSet.empty();
+    }
+    common::table_id_set_t getNbrTableIDSet() const {
+        return nbrTableIDSet;
+    }
 
     void setNodePredicateRoot(std::shared_ptr<LogicalOperator> op) {
         nodePredicateRoot = std::move(op);
@@ -32,11 +42,12 @@ public:
     std::string getExpressionsForPrinting() const override { return info.func.name; }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return std::make_unique<LogicalGDSCall>(info.copy(), nodePredicateRoot);
+        return std::make_unique<LogicalGDSCall>(info.copy(), nbrTableIDSet, nodePredicateRoot);
     }
 
 private:
     binder::BoundGDSCallInfo info;
+    common::table_id_set_t nbrTableIDSet;
     std::shared_ptr<LogicalOperator> nodePredicateRoot;
 };
 

--- a/src/include/planner/operator/logical_gds_call.h
+++ b/src/include/planner/operator/logical_gds_call.h
@@ -23,15 +23,9 @@ public:
     const binder::BoundGDSCallInfo& getInfo() const { return info; }
     binder::BoundGDSCallInfo& getInfoUnsafe() { return info; }
 
-    void setNbrTableIDSet(common::table_id_set_t set) {
-        nbrTableIDSet = set;
-    }
-    bool hasNbrTableIDSet() const {
-        return !nbrTableIDSet.empty();
-    }
-    common::table_id_set_t getNbrTableIDSet() const {
-        return nbrTableIDSet;
-    }
+    void setNbrTableIDSet(common::table_id_set_t set) { nbrTableIDSet = set; }
+    bool hasNbrTableIDSet() const { return !nbrTableIDSet.empty(); }
+    common::table_id_set_t getNbrTableIDSet() const { return nbrTableIDSet; }
 
     void setNodePredicateRoot(std::shared_ptr<LogicalOperator> op) {
         nodePredicateRoot = std::move(op);

--- a/src/include/processor/operator/gds_call_shared_state.h
+++ b/src/include/processor/operator/gds_call_shared_state.h
@@ -103,9 +103,7 @@ struct GDSCallSharedState {
     void returnLocalTable(FactorizedTable* table);
     void mergeLocalTables();
 
-    void setNbrTableIDSet(common::table_id_set_t set) {
-        nbrTableIDSet = set;
-    }
+    void setNbrTableIDSet(common::table_id_set_t set) { nbrTableIDSet = set; }
     bool inNbrTableIDs(common::table_id_t tableID) const {
         if (nbrTableIDSet.empty()) {
             return true;

--- a/src/include/processor/operator/gds_call_shared_state.h
+++ b/src/include/processor/operator/gds_call_shared_state.h
@@ -103,6 +103,16 @@ struct GDSCallSharedState {
     void returnLocalTable(FactorizedTable* table);
     void mergeLocalTables();
 
+    void setNbrTableIDSet(common::table_id_set_t set) {
+        nbrTableIDSet = set;
+    }
+    bool inNbrTableIDs(common::table_id_t tableID) const {
+        if (nbrTableIDSet.empty()) {
+            return true;
+        }
+        return nbrTableIDSet.contains(tableID);
+    }
+
 private:
     std::unique_ptr<NodeOffsetMaskMap> inputNodeMask = nullptr;
     std::unique_ptr<NodeOffsetMaskMap> outputNodeMask = nullptr;
@@ -112,6 +122,8 @@ private:
     // minimized. Or we optimize ftable to be more memory efficient when number of tuples is small.
     std::stack<FactorizedTable*> availableLocalTables;
     std::vector<std::shared_ptr<FactorizedTable>> localTables;
+
+    common::table_id_set_t nbrTableIDSet;
 };
 
 } // namespace processor

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -152,6 +152,21 @@ void Planner::appendRecursiveExtendAsGDS(const std::shared_ptr<NodeExpression>& 
         createPathNodeFilterPlan(recursiveInfo->node, recursiveInfo->originalNodePredicate, p);
         gdsCall->ptrCast<LogicalGDSCall>()->setNodePredicateRoot(p.getLastOperator());
     }
+    // E.g. Given schema person-knows->person & person-knows->animal
+    // And query MATCH (a:person:animal)-[e*]->(b:person)
+    // The destination node b after GDS will contain both person & animal label. We need to prune
+    // the animal out.
+    common::table_id_set_t nbrTableIDSet;
+    auto targetNbrTableIDSet = nbrNode->getTableIDsSet();
+    auto recursiveNbrTableIDSet = recursiveInfo->node->getTableIDsSet();
+    for (auto& tableID : recursiveNbrTableIDSet) {
+        if (targetNbrTableIDSet.contains(tableID)) {
+            nbrTableIDSet.insert(tableID);
+        }
+    }
+    if (nbrTableIDSet.size() < recursiveNbrTableIDSet.size()) {
+        gdsCall->ptrCast<LogicalGDSCall>()->setNbrTableIDSet(nbrTableIDSet);
+    }
     probePlan.setLastOperator(std::move(gdsCall));
     // Scan path node property pipeline
     std::shared_ptr<LogicalOperator> pathNodePropertyScanRoot = nullptr;
@@ -184,18 +199,10 @@ void Planner::appendRecursiveExtendAsGDS(const std::shared_ptr<NodeExpression>& 
     pathPropertyProbe->getSIPInfoUnsafe().position = SemiMaskPosition::PROHIBIT;
     pathPropertyProbe->computeFactorizedSchema();
     probePlan.setLastOperator(pathPropertyProbe);
-    // E.g. Given schema person-knows->person & person-knows->animal
-    // And query MATCH (a:person:animal)-[e*]->(b:person)
-    // The destination node b after GDS will contain both person & animal label. We need to prune
-    // the animal out. Using operator makes more sense because we can vectorize this filter.
-    if (nbrNode->getTableIDsSet().size() < recursiveInfo->node->getTableIDsSet().size()) {
-        appendNodeLabelFilter(nbrNode->getInternalID(), nbrNode->getTableIDsSet(), probePlan);
-    }
     auto extensionRate =
         cardinalityEstimator.getExtensionRate(*rel, *boundNode, clientContext->getTx());
     probePlan.setCost(plan.getCardinality());
     probePlan.setCardinality(plan.getCardinality() * extensionRate);
-
     // Join with input node
     auto joinConditions = expression_vector{boundNode->getInternalID()};
     appendHashJoin(joinConditions, JoinType::INNER, probePlan, plan, plan);

--- a/src/processor/map/map_gds.cpp
+++ b/src/processor/map/map_gds.cpp
@@ -44,6 +44,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapGDSCall(LogicalOperator* logica
     auto graph = std::make_unique<OnDiskGraph>(clientContext, logicalInfo.graphEntry);
     auto storageManager = clientContext->getStorageManager();
     auto sharedState = std::make_shared<GDSCallSharedState>(table, std::move(graph));
+    if (call.hasNbrTableIDSet()) {
+        sharedState->setNbrTableIDSet(call.getNbrTableIDSet());
+    }
     auto bindData = call.getInfo().getBindData();
     if (bindData->hasNodeInput()) {
         auto& node = bindData->getNodeInput()->constCast<NodeExpression>();


### PR DESCRIPTION
# Description

Improve GDS performance on multi-labeled query.

```
MATCH p=(a:Person)-[*4..4]->(b:TagClass) WHERE a.id=96 RETURN COUNT(*);
```
The above query goes from 27s to 0.8s after this PR.

Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).