### PR TITLE
Rel scan selection optimizations

### DIFF
--- a/src/common/null_mask.cpp
+++ b/src/common/null_mask.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include "common/assert.h"
+#include <bit>
 
 namespace kuzu {
 namespace common {
@@ -220,6 +221,16 @@ std::pair<bool, bool> NullMask::getMinMax(const uint64_t* nullEntries, uint64_t 
         }
     }
     return std::make_pair(min, max);
+}
+
+uint64_t NullMask::countNulls() const {
+    // If capacity % 64 != 0 then there may be unused bits at the end of the last entry,
+    // but these should always be 0.
+    uint64_t sum = 0;
+    for (auto entry : data) {
+        sum += std::popcount(entry);
+    }
+    return sum;
 }
 
 } // namespace common

--- a/src/function/aggregate/count.cpp
+++ b/src/function/aggregate/count.cpp
@@ -14,18 +14,7 @@ namespace function {
 void CountFunction::updateAll(uint8_t* state_, ValueVector* input, uint64_t multiplicity,
     MemoryManager* /*memoryManager*/) {
     auto state = reinterpret_cast<CountState*>(state_);
-    if (input->hasNoNullsGuarantee()) {
-        for (auto i = 0u; i < input->state->getSelVector().getSelSize(); ++i) {
-            state->count += multiplicity;
-        }
-    } else {
-        for (auto i = 0u; i < input->state->getSelVector().getSelSize(); ++i) {
-            auto pos = input->state->getSelVector()[i];
-            if (!input->isNull(pos)) {
-                state->count += multiplicity;
-            }
-        }
-    }
+    state->count += multiplicity * input->countNonNull();
 }
 
 void CountFunction::paramRewriteFunc(binder::expression_vector& arguments) {

--- a/src/include/common/data_chunk/sel_vector.h
+++ b/src/include/common/data_chunk/sel_vector.h
@@ -52,7 +52,7 @@ public:
         KU_ASSERT(startPos + size <= capacity);
         selectedPositions = const_cast<sel_t*>(INCREMENTAL_SELECTED_POS.data()) + startPos;
         selectedSize = size;
-        continuous = true;
+        state = State::STATIC_FILTERED;
     }
 
     // Set to filtered is not very accurate. It sets selectedPositions to a mutable array.

--- a/src/include/common/data_chunk/sel_vector.h
+++ b/src/include/common/data_chunk/sel_vector.h
@@ -48,6 +48,12 @@ public:
         selectedSize = size;
         state = State::STATIC;
     }
+    void setRange(sel_t startPos, sel_t size) {
+        KU_ASSERT(startPos + size <= capacity);
+        selectedPositions = const_cast<sel_t*>(INCREMENTAL_SELECTED_POS.data()) + startPos;
+        selectedSize = size;
+        continuous = true;
+    }
 
     // Set to filtered is not very accurate. It sets selectedPositions to a mutable array.
     void setToFiltered() {

--- a/src/include/common/null_mask.h
+++ b/src/include/common/null_mask.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #include <span>
@@ -100,6 +101,7 @@ public:
     }
 
     inline bool hasNoNullsGuarantee() const { return !mayContainNulls; }
