### PR TITLE
Remove unnecessary logic in ProcessorTask::finalizeIfNecessary

### DIFF
--- a/src/include/processor/operator/aggregate/simple_aggregate.h
+++ b/src/include/processor/operator/aggregate/simple_aggregate.h
@@ -62,7 +62,9 @@ public:
 
     void finalizeInternal(ExecutionContext* /*context*/) override {
         sharedState->finalizeAggregateStates();
-        metrics->numOutputTuple.incrementByOne();
+        if (metrics) {
+            metrics->numOutputTuple.incrementByOne();
+        }
     }
 
     inline std::unique_ptr<PhysicalOperator> clone() override {

--- a/src/include/processor/operator/persistent/node_batch_insert.h
+++ b/src/include/processor/operator/persistent/node_batch_insert.h
@@ -140,6 +140,13 @@ private:
         common::offset_t startIndexInGroup) const;
 
     void copyToNodeGroup(transaction::Transaction* transaction, storage::MemoryManager* mm) const;
+
+    NodeBatchInsertErrorHandler createErrorHandler(ExecutionContext* context);
+
+    void writeAndResetNodeGroup(transaction::Transaction* transaction,
+        std::unique_ptr<storage::ChunkedNodeGroup>& nodeGroup,
+        std::optional<IndexBuilder>& indexBuilder, storage::MemoryManager* mm,
+        NodeBatchInsertErrorHandler& errorHandler) const;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/result_collector.h
+++ b/src/include/processor/operator/result_collector.h
@@ -70,21 +70,21 @@ public:
         : Sink{std::move(resultSetDescriptor), type_, std::move(child), id, std::move(printInfo)},
           info{std::move(info)}, sharedState{std::move(sharedState)} {}
 
-    void executeInternal(ExecutionContext* context) override final;
+    void executeInternal(ExecutionContext* context) final;
 
-    void finalizeInternal(ExecutionContext* context) override final;
+    void finalizeInternal(ExecutionContext* context) final;
 
     std::shared_ptr<FactorizedTable> getResultFactorizedTable() { return sharedState->getTable(); }
 
-    std::unique_ptr<PhysicalOperator> clone() override final {
+    std::unique_ptr<PhysicalOperator> clone() final {
         return make_unique<ResultCollector>(resultSetDescriptor->copy(), info.copy(), sharedState,
             children[0]->clone(), id, printInfo->copy());
     }
 
 private:
-    void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override final;
+    void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) final;
 
-    void initOptionalLocalState(ResultSet* resultSet, ExecutionContext* context);
+    void initNecessaryLocalState(ResultSet* resultSet, ExecutionContext* context);
 
 private:
     ResultCollectorInfo info;

--- a/src/include/processor/operator/result_collector.h
+++ b/src/include/processor/operator/result_collector.h
@@ -70,19 +70,21 @@ public:
         : Sink{std::move(resultSetDescriptor), type_, std::move(child), id, std::move(printInfo)},
           info{std::move(info)}, sharedState{std::move(sharedState)} {}
 
-    void executeInternal(ExecutionContext* context) final;
+    void executeInternal(ExecutionContext* context) override final;
 
-    void finalizeInternal(ExecutionContext* context) final;
+    void finalizeInternal(ExecutionContext* context) override final;
 
     std::shared_ptr<FactorizedTable> getResultFactorizedTable() { return sharedState->getTable(); }
 
-    std::unique_ptr<PhysicalOperator> clone() final {
+    std::unique_ptr<PhysicalOperator> clone() override final {
         return make_unique<ResultCollector>(resultSetDescriptor->copy(), info.copy(), sharedState,
             children[0]->clone(), id, printInfo->copy());
     }
 
 private:
-    void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) final;
+    void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override final;
+
+    void initOptionalLocalState(ResultSet* resultSet, ExecutionContext* context);
 
 private:
     ResultCollectorInfo info;

--- a/src/include/processor/processor_task.h
+++ b/src/include/processor/processor_task.h
@@ -15,7 +15,6 @@ public:
     void run() override;
     void finalizeIfNecessary() override;
 
