### PR TITLE
Acquire a lock when destroying/copying a python udf function

### DIFF
--- a/src/binder/bind_expression/bind_boolean_expression.cpp
+++ b/src/binder/bind_expression/bind_boolean_expression.cpp
@@ -35,8 +35,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindBooleanExpression(ExpressionTy
     auto bindData = std::make_unique<function::FunctionBindData>(LogicalType::BOOL());
     auto uniqueExpressionName =
         ScalarFunctionExpression::getUniqueName(functionName, childrenAfterCast);
-    auto func =
-        ScalarFunction(functionName, inputTypeIDs, LogicalTypeID::BOOL, execFunc, selectFunc);
+    auto func = std::make_unique<ScalarFunction>(functionName, inputTypeIDs, LogicalTypeID::BOOL,
+        execFunc, selectFunc);
     return std::make_shared<ScalarFunctionExpression>(expressionType, std::move(func),
         std::move(bindData), std::move(childrenAfterCast), uniqueExpressionName);
 }

--- a/src/binder/bind_expression/bind_null_operator_expression.cpp
+++ b/src/binder/bind_expression/bind_null_operator_expression.cpp
@@ -38,8 +38,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindNullOperatorExpression(
     auto bindData = std::make_unique<function::FunctionBindData>(LogicalType::BOOL());
     auto uniqueExpressionName =
         ScalarFunctionExpression::getUniqueName(functionName, childrenAfterCast);
-    auto func =
-        ScalarFunction(functionName, inputTypeIDs, LogicalTypeID::BOOL, execFunc, selectFunc);
+    auto func = std::make_unique<ScalarFunction>(functionName, inputTypeIDs, LogicalTypeID::BOOL,
+        execFunc, selectFunc);
     return make_shared<ScalarFunctionExpression>(expressionType, std::move(func),
         std::move(bindData), std::move(childrenAfterCast), uniqueExpressionName);
 }

