### PR TITLE
Fix VersionInfo SelectionVector creation

### DIFF
--- a/src/include/common/data_chunk/sel_vector.h
+++ b/src/include/common/data_chunk/sel_vector.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string.h>
+
 #include <memory>
 
 #include "common/constants.h"
@@ -56,6 +58,13 @@ public:
         KU_ASSERT(size <= capacity && selectedPositionsBuffer);
         setToFiltered();
         selectedSize = size;
+    }
+
+    // Copies the data in selectedPositions into selectedPositionsBuffer
+    void makeDynamic() {
+        memcpy(selectedPositionsBuffer.get(), selectedPositions, selectedSize * sizeof(sel_t));
+        state = State::DYNAMIC;
+        selectedPositions = selectedPositionsBuffer.get();
     }
 
     std::span<sel_t> getMutableBuffer() const {

--- a/src/storage/store/version_info.cpp
+++ b/src/storage/store/version_info.cpp
@@ -100,6 +100,11 @@ void VectorVersionInfo::getSelVectorForScan(const transaction_t startTS,
             selVector.setToFiltered(numSelected);
         }
     } else if (insertionStatus != InsertionStatus::NO_INSERTED) {
+        // If there were no deleted values up to this point the selVector may be unfiltered but have
+        // non-zero size, and the mutable buffer may have arbitrary contents
+        if (selVector.isUnfiltered()) {
+            selVector.makeDynamic();
+        }
         for (auto i = 0u; i < numRows; i++) {
             if (const auto rowIdx = startRow + i; isInserted(startTS, transactionID, rowIdx) &&
                                                   !isDeleted(startTS, transactionID, rowIdx)) {

--- a/test/test_files/dml_rel/delete/delete_ldbc_sf01.test
+++ b/test/test_files/dml_rel/delete/delete_ldbc_sf01.test
@@ -1,9 +1,7 @@
 -DATASET CSV ldbc-sf01
 --
 
-# FIX-ME(Guodong): https://github.com/kuzudb/kuzu/issues/4271
 -CASE DeleteLikeComment1
--SKIP
 -STATEMENT MATCH (n:Person)-[e:likes_Comment]->(m:Comment) WHERE n.id=6597069767457 RETURN COUNT(*);
 ---- 1
 66


### PR DESCRIPTION
Fixes #4271.

The issue was that `VersionInfo::getSelVectorForScan` (and `VectorVersionInfo::getSelVectorForScan`) append repeatedly to a `SelectionVector` and in certain circumstances it will turn a non-empty unfiltered SelectionVector into a filtered one without preserving the former values and then just appending to the end. My solution was to add a new makeDynamic function that copies the old selectedPositions into the mutable buffer before switching them.

E.g. this can occur when the first few VectorVersionInfos have no deletions, such that the first branch is taken in `VectorVersionInfo::getSelVectorToScan` and it just increases the length of the unfiltered SelectionVector, but then later VectorVersionInfos have deletions, taking the second branch where there is no check for unfiltered data (since it has to be converted to filtered at that point).