### PR TITLE
Remove clang-format as dependency for jobs

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -14,13 +14,13 @@ on:
         required: false
         default: true
         type: boolean
-    
+
       buffer_pool_size:
         description: 'Database config - buffer pool size'
         required: false
         default: 67108864
         type: number
-      
+
       max_num_threads:
         description: 'Database config - max number of threads'
         required: false
@@ -32,7 +32,7 @@ on:
         required: false
         default: true
         type: boolean
-      
+
       checkpoint_threshold:
         description: 'Database config - checkpoint threshold'
         required: false
@@ -62,7 +62,7 @@ concurrency:
 jobs:
   generate-binary-datasets:
     name: generate binary dataset
-    needs: [clang-format, sanity-checks, python-lint-check]
+    needs: [sanity-checks, python-lint-check]
     runs-on: kuzu-self-hosted-testing
     env:
       NUM_THREADS: 32
@@ -77,7 +77,7 @@ jobs:
 
       - name: Generate datasets
         run: bash scripts/generate_binary_demo.sh
-      
+
       - name: Generate and upload tinysnb
         run: |
           bash scripts/generate_binary_tinysnb.sh
@@ -91,7 +91,7 @@ jobs:
           s3cmd del -r s3://kuzu-test/tinysnb/
           s3cmd sync ./tinysnb s3://kuzu-test/
           rm -rf tinysnb version.txt
-      
+
       - name: Generate and upload ldbc-sf01
         run: |
           bash scripts/generate_binary_ldbc-sf01.sh
@@ -114,7 +114,7 @@ jobs:
 
   gcc-build-test:
     name: gcc build & test
-    needs: [clang-format, sanity-checks, python-lint-check, generate-binary-datasets]
+    needs: [sanity-checks, python-lint-check, generate-binary-datasets]
     runs-on: kuzu-self-hosted-testing
     env:
       NUM_THREADS: 32
@@ -237,7 +237,7 @@ jobs:
   code-coverage:
     name: code coverage
     runs-on: ubuntu-22.04
-    needs: [clang-format, sanity-checks, python-lint-check, generate-binary-datasets]
+    needs: [sanity-checks, python-lint-check, generate-binary-datasets]
     env:
       TEST_JOBS: 10
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -273,7 +273,7 @@ jobs:
 
   webassembly-build-test:
     name: webassembly build & test
-    needs: [clang-format, sanity-checks, generate-binary-datasets]
+    needs: [sanity-checks, generate-binary-datasets]
     runs-on: kuzu-self-hosted-testing
     env:
       WERROR: 0
@@ -288,13 +288,13 @@ jobs:
         with:
           name: binary-demo
           path: dataset/binary-demo
-        
+
       - name: Build & test
         run: |
           ln -s /home/runner/ldbc-1-csv dataset/ldbc-1/csv
           source /home/runner/emsdk/emsdk_env.sh
           make wasmtest
-      
+
       - name: Build & test (single-thread mode)
         env:
           SINGLE_THREADED: true
@@ -365,7 +365,7 @@ jobs:
 
   clang-build-test:
     name: clang build & test
-    needs: [clang-format, sanity-checks, python-lint-check, generate-binary-datasets]
+    needs: [sanity-checks, python-lint-check, generate-binary-datasets]
     runs-on: kuzu-self-hosted-testing
     env:
       NUM_THREADS: 32
@@ -475,7 +475,7 @@ jobs:
 
   msvc-build-test:
     name: msvc build & test
-    needs: [clang-format, sanity-checks, python-lint-check, generate-binary-datasets]
+    needs: [sanity-checks, python-lint-check, generate-binary-datasets]
     runs-on: self-hosted-windows
     env:
       # Shorten build path as much as possible
@@ -606,7 +606,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y clang-format-18
-          
+
       - uses: actions/checkout@v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -688,7 +688,7 @@ jobs:
 
   clang-tidy:
     name: clang tidy & clangd diagnostics check
-    needs: [clang-format, sanity-checks]
+    needs: [sanity-checks]
     runs-on: kuzu-self-hosted-testing
     env:
       GEN: Ninja
@@ -715,7 +715,7 @@ jobs:
 
   macos-build-test-x86_64:
     name: apple clang build & test (x86_64)
-    needs: [clang-format, sanity-checks, rustfmt-check, python-lint-check, generate-binary-datasets]
+    needs: [sanity-checks, rustfmt-check, python-lint-check, generate-binary-datasets]
     runs-on: self-hosted-mac-x64
     env:
       NUM_THREADS: 32
@@ -808,7 +808,7 @@ jobs:
   shell-test:
     name: shell test
     runs-on: ubuntu-latest
-    needs: [clang-format, sanity-checks]
+    needs: [sanity-checks]
     steps:
       - uses: actions/checkout@v4
 
@@ -867,7 +867,7 @@ jobs:
           python3 scripts/generate-tinysnb.py
           cd scripts/ && python3 http-server.py &
           make extension-test
-          
+
       - name: Extension test in mem
         env:
           IN_MEM_MODE: true
@@ -927,7 +927,7 @@ jobs:
           IN_MEM_MODE: true
           HTTP_CACHE_FILE: false
         run: |
-          make extension-test && make clean    
+          make extension-test && make clean
 
   windows-extension-test:
     name: windows extension test
@@ -983,7 +983,7 @@ jobs:
           if %errorlevel% neq 0 exit /b %errorlevel%
           cd scripts/ && start /b python http-server.py && cd ..
           make extension-test
-          
+
       - name: Extension test in mem
         shell: cmd
         env:


### PR DESCRIPTION
# Description
Our CI has been failing early on third-party contributors' PRs due to clang format not having permission to write to their forks of the repo. We should remove the dependencies of other CI jobs (mainly the test jobs) on the clang format job so that we can at least see if our tests pass on the PRs before merging them in.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).