### PR TITLE
Fix wrong sniff type when sample_size = 1

### DIFF
--- a/dataset/csv-error-tests/sniff_first_row.csv
+++ b/dataset/csv-error-tests/sniff_first_row.csv
@@ -1,0 +1,4 @@
+Alice,4
+Bob,2147483650
+Eliz, Eliz
+Andy, 9

--- a/src/processor/operator/persistent/reader/csv/driver.cpp
+++ b/src/processor/operator/persistent/reader/csv/driver.cpp
@@ -185,7 +185,7 @@ bool SniffCSVNameAndTypeDriver::done(uint64_t rowNum) {
     auto& csvOption = reader->getCSVOption();
     bool finished = (csvOption.hasHeader ? 1 : 0) + csvOption.sampleSize <= rowNum;
     // if the csv only has one row
-    if (finished && rowNum == 0 && csvOption.autoDetection && !csvOption.setHeader) {
+    if (finished && rowNum <= 1 && csvOption.autoDetection && !csvOption.setHeader) {
         for (auto columnIdx = 0u; columnIdx < firstRow.size(); ++columnIdx) {
             std::string columnName = std::string(firstRow[columnIdx]);
             LogicalType columnType = function::inferMinimalTypeFromString(firstRow[columnIdx]);

--- a/test/test_files/csv/errors.test
+++ b/test/test_files/csv/errors.test
@@ -31,6 +31,15 @@ Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/csv-error-tests/too
 ---- error
 Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/csv-error-tests/union-no-conversion.csv on line 2: Conversion exception: Could not convert to union type UNION(u UINT8, s INT8): a. Line/record containing the error: 'a'
 
+# Test for issue 4531 (sniff wrong type when sample_size = 1)
+-STATEMENT LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/csv-error-tests/sniff_first_row.csv" (ignore_errors=false, sample_size=1) RETURN *;
+---- error
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/csv-error-tests/sniff_first_row.csv on line 3: Conversion exception: Cast failed. Could not convert " Eliz" to INT64. Line/record containing the error: 'Eliz, Eliz'
+
+-STATEMENT LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/csv-error-tests/sniff_first_row.csv" (ignore_errors=false, sample_size=2) RETURN *;
+---- error
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/csv-error-tests/sniff_first_row.csv on line 3: Conversion exception: Cast failed. Could not convert " Eliz" to INT64. Line/record containing the error: 'Eliz, Eliz'
+
 # Test that errors in serial mode don't hang the database.
 # File is large so the window for the race is large enough.
 -STATEMENT LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/csv-error-tests/large-conversion-failure.csv" (HEADER=TRUE, PARALLEL=FALSE, AUTO_DETECT=false) RETURN *


### PR DESCRIPTION
# Description

The rowNum check in `SniffNameandTypeDriver::done` was wrong.

Fixed it and added test

Fix #4531 


# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).