### PR TITLE
Avoid importing polars in arrow scan

### DIFF
--- a/tools/python_api/src_cpp/include/cached_import/py_cached_modules.h
+++ b/tools/python_api/src_cpp/include/cached_import/py_cached_modules.h
@@ -94,6 +94,9 @@ public:
 
 class PolarsCachedItem : public PythonCachedItem {
 public:
+    static constexpr const char* name_ = "polars";
+
+public:
     PolarsCachedItem() : PythonCachedItem("polars"), DataFrame("DataFrame", this) {}
 
     PythonCachedItem DataFrame;


### PR DESCRIPTION
This PR removes the dependency of polars library when scanning from arrow.