### PR TITLE
Add check of test file name on `-`, fix doc_example.test of JSON extension

### DIFF
--- a/extension/json/test/doc_examples.test
+++ b/extension/json/test/doc_examples.test
@@ -29,27 +29,26 @@
 -STATEMENT LOAD FROM '${KUZU_ROOT_DIRECTORY}/dataset/doc-examples-json/people-unstructured.json' (format='unstructured', sample_size=1) RETURN * ORDER BY id DESC;
 ---- 3
 2|Gregory
-1|Bob
+1|Bobtgyhj
 0|Alice
 
 -STATEMENT LOAD FROM '${KUZU_ROOT_DIRECTORY}/dataset/doc-examples-json/people-unstructured.json' (format='unstructured', sample_size=2) RETURN *;
----- 3
+---- 2
 2│Gregory│
-1│Bob│{"height":1.81,"age":71,"previousUsernames":["theBuilder","theMinion"]}│
-0│Alice│{"height":1.68,"age":45,"previousUsernames":["obviouslyAlice","definitelyNotAlice"]}│2024-07-31
+1│Bob│{"height":1.81,"age":71,"pnames":["obviouslyAlice","definitelyNotAlice"]}│2024-07-31
 
 -CASE CopyFromTest
 -STATEMENT LOAD EXTENSION "${KUZU_ROOT_DIRECTORY}/extension/json/build/libjson.kuzu_extension";
 ---- ok
--STATEMENT CREATE NODE TABLE Person (id SERIAL, name STRING, info STRUCT(height DOUBLE, age INT64, registryDate DATE previousUsernames STRING[]), PRIMARY KEY(id));
+-STATEMENT CREATE NODE TABLE Person (id SERIAL, name STRING, registryDate DATE, info STRUCT(height DOUBLE, age INT64, previousUsernames STRING[]), PRIMARY KEY(id));
 ---- ok
 -STATEMENT COPY Person FROM '${KUZU_ROOT_DIRECTORY}/dataset/doc-examples-json/people.json';
 ---- ok
 -STATEMENT MATCH (p:Person) return p.* ORDER BY p.id DESC;
 ---- 3
-2│Gregory││
-1│Bob││{height: 1.810000, age: 71, previousUsernames: [theBuilder,theMinion]}
-0│Alice│2024-07-31│{height: 1.680000, age: 45, previousUsernames: [obviouslyAlice,definitelyNotAlice]}
+0|Gregory||
+1|Bob||{height: 1.810000, age: 71, previousUsernames: [theBuilder,theMinion]}
+2|Alice|2024-07-31|{height: 1.680000, age: 45, previousUsernames: [obviouslyAlice,definitelyNotAlice]}
 -STATEMENT DROP TABLE Person;
 ---- ok
 -STATEMENT CREATE NODE TABLE Person (id SERIAL, name STRING, info STRUCT(height DOUBLE, age INT64, previousUsernames STRING[]), PRIMARY KEY(id));
@@ -64,9 +63,9 @@
 ---- ok
 -STATEMENT LOAD FROM '${DATABASE_PATH}/people-output.json' RETURN *;
 ---- 3
-0│Alice│{height: 1.680000, age: 45, previousUsernames: [obviouslyAlice,definitelyNotAlice]}
-1│Bob│{height: 1.810000, age: 71, previousUsernames: [theBuilder,theMinion]}
-2│Gregory│{height: 1.730000, age: 22, previousUsernames: [gregory7]}
+0|Alice|{height: 1.680000, age: 45, previousUsernames: [obviouslyAlice,definitelyNotAlice]}
+1|Bob|{height: 1.810000, age: 71, previousUsernames: [theBuilder,theMinion]}
+2|Gregory|{height: 1.730000, age: 22, previousUsernames: [gregory7]}
 
 -CASE JsonTypeDoc
 -STATEMENT LOAD EXTENSION "${KUZU_ROOT_DIRECTORY}/extension/json/build/libjson.kuzu_extension";

--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -103,6 +103,11 @@ private:
 };
 
 void parseAndRegisterTestGroup(const std::string& path, bool generateTestList = false) {
+    // Check for invalid characters in the file name (see ISSUE 4510)
+    auto filename = std::filesystem::path(path).filename().string();
+    if (filename.find('-') != std::string::npos) {
+        throw TestException("Invalid test file name containing '-': " + filename);
+    }
     auto testParser = std::make_unique<TestParser>(path);
     auto testGroup = testParser->parseTestFile();
     if (testGroup->isValid() && testGroup->hasStatements()) {


### PR DESCRIPTION
# Description

We should not all `-` in the test file name because `-` has special meaning of exempt in google test frame

this caused our `doc-example.test` never being run before

Added a exception throw in e2e_test.cpp to check if the test file name has `-`

Fixes #4510 

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).