### PR TITLE
Using shared_mutex instead of mutex in CatalogSet

### DIFF
--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -210,7 +210,7 @@ CatalogEntrySet CatalogSet::getEntries(const Transaction* transaction) {
 }
 
 void CatalogSet::iterateEntriesOfType(const Transaction* transaction, CatalogEntryType type,
-    const std::function<void(CatalogEntry*)>& func) {
+    const std::function<void(const CatalogEntry*)>& func) {
     std::shared_lock lck{mtx};
     for (auto& [_, entry] : entries) {
         if (entry->getType() != CatalogEntryType::DUMMY_ENTRY && entry->getType() != type) {

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -1,5 +1,7 @@
 #include "catalog/catalog_set.h"
 
+#include <mutex>
+
 #include "binder/ddl/bound_alter_info.h"
 #include "catalog/catalog_entry/dummy_catalog_entry.h"
 #include "catalog/catalog_entry/table_catalog_entry.h"

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -162,8 +162,9 @@ private:
     std::vector<T*> getTableCatalogEntries(transaction::Transaction* transaction,
         CatalogEntryType catalogType) const {
         std::vector<T*> result;
-        tables->iterateEntriesOfType(transaction, catalogType,
-            [&](CatalogEntry* entry) { result.push_back(common::ku_dynamic_cast<T*>(entry)); });
+        tables->iterateEntriesOfType(transaction, catalogType, [&](const CatalogEntry* entry) {
+            result.push_back(const_cast<T*>(common::ku_dynamic_cast<const T*>(entry)));
+        });
         return result;
     }
 

--- a/src/include/catalog/catalog_set.h
+++ b/src/include/catalog/catalog_set.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <functional>
-#include <mutex>
+#include <shared_mutex>
 
 #include "catalog_entry/catalog_entry.h"
 #include "common/case_insensitive_map.h"
@@ -68,7 +68,7 @@ private:
     static CatalogEntry* getCommittedEntryNoLock(CatalogEntry* entry);
 
 private:
-    std::mutex mtx;
+    std::shared_mutex mtx;
     common::oid_t nextOID = 0;
     common::case_insensitive_map_t<std::unique_ptr<CatalogEntry>> entries;
 };

--- a/src/include/catalog/catalog_set.h
+++ b/src/include/catalog/catalog_set.h
@@ -36,7 +36,7 @@ public:
 
     CatalogEntrySet getEntries(const transaction::Transaction* transaction);
     void iterateEntriesOfType(const transaction::Transaction* transaction, CatalogEntryType type,
-        const std::function<void(CatalogEntry*)>& func);
+        const std::function<void(const CatalogEntry*)>& func);
     CatalogEntry* getEntryOfOID(const transaction::Transaction* transaction, common::oid_t oid);
 
     void serialize(common::Serializer serializer) const;


### PR DESCRIPTION
# Description

With 50 concurrent short queries, mutex becomes a performance bottleneck.

DataStet: Sf100
Concurrency: 50
Query: match (a:person {id:24189255912498})-[f]-(b) return count(1) ;
Throughput(QPS): 11645.5-->19364.1

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).