### PR TITLE
Rework build pipeline

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -49,13 +49,13 @@ env:
   PIP_BREAK_SYSTEM_PACKAGES: 1
 
 jobs:
-  get-version:
+  get-nightly-version:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'schedule' || github.event.inputs.isNightly == 'true' }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Update nightly version
-        if: ${{ github.event_name == 'schedule' || github.event.inputs.isNightly == 'true' }}
         run: |
           python3 -m pip install packaging
           python3 update-nightly-build-version.py | grep "New Python dev version:" | awk -F'New Python dev version: ' '{print $2}' | sed 's/\.$//' > version.txt

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -49,6 +49,25 @@ env:
   PIP_BREAK_SYSTEM_PACKAGES: 1
 
 jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update nightly version
+        if: ${{ github.event_name == 'schedule' || github.event.inputs.isNightly == 'true' }}
+        run: |
+          python3 -m pip install packaging
+          python3 update-nightly-build-version.py | grep "New Python dev version:" | awk -F'New Python dev version: ' '{print $2}' | sed 's/\.$//' > version.txt
+          cat version.txt
+        working-directory: scripts
+      
+      - name: Upload version
+        uses: actions/upload-artifact@v4
+        with:
+          name: version
+          path: scripts/version.txt
+
   build-extension:
     if: ${{ github.event_name == 'schedule' || github.event.inputs.skipExtensions != 'true' }}
     uses: ./.github/workflows/build-and-deploy-extension.yml

--- a/.github/workflows/linux-precompiled-bin-workflow.yml
+++ b/.github/workflows/linux-precompiled-bin-workflow.yml
@@ -9,6 +9,9 @@ on:
         required: true
         default: false
 
+env:
+  PIP_BREAK_SYSTEM_PACKAGES: 1
+
 jobs:
   build-precompiled-bin-x86_64:
     runs-on: kuzu-self-hosted-linux-building-x86_64
@@ -87,3 +90,46 @@ jobs:
         with:
           name: kuzu_cli-linux-aarch64
           path: kuzu_cli-linux-aarch64.tar.gz
+
+  build-precompiled-bin-android-armv8a:
+    runs-on: kuzu-self-hosted-testing
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update nightly version
+        if: ${{ inputs.isNightly == true }}
+        run: |
+          python3 -m pip install packaging
+          python3 update-nightly-build-version.py
+        working-directory: scripts
+
+      - name: Build precompiled binaries
+        run: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_ROOT/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a  ..
+          make -j$(nproc)
+          cd ..
+          cmake --install build --prefix install
+    
+      - name: Collect artifacts
+        run: |
+          mv install/include/kuzu.h .
+          mv install/include/kuzu.hpp .
+          mv install/lib/libkuzu.so .
+          mv install/bin/kuzu .
+        
+      - name: Create tarball
+        run: |
+          tar -czvf libkuzu-android-armv8a.tar.gz kuzu.h kuzu.hpp libkuzu.so
+          tar -czvf kuzu_cli-android-armv8a.tar.gz kuzu
+        
+      - uses: actions/upload-artifact@v4
+        with:
+          name: libkuzu-android-armv8a
+          path: libkuzu-android-armv8a.tar.gz
+        
+      - uses: actions/upload-artifact@v4
+        with:
+          name: kuzu_cli-android-armv8a
+          path: kuzu_cli-android-armv8a.tar.gz

--- a/.github/workflows/mac-wheel-workflow.yml
+++ b/.github/workflows/mac-wheel-workflow.yml
@@ -32,7 +32,7 @@ jobs:
           python3 package_tar.py kuzu.tar.gz
 
       - name: Build wheels for Apple Silicon
-        uses: pypa/cibuildwheel@v2.19.1
+        uses: pypa/cibuildwheel@v2.22
         env:
           CIBW_SKIP: pp*
           CIBW_ARCHS_MACOS: arm64
@@ -67,7 +67,7 @@ jobs:
           python3 package_tar.py kuzu.tar.gz
 
       - name: Build wheels for Intel
-        uses: pypa/cibuildwheel@v2.19.1
+        uses: pypa/cibuildwheel@v2.22
         env:
           CIBW_SKIP: pp* cp36*
           CIBW_ARCHS_MACOS: x86_64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,11 @@ if(BUILD_WASM)
     add_compile_definitions(__WASM__)
 endif()
 
+if(CMAKE_ANDROID_NDK_VERSION)
+    message(STATUS "Android NDK version: ${CMAKE_ANDROID_NDK_VERSION}")
+    add_compile_definitions(__ANDROID__)
+endif()
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-Wno-restrict) # no restrict until https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105651 is fixed
 endif()

--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -81,6 +81,8 @@ struct BufferPoolConstants {
 // The default max size for a VMRegion.
 #ifdef __32BIT__
     static constexpr uint64_t DEFAULT_VM_REGION_MAX_SIZE = (uint64_t)1 << 30; // (1GB)
+#elif defined(__ANDROID__)
+    static constexpr uint64_t DEFAULT_VM_REGION_MAX_SIZE = (uint64_t)1 << 38; // (256GB)
 #else
     static constexpr uint64_t DEFAULT_VM_REGION_MAX_SIZE = static_cast<uint64_t>(1) << 43; // (8TB)
 #endif


### PR DESCRIPTION
This PR reworks the CI build pipeline a bit and add the following things:
1. Add a version.txt file for identifying the nightly build version more easily.
2. Add pre-compiled bins for Android armv8a platform.
3. Upgrade `cibuildwheel` on macOS to build wheels for Python 3.13.

Verified by https://github.com/kuzudb/kuzu/actions/runs/12121700391