### PR TITLE
Handle failed queries in test runner if expected output is tuples

### DIFF
--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -137,6 +137,8 @@ void TestRunner::checkLogicalPlan(std::unique_ptr<PreparedStatement>& preparedSt
     default: {
         ASSERT_TRUE(preparedStatement->success)
             << "Query compilation failed with error: " << preparedStatement->getErrorMessage();
+        ASSERT_TRUE(result->isSuccess())
+            << "Unexpected error for query: " << result->getErrorMessage();
         auto planStr = preparedStatement->logicalPlans[planIdx]->toString();
         checkPlanResult(result, statement, resultIdx, planStr, planIdx);
         break;


### PR DESCRIPTION
# Description

In the test runner we only handle failed queries if the expected output is `OK`, leading to segfaults if we actually run into this case. We should also handle exceptions if we are expecting actual tuples.

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).