### PR TITLE
GDS interface cleanup

### DIFF
--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -160,8 +160,8 @@ public:
             // for the first time, i.e., when its value in the pathLengths frontier is
             // PathLengths::UNVISITED. Or 2) if nbrID has already been visited but in this
             // iteration, so it's value is curIter + 1.
-            auto shouldUpdate = nbrVal == PathLengths::UNVISITED ||
-                                nbrVal == frontierPair->getCurrentIter();
+            auto shouldUpdate =
+                nbrVal == PathLengths::UNVISITED || nbrVal == frontierPair->getCurrentIter();
             if (shouldUpdate) {
                 // Note: This is safe because curNodeID is in the current frontier, so its
                 // shortest paths multiplicity is guaranteed to not change in the current iteration.
@@ -200,15 +200,14 @@ public:
             // for the first time, i.e., when its value in the pathLengths frontier is
             // PathLengths::UNVISITED. Or 2) if nbrID has already been visited but in this
             // iteration, so it's value is curIter + 1.
-            auto shouldUpdate = nbrLen == PathLengths::UNVISITED ||
-                                nbrLen == frontierPair->getCurrentIter();
+            auto shouldUpdate =
+                nbrLen == PathLengths::UNVISITED || nbrLen == frontierPair->getCurrentIter();
             if (shouldUpdate) {
                 if (!parentListBlock->hasSpace()) {
                     parentListBlock = bfsGraph->addNewBlock();
                 }
-                bfsGraph->addParent(frontierPair->getCurrentIter(),
-                    parentListBlock, nbrNodeID /* child */, boundNodeID /* parent */, edgeID,
-                    fwdEdge);
+                bfsGraph->addParent(frontierPair->getCurrentIter(), parentListBlock,
+                    nbrNodeID /* child */, boundNodeID /* parent */, edgeID, fwdEdge);
             }
             if (nbrLen == PathLengths::UNVISITED) {
                 activeNodes.push_back(nbrNodeID);

--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -47,8 +47,8 @@ public:
         curPtr[nodeID.offset].fetch_add(multiplicity);
     }
 
-    void incrementTargetMultiplicity(common::offset_t nodeIDOffset, uint64_t multiplicity) {
-        getCurTargetMultiplicities()[nodeIDOffset].fetch_add(multiplicity);
+    void incrementTargetMultiplicity(common::offset_t offset, uint64_t multiplicity) {
+        getCurTargetMultiplicities()[offset].fetch_add(multiplicity);
     }
 
     uint64_t getBoundMultiplicity(common::offset_t nodeOffset) {
@@ -110,7 +110,7 @@ public:
     };
 
     void beginWritingOutputsForDstNodesInTable(table_id_t tableID) override {
-        pathLengths->fixCurFrontierNodeTable(tableID);
+        pathLengths->pinCurFrontierTableID(tableID);
         multiplicities.fixTargetNodeTable(tableID);
     }
 
@@ -127,7 +127,7 @@ public:
     void write(FactorizedTable& fTable, nodeID_t dstNodeID,
         processor::GDSOutputCounter* counter) override {
         auto outputs = rjOutputs->ptrCast<AllSPDestinationsOutputs>();
-        auto length = outputs->pathLengths->getMaskValueFromCurFrontierFixedMask(dstNodeID.offset);
+        auto length = outputs->pathLengths->getMaskValueFromCurFrontier(dstNodeID.offset);
         dstNodeIDVector->setValue<nodeID_t>(0, dstNodeID);
         lengthVector->setValue<uint16_t>(0, length);
         auto multiplicity = outputs->multiplicities.getTargetMultiplicity(dstNodeID.offset);
@@ -155,13 +155,13 @@ public:
         std::vector<nodeID_t> activeNodes;
         resultChunk.forEach([&](auto nbrNodeID, auto /*edgeID*/) {
             auto nbrVal =
-                frontierPair->pathLengths->getMaskValueFromNextFrontierFixedMask(nbrNodeID.offset);
+                frontierPair->getPathLengths()->getMaskValueFromNextFrontier(nbrNodeID.offset);
             // We should update the nbrID's multiplicity in 2 cases: 1) if nbrID is being visited
             // for the first time, i.e., when its value in the pathLengths frontier is
             // PathLengths::UNVISITED. Or 2) if nbrID has already been visited but in this
             // iteration, so it's value is curIter + 1.
             auto shouldUpdate = nbrVal == PathLengths::UNVISITED ||
-                                nbrVal == frontierPair->pathLengths->getCurIter();
+                                nbrVal == frontierPair->getCurrentIter();
             if (shouldUpdate) {
                 // Note: This is safe because curNodeID is in the current frontier, so its
                 // shortest paths multiplicity is guaranteed to not change in the current iteration.
@@ -195,18 +195,18 @@ public:
         std::vector<nodeID_t> activeNodes;
         resultChunk.forEach([&](auto nbrNodeID, auto edgeID) {
             auto nbrLen =
-                frontierPair->pathLengths->getMaskValueFromNextFrontierFixedMask(nbrNodeID.offset);
-            // We should update the nbrID's multiplicity in 2 cases: 1) if nbrID is being visited
+                frontierPair->getPathLengths()->getMaskValueFromNextFrontier(nbrNodeID.offset);
+            // We should update in 2 cases: 1) if nbrID is being visited
             // for the first time, i.e., when its value in the pathLengths frontier is
             // PathLengths::UNVISITED. Or 2) if nbrID has already been visited but in this
             // iteration, so it's value is curIter + 1.
             auto shouldUpdate = nbrLen == PathLengths::UNVISITED ||
-                                nbrLen == frontierPair->pathLengths->getCurIter();
+                                nbrLen == frontierPair->getCurrentIter();
             if (shouldUpdate) {
                 if (!parentListBlock->hasSpace()) {
                     parentListBlock = bfsGraph->addNewBlock();
                 }
-                bfsGraph->addParent(frontierPair->curIter.load(std::memory_order_relaxed),
+                bfsGraph->addParent(frontierPair->getCurrentIter(),
                     parentListBlock, nbrNodeID /* child */, boundNodeID /* parent */, edgeID,
                     fwdEdge);
             }

--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -27,14 +27,14 @@ void FrontierTask::run() {
                 switch (info.direction) {
                 case ExtendDirection::FWD: {
                     for (auto chunk : graph->scanFwd(nodeID, *scanState)) {
-                        numActiveNodes += computeScanResult(nodeID, chunk,
-                            *localEc, sharedState->frontierPair, true);
+                        numActiveNodes += computeScanResult(nodeID, chunk, *localEc,
+                            sharedState->frontierPair, true);
                     }
                 } break;
                 case ExtendDirection::BWD: {
                     for (auto chunk : graph->scanBwd(nodeID, *scanState)) {
-                        numActiveNodes += computeScanResult(nodeID, chunk,
-                            *localEc, sharedState->frontierPair, false);
+                        numActiveNodes += computeScanResult(nodeID, chunk, *localEc,
+                            sharedState->frontierPair, false);
                     }
                 } break;
                 default:

--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -16,7 +16,7 @@ static uint64_t computeScanResult(nodeID_t sourceNodeID, graph::GraphScanState::
 
 void FrontierTask::run() {
     FrontierMorsel frontierMorsel;
-    auto numApproxActiveNodesForNextIter = 0u;
+    auto numActiveNodes = 0u;
     auto graph = info.graph;
     auto scanState = graph->prepareScan(info.relTableIDToScan);
     auto localEc = info.edgeCompute.copy();
@@ -27,13 +27,13 @@ void FrontierTask::run() {
                 switch (info.direction) {
                 case ExtendDirection::FWD: {
                     for (auto chunk : graph->scanFwd(nodeID, *scanState)) {
-                        numApproxActiveNodesForNextIter += computeScanResult(nodeID, chunk,
+                        numActiveNodes += computeScanResult(nodeID, chunk,
                             *localEc, sharedState->frontierPair, true);
                     }
                 } break;
                 case ExtendDirection::BWD: {
                     for (auto chunk : graph->scanBwd(nodeID, *scanState)) {
-                        numApproxActiveNodesForNextIter += computeScanResult(nodeID, chunk,
+                        numActiveNodes += computeScanResult(nodeID, chunk,
                             *localEc, sharedState->frontierPair, false);
                     }
                 } break;
@@ -43,8 +43,9 @@ void FrontierTask::run() {
             }
         }
     }
-    sharedState->frontierPair.incrementApproxActiveNodesForNextIter(
-        numApproxActiveNodesForNextIter);
+    if (numActiveNodes) {
+        sharedState->frontierPair.setActiveNodesForNextIter();
+    }
 }
 
 void VertexComputeTask::run() {

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -40,7 +40,7 @@ void GDSUtils::runFrontiersUntilConvergence(processor::ExecutionContext* context
     auto frontierPair = rjCompState.frontierPair.get();
     auto outputNodeMask = rjCompState.outputWriter->getOutputNodeMask();
     rjCompState.edgeCompute->resetSingleThreadState();
-    while (frontierPair->hasActiveNodesForNextLevel() && frontierPair->getNextIter() <= maxIters) {
+    while (frontierPair->hasActiveNodesForNextIter() && frontierPair->getNextIter() <= maxIters) {
         frontierPair->beginNewIteration();
         if (outputNodeMask->enabled() && rjCompState.edgeCompute->terminate(*outputNodeMask)) {
             break;

--- a/src/function/gds/output_writer.cpp
+++ b/src/function/gds/output_writer.cpp
@@ -278,8 +278,8 @@ DestinationsOutputWriter::DestinationsOutputWriter(main::ClientContext* context,
 
 void DestinationsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNodeID,
     GDSOutputCounter* counter) {
-    auto length = rjOutputs->ptrCast<SPOutputs>()->pathLengths->getMaskValueFromCurFrontier(
-            dstNodeID.offset);
+    auto length =
+        rjOutputs->ptrCast<SPOutputs>()->pathLengths->getMaskValueFromCurFrontier(dstNodeID.offset);
     dstNodeIDVector->setValue<nodeID_t>(0, dstNodeID);
     setLength(lengthVector.get(), length);
     fTable.append(vectors);
@@ -291,7 +291,8 @@ void DestinationsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_
 
 bool DestinationsOutputWriter::skipInternal(common::nodeID_t dstNodeID) const {
     auto outputs = rjOutputs->ptrCast<SPOutputs>();
-    return dstNodeID == outputs->sourceNodeID || outputs->pathLengths->getMaskValueFromCurFrontier(dstNodeID.offset) == PathLengths::UNVISITED;
+    return dstNodeID == outputs->sourceNodeID || outputs->pathLengths->getMaskValueFromCurFrontier(
+                                                     dstNodeID.offset) == PathLengths::UNVISITED;
 }
 
 } // namespace function

--- a/src/function/gds/single_shortest_paths.cpp
+++ b/src/function/gds/single_shortest_paths.cpp
@@ -26,7 +26,7 @@ struct SingleSPDestinationsOutputs : public SPOutputs {
     void beginFrontierComputeBetweenTables(table_id_t, table_id_t) override{};
 
     void beginWritingOutputsForDstNodesInTable(table_id_t tableID) override {
-        pathLengths->fixCurFrontierNodeTable(tableID);
+        pathLengths->pinCurFrontierTableID(tableID);
     }
 };
 
@@ -39,8 +39,7 @@ public:
         bool) override {
         std::vector<nodeID_t> activeNodes;
         resultChunk.forEach([&](auto nbrNode, auto) {
-            if (frontierPair->pathLengths->getMaskValueFromNextFrontierFixedMask(nbrNode.offset) ==
-                PathLengths::UNVISITED) {
+            if (frontierPair->getPathLengths()->getMaskValueFromNextFrontier(nbrNode.offset) == PathLengths::UNVISITED) {
                 activeNodes.push_back(nbrNode);
             }
         });
@@ -63,13 +62,11 @@ public:
         bool isFwd) override {
         std::vector<nodeID_t> activeNodes;
         resultChunk.forEach([&](auto nbrNodeID, auto edgeID) {
-            auto shouldUpdate = frontierPair->pathLengths->getMaskValueFromNextFrontierFixedMask(
-                                    nbrNodeID.offset) == PathLengths::UNVISITED;
-            if (shouldUpdate) {
+            if (frontierPair->getPathLengths()->getMaskValueFromNextFrontier(nbrNodeID.offset) == PathLengths::UNVISITED) {
                 if (!parentListBlock->hasSpace()) {
                     parentListBlock = bfsGraph->addNewBlock();
                 }
-                bfsGraph->tryAddSingleParent(frontierPair->curIter.load(std::memory_order_relaxed),
+                bfsGraph->tryAddSingleParent(frontierPair->getCurrentIter(),
                     parentListBlock, nbrNodeID /* child */, boundNodeID /* parent */, edgeID,
                     isFwd);
                 activeNodes.push_back(nbrNodeID);

--- a/src/function/gds/single_shortest_paths.cpp
+++ b/src/function/gds/single_shortest_paths.cpp
@@ -39,7 +39,8 @@ public:
         bool) override {
         std::vector<nodeID_t> activeNodes;
         resultChunk.forEach([&](auto nbrNode, auto) {
-            if (frontierPair->getPathLengths()->getMaskValueFromNextFrontier(nbrNode.offset) == PathLengths::UNVISITED) {
+            if (frontierPair->getPathLengths()->getMaskValueFromNextFrontier(nbrNode.offset) ==
+                PathLengths::UNVISITED) {
                 activeNodes.push_back(nbrNode);
             }
         });
@@ -62,13 +63,13 @@ public:
         bool isFwd) override {
         std::vector<nodeID_t> activeNodes;
         resultChunk.forEach([&](auto nbrNodeID, auto edgeID) {
-            if (frontierPair->getPathLengths()->getMaskValueFromNextFrontier(nbrNodeID.offset) == PathLengths::UNVISITED) {
+            if (frontierPair->getPathLengths()->getMaskValueFromNextFrontier(nbrNodeID.offset) ==
+                PathLengths::UNVISITED) {
                 if (!parentListBlock->hasSpace()) {
                     parentListBlock = bfsGraph->addNewBlock();
                 }
-                bfsGraph->tryAddSingleParent(frontierPair->getCurrentIter(),
-                    parentListBlock, nbrNodeID /* child */, boundNodeID /* parent */, edgeID,
-                    isFwd);
+                bfsGraph->tryAddSingleParent(frontierPair->getCurrentIter(), parentListBlock,
+                    nbrNodeID /* child */, boundNodeID /* parent */, edgeID, isFwd);
                 activeNodes.push_back(nbrNodeID);
             }
         });

--- a/src/function/gds/variable_length_path.cpp
+++ b/src/function/gds/variable_length_path.cpp
@@ -22,17 +22,16 @@ public:
 
     bool skipInternal(common::nodeID_t dstNodeID) const override {
         auto pathsOutputs = rjOutputs->ptrCast<PathsOutputs>();
-        auto firstParent = pathsOutputs->bfsGraph.getCurFixedParentPtrs()[dstNodeID.offset].load(
-            std::memory_order_relaxed);
+        auto head = pathsOutputs->bfsGraph.getParentListHead(dstNodeID.offset);
         // For variable lengths joins, we skip a destination node d in the following conditions:
         //    (i) if no path has reached d from the source, except when the lower bound is 0.
         //    (ii) the longest path that has reached d, which is stored in the iter value of the
         //    firstParent is smaller than the lower bound.
         // We also do not output any results if a destination node has not been reached.
-        if (nullptr == firstParent) {
+        if (nullptr == head) {
             return info.lowerBound > 0;
         } else {
-            return firstParent->getIter() < info.lowerBound;
+            return head->getIter() < info.lowerBound;
         }
     }
 
@@ -61,7 +60,6 @@ struct VarLenJoinsEdgeCompute : public EdgeCompute {
             }
             bfsGraph->addParent(frontierPair->getCurrentIter(), parentPtrsBlock,
                 nbrNode /* child */, boundNodeID /* parent */, edgeID, isFwd);
-
             activeNodes.push_back(nbrNode);
         });
         return activeNodes;
@@ -128,15 +126,17 @@ private:
     RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
         auto mm = clientContext->getMemoryManager();
-        auto nodeTableToNumNodes = sharedState->graph->getNumNodesMap(clientContext->getTx());
-        auto output = std::make_unique<PathsOutputs>(nodeTableToNumNodes, sourceNodeID, mm);
+        auto numNodesMap = sharedState->graph->getNumNodesMap(clientContext->getTx());
+        auto output = std::make_unique<PathsOutputs>(numNodesMap, sourceNodeID, mm);
         auto rjBindData = bindData->ptrCast<RJBindData>();
         auto writerInfo = rjBindData->getPathWriterInfo();
         writerInfo.pathNodeMask = sharedState->getPathNodeMaskMap();
         auto outputWriter = std::make_unique<VarLenPathsOutputWriter>(clientContext, output.get(),
             sharedState->getOutputNodeMaskMap(), std::move(writerInfo));
-        auto frontierPair = std::make_unique<DoublePathLengthsFrontierPair>(nodeTableToNumNodes,
-            clientContext->getMaxNumThreadForExec(), mm);
+        auto currentFrontier = std::make_shared<PathLengths>(numNodesMap, mm);
+        auto nextFrontier = std::make_shared<PathLengths>(numNodesMap, mm);
+        auto frontierPair = std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier, nextFrontier,
+            clientContext->getMaxNumThreadForExec());
         auto edgeCompute =
             std::make_unique<VarLenJoinsEdgeCompute>(frontierPair.get(), &output->bfsGraph);
         return RJCompState(std::move(frontierPair), std::move(edgeCompute), std::move(output),

--- a/src/function/gds/variable_length_path.cpp
+++ b/src/function/gds/variable_length_path.cpp
@@ -135,8 +135,8 @@ private:
             sharedState->getOutputNodeMaskMap(), std::move(writerInfo));
         auto currentFrontier = std::make_shared<PathLengths>(numNodesMap, mm);
         auto nextFrontier = std::make_shared<PathLengths>(numNodesMap, mm);
-        auto frontierPair = std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier, nextFrontier,
-            clientContext->getMaxNumThreadForExec());
+        auto frontierPair = std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier,
+            nextFrontier, clientContext->getMaxNumThreadForExec());
         auto edgeCompute =
             std::make_unique<VarLenJoinsEdgeCompute>(frontierPair.get(), &output->bfsGraph);
         return RJCompState(std::move(frontierPair), std::move(edgeCompute), std::move(output),

--- a/src/include/function/gds/bfs_graph.h
+++ b/src/include/function/gds/bfs_graph.h
@@ -81,8 +81,12 @@ public:
         return blocks[blocks.size() - 1].get();
     }
 
-    ParentList* getInitialParentAndNextPtr(common::nodeID_t nodeID) {
+    ParentList* getParentListHead(common::nodeID_t nodeID) {
         return parentArray.getData(nodeID.tableID)[nodeID.offset].load(std::memory_order_relaxed);
+    }
+    ParentList* getParentListHead(common::offset_t offset) {
+        KU_ASSERT(currParentPtrs.load(std::memory_order_relaxed) != nullptr);
+        return currParentPtrs.load(std::memory_order_relaxed)[offset].load(std::memory_order_relaxed);
     }
 
     // Warning: Make sure hasSpace has returned true on parentPtrBlock already before calling this
@@ -115,10 +119,6 @@ public:
             // Do NOT add parent and revert reserved slot.
             parentListBlock->revertLast();
         }
-    }
-
-    parent_entry_t* getCurFixedParentPtrs() {
-        return currParentPtrs.load(std::memory_order_relaxed);
     }
 
     void pinNodeTable(common::table_id_t tableID) {

--- a/src/include/function/gds/bfs_graph.h
+++ b/src/include/function/gds/bfs_graph.h
@@ -86,7 +86,8 @@ public:
     }
     ParentList* getParentListHead(common::offset_t offset) {
         KU_ASSERT(currParentPtrs.load(std::memory_order_relaxed) != nullptr);
-        return currParentPtrs.load(std::memory_order_relaxed)[offset].load(std::memory_order_relaxed);
+        return currParentPtrs.load(std::memory_order_relaxed)[offset].load(
+            std::memory_order_relaxed);
     }
 
     // Warning: Make sure hasSpace has returned true on parentPtrBlock already before calling this

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -250,9 +250,7 @@ public:
         return morselDispatcher.getNextRangeMorsel(morsel);
     }
 
-    void setActiveNodesForNextIter() {
-        hasActiveNodesForNextIter_.store(true);
-    }
+    void setActiveNodesForNextIter() { hasActiveNodesForNextIter_.store(true); }
     bool hasActiveNodesForNextIter() { return hasActiveNodesForNextIter_.load(); }
     void beginNewIteration();
 
@@ -283,8 +281,10 @@ protected:
 
 class SinglePathLengthsFrontierPair : public FrontierPair {
 public:
-    SinglePathLengthsFrontierPair(std::shared_ptr<PathLengths> pathLengths, uint64_t maxThreadsForExec)
-        : FrontierPair(pathLengths /* curFrontier */, pathLengths /* nextFrontier */, maxThreadsForExec),
+    SinglePathLengthsFrontierPair(std::shared_ptr<PathLengths> pathLengths,
+        uint64_t maxThreadsForExec)
+        : FrontierPair(pathLengths /* curFrontier */, pathLengths /* nextFrontier */,
+              maxThreadsForExec),
           pathLengths{pathLengths} {}
 
     PathLengths* getPathLengths() const { return pathLengths.get(); }
@@ -302,8 +302,9 @@ private:
 
 class DoublePathLengthsFrontierPair : public FrontierPair {
 public:
-    DoublePathLengthsFrontierPair(std::shared_ptr<PathLengths> curFrontier, std::shared_ptr<PathLengths> nextFrontier,
-        uint64_t maxThreadsForExec) : FrontierPair{curFrontier, nextFrontier, maxThreadsForExec} {}
+    DoublePathLengthsFrontierPair(std::shared_ptr<PathLengths> curFrontier,
+        std::shared_ptr<PathLengths> nextFrontier, uint64_t maxThreadsForExec)
+        : FrontierPair{curFrontier, nextFrontier, maxThreadsForExec} {}
 
     void initRJFromSource(common::nodeID_t source) override;
 

--- a/src/include/function/gds/output_writer.h
+++ b/src/include/function/gds/output_writer.h
@@ -171,8 +171,7 @@ protected:
         // For single/all shortest path computations, we do not output any results from source to
         // source. We also do not output any results if a destination node has not been reached.
         return dstNodeID == pathsOutputs->sourceNodeID ||
-               nullptr == pathsOutputs->bfsGraph.getCurFixedParentPtrs()[dstNodeID.offset].load(
-                              std::memory_order_relaxed);
+               nullptr == pathsOutputs->bfsGraph.getParentListHead(dstNodeID.offset);
     }
 };
 


### PR DESCRIPTION
# Description

Clean up some GDS interfaces

- rename `fixXXXTable` to `pinXXXTableID` so that naming is consistent.
- remove `approximateNumNodesInNextFrontier` and replace with `hasActiveNodesInNextFrontier`. We only use this number of check whether there are active nodes in next frontier so might as well just keep a boolean.
- remove some friend class and not directly expose member field.
- construct frontier outside of frontierPair to simplify the constructor of frontierPair.
- use a private typedef `frontier_entry_t` to simplify complex type declaration like `std::atomic<std::atomic<uint16_t>*>`

As I implement more optimization these interfaces shall continue evolve.

Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).