### PR TITLE
fix string cast in nested json object

### DIFF
--- a/extension/json/src/include/json_type.h
+++ b/extension/json/src/include/json_type.h
@@ -7,6 +7,7 @@ namespace json_extension {
 
 struct JsonType {
     static common::LogicalType getJsonType();
+    static bool isJson(const common::LogicalType& type);
 };
 
 } // namespace json_extension

--- a/extension/json/src/type/json_type.cpp
+++ b/extension/json/src/type/json_type.cpp
@@ -12,5 +12,12 @@ common::LogicalType JsonType::getJsonType() {
     return type;
 }
 
+bool JsonType::isJson(const common::LogicalType& type) {
+    if (!type.isInternalType() && type.getExtraTypeInfo()->constPtrCast<common::UDTTypeInfo>()->getTypeName() == JsonExtension::JSON_TYPE_NAME) {
+        return true;
+    }
+    return false;
+}
+
 } // namespace json_extension
 } // namespace kuzu

--- a/extension/json/src/type/json_type.cpp
+++ b/extension/json/src/type/json_type.cpp
@@ -13,7 +13,9 @@ common::LogicalType JsonType::getJsonType() {
 }
 
 bool JsonType::isJson(const common::LogicalType& type) {
-    if (!type.isInternalType() && type.getExtraTypeInfo()->constPtrCast<common::UDTTypeInfo>()->getTypeName() == JsonExtension::JSON_TYPE_NAME) {
+    if (!type.isInternalType() &&
+        type.getExtraTypeInfo()->constPtrCast<common::UDTTypeInfo>()->getTypeName() ==
+            JsonExtension::JSON_TYPE_NAME) {
         return true;
     }
     return false;

--- a/extension/json/src/utils/json_utils.cpp
+++ b/extension/json/src/utils/json_utils.cpp
@@ -2,7 +2,6 @@
 
 #include <cstdlib>
 
-#include "json_type.h"
 #include "common/exception/not_implemented.h"
 #include "common/exception/runtime.h"
 #include "common/file_system/virtual_file_system.h"
@@ -11,6 +10,7 @@
 #include "function/cast/functions/cast_from_string_functions.h"
 #include "function/cast/functions/cast_string_non_nested_functions.h"
 #include "function/cast/functions/numeric_limits.h"
+#include "json_type.h"
 
 using namespace kuzu::common;
 
@@ -55,8 +55,10 @@ yyjson_mut_val* jsonify(JsonMutWrapper& wrapper, const common::ValueVector& vec,
             return yyjson_mut_null(wrapper.ptr);
         }
 
-        // Create a new mutable document in the wrapper and copy the root from the immutable document
-        yyjson_mut_val* mut_root = yyjson_val_mut_copy(wrapper.ptr, yyjson_doc_get_root(immutable_doc));
+        // Create a new mutable document in the wrapper and copy the root from the immutable
+        // document
+        yyjson_mut_val* mut_root =
+            yyjson_val_mut_copy(wrapper.ptr, yyjson_doc_get_root(immutable_doc));
 
         return mut_root;
     } else {

--- a/extension/json/src/utils/json_utils.cpp
+++ b/extension/json/src/utils/json_utils.cpp
@@ -148,6 +148,15 @@ yyjson_mut_val* jsonify(JsonMutWrapper& wrapper, const common::ValueVector& vec,
 
 JsonWrapper jsonify(const common::ValueVector& vec, uint64_t pos) {
     JsonMutWrapper result; // mutability necessary for manual construction
+    if (!vec.isNull(pos) && vec.dataType.getLogicalTypeID() == LogicalTypeID::STRING) {
+        auto strVal = vec.getValue<ku_string_t>(pos);
+        // check one more time in case this string a struct
+        auto strContent = strVal.getAsStringView();
+        LogicalType detectedType = function::inferMinimalTypeFromString(strContent);
+        if (detectedType.getLogicalTypeID() != LogicalTypeID::STRING) {
+            return stringToJson(std::string(strContent));
+        }
+    }
     yyjson_mut_val* root = jsonify(result, vec, pos);
     yyjson_mut_doc_set_root(result.ptr, root);
     return JsonWrapper(yyjson_mut_doc_imut_copy(result.ptr, nullptr));

--- a/extension/json/src/utils/json_utils.cpp
+++ b/extension/json/src/utils/json_utils.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdlib>
 
+#include "json_type.h"
 #include "common/exception/not_implemented.h"
 #include "common/exception/runtime.h"
 #include "common/file_system/virtual_file_system.h"
@@ -42,6 +43,22 @@ yyjson_mut_val* jsonify(JsonMutWrapper& wrapper, const common::ValueVector& vec,
     yyjson_mut_val* result = nullptr;
     if (vec.isNull(pos)) {
         result = yyjson_mut_null(wrapper.ptr);
+    } else if (JsonType::isJson(vec.dataType)) {
+        auto strVal = vec.getValue<ku_string_t>(pos);
+        auto strContent = strVal.getAsStringView();
+
+        // Convert JSON string to an immutable JSON document using stringToJson
+        JsonWrapper immutable_json_wrapper = stringToJson(std::string(strContent));
+        yyjson_doc* immutable_doc = immutable_json_wrapper.ptr;
+        if (!immutable_doc) {
+            // Handle error if parsing fails
+            return yyjson_mut_null(wrapper.ptr);
+        }
+
+        // Create a new mutable document in the wrapper and copy the root from the immutable document
+        yyjson_mut_val* mut_root = yyjson_val_mut_copy(wrapper.ptr, yyjson_doc_get_root(immutable_doc));
+
+        return mut_root;
     } else {
         switch (vec.dataType.getLogicalTypeID()) {
         case LogicalTypeID::BOOL:
@@ -131,15 +148,6 @@ yyjson_mut_val* jsonify(JsonMutWrapper& wrapper, const common::ValueVector& vec,
 
 JsonWrapper jsonify(const common::ValueVector& vec, uint64_t pos) {
     JsonMutWrapper result; // mutability necessary for manual construction
-    if (!vec.isNull(pos) && vec.dataType.getLogicalTypeID() == LogicalTypeID::STRING) {
-        auto strVal = vec.getValue<ku_string_t>(pos);
-        // check one more time in case this string a struct
-        auto strContent = strVal.getAsStringView();
-        LogicalType detectedType = function::inferMinimalTypeFromString(strContent);
-        if (detectedType.getLogicalTypeID() != LogicalTypeID::STRING) {
-            return stringToJson(std::string(strContent));
-        }
-    }
     yyjson_mut_val* root = jsonify(result, vec, pos);
     yyjson_mut_doc_set_root(result.ptr, root);
     return JsonWrapper(yyjson_mut_doc_imut_copy(result.ptr, nullptr));

--- a/extension/json/test/json_array.test
+++ b/extension/json/test/json_array.test
@@ -24,7 +24,7 @@
 -LOG NestedJsonArray
 -STATEMENT RETURN JSON_ARRAY(JSON_ARRAY(2,4, 'TEST'), 'kuzu', [2,5,1], null, [null])
 ---- 1
-["[2,4,\"TEST\"]","kuzu",[2,5,1],null,[null]]
+[[2,4,"TEST"],"kuzu",[2,5,1],null,[null]]
 
 -LOG UnflatFlatJsonArray
 -STATEMENT MATCH (p:person)-[e:knows]->(p1:person) RETURN JSON_ARRAY(p.fName, p.ID, p1.fName, 5)


### PR DESCRIPTION
# Description

Before our Jsonify has problem of casting strings in nested JSON struct such as: 
`return to_json({age: 55, foo: to_json({ scores: [1, 32], tee : "New York" });`

which is because we didn't check if the datatype is a `json` in `jsonify` function and treated them all as strings. 

Fixes #4513 

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).