### PR TITLE
Fix config parameters binding for C API

### DIFF
--- a/src/c_api/database.cpp
+++ b/src/c_api/database.cpp
@@ -10,7 +10,7 @@ kuzu_state kuzu_database_init(const char* database_path, kuzu_system_config conf
         std::string database_path_str = database_path;
         out_database->_database = new Database(database_path_str,
             SystemConfig(config.buffer_pool_size, config.max_num_threads, config.enable_compression,
-                config.read_only, config.max_db_size, config.max_db_size, config.auto_checkpoint, config.check_point_threshold));
+                config.read_only, config.max_db_size, config.auto_checkpoint, config.check_point_threshold));
     } catch (Exception& e) {
         out_database->_database = nullptr;
         return KuzuError;

--- a/src/c_api/database.cpp
+++ b/src/c_api/database.cpp
@@ -1,7 +1,6 @@
 #include "c_api/kuzu.h"
 #include "common/exception/exception.h"
 #include "main/kuzu.h"
-
 using namespace kuzu::main;
 using namespace kuzu::common;
 
@@ -11,7 +10,7 @@ kuzu_state kuzu_database_init(const char* database_path, kuzu_system_config conf
         std::string database_path_str = database_path;
         out_database->_database = new Database(database_path_str,
             SystemConfig(config.buffer_pool_size, config.max_num_threads, config.enable_compression,
-                config.read_only));
+                config.read_only, config.max_db_size, config.max_db_size, config.auto_checkpoint, config.check_point_threshold));
     } catch (Exception& e) {
         out_database->_database = nullptr;
         return KuzuError;
@@ -29,6 +28,7 @@ void kuzu_database_destroy(kuzu_database* database) {
 }
 
 kuzu_system_config kuzu_default_system_config() {
-    return {0 /*bufferPoolSize*/, 0 /*maxNumThreads*/, true /*enableCompression*/,
-        false /*readOnly*/, BufferPoolConstants::DEFAULT_VM_REGION_MAX_SIZE};
+    SystemConfig config = SystemConfig();
+    return {config.bufferPoolSize, config.maxNumThreads, config.enableCompression, config.readOnly,
+        config.maxDBSize, config.autoCheckpoint, config.checkpointThreshold};
 }

--- a/src/c_api/database.cpp
+++ b/src/c_api/database.cpp
@@ -10,7 +10,7 @@ kuzu_state kuzu_database_init(const char* database_path, kuzu_system_config conf
         std::string database_path_str = database_path;
         out_database->_database = new Database(database_path_str,
             SystemConfig(config.buffer_pool_size, config.max_num_threads, config.enable_compression,
-                config.read_only, config.max_db_size, config.auto_checkpoint, config.check_point_threshold));
+                config.read_only, config.max_db_size, config.auto_checkpoint, config.checkpoint_threshold));
     } catch (Exception& e) {
         out_database->_database = nullptr;
         return KuzuError;

--- a/src/c_api/database.cpp
+++ b/src/c_api/database.cpp
@@ -10,7 +10,8 @@ kuzu_state kuzu_database_init(const char* database_path, kuzu_system_config conf
         std::string database_path_str = database_path;
         out_database->_database = new Database(database_path_str,
             SystemConfig(config.buffer_pool_size, config.max_num_threads, config.enable_compression,
-                config.read_only, config.max_db_size, config.auto_checkpoint, config.checkpoint_threshold));
+                config.read_only, config.max_db_size, config.auto_checkpoint,
+                config.checkpoint_threshold));
     } catch (Exception& e) {
         out_database->_database = nullptr;
         return KuzuError;

--- a/src/include/c_api/kuzu.h
+++ b/src/include/c_api/kuzu.h
@@ -131,7 +131,7 @@ typedef struct {
     bool auto_checkpoint;
     // The threshold of the WAL file size in bytes. When the size of the
     // WAL file exceeds this threshold, the database will checkpoint if autoCheckpoint is true.
-    uint64_t check_point_threshold;
+    uint64_t checkpoint_threshold;
 } kuzu_system_config;
 
 /**

--- a/src/include/c_api/kuzu.h
+++ b/src/include/c_api/kuzu.h
@@ -127,10 +127,10 @@ typedef struct {
     //  (8TB) under 64-bit environment and 1GB under 32-bit one (see `DEFAULT_VM_REGION_MAX_SIZE`).
     uint64_t max_db_size;
     // If true, the database will automatically checkpoint when the size of
-    // the WAL file exceeds the checkpoint threshold.bool auto_checkpoint;
+    // the WAL file exceeds the checkpoint threshold.
     bool auto_checkpoint;
     // The threshold of the WAL file size in bytes. When the size of the
-    // WAL file exceeds this threshold, the database will checkpoint if autoCheckpoint is true.
+    // WAL file exceeds this threshold, the database will checkpoint if auto_checkpoint is true.
     uint64_t checkpoint_threshold;
 } kuzu_system_config;
 

--- a/src/include/c_api/kuzu.h
+++ b/src/include/c_api/kuzu.h
@@ -126,6 +126,12 @@ typedef struct {
     //  will be removed once we implemente a better solution later. The value is default to 1 << 43
     //  (8TB) under 64-bit environment and 1GB under 32-bit one (see `DEFAULT_VM_REGION_MAX_SIZE`).
     uint64_t max_db_size;
+    // If true, the database will automatically checkpoint when the size of
+    // the WAL file exceeds the checkpoint threshold.bool auto_checkpoint;
+    bool auto_checkpoint;
+    // The threshold of the WAL file size in bytes. When the size of the
+    // WAL file exceeds this threshold, the database will checkpoint if autoCheckpoint is true.
+    uint64_t check_point_threshold;
 } kuzu_system_config;
 
 /**


### PR DESCRIPTION
This PR fixes the config parameter binding for C API (the parameter `max_db_size` was taken but not actually passed into C++). It also added checkpoint parameters. Additionally, it changes the way of getting the default parameter for C API.