### PR TITLE
Use a flag to determine if the SelectionVector uses INCREMENTAL_SELECTED_POS

### DIFF
--- a/src/include/common/data_chunk/sel_vector.h
+++ b/src/include/common/data_chunk/sel_vector.h
@@ -10,37 +10,51 @@ namespace kuzu {
 namespace common {
 
 class SelectionVector {
-public:
     KUZU_API static const std::array<sel_t, DEFAULT_VECTOR_CAPACITY> INCREMENTAL_SELECTED_POS;
 
+    // In DYNAMIC mode, selectedPositions points to a mutable buffer that can be modified through
+    // getMutableBuffer In STATIC mode, selectedPositions points to the beginning of
+    // INCREMENTAL_SELECTED_POS In STATIC_FILTERED mode, selectedPositions points to some position
+    // in INCREMENTAL_SELECTED_POS
+    //      If reading manually in STATIC_FILTERED mode, you should read getSelectedPositions()[0],
+    //      and then you can assume that the next getSelSize() positions are selected
+    //      (This also works in STATIC mode)
+    enum class State {
+        DYNAMIC,
+        STATIC,
+        STATIC_FILTERED,
+    };
+
+public:
     explicit SelectionVector(sel_t capacity)
-        : selectedSize{0}, capacity{capacity}, selectedPositions{nullptr} {
+        : selectedSize{0}, capacity{capacity}, selectedPositions{nullptr}, state{State::STATIC} {
         selectedPositionsBuffer = std::make_unique<sel_t[]>(capacity);
         setToUnfiltered();
     }
 
     SelectionVector() : SelectionVector{DEFAULT_VECTOR_CAPACITY} {}
 
-    bool isUnfiltered() const { return selectedPositions == INCREMENTAL_SELECTED_POS.data(); }
-    bool isContinuous() const {
-        return selectedPositions >= &*INCREMENTAL_SELECTED_POS.begin() &&
-               selectedPositions <= &*INCREMENTAL_SELECTED_POS.end();
-    }
+    bool isUnfiltered() const { return state == State::STATIC && selectedPositions[0] == 0; }
 
     void setToUnfiltered() {
         selectedPositions = const_cast<sel_t*>(INCREMENTAL_SELECTED_POS.data());
+        state = State::STATIC;
     }
     void setToUnfiltered(sel_t size) {
         KU_ASSERT(size <= capacity);
         selectedPositions = const_cast<sel_t*>(INCREMENTAL_SELECTED_POS.data());
         selectedSize = size;
+        state = State::STATIC;
     }
 
     // Set to filtered is not very accurate. It sets selectedPositions to a mutable array.
-    void setToFiltered() { selectedPositions = selectedPositionsBuffer.get(); }
+    void setToFiltered() {
+        selectedPositions = selectedPositionsBuffer.get();
+        state = State::DYNAMIC;
+    }
     void setToFiltered(sel_t size) {
         KU_ASSERT(size <= capacity && selectedPositionsBuffer);
-        selectedPositions = selectedPositionsBuffer.get();
+        setToFiltered();
         selectedSize = size;
     }
 
@@ -53,14 +67,14 @@ public:
 
     template<class Func>
     void forEach(Func&& func) const {
-        if (isContinuous()) {
+        if (state == State::DYNAMIC) {
+            for (size_t i = 0; i < selectedSize; i++) {
+                func(selectedPositions[i]);
+            }
+        } else {
             const auto start = selectedPositions[0];
             for (size_t i = start; i < start + selectedSize; i++) {
                 func(i);
-            }
-        } else {
-            for (size_t i = 0; i < selectedSize; i++) {
-                func(selectedPositions[i]);
             }
         }
     }
@@ -89,6 +103,7 @@ private:
     sel_t capacity;
     std::unique_ptr<sel_t[]> selectedPositionsBuffer;
     sel_t* selectedPositions;
+    State state;
 };
 
 } // namespace common

--- a/src/processor/operator/hash_join/join_hash_table.cpp
+++ b/src/processor/operator/hash_join/join_hash_table.cpp
@@ -64,8 +64,7 @@ static void sortSelectedPos(ValueVector* nodeIDVector) {
     auto size = selVector.getSelSize();
     auto buffer = selVector.getMutableBuffer();
     if (selVector.isUnfiltered()) {
-        std::memcpy(buffer.data(), &SelectionVector::INCREMENTAL_SELECTED_POS,
-            size * sizeof(sel_t));
+        std::memcpy(buffer.data(), selVector.getSelectedPositions().data(), size * sizeof(sel_t));
         selVector.setToFiltered();
     }
     std::sort(buffer.begin(), buffer.begin() + size, [nodeIDVector](sel_t left, sel_t right) {


### PR DESCRIPTION
Instead of comparing addresses. There may be multiple addresses for `INCREMENTAL_SELECTED_POS` on windows when used in extensions (I guess it's something to do with the static linking done with the extensions, so the extension gets its own version of `INCREMENTAL_STATIC_POS`, but may interact with functions/data that were built using a different definition).

Fixes #4549

I also made `SelectionVector::INCREMENTAL_SELECTED_POS` private as it's an implementation detail that doesn't need to be exposed and the only place outside of SelectionVector which uses it can be rewritten to use `getSelectedPositions` instead.