### PR TITLE
Fix import db deadlock

### DIFF
--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -31,6 +31,10 @@ namespace extension {
 struct ExtensionOptions;
 }
 
+namespace processor {
+class ImportDB;
+}
+
 namespace main {
 struct DBConfig;
 class Database;
@@ -53,6 +57,7 @@ class KUZU_API ClientContext {
     friend class Connection;
     friend class binder::Binder;
     friend class binder::ExpressionBinder;
+    friend class processor::ImportDB;
 
 public:
     explicit ClientContext(Database* database);
@@ -133,7 +138,7 @@ public:
     void cleanUP();
 
 private:
-    std::unique_ptr<QueryResult> query(std::string_view query, std::string_view encodedJoin,
+    std::unique_ptr<QueryResult> queryInternal(std::string_view query, std::string_view encodedJoin,
         bool enumerateAllPlans = true, std::optional<uint64_t> queryID = std::nullopt);
 
     std::unique_ptr<QueryResult> queryResultWithError(std::string_view errMsg);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -257,13 +257,13 @@ std::unique_ptr<PreparedStatement> ClientContext::prepare(std::string_view query
 
 std::unique_ptr<QueryResult> ClientContext::query(std::string_view queryStatement,
     std::optional<uint64_t> queryID) {
-    return query(queryStatement, std::string_view() /*encodedJoin*/, false /*enumerateAllPlans */,
-        queryID);
+    lock_t lck{mtx};
+    return queryInternal(queryStatement, std::string_view() /*encodedJoin*/,
+        false /*enumerateAllPlans */, queryID);
 }
 
-std::unique_ptr<QueryResult> ClientContext::query(std::string_view query,
+std::unique_ptr<QueryResult> ClientContext::queryInternal(std::string_view query,
     std::string_view encodedJoin, bool enumerateAllPlans, std::optional<uint64_t> queryID) {
-    lock_t lck{mtx};
     auto parsedStatements = std::vector<std::shared_ptr<Statement>>();
     try {
         parsedStatements = parseQuery(query);

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -45,7 +45,7 @@ std::unique_ptr<QueryResult> Connection::queryWithID(std::string_view queryState
 
 std::unique_ptr<QueryResult> Connection::query(std::string_view query, std::string_view encodedJoin,
     bool enumerateAllPlans) {
-    return clientContext->query(query, encodedJoin, enumerateAllPlans);
+    return clientContext->queryInternal(query, encodedJoin, enumerateAllPlans);
 }
 
 std::unique_ptr<QueryResult> Connection::queryResultWithError(std::string_view errMsg) {

--- a/src/processor/operator/simple/import_db.cpp
+++ b/src/processor/operator/simple/import_db.cpp
@@ -20,7 +20,8 @@ void ImportDB::executeInternal(ExecutionContext* context) {
     if (context->clientContext->getTransactionContext()->hasActiveTransaction()) {
         context->clientContext->getTransactionContext()->commit();
     }
-    context->clientContext->query(query);
+    context->clientContext->queryInternal(query, "" /* encodedJoin */,
+        false /* enumerateAllPlans */, std::nullopt /* queryID */);
 }
 
 std::string ImportDB::getOutputMsg() {

--- a/test/copy/CMakeLists.txt
+++ b/test/copy/CMakeLists.txt
@@ -1,1 +1,4 @@
-add_kuzu_test(copy_tests multi_copy_test.cpp copy_test.cpp)
+add_kuzu_test(copy_tests
+        multi_copy_test.cpp
+        import_export.cpp
+        copy_test.cpp)

--- a/test/copy/import_export.cpp
+++ b/test/copy/import_export.cpp
@@ -1,0 +1,32 @@
+#include "common/file_system/local_file_system.h"
+#include "graph_test/base_graph_test.h"
+#include "graph_test/graph_test.h"
+#include "main/database.h"
+
+namespace kuzu {
+namespace testing {
+
+class ImportExportDBTest : public DBTest {
+public:
+    std::string getInputDir() override {
+        return TestHelper::appendKuzuRootPath("dataset/tinysnb/");
+    }
+};
+
+TEST_F(ImportExportDBTest, Test) {
+    auto tempDir = TestHelper::getTempDir(getTestGroupAndName());
+    auto dbPath = common::LocalFileSystem::joinPath(tempDir, "export.tmp");
+    auto result = conn->query("EXPORT DATABASE '" + dbPath + "'");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    result.reset();
+    createNewDB();
+    result = conn->query("IMPORT DATABASE '" + dbPath + "'");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    result = conn->query("MATCH (a:person)-[e:knows]->(b:person) RETURN COUNT(*)");
+    ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+    ASSERT_TRUE(result->hasNext());
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 14);
+}
+
+} // namespace testing
+} // namespace kuzu


### PR DESCRIPTION
# Description

See the title.
The problem wasn't caught by the testing framework because our testing framework was using `prepare` + `execute`, which avoids the lock inside `query`.