+    uint64_t countNulls() const;
 
     static void setNull(uint64_t* nullEntries, uint32_t pos, bool isNull);
     inline void setNull(uint32_t pos, bool isNull) {

--- a/src/include/function/aggregate/avg.h
+++ b/src/include/function/aggregate/avg.h
@@ -47,19 +47,8 @@ struct AvgFunction {
         storage::MemoryManager* /*memoryManager*/) {
         auto* state = reinterpret_cast<AvgState<RESULT_TYPE>*>(state_);
         KU_ASSERT(!input->state->isFlat());
-        if (input->hasNoNullsGuarantee()) {
-            for (auto i = 0u; i < input->state->getSelVector().getSelSize(); ++i) {
-                auto pos = input->state->getSelVector()[i];
-                updateSingleValue(state, input, pos, multiplicity);
-            }
-        } else {
-            for (auto i = 0u; i < input->state->getSelVector().getSelSize(); ++i) {
-                auto pos = input->state->getSelVector()[i];
-                if (!input->isNull(pos)) {
-                    updateSingleValue(state, input, pos, multiplicity);
-                }
-            }
-        }
+        input->forEachNonNull(
+            [&](auto pos) { updateSingleValue(state, input, pos, multiplicity); });
     }
 
     static void updatePos(uint8_t* state_, common::ValueVector* input, uint64_t multiplicity,

--- a/src/include/function/aggregate/min_max.h
+++ b/src/include/function/aggregate/min_max.h
@@ -27,20 +27,8 @@ struct MinMaxFunction {
         storage::MemoryManager* memoryManager) {
         KU_ASSERT(!input->state->isFlat());
         auto* state = reinterpret_cast<MinMaxState*>(state_);
-        auto& inputSelVector = input->state->getSelVector();
-        if (input->hasNoNullsGuarantee()) {
-            for (auto i = 0u; i < inputSelVector.getSelSize(); ++i) {
-                auto pos = inputSelVector[i];
-                updateSingleValue<OP>(state, input, pos, memoryManager);
-            }
-        } else {
-            for (auto i = 0u; i < inputSelVector.getSelSize(); ++i) {
-                auto pos = inputSelVector[i];
-                if (!input->isNull(pos)) {
-                    updateSingleValue<OP>(state, input, pos, memoryManager);
-                }
-            }
-        }
+        input->forEachNonNull(
+            [&](auto pos) { updateSingleValue<OP>(state, input, pos, memoryManager); });
     }
 
     template<class OP>

--- a/src/include/function/aggregate/sum.h
+++ b/src/include/function/aggregate/sum.h
@@ -26,20 +26,8 @@ struct SumFunction {
         storage::MemoryManager* /*memoryManager*/) {
         KU_ASSERT(!input->state->isFlat());
         auto* state = reinterpret_cast<SumState<RESULT_TYPE>*>(state_);
-        auto& inputSelVector = input->state->getSelVector();
-        if (input->hasNoNullsGuarantee()) {
-            for (auto i = 0u; i < inputSelVector.getSelSize(); ++i) {
-                auto pos = inputSelVector[i];
-                updateSingleValue(state, input, pos, multiplicity);
-            }
-        } else {
-            for (auto i = 0u; i < inputSelVector.getSelSize(); ++i) {
-                auto pos = inputSelVector[i];
-                if (!input->isNull(pos)) {
-                    updateSingleValue(state, input, pos, multiplicity);
-                }
-            }
-        }
+        input->forEachNonNull(
+            [&](auto pos) { updateSingleValue(state, input, pos, multiplicity); });
     }
 
     static void updatePos(uint8_t* state_, common::ValueVector* input, uint64_t multiplicity,

--- a/src/include/storage/store/csr_node_group.h
+++ b/src/include/storage/store/csr_node_group.h
@@ -119,7 +119,7 @@ struct CSRNodeGroupScanState final : NodeGroupScanState {
     // boundNodes.
     std::unique_ptr<ChunkedCSRHeader> header;
 
-    std::bitset<common::DEFAULT_VECTOR_CAPACITY> cachedScannedVectorsSelBitset;
+    std::optional<std::bitset<common::DEFAULT_VECTOR_CAPACITY>> cachedScannedVectorsSelBitset;
     // The total number of rows (i.e., rels) in the current node group.
     common::row_idx_t numTotalRows;
     // The number of rows (i.e., rels) that have been scanned so far in current node group.
@@ -139,7 +139,6 @@ struct CSRNodeGroupScanState final : NodeGroupScanState {
           source{CSRNodeGroupScanSource::COMMITTED_PERSISTENT} {
         header = std::make_unique<ChunkedCSRHeader>(mm, false,
             common::StorageConstants::NODE_GROUP_SIZE, ResidencyState::IN_MEMORY);
-        cachedScannedVectorsSelBitset.set();
     }
 
     bool tryScanCachedTuples(RelTableScanState& tableScanState);

--- a/src/processor/result/result_set.cpp
+++ b/src/processor/result/result_set.cpp
@@ -31,8 +31,7 @@ uint64_t ResultSet::getNumTuplesWithoutMultiplicity(
     KU_ASSERT(!dataChunksPosInScope.empty());
     uint64_t numTuples = 1;
     for (auto& dataChunkPos : dataChunksPosInScope) {
-        auto state = dataChunks[dataChunkPos]->state;
-        numTuples *= state->getSelVector().getSelSize();
+        numTuples *= dataChunks[dataChunkPos]->state->getSelVector().getSelSize();
     }
     return numTuples;
 }

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -105,7 +105,7 @@ bool RelTableScanState::scanNext(Transaction* transaction) {
 
 void RelTableScanState::setNodeIDVectorToFlat(sel_t selPos) const {
     nodeIDVector->state->setToFlat();
-    nodeIDVector->state->getSelVectorShared()->setToFiltered(1);
+    nodeIDVector->state->getSelVectorUnsafe().setToFiltered(1);
     nodeIDVector->state->getSelVectorUnsafe()[0] = selPos;
 }
 


### PR DESCRIPTION
The biggest optimization here is avoiding using the bitset in `CSRNodeGroup::tryScanCachedTuples` if it's known that all values are selected. 

In some unfiltered rel table scans this improved performance of `CSRNodeGroup::tryScanCachedTuples` by about 4x, for a total of about a 15% on some queries I'd benchmarked which were mostly scans.

E.g. 'MATCH (v:N)-[e:E]->(v2:N) RETURN SUM(v.ID);' on the ldbc graph500-30 dataset (with 128 threads) went from ~2.65s to ~2.25s

I've also:
- removed a couple of unnecessary `std::shared_ptr` copies (which are immediately destroyed).
- Added `ValueVector::forEachNonNull` to consolidate some code in the aggregate functions