### PR TITLE
Allow loading extension for multiple times

### DIFF
--- a/extension/duckdb/test/test_files/duckdb.test
+++ b/extension/duckdb/test/test_files/duckdb.test
@@ -5,6 +5,11 @@
 -CASE ScanDuckDBTable
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/duckdb/build/libduckdb.kuzu_extension"
 ---- ok
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/duckdb/build/libduckdb.kuzu_extension"
+---- ok
+# Duckdb and httpfs share a set of same options, check whether they collide with each other.
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/httpfs/build/libhttpfs.kuzu_extension"
+---- ok
 -LOG AttachUnsupportedTableError
 -STATEMENT ATTACH '${KUZU_ROOT_DIRECTORY}/dataset/databases/duckdb_database/tinysnb.db' as tinysnb (dbtype duckdb);
 ---- error

--- a/extension/httpfs/test/test_files/http.test
+++ b/extension/httpfs/test/test_files/http.test
@@ -5,6 +5,8 @@
 -CASE ScanFromHTTPCSV
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/httpfs/build/libhttpfs.kuzu_extension"
 ---- ok
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/httpfs/build/libhttpfs.kuzu_extension"
+---- ok
 -STATEMENT load from "http://localhost/tinysnb/vPerson.csv" return * limit 5;
 ---- 5
 0|Alice|1|True|False|35|5.0|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10,5]|[Aida]|[[10,8],[6,7,8]]|[96,54,86,92]|1.731|A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11

--- a/extension/httpfs/test/test_files/s3_download.test
+++ b/extension/httpfs/test/test_files/s3_download.test
@@ -24,13 +24,6 @@ kuzuS3keyid
 ---- 1
 anotherkey
 
--CASE DuplicateOption
--STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/httpfs/build/libhttpfs.kuzu_extension"
----- ok
--STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/httpfs/build/libhttpfs.kuzu_extension"
----- error
-Extension exception: Extension option S3_ACCESS_KEY_ID already exists.
-
 -CASE ScanFromUWS3File
 # In-memory mode doesn't support file cache.
 -SKIP_IN_MEM

--- a/extension/json/src/json_extension.cpp
+++ b/extension/json/src/json_extension.cpp
@@ -39,7 +39,6 @@ static void addJsonScalarFunction(main::Database& db) {
 
 void JsonExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    KU_ASSERT(!db.getCatalog()->containsType(&transaction::DUMMY_TRANSACTION, JSON_TYPE_NAME));
     db.getCatalog()->createType(&transaction::DUMMY_TRANSACTION, JSON_TYPE_NAME,
         common::LogicalType::STRING());
     addJsonCreationFunction(db);

--- a/extension/postgres/test/test_files/postgres.test
+++ b/extension/postgres/test/test_files/postgres.test
@@ -5,6 +5,8 @@
 -CASE ScanPostgresTable
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/postgres/build/libpostgres.kuzu_extension"
 ---- ok
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/postgres/build/libpostgres.kuzu_extension"
+---- ok
 -STATEMENT ATTACH 'dbname=pgscan user=ci host=localhost' as tinysnb (dbtype POSTGRES);
 ---- ok
 -STATEMENT create node table person_copy (ID INt64, fName StRING, gender INT64, isStudent BoOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration interval, workedHours INT64[], usedNames STRING[], height double, u UUID, PRIMARY KEY (ID));

--- a/extension/sqlite/test/test_files/sqlite.test
+++ b/extension/sqlite/test/test_files/sqlite.test
@@ -5,6 +5,8 @@
 -CASE ScanSqliteTable
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/sqlite/build/libsqlite.kuzu_extension"
 ---- ok
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/sqlite/build/libsqlite.kuzu_extension"
+---- ok
 -STATEMENT ATTACH '${KUZU_ROOT_DIRECTORY}/extension/sqlite/test/sqlite_database/tinysnb' as tinysnb (dbtype sqlite);
 ---- 1
 Attached database successfully.

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -280,7 +280,9 @@ std::string Catalog::genSerialName(const std::string& tableName, const std::stri
 }
 
 void Catalog::createType(Transaction* transaction, std::string name, LogicalType type) {
-    KU_ASSERT(!types->containsEntry(transaction, name));
+    if (types->containsEntry(transaction, name)) {
+        return;
+    }
     auto entry = std::make_unique<TypeCatalogEntry>(std::move(name), std::move(type));
     types->createEntry(transaction, std::move(entry));
 }

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -10,7 +10,6 @@
 #endif
 
 #include "common/exception/exception.h"
-#include "common/exception/extension.h"
 #include "common/file_system/virtual_file_system.h"
 #include "extension/extension.h"
 #include "main/db_config.h"

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -126,12 +126,16 @@ void Database::registerFileSystem(std::unique_ptr<FileSystem> fs) {
 
 void Database::registerStorageExtension(std::string name,
     std::unique_ptr<StorageExtension> storageExtension) {
+    if (storageExtensions.contains(name)) {
+        return;
+    }
     storageExtensions.emplace(std::move(name), std::move(storageExtension));
 }
 
 void Database::addExtensionOption(std::string name, LogicalTypeID type, Value defaultValue) {
     if (extensionOptions->getExtensionOption(name) != nullptr) {
-        throw ExtensionException{stringFormat("Extension option {} already exists.", name)};
+        // One extension option can be shared by multiple extensions.
+        return;
     }
     extensionOptions->addExtensionOption(name, type, std::move(defaultValue));
 }


### PR DESCRIPTION
This PR allows loading the same extension for multiple times, which means:
```
LOAD EXTENSION HTTPFS;
LOAD EXTENSION HTTPFS;
```
Will not throw any errors.