### PR TITLE
Add sparse frontier implementation

### DIFF
--- a/extension/fts/src/function/query_fts_gds.cpp
+++ b/extension/fts/src/function/query_fts_gds.cpp
@@ -147,8 +147,9 @@ void runFrontiersOnce(processor::ExecutionContext* executionContext, QFTSState& 
     auto& appearsInTableInfo = relTableIDInfos[0];
     frontierPair->beginFrontierComputeBetweenTables(appearsInTableInfo.fromNodeTableID,
         appearsInTableInfo.toNodeTableID);
-    GDSUtils::scheduleFrontierTask(appearsInTableInfo.toNodeTableID, appearsInTableInfo.relTableID, graph, ExtendDirection::FWD,
-        qFtsState, executionContext, 1 /* numThreads */, tfPropertyIdx);
+    GDSUtils::scheduleFrontierTask(appearsInTableInfo.toNodeTableID, appearsInTableInfo.relTableID,
+        graph, ExtendDirection::FWD, qFtsState, executionContext, 1 /* numThreads */,
+        tfPropertyIdx);
 }
 
 class QFTSOutputWriter {

--- a/src/function/gds/gds_frontier.cpp
+++ b/src/function/gds/gds_frontier.cpp
@@ -6,7 +6,8 @@ namespace kuzu {
 namespace function {
 
 FrontierMorselDispatcher::FrontierMorselDispatcher(uint64_t maxThreads)
-    : tableID{INVALID_TABLE_ID}, maxOffset{INVALID_OFFSET}, maxThreads{maxThreads}, morselSize(UINT64_MAX) {
+    : tableID{INVALID_TABLE_ID}, maxOffset{INVALID_OFFSET}, maxThreads{maxThreads},
+      morselSize(UINT64_MAX) {
     nextOffset.store(INVALID_OFFSET);
 }
 
@@ -17,8 +18,8 @@ void FrontierMorselDispatcher::init(common::table_id_t _tableID, common::offset_
     // Frontier size calculation: The ideal scenario is to have k^2 many morsels where k
     // the number of maximum threads that could be working on this frontier. However, if
     // that is too small then we default to MIN_FRONTIER_MORSEL_SIZE.
-    auto idealMorselSize = maxOffset /
-                           std::max(MIN_NUMBER_OF_FRONTIER_MORSELS, maxThreads * maxThreads);
+    auto idealMorselSize =
+        maxOffset / std::max(MIN_NUMBER_OF_FRONTIER_MORSELS, maxThreads * maxThreads);
     morselSize = std::max(MIN_FRONTIER_MORSEL_SIZE, idealMorselSize);
 }
 
@@ -27,8 +28,8 @@ bool FrontierMorselDispatcher::getNextRangeMorsel(FrontierMorsel& frontierMorsel
     if (beginOffset >= maxOffset) {
         return false;
     }
-    auto endOffset = beginOffset + morselSize > maxOffset ?  maxOffset : beginOffset + morselSize;
-    frontierMorsel.init(tableID, beginOffset,endOffset);
+    auto endOffset = beginOffset + morselSize > maxOffset ? maxOffset : beginOffset + morselSize;
+    frontierMorsel.init(tableID, beginOffset, endOffset);
     return true;
 }
 
@@ -120,7 +121,8 @@ void PathLengthsInitVertexCompute::vertexCompute(common::offset_t startOffset,
 
 FrontierPair::FrontierPair(std::shared_ptr<GDSFrontier> curFrontier,
     std::shared_ptr<GDSFrontier> nextFrontier, uint64_t maxThreadsForExec)
-    : curDenseFrontier{curFrontier}, nextDenseFrontier{nextFrontier}, morselDispatcher{maxThreadsForExec} {
+    : curDenseFrontier{curFrontier}, nextDenseFrontier{nextFrontier},
+      morselDispatcher{maxThreadsForExec} {
     curSparseFrontier = std::make_shared<SparseFrontier>();
     nextSparseFrontier = std::make_shared<SparseFrontier>();
     vertexComputeCandidates = std::make_shared<SparseFrontier>();
@@ -138,7 +140,8 @@ void FrontierPair::beginNewIteration() {
     beginNewIterationInternalNoLock();
 }
 
-void FrontierPair::beginFrontierComputeBetweenTables(common::table_id_t curTableID, common::table_id_t nextTableID) {
+void FrontierPair::beginFrontierComputeBetweenTables(common::table_id_t curTableID,
+    common::table_id_t nextTableID) {
     pinCurrFrontier(curTableID);
     pinNextFrontier(nextTableID);
     morselDispatcher.init(curTableID, curDenseFrontier->getNumNodes(curTableID));

--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -34,8 +34,8 @@ void FrontierTask::run() {
                 }
                 nodeID_t nodeID = {offset, morsel.getTableID()};
                 for (auto chunk : graph->scanFwd(nodeID, *scanState)) {
-                    numActiveNodes += runEdgeCompute(nodeID, chunk,
-                        *localEc, sharedState->frontierPair, true, localFrontier);
+                    numActiveNodes += runEdgeCompute(nodeID, chunk, *localEc,
+                        sharedState->frontierPair, true, localFrontier);
                 }
             }
         }
@@ -48,8 +48,8 @@ void FrontierTask::run() {
                 }
                 nodeID_t nodeID = {offset, morsel.getTableID()};
                 for (auto chunk : graph->scanBwd(nodeID, *scanState)) {
-                    numActiveNodes += runEdgeCompute(nodeID, chunk,
-                        *localEc, sharedState->frontierPair, false, localFrontier);
+                    numActiveNodes += runEdgeCompute(nodeID, chunk, *localEc,
+                        sharedState->frontierPair, false, localFrontier);
                 }
             }
         }
@@ -76,8 +76,8 @@ void FrontierTask::runSparse() {
         for (auto& offset : curFrontier.getOffsetSet()) {
             auto nodeID = nodeID_t{offset, curFrontier.getTableID()};
             for (auto chunk : graph->scanFwd(nodeID, *scanState)) {
-                numActiveNodes += runEdgeCompute(nodeID, chunk,
-                    *localEc, sharedState->frontierPair, true, localFrontier);
+                numActiveNodes += runEdgeCompute(nodeID, chunk, *localEc, sharedState->frontierPair,
+                    true, localFrontier);
             }
         }
     } break;
@@ -85,8 +85,8 @@ void FrontierTask::runSparse() {
         for (auto& offset : curFrontier.getOffsetSet()) {
             auto nodeID = nodeID_t{offset, curFrontier.getTableID()};
             for (auto chunk : graph->scanBwd(nodeID, *scanState)) {
-                numActiveNodes += runEdgeCompute(nodeID, chunk,
-                    *localEc, sharedState->frontierPair, false, localFrontier);
+                numActiveNodes += runEdgeCompute(nodeID, chunk, *localEc, sharedState->frontierPair,
+                    false, localFrontier);
             }
         }
     } break;
@@ -107,15 +107,14 @@ void VertexComputeTask::run() {
     if (info.hasPropertiesToScan()) {
         auto scanState = graph->prepareVertexScan(tableID, info.propertiesToScan);
         while (sharedState->morselDispatcher.getNextRangeMorsel(morsel)) {
-            for (auto chunk : graph->scanVertices(morsel.getBeginOffset(),
-                     morsel.getEndOffset(), *scanState)) {
+            for (auto chunk :
+                graph->scanVertices(morsel.getBeginOffset(), morsel.getEndOffset(), *scanState)) {
                 localVc->vertexCompute(chunk);
             }
         }
     } else {
         while (sharedState->morselDispatcher.getNextRangeMorsel(morsel)) {
-            localVc->vertexCompute(morsel.getBeginOffset(),
-                morsel.getEndOffset(), tableID);
+            localVc->vertexCompute(morsel.getBeginOffset(), morsel.getEndOffset(), tableID);
         }
     }
 }

--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -7,64 +7,115 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace function {
 
-static uint64_t computeScanResult(nodeID_t sourceNodeID, graph::NbrScanState::Chunk& nbrChunk,
-    EdgeCompute& ec, FrontierPair& frontierPair, bool isFwd) {
+static uint64_t runEdgeCompute(nodeID_t sourceNodeID, graph::NbrScanState::Chunk& nbrChunk,
+    EdgeCompute& ec, FrontierPair& frontierPair, bool isFwd, SparseFrontier& localFrontier) {
     auto activeNodes = ec.edgeCompute(sourceNodeID, nbrChunk, isFwd);
-    frontierPair.getNextFrontierUnsafe().setActive(activeNodes);
+    frontierPair.addNodesToNextDenseFrontier(activeNodes);
+    localFrontier.addNodes(activeNodes);
+    localFrontier.checkSampleSize();
     return nbrChunk.size();
 }
 
 void FrontierTask::run() {
-    FrontierMorsel frontierMorsel;
+    FrontierMorsel morsel;
     auto numActiveNodes = 0u;
     auto graph = info.graph;
-    auto scanState = graph->prepareScan(info.relTableIDToScan, info.edgePropertyIdx);
+    auto scanState = graph->prepareScan(info.relTableID, info.edgePropertyIdx);
     auto localEc = info.edgeCompute.copy();
-    while (sharedState->frontierPair.getNextRangeMorsel(frontierMorsel)) {
-        while (frontierMorsel.hasNextOffset()) {
-            common::nodeID_t nodeID = frontierMorsel.getNextNodeID();
-            if (sharedState->frontierPair.curFrontier->isActive(nodeID.offset)) {
-                switch (info.direction) {
-                case ExtendDirection::FWD: {
-                    for (auto chunk : graph->scanFwd(nodeID, *scanState)) {
-                        numActiveNodes += computeScanResult(nodeID, chunk, *localEc,
-                            sharedState->frontierPair, true);
-                    }
-                } break;
-                case ExtendDirection::BWD: {
-                    for (auto chunk : graph->scanBwd(nodeID, *scanState)) {
-                        numActiveNodes += computeScanResult(nodeID, chunk, *localEc,
-                            sharedState->frontierPair, false);
-                    }
-                } break;
-                default:
-                    KU_UNREACHABLE;
+    SparseFrontier localFrontier;
+    localFrontier.pinTableID(info.nbrTableID);
+    auto& curFrontier = sharedState->frontierPair.getCurDenseFrontier();
+    switch (info.direction) {
+    case ExtendDirection::FWD: {
+        while (sharedState->frontierPair.getNextRangeMorsel(morsel)) {
+            for (auto offset = morsel.getBeginOffset(); offset < morsel.getEndOffset(); ++offset) {
+                if (!curFrontier.isActive(offset)) {
+                    continue;
+                }
+                nodeID_t nodeID = {offset, morsel.getTableID()};
+                for (auto chunk : graph->scanFwd(nodeID, *scanState)) {
+                    numActiveNodes += runEdgeCompute(nodeID, chunk,
+                        *localEc, sharedState->frontierPair, true, localFrontier);
                 }
             }
         }
+    } break;
+    case ExtendDirection::BWD: {
+        while (sharedState->frontierPair.getNextRangeMorsel(morsel)) {
+            for (auto offset = morsel.getBeginOffset(); offset < morsel.getEndOffset(); ++offset) {
+                if (!curFrontier.isActive(offset)) {
+                    continue;
+                }
+                nodeID_t nodeID = {offset, morsel.getTableID()};
+                for (auto chunk : graph->scanBwd(nodeID, *scanState)) {
+                    numActiveNodes += runEdgeCompute(nodeID, chunk,
+                        *localEc, sharedState->frontierPair, false, localFrontier);
+                }
+            }
+        }
+    } break;
+    default:
+        KU_UNREACHABLE;
     }
     if (numActiveNodes) {
         sharedState->frontierPair.setActiveNodesForNextIter();
+        sharedState->frontierPair.mergeLocalFrontier(localFrontier);
+    }
+}
+
+void FrontierTask::runSparse() {
+    auto numActiveNodes = 0u;
+    auto graph = info.graph;
+    auto scanState = graph->prepareScan(info.relTableID, info.edgePropertyIdx);
+    auto localEc = info.edgeCompute.copy();
+    SparseFrontier localFrontier;
+    localFrontier.pinTableID(info.nbrTableID);
+    auto& curFrontier = sharedState->frontierPair.getCurSparseFrontier();
+    switch (info.direction) {
+    case ExtendDirection::FWD: {
+        for (auto& offset : curFrontier.getOffsetSet()) {
+            auto nodeID = nodeID_t{offset, curFrontier.getTableID()};
+            for (auto chunk : graph->scanFwd(nodeID, *scanState)) {
+                numActiveNodes += runEdgeCompute(nodeID, chunk,
+                    *localEc, sharedState->frontierPair, true, localFrontier);
+            }
+        }
+    } break;
+    case ExtendDirection::BWD: {
+        for (auto& offset : curFrontier.getOffsetSet()) {
+            auto nodeID = nodeID_t{offset, curFrontier.getTableID()};
+            for (auto chunk : graph->scanBwd(nodeID, *scanState)) {
+                numActiveNodes += runEdgeCompute(nodeID, chunk,
+                    *localEc, sharedState->frontierPair, false, localFrontier);
+            }
+        }
+    } break;
+    default:
+        KU_UNREACHABLE;
+    }
+    if (numActiveNodes) {
+        sharedState->frontierPair.setActiveNodesForNextIter();
+        sharedState->frontierPair.mergeLocalFrontier(localFrontier);
     }
 }
 
 void VertexComputeTask::run() {
-    FrontierMorsel frontierMorsel;
+    FrontierMorsel morsel;
     auto graph = sharedState->graph;
     auto localVc = info.vc.copy();
     auto tableID = sharedState->morselDispatcher.getTableID();
     if (info.hasPropertiesToScan()) {
         auto scanState = graph->prepareVertexScan(tableID, info.propertiesToScan);
-        while (sharedState->morselDispatcher.getNextRangeMorsel(frontierMorsel)) {
-            for (auto chunk : graph->scanVertices(frontierMorsel.getBeginOffset(),
-                     frontierMorsel.getEndOffsetExclusive(), *scanState)) {
+        while (sharedState->morselDispatcher.getNextRangeMorsel(morsel)) {
+            for (auto chunk : graph->scanVertices(morsel.getBeginOffset(),
+                     morsel.getEndOffset(), *scanState)) {
                 localVc->vertexCompute(chunk);
             }
         }
     } else {
-        while (sharedState->morselDispatcher.getNextRangeMorsel(frontierMorsel)) {
-            localVc->vertexCompute(frontierMorsel.getBeginOffset(),
-                frontierMorsel.getEndOffsetExclusive(), tableID);
+        while (sharedState->morselDispatcher.getNextRangeMorsel(morsel)) {
+            localVc->vertexCompute(morsel.getBeginOffset(),
+                morsel.getEndOffset(), tableID);
         }
     }
 }

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -25,13 +25,13 @@ static uint64_t getNumThreads(processor::ExecutionContext& context) {
         .getValue<uint64_t>();
 }
 
-void GDSUtils::scheduleFrontierTask(table_id_t nbrTableID, table_id_t relTableID, graph::Graph* graph,
-    ExtendDirection extendDirection, GDSComputeState& gdsComputeState,
+void GDSUtils::scheduleFrontierTask(table_id_t nbrTableID, table_id_t relTableID,
+    graph::Graph* graph, ExtendDirection extendDirection, GDSComputeState& gdsComputeState,
     processor::ExecutionContext* context, std::optional<uint64_t> numThreads,
     std::optional<common::idx_t> edgePropertyIdx) {
     auto clientContext = context->clientContext;
-    auto info = FrontierTaskInfo(nbrTableID, relTableID, graph, extendDirection, *gdsComputeState.edgeCompute,
-        edgePropertyIdx);
+    auto info = FrontierTaskInfo(nbrTableID, relTableID, graph, extendDirection,
+        *gdsComputeState.edgeCompute, edgePropertyIdx);
     auto sharedState = std::make_shared<FrontierTaskSharedState>(*gdsComputeState.frontierPair);
     uint64_t maxThreads = numThreads ? numThreads.value() : getNumThreads(*context);
     auto task = std::make_shared<FrontierTask>(maxThreads, info, sharedState);
@@ -69,24 +69,24 @@ void GDSUtils::runFrontiersUntilConvergence(processor::ExecutionContext* context
             case ExtendDirection::FWD: {
                 rjCompState.beginFrontierComputeBetweenTables(relTableIDInfo.fromNodeTableID,
                     relTableIDInfo.toNodeTableID);
-                scheduleFrontierTask(relTableIDInfo.toNodeTableID, relTableIDInfo.relTableID, graph, ExtendDirection::FWD,
-                    rjCompState, context);
+                scheduleFrontierTask(relTableIDInfo.toNodeTableID, relTableIDInfo.relTableID, graph,
+                    ExtendDirection::FWD, rjCompState, context);
             } break;
             case ExtendDirection::BWD: {
                 rjCompState.beginFrontierComputeBetweenTables(relTableIDInfo.toNodeTableID,
                     relTableIDInfo.fromNodeTableID);
-                scheduleFrontierTask(relTableIDInfo.fromNodeTableID, relTableIDInfo.relTableID, graph, ExtendDirection::BWD,
-                    rjCompState, context);
+                scheduleFrontierTask(relTableIDInfo.fromNodeTableID, relTableIDInfo.relTableID,
+                    graph, ExtendDirection::BWD, rjCompState, context);
             } break;
             case ExtendDirection::BOTH: {
                 rjCompState.beginFrontierComputeBetweenTables(relTableIDInfo.fromNodeTableID,
                     relTableIDInfo.toNodeTableID);
-                scheduleFrontierTask(relTableIDInfo.toNodeTableID, relTableIDInfo.relTableID, graph, ExtendDirection::FWD,
-                    rjCompState, context);
+                scheduleFrontierTask(relTableIDInfo.toNodeTableID, relTableIDInfo.relTableID, graph,
+                    ExtendDirection::FWD, rjCompState, context);
                 rjCompState.beginFrontierComputeBetweenTables(relTableIDInfo.toNodeTableID,
                     relTableIDInfo.fromNodeTableID);
-                scheduleFrontierTask(relTableIDInfo.fromNodeTableID, relTableIDInfo.relTableID, graph, ExtendDirection::BWD,
-                    rjCompState, context);
+                scheduleFrontierTask(relTableIDInfo.fromNodeTableID, relTableIDInfo.relTableID,
+                    graph, ExtendDirection::BWD, rjCompState, context);
             } break;
             default:
                 KU_UNREACHABLE;
@@ -133,7 +133,8 @@ void GDSUtils::runVertexCompute(ExecutionContext* context, Graph* graph, VertexC
     runVertexComputeInternal(tableID, graph, task, context);
 }
 
-void GDSUtils::runVertexComputeSparse(SparseFrontier& sparseFrontier, graph::Graph* graph, VertexCompute& vc) {
+void GDSUtils::runVertexComputeSparse(SparseFrontier& sparseFrontier, graph::Graph* graph,
+    VertexCompute& vc) {
     std::vector<std::string> propertiesToScan;
     for (auto& tableID : graph->getNodeTableIDs()) {
         if (!vc.beginOnTable(tableID)) {
@@ -142,7 +143,7 @@ void GDSUtils::runVertexComputeSparse(SparseFrontier& sparseFrontier, graph::Gra
         sparseFrontier.pinTableID(tableID);
         auto localVc = vc.copy();
         for (auto& offset : sparseFrontier.getOffsetSet()) {
-            localVc->vertexCompute(offset, offset+1, tableID);
+            localVc->vertexCompute(offset, offset + 1, tableID);
         }
     }
 }

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -25,16 +25,22 @@ static uint64_t getNumThreads(processor::ExecutionContext& context) {
         .getValue<uint64_t>();
 }
 
-void GDSUtils::scheduleFrontierTask(table_id_t relTableID, graph::Graph* graph,
+void GDSUtils::scheduleFrontierTask(table_id_t nbrTableID, table_id_t relTableID, graph::Graph* graph,
     ExtendDirection extendDirection, GDSComputeState& gdsComputeState,
     processor::ExecutionContext* context, std::optional<uint64_t> numThreads,
     std::optional<common::idx_t> edgePropertyIdx) {
     auto clientContext = context->clientContext;
-    auto info = FrontierTaskInfo(relTableID, graph, extendDirection, *gdsComputeState.edgeCompute,
+    auto info = FrontierTaskInfo(nbrTableID, relTableID, graph, extendDirection, *gdsComputeState.edgeCompute,
         edgePropertyIdx);
     auto sharedState = std::make_shared<FrontierTaskSharedState>(*gdsComputeState.frontierPair);
     uint64_t maxThreads = numThreads ? numThreads.value() : getNumThreads(*context);
     auto task = std::make_shared<FrontierTask>(maxThreads, info, sharedState);
+
+    if (gdsComputeState.frontierPair->isCurFrontierSparse()) {
+        task->runSparse();
+        return;
+    }
+
     // GDSUtils::runFrontiersUntilConvergence is called from a GDSCall operator, which is
     // already executed by a worker thread Tm of the task scheduler. So this function is
     // executed by Tm. Because this function will monitor the task and wait for it to
@@ -53,7 +59,7 @@ void GDSUtils::runFrontiersUntilConvergence(processor::ExecutionContext* context
     auto frontierPair = rjCompState.frontierPair.get();
     auto outputNodeMask = rjCompState.outputWriter->getOutputNodeMask();
     rjCompState.edgeCompute->resetSingleThreadState();
-    while (frontierPair->hasActiveNodesForNextIter() && frontierPair->getNextIter() <= maxIters) {
+    while (frontierPair->continueNextIter(maxIters)) {
         frontierPair->beginNewIteration();
         if (outputNodeMask->enabled() && rjCompState.edgeCompute->terminate(*outputNodeMask)) {
             break;
@@ -63,23 +69,23 @@ void GDSUtils::runFrontiersUntilConvergence(processor::ExecutionContext* context
             case ExtendDirection::FWD: {
                 rjCompState.beginFrontierComputeBetweenTables(relTableIDInfo.fromNodeTableID,
                     relTableIDInfo.toNodeTableID);
-                scheduleFrontierTask(relTableIDInfo.relTableID, graph, ExtendDirection::FWD,
+                scheduleFrontierTask(relTableIDInfo.toNodeTableID, relTableIDInfo.relTableID, graph, ExtendDirection::FWD,
                     rjCompState, context);
             } break;
             case ExtendDirection::BWD: {
                 rjCompState.beginFrontierComputeBetweenTables(relTableIDInfo.toNodeTableID,
                     relTableIDInfo.fromNodeTableID);
-                scheduleFrontierTask(relTableIDInfo.relTableID, graph, ExtendDirection::BWD,
+                scheduleFrontierTask(relTableIDInfo.fromNodeTableID, relTableIDInfo.relTableID, graph, ExtendDirection::BWD,
                     rjCompState, context);
             } break;
             case ExtendDirection::BOTH: {
                 rjCompState.beginFrontierComputeBetweenTables(relTableIDInfo.fromNodeTableID,
                     relTableIDInfo.toNodeTableID);
-                scheduleFrontierTask(relTableIDInfo.relTableID, graph, ExtendDirection::FWD,
+                scheduleFrontierTask(relTableIDInfo.toNodeTableID, relTableIDInfo.relTableID, graph, ExtendDirection::FWD,
                     rjCompState, context);
                 rjCompState.beginFrontierComputeBetweenTables(relTableIDInfo.toNodeTableID,
                     relTableIDInfo.fromNodeTableID);
-                scheduleFrontierTask(relTableIDInfo.relTableID, graph, ExtendDirection::BWD,
+                scheduleFrontierTask(relTableIDInfo.fromNodeTableID, relTableIDInfo.relTableID, graph, ExtendDirection::BWD,
                     rjCompState, context);
             } break;
             default:
@@ -125,6 +131,20 @@ void GDSUtils::runVertexCompute(ExecutionContext* context, Graph* graph, VertexC
     }
     auto task = std::make_shared<VertexComputeTask>(maxThreads, info, sharedState);
     runVertexComputeInternal(tableID, graph, task, context);
+}
+
+void GDSUtils::runVertexComputeSparse(SparseFrontier& sparseFrontier, graph::Graph* graph, VertexCompute& vc) {
+    std::vector<std::string> propertiesToScan;
+    for (auto& tableID : graph->getNodeTableIDs()) {
+        if (!vc.beginOnTable(tableID)) {
+            continue;
+        }
+        sparseFrontier.pinTableID(tableID);
+        auto localVc = vc.copy();
+        for (auto& offset : sparseFrontier.getOffsetSet()) {
+            localVc->vertexCompute(offset, offset+1, tableID);
+        }
+    }
 }
 
 } // namespace function

--- a/src/function/gds/rec_joins.cpp
+++ b/src/function/gds/rec_joins.cpp
@@ -212,7 +212,13 @@ void RJAlgorithm::exec(processor::ExecutionContext* context) {
             auto vertexCompute =
                 std::make_unique<RJVertexCompute>(clientContext->getMemoryManager(),
                     sharedState.get(), rjCompState.outputWriter->copy());
-            GDSUtils::runVertexCompute(context, graph, *vertexCompute);
+            auto& candidates = rjCompState.frontierPair->getVertexComputeCandidates();
+            candidates.mergeSparseFrontier(rjCompState.frontierPair->getNextSparseFrontier());
+            if (candidates.enabled()) {
+                GDSUtils::runVertexComputeSparse(candidates, graph, *vertexCompute);
+            } else {
+                GDSUtils::runVertexCompute(context, graph, *vertexCompute);
+            }
         };
         auto numNodes = graph->getNumNodes(clientContext->getTx(), tableID);
         auto mask = inputNodeMaskMap->getOffsetMask(tableID);

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -96,30 +96,23 @@ protected:
  * If enabled, this frontier represents a complete frontier.
  * Otherwise, complete frontier is larger than this sparse frontier.
  * */
-class KUZU_API SparseFrontier  {
+class KUZU_API SparseFrontier {
 public:
-    SparseFrontier() : enabled_{true}, curTableID{common::INVALID_TABLE_ID}, curOffsetSet{nullptr} {}
+    SparseFrontier()
+        : enabled_{true}, curTableID{common::INVALID_TABLE_ID}, curOffsetSet{nullptr} {}
 
-    void disable() {
-        enabled_ = false;
-    }
+    void disable() { enabled_ = false; }
     void resetState() {
         enabled_ = true;
         curOffsetSet = nullptr;
         tableIDToOffsetMap.clear();
     }
-    bool enabled() const {
-        return enabled_;
-    }
+    bool enabled() const { return enabled_; }
 
     void pinTableID(common::table_id_t tableID);
 
-    common::table_id_t getTableID() const {
-        return curTableID;
-    }
-    const std::unordered_set<common::offset_t>& getOffsetSet() const {
-        return *curOffsetSet;
-    }
+    common::table_id_t getTableID() const { return curTableID; }
+    const std::unordered_set<common::offset_t>& getOffsetSet() const { return *curOffsetSet; }
 
     void addNode(common::nodeID_t nodeID);
     void addNodes(const std::vector<common::nodeID_t> nodeIDs);
@@ -133,7 +126,7 @@ private:
 
     std::mutex mtx;
     bool enabled_;
-    std::unordered_map<common::table_id_t, std::unordered_set<common::offset_t >> tableIDToOffsetMap;
+    std::unordered_map<common::table_id_t, std::unordered_set<common::offset_t>> tableIDToOffsetMap;
     common::table_id_t curTableID;
     std::unordered_set<common::offset_t>* curOffsetSet;
 };

--- a/src/include/function/gds/gds_task.h
+++ b/src/include/function/gds/gds_task.h
@@ -9,19 +9,20 @@ namespace kuzu {
 namespace function {
 
 struct FrontierTaskInfo {
-    common::table_id_t relTableIDToScan;
+    common::table_id_t nbrTableID;
+    common::table_id_t relTableID;
     graph::Graph* graph;
     common::ExtendDirection direction;
     EdgeCompute& edgeCompute;
     std::optional<common::idx_t> edgePropertyIdx;
 
-    FrontierTaskInfo(common::table_id_t tableID, graph::Graph* graph,
+    FrontierTaskInfo(common::table_id_t nbrTableID, common::table_id_t relTableID, graph::Graph* graph,
         common::ExtendDirection direction, EdgeCompute& edgeCompute,
         std::optional<common::idx_t> edgePropertyIdx)
-        : relTableIDToScan{tableID}, graph{graph}, direction{direction}, edgeCompute{edgeCompute},
+        : nbrTableID{nbrTableID}, relTableID{relTableID}, graph{graph}, direction{direction}, edgeCompute{edgeCompute},
           edgePropertyIdx{edgePropertyIdx} {}
     FrontierTaskInfo(const FrontierTaskInfo& other)
-        : relTableIDToScan{other.relTableIDToScan}, graph{other.graph}, direction{other.direction},
+        : nbrTableID{other.nbrTableID}, relTableID{other.relTableID}, graph{other.graph}, direction{other.direction},
           edgeCompute{other.edgeCompute}, edgePropertyIdx{other.edgePropertyIdx} {}
 };
 
@@ -39,6 +40,8 @@ public:
         : common::Task{maxNumThreads}, info{info}, sharedState{std::move(sharedState)} {}
 
     void run() override;
+
+    void runSparse();
 
 private:
     FrontierTaskInfo info;

--- a/src/include/function/gds/gds_task.h
+++ b/src/include/function/gds/gds_task.h
@@ -16,14 +16,15 @@ struct FrontierTaskInfo {
     EdgeCompute& edgeCompute;
     std::optional<common::idx_t> edgePropertyIdx;
 
-    FrontierTaskInfo(common::table_id_t nbrTableID, common::table_id_t relTableID, graph::Graph* graph,
-        common::ExtendDirection direction, EdgeCompute& edgeCompute,
+    FrontierTaskInfo(common::table_id_t nbrTableID, common::table_id_t relTableID,
+        graph::Graph* graph, common::ExtendDirection direction, EdgeCompute& edgeCompute,
         std::optional<common::idx_t> edgePropertyIdx)
-        : nbrTableID{nbrTableID}, relTableID{relTableID}, graph{graph}, direction{direction}, edgeCompute{edgeCompute},
-          edgePropertyIdx{edgePropertyIdx} {}
+        : nbrTableID{nbrTableID}, relTableID{relTableID}, graph{graph}, direction{direction},
+          edgeCompute{edgeCompute}, edgePropertyIdx{edgePropertyIdx} {}
     FrontierTaskInfo(const FrontierTaskInfo& other)
-        : nbrTableID{other.nbrTableID}, relTableID{other.relTableID}, graph{other.graph}, direction{other.direction},
-          edgeCompute{other.edgeCompute}, edgePropertyIdx{other.edgePropertyIdx} {}
+        : nbrTableID{other.nbrTableID}, relTableID{other.relTableID}, graph{other.graph},
+          direction{other.direction}, edgeCompute{other.edgeCompute},
+          edgePropertyIdx{other.edgePropertyIdx} {}
 };
 
 struct FrontierTaskSharedState {

--- a/src/include/function/gds/gds_utils.h
+++ b/src/include/function/gds/gds_utils.h
@@ -35,8 +35,8 @@ struct KUZU_API GDSComputeState {
 
 class KUZU_API GDSUtils {
 public:
-    static void scheduleFrontierTask(common::table_id_t nbrTableID, common::table_id_t relTableID, graph::Graph* graph,
-        common::ExtendDirection extendDirection, GDSComputeState& rjCompState,
+    static void scheduleFrontierTask(common::table_id_t nbrTableID, common::table_id_t relTableID,
+        graph::Graph* graph, common::ExtendDirection extendDirection, GDSComputeState& rjCompState,
         processor::ExecutionContext* context, std::optional<uint64_t> numThreads = std::nullopt,
         std::optional<common::idx_t> edgePropertyIdx = std::nullopt);
     static void runFrontiersUntilConvergence(processor::ExecutionContext* executionContext,
@@ -51,7 +51,8 @@ public:
     // Run vertex compute on specific table with property scan
     static void runVertexCompute(processor::ExecutionContext* context, graph::Graph* graph,
         VertexCompute& vc, common::table_id_t tableID, std::vector<std::string> propertiesToScan);
-    static void runVertexComputeSparse(SparseFrontier& sparseFrontier, graph::Graph* graph, VertexCompute& vc);
+    static void runVertexComputeSparse(SparseFrontier& sparseFrontier, graph::Graph* graph,
+        VertexCompute& vc);
 };
 
 } // namespace function

--- a/src/include/function/gds/gds_utils.h
+++ b/src/include/function/gds/gds_utils.h
@@ -20,6 +20,7 @@ struct RJCompState;
 class VertexCompute;
 class EdgeCompute;
 class FrontierPair;
+class SparseFrontier;
 struct VertexComputeTaskSharedState;
 struct VertexComputeTaskInfo;
 
@@ -34,14 +35,13 @@ struct KUZU_API GDSComputeState {
 
 class KUZU_API GDSUtils {
 public:
-    static void scheduleFrontierTask(common::table_id_t relTableID, graph::Graph* graph,
+    static void scheduleFrontierTask(common::table_id_t nbrTableID, common::table_id_t relTableID, graph::Graph* graph,
         common::ExtendDirection extendDirection, GDSComputeState& rjCompState,
         processor::ExecutionContext* context, std::optional<uint64_t> numThreads = std::nullopt,
         std::optional<common::idx_t> edgePropertyIdx = std::nullopt);
     static void runFrontiersUntilConvergence(processor::ExecutionContext* executionContext,
         RJCompState& rjCompState, graph::Graph* graph, common::ExtendDirection extendDirection,
         uint64_t maxIters);
-
     // Run vertex compute without property scan
     static void runVertexCompute(processor::ExecutionContext* context, graph::Graph* graph,
         VertexCompute& vc);
@@ -51,6 +51,7 @@ public:
     // Run vertex compute on specific table with property scan
     static void runVertexCompute(processor::ExecutionContext* context, graph::Graph* graph,
         VertexCompute& vc, common::table_id_t tableID, std::vector<std::string> propertiesToScan);
+    static void runVertexComputeSparse(SparseFrontier& sparseFrontier, graph::Graph* graph, VertexCompute& vc);
 };
 
 } // namespace function


### PR DESCRIPTION
# Description

This optimization should improve the performance of `recursive-join-sparse` by order-of-magnitude. I'm not seeing it in PR benchmark. Though it performs pretty well when I test both locally and on ac5. So I'm merging to see the performance difference on our daily benchmark.

Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).