-private:
     static std::unique_ptr<ResultSet> populateResultSet(Sink* op,
         storage::MemoryManager* memoryManager);
 

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -54,12 +54,7 @@ void NodeBatchInsert::initLocalStateInternal(ResultSet* resultSet, ExecutionCont
     const auto nodeLocalState = localState->ptrCast<NodeBatchInsertLocalState>();
     KU_ASSERT(nodeSharedState->globalIndexBuilder);
     nodeLocalState->localIndexBuilder = nodeSharedState->globalIndexBuilder->clone();
-
-    auto* nodeTable = ku_dynamic_cast<NodeTable*>(sharedState->table);
-    nodeLocalState->errorHandler =
-        NodeBatchInsertErrorHandler{context, nodeSharedState->pkType.getLogicalTypeID(), nodeTable,
-            context->clientContext->getWarningContext().getIgnoreErrorsOption(),
-            sharedState->numErroredRows, &sharedState->erroredRowMutex};
+    nodeLocalState->errorHandler = createErrorHandler(context);
 
     const auto numColumns = nodeInfo->columnEvaluators.size();
     nodeLocalState->columnVectors.resize(numColumns);
@@ -139,6 +134,14 @@ void NodeBatchInsert::copyToNodeGroup(transaction::Transaction* transaction,
     sharedState->incrementNumRows(numAppendedTuples);
 }
 
+NodeBatchInsertErrorHandler NodeBatchInsert::createErrorHandler(ExecutionContext* context) {
+    const auto nodeSharedState = ku_dynamic_cast<NodeBatchInsertSharedState*>(sharedState.get());
+    auto* nodeTable = ku_dynamic_cast<NodeTable*>(sharedState->table);
+    return NodeBatchInsertErrorHandler{context, nodeSharedState->pkType.getLogicalTypeID(),
+        nodeTable, context->clientContext->getWarningContext().getIgnoreErrorsOption(),
+        sharedState->numErroredRows, &sharedState->erroredRowMutex};
+}
+
 void NodeBatchInsert::clearToIndex(MemoryManager* mm, std::unique_ptr<ChunkedNodeGroup>& nodeGroup,
     offset_t startIndexInGroup) const {
     // Create a new chunked node group and move the unwritten values to it
@@ -156,6 +159,16 @@ void NodeBatchInsert::writeAndResetNodeGroup(transaction::Transaction* transacti
     MemoryManager* mm) const {
     const auto nodeSharedState = ku_dynamic_cast<NodeBatchInsertSharedState*>(sharedState.get());
     const auto nodeLocalState = localState->ptrCast<NodeBatchInsertLocalState>();
+    KU_ASSERT(nodeLocalState->errorHandler.has_value());
+    writeAndResetNodeGroup(transaction, nodeGroup, indexBuilder, mm,
+        nodeLocalState->errorHandler.value());
+}
+
+void NodeBatchInsert::writeAndResetNodeGroup(transaction::Transaction* transaction,
+    std::unique_ptr<ChunkedNodeGroup>& nodeGroup, std::optional<IndexBuilder>& indexBuilder,
+    MemoryManager* mm, NodeBatchInsertErrorHandler& errorHandler) const {
+    const auto nodeSharedState = ku_dynamic_cast<NodeBatchInsertSharedState*>(sharedState.get());
+    //    const auto nodeLocalState = localState->ptrCast<NodeBatchInsertLocalState>();
     const auto nodeTable = ku_dynamic_cast<NodeTable*>(sharedState->table);
     auto nodeInfo = info->ptrCast<NodeBatchInsertInfo>();
 
@@ -167,13 +180,12 @@ void NodeBatchInsert::writeAndResetNodeGroup(transaction::Transaction* transacti
     nodeGroup->merge(sliceToWriteToDisk, nodeInfo->outputDataColumns);
 
     if (indexBuilder) {
-        KU_ASSERT(nodeLocalState->errorHandler.has_value());
         std::vector<ColumnChunkData*> warningChunkData;
         for (const auto warningDataColumn : nodeInfo->warningDataColumns) {
             warningChunkData.push_back(&nodeGroup->getColumnChunk(warningDataColumn).getData());
         }
         indexBuilder->insert(nodeGroup->getColumnChunk(nodeSharedState->pkColumnID).getData(),
-            warningChunkData, nodeOffset, numRowsWritten, nodeLocalState->errorHandler.value());
+            warningChunkData, nodeOffset, numRowsWritten, errorHandler);
     }
     if (numRowsWritten == nodeGroup->getNumRows()) {
         nodeGroup->resetToEmpty();
@@ -207,19 +219,17 @@ void NodeBatchInsert::appendIncompleteNodeGroup(transaction::Transaction* transa
 
 void NodeBatchInsert::finalize(ExecutionContext* context) {
     const auto nodeSharedState = ku_dynamic_cast<NodeBatchInsertSharedState*>(sharedState.get());
+    auto errorHandler = createErrorHandler(context);
     if (nodeSharedState->sharedNodeGroup) {
         while (nodeSharedState->sharedNodeGroup->getNumRows() > 0) {
             writeAndResetNodeGroup(context->clientContext->getTx(),
                 nodeSharedState->sharedNodeGroup, nodeSharedState->globalIndexBuilder,
-                context->clientContext->getMemoryManager());
+                context->clientContext->getMemoryManager(), errorHandler);
         }
     }
     if (nodeSharedState->globalIndexBuilder) {
-        auto* localNodeState = ku_dynamic_cast<NodeBatchInsertLocalState*>(localState.get());
-        KU_ASSERT(localNodeState->errorHandler.has_value());
-        nodeSharedState->globalIndexBuilder->finalize(context,
-            localNodeState->errorHandler.value());
-        localNodeState->errorHandler->flushStoredErrors();
+        nodeSharedState->globalIndexBuilder->finalize(context, errorHandler);
+        errorHandler.flushStoredErrors();
     }
 
     // we want to flush all index errors before children call finalize

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -216,9 +216,8 @@ void NodeBatchInsert::appendIncompleteNodeGroup(transaction::Transaction* transa
 }
 
 void NodeBatchInsert::finalize(ExecutionContext* context) {
+    KU_ASSERT(localState == nullptr);
     const auto nodeSharedState = ku_dynamic_cast<NodeBatchInsertSharedState*>(sharedState.get());
-    const auto nodeLocalState = localState->ptrCast<NodeBatchInsertLocalState>();
-    KU_ASSERT(!nodeLocalState->errorHandler.has_value());
     auto errorHandler = createErrorHandler(context);
     if (nodeSharedState->sharedNodeGroup) {
         while (nodeSharedState->sharedNodeGroup->getNumRows() > 0) {

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -168,7 +168,6 @@ void NodeBatchInsert::writeAndResetNodeGroup(transaction::Transaction* transacti
     std::unique_ptr<ChunkedNodeGroup>& nodeGroup, std::optional<IndexBuilder>& indexBuilder,
     MemoryManager* mm, NodeBatchInsertErrorHandler& errorHandler) const {
     const auto nodeSharedState = ku_dynamic_cast<NodeBatchInsertSharedState*>(sharedState.get());
-    //    const auto nodeLocalState = localState->ptrCast<NodeBatchInsertLocalState>();
     const auto nodeTable = ku_dynamic_cast<NodeTable*>(sharedState->table);
     auto nodeInfo = info->ptrCast<NodeBatchInsertInfo>();
 
@@ -219,6 +218,8 @@ void NodeBatchInsert::appendIncompleteNodeGroup(transaction::Transaction* transa
 
 void NodeBatchInsert::finalize(ExecutionContext* context) {
     const auto nodeSharedState = ku_dynamic_cast<NodeBatchInsertSharedState*>(sharedState.get());
+    const auto nodeLocalState = localState->ptrCast<NodeBatchInsertLocalState>();
+    KU_ASSERT(!nodeLocalState->errorHandler.has_value());
     auto errorHandler = createErrorHandler(context);
     if (nodeSharedState->sharedNodeGroup) {
         while (nodeSharedState->sharedNodeGroup->getNumRows() > 0) {

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -157,7 +157,6 @@ void NodeBatchInsert::clearToIndex(MemoryManager* mm, std::unique_ptr<ChunkedNod
 void NodeBatchInsert::writeAndResetNodeGroup(transaction::Transaction* transaction,
     std::unique_ptr<ChunkedNodeGroup>& nodeGroup, std::optional<IndexBuilder>& indexBuilder,
     MemoryManager* mm) const {
-    const auto nodeSharedState = ku_dynamic_cast<NodeBatchInsertSharedState*>(sharedState.get());
     const auto nodeLocalState = localState->ptrCast<NodeBatchInsertLocalState>();
     KU_ASSERT(nodeLocalState->errorHandler.has_value());
     writeAndResetNodeGroup(transaction, nodeGroup, indexBuilder, mm,

--- a/src/processor/operator/result_collector.cpp
+++ b/src/processor/operator/result_collector.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/result_collector.h"
 
 #include "binder/expression/expression_util.h"
+#include "processor/processor_task.h"
 
 using namespace kuzu::common;
 using namespace kuzu::storage;
@@ -18,7 +19,7 @@ std::string ResultCollectorPrintInfo::toString() const {
     return result;
 }
 
-void ResultCollector::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
+void ResultCollector::initOptionalLocalState(ResultSet* resultSet, ExecutionContext* context) {
     payloadVectors.reserve(info.payloadPositions.size());
     for (auto& pos : info.payloadPositions) {
         auto vec = resultSet->getValueVector(pos).get();
@@ -32,6 +33,10 @@ void ResultCollector::initLocalStateInternal(ResultSet* resultSet, ExecutionCont
         markVector->setValue<bool>(0, true);
         payloadAndMarkVectors.push_back(markVector.get());
     }
+}
+
+void ResultCollector::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
+    initOptionalLocalState(resultSet, context);
     localTable = std::make_unique<FactorizedTable>(context->clientContext->getMemoryManager(),
         info.tableSchema.copy());
 }
@@ -50,9 +55,12 @@ void ResultCollector::executeInternal(ExecutionContext* context) {
     }
 }
 
-void ResultCollector::finalizeInternal(ExecutionContext* /*context*/) {
+void ResultCollector::finalizeInternal(ExecutionContext* context) {
     switch (info.accumulateType) {
     case AccumulateType::OPTIONAL_: {
+        auto localResultSet = processor::ProcessorTask::populateResultSet(this,
+            context->clientContext->getMemoryManager());
+        initOptionalLocalState(localResultSet.get(), context);
         // We should remove currIdx completely as some of the code still relies on currIdx = -1 to
         // check if the state if unFlat or not. This should no longer be necessary.
         // TODO(Ziyi): add an interface in factorized table

--- a/src/processor/operator/result_collector.cpp
+++ b/src/processor/operator/result_collector.cpp
@@ -19,7 +19,7 @@ std::string ResultCollectorPrintInfo::toString() const {
     return result;
 }
 
-void ResultCollector::initOptionalLocalState(ResultSet* resultSet, ExecutionContext* context) {
+void ResultCollector::initNecessaryLocalState(ResultSet* resultSet, ExecutionContext* context) {
     payloadVectors.reserve(info.payloadPositions.size());
     for (auto& pos : info.payloadPositions) {
         auto vec = resultSet->getValueVector(pos).get();
@@ -36,7 +36,7 @@ void ResultCollector::initOptionalLocalState(ResultSet* resultSet, ExecutionCont
 }
 
 void ResultCollector::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
-    initOptionalLocalState(resultSet, context);
+    initNecessaryLocalState(resultSet, context);
     localTable = std::make_unique<FactorizedTable>(context->clientContext->getMemoryManager(),
         info.tableSchema.copy());
 }
@@ -60,7 +60,7 @@ void ResultCollector::finalizeInternal(ExecutionContext* context) {
     case AccumulateType::OPTIONAL_: {
         auto localResultSet = processor::ProcessorTask::populateResultSet(this,
             context->clientContext->getMemoryManager());
-        initOptionalLocalState(localResultSet.get(), context);
+        initNecessaryLocalState(localResultSet.get(), context);
         // We should remove currIdx completely as some of the code still relies on currIdx = -1 to
         // check if the state if unFlat or not. This should no longer be necessary.
         // TODO(Ziyi): add an interface in factorized table

--- a/src/processor/processor_task.cpp
+++ b/src/processor/processor_task.cpp
@@ -9,7 +9,7 @@ namespace processor {
 
 ProcessorTask::ProcessorTask(Sink* sink, ExecutionContext* executionContext)
     : Task{executionContext->clientContext->getCurrentSetting(main::ThreadsSetting::name)
-               .getValue<uint64_t>()},
+              .getValue<uint64_t>()},
       sharedStateInitialized{false}, sink{sink}, executionContext{executionContext} {}
 
 void ProcessorTask::run() {
@@ -29,8 +29,6 @@ void ProcessorTask::run() {
 }
 
 void ProcessorTask::finalizeIfNecessary() {
-    auto resultSet = populateResultSet(sink, executionContext->clientContext->getMemoryManager());
-    sink->initLocalState(resultSet.get(), executionContext);
     executionContext->clientContext->getProgressBar()->finishPipeline(executionContext->queryID);
     sink->finalize(executionContext);
 }


### PR DESCRIPTION
# Description

The `Sink::initLocalState` method is only useful when a query starts with `optional match`,we can move this logic into the `ResultCollector::finalizeInternal` method to optimize performance.

## Performance test

In sf100 datasets,query `match p=(a:person {id:24189255912498})-[f]-(b) return p limit 20`,10 concurrency, QPS improve 8.2%.


![image](https://github.com/user-attachments/assets/79b79034-abac-4023-a8a3-aa31239abdef)


# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).