--- a/src/binder/expression/scalar_function_expression.cpp
+++ b/src/binder/expression/scalar_function_expression.cpp
@@ -8,11 +8,11 @@ namespace kuzu {
 namespace binder {
 
 std::string ScalarFunctionExpression::toStringInternal() const {
-    if (function.name.starts_with("CAST")) {
+    if (function->name.starts_with("CAST")) {
         return stringFormat("CAST({}, {})", ExpressionUtil::toString(children),
             bindData->resultType.toString());
     }
-    return stringFormat("{}({})", function.name, ExpressionUtil::toString(children));
+    return stringFormat("{}({})", function->name, ExpressionUtil::toString(children));
 }
 
 std::string ScalarFunctionExpression::getUniqueName(const std::string& functionName,

--- a/src/expression_evaluator/function_evaluator.cpp
+++ b/src/expression_evaluator/function_evaluator.cpp
@@ -25,10 +25,10 @@ void FunctionExpressionEvaluator::evaluate() {
     for (auto& child : children) {
         child->evaluate();
     }
-    if (function.execFunc != nullptr) {
+    if (function->execFunc != nullptr) {
         bindData->clientContext = ctx;
         bindData->count = cnt;
-        function.execFunc(parameters, *resultVector, bindData.get());
+        function->execFunc(parameters, *resultVector, bindData.get());
     }
 }
 
@@ -38,9 +38,9 @@ bool FunctionExpressionEvaluator::select(SelectionVector& selVector) {
     }
     // Temporary code path for function whose return type is BOOL but select interface is not
     // implemented (e.g. list_contains). We should remove this if statement eventually.
-    if (function.selectFunc == nullptr) {
+    if (function->selectFunc == nullptr) {
         KU_ASSERT(resultVector->dataType.getLogicalTypeID() == LogicalTypeID::BOOL);
-        function.execFunc(parameters, *resultVector, nullptr);
+        function->execFunc(parameters, *resultVector, nullptr);
         auto numSelectedValues = 0u;
         for (auto i = 0u; i < resultVector->state->getSelVector().getSelSize(); ++i) {
             auto pos = resultVector->state->getSelVector()[i];
@@ -51,7 +51,7 @@ bool FunctionExpressionEvaluator::select(SelectionVector& selVector) {
         selVector.setSelSize(numSelectedValues);
         return numSelectedValues > 0;
     }
-    return function.selectFunc(parameters, selVector);
+    return function->selectFunc(parameters, selVector);
 }
 
 void FunctionExpressionEvaluator::resolveResultVector(const ResultSet& /*resultSet*/,
@@ -64,8 +64,8 @@ void FunctionExpressionEvaluator::resolveResultVector(const ResultSet& /*resultS
         inputEvaluators.push_back(child.get());
     }
     resolveResultStateFromChildren(inputEvaluators);
-    if (function.compileFunc != nullptr) {
-        function.compileFunc(bindData.get(), parameters, resultVector);
+    if (function->compileFunc != nullptr) {
+        function->compileFunc(bindData.get(), parameters, resultVector);
     }
 }
 

--- a/src/include/binder/expression/scalar_function_expression.h
+++ b/src/include/binder/expression/scalar_function_expression.h
@@ -9,12 +9,13 @@ namespace binder {
 class ScalarFunctionExpression : public Expression {
 public:
     ScalarFunctionExpression(common::ExpressionType expressionType,
-        function::ScalarFunction function, std::unique_ptr<function::FunctionBindData> bindData,
-        expression_vector children, std::string uniqueName)
+        std::unique_ptr<function::ScalarFunction> function,
+        std::unique_ptr<function::FunctionBindData> bindData, expression_vector children,
+        std::string uniqueName)
         : Expression{expressionType, bindData->resultType.copy(), std::move(children), uniqueName},
           function{std::move(function)}, bindData{std::move(bindData)} {}
 
-    const function::ScalarFunction& getFunction() const { return function; }
+    const function::ScalarFunction& getFunction() const { return *function; }
     function::FunctionBindData* getBindData() const { return bindData.get(); }
 
     std::string toStringInternal() const final;
@@ -23,7 +24,7 @@ public:
         const expression_vector& children);
 
 private:
-    function::ScalarFunction function;
+    std::unique_ptr<function::ScalarFunction> function;
     std::unique_ptr<function::FunctionBindData> bindData;
 };
 

--- a/src/include/expression_evaluator/function_evaluator.h
+++ b/src/include/expression_evaluator/function_evaluator.h
@@ -27,7 +27,7 @@ protected:
 
 private:
     std::vector<std::shared_ptr<common::ValueVector>> parameters;
-    function::ScalarFunction function;
+    std::unique_ptr<function::ScalarFunction> function;
     std::unique_ptr<function::FunctionBindData> bindData;
 };
 

--- a/src/include/function/scalar_function.h
+++ b/src/include/function/scalar_function.h
@@ -21,7 +21,7 @@ using scalar_func_exec_t = std::function<void(
 using scalar_func_select_t = std::function<bool(
     const std::vector<std::shared_ptr<common::ValueVector>>&, common::SelectionVector&)>;
 
-struct ScalarFunction final : public ScalarOrAggregateFunction {
+struct ScalarFunction : public ScalarOrAggregateFunction {
     scalar_func_exec_t execFunc = nullptr;
     scalar_func_select_t selectFunc = nullptr;
     scalar_func_compile_exec_t compileFunc = nullptr;
@@ -62,7 +62,6 @@ struct ScalarFunction final : public ScalarOrAggregateFunction {
         common::LogicalTypeID returnTypeID, scalar_func_exec_t execFunc, scalar_bind_func bindFunc)
         : ScalarFunction{std::move(name), std::move(parameterTypeIDs), returnTypeID, execFunc,
               nullptr /* selectFunc */, bindFunc} {}
-    EXPLICIT_COPY_DEFAULT_MOVE(ScalarFunction);
 
     template<typename A_TYPE, typename B_TYPE, typename C_TYPE, typename RESULT_TYPE, typename FUNC>
     static void TernaryExecFunction(const std::vector<std::shared_ptr<common::ValueVector>>& params,
@@ -224,8 +223,9 @@ struct ScalarFunction final : public ScalarOrAggregateFunction {
             *params[0], *params[1], result, dataPtr);
     }
 
-private:
-    ScalarFunction(const ScalarFunction& other) = default;
+    virtual std::unique_ptr<ScalarFunction> copy() const {
+        return std::make_unique<ScalarFunction>(*this);
+    }
 };
 
 } // namespace function

--- a/tools/python_api/src_cpp/py_udf.cpp
+++ b/tools/python_api/src_cpp/py_udf.cpp
@@ -20,25 +20,16 @@ struct PyUDFScalarFunction : public ScalarFunction {
         : ScalarFunction{std::move(name), std::move(parameterTypeIDs), returnTypeID,
               std::move(execFunc), std::move(bindFunc)} {}
 
-    PyUDFScalarFunction(const PyUDFScalarFunction& other);
+    DELETE_COPY_DEFAULT_MOVE(PyUDFScalarFunction);
 
     ~PyUDFScalarFunction() override;
 
     std::unique_ptr<ScalarFunction> copy() const override {
-        return std::make_unique<PyUDFScalarFunction>(*this);
+        py::gil_scoped_acquire acquire;
+        return std::make_unique<PyUDFScalarFunction>(this->name, this->parameterTypeIDs,
+            this->returnTypeID, this->execFunc, this->bindFunc);
     }
 };
-
-PyUDFScalarFunction::PyUDFScalarFunction(const PyUDFScalarFunction& other) : ScalarFunction{} {
-    py::gil_scoped_acquire acquire;
-    this->execFunc = other.execFunc;
-    this->selectFunc = other.selectFunc;
-    this->compileFunc = other.compileFunc;
-    this->returnTypeID = other.returnTypeID;
-    this->bindFunc = other.bindFunc;
-    this->name = other.name;
-    this->parameterTypeIDs = other.parameterTypeIDs;
-}
 
 PyUDFScalarFunction::~PyUDFScalarFunction() {
     py::gil_scoped_acquire acquire;

--- a/tools/python_api/src_cpp/py_udf.cpp
+++ b/tools/python_api/src_cpp/py_udf.cpp
@@ -29,7 +29,7 @@ struct PyUDFScalarFunction : public ScalarFunction {
     }
 };
 
-PyUDFScalarFunction::PyUDFScalarFunction(const PyUDFScalarFunction& other) {
+PyUDFScalarFunction::PyUDFScalarFunction(const PyUDFScalarFunction& other) : ScalarFunction{} {
     py::gil_scoped_acquire acquire;
     this->execFunc = other.execFunc;
     this->selectFunc = other.selectFunc;


### PR DESCRIPTION
This PR fixes a PR which is caused by copying/destroying a python funciton object without acquiring the GIL.