### PR TITLE
Parallel init dense gds array

### DIFF
--- a/extension/fts/src/function/create_fts_index.cpp
+++ b/extension/fts/src/function/create_fts_index.cpp
@@ -200,7 +200,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& /*outp
     graph::OnDiskGraph graph(context.clientContext, std::move(entry));
     auto sharedState = LenComputeSharedState{};
     LenCompute lenCompute{&sharedState};
-    GDSUtils::runVertexComputeIteration(&context, &graph, lenCompute,
+    GDSUtils::runVertexCompute(&context, &graph, lenCompute,
         std::vector<std::string>{CreateFTSFunction::DOC_LEN_PROP_NAME});
     auto numDocs = sharedState.numDocs.load();
     auto avgDocLen = numDocs == 0 ? 0 : (double)sharedState.totalLen.load() / numDocs;

--- a/extension/fts/src/function/query_fts_gds.cpp
+++ b/extension/fts/src/function/query_fts_gds.cpp
@@ -243,16 +243,6 @@ void QFTSVertexCompute::vertexCompute(const graph::VertexScanState::Chunk& chunk
     }
 }
 
-void runVertexComputeIteration(processor::ExecutionContext* executionContext, graph::Graph* graph,
-    VertexCompute& vc) {
-    auto maxThreads = executionContext->clientContext->getCurrentSetting(main::ThreadsSetting::name)
-                          .getValue<uint64_t>();
-    auto sharedState = std::make_shared<VertexComputeTaskSharedState>(maxThreads, graph);
-    auto docsTableID = graph->getNodeTableIDs()[1];
-    auto info = VertexComputeTaskInfo(vc, {QFTSAlgorithm::DOC_LEN_PROP_NAME});
-    GDSUtils::runVertexComputeOnTable(docsTableID, graph, sharedState, info, *executionContext);
-}
-
 void QFTSAlgorithm::exec(processor::ExecutionContext* executionContext) {
     auto termsTableID = sharedState->graph->getNodeTableIDs()[0];
     KU_ASSERT(sharedState->getInputNodeMaskMap()->containsTableID(termsTableID));
@@ -263,11 +253,8 @@ void QFTSAlgorithm::exec(processor::ExecutionContext* executionContext) {
     // for each term-doc pair. The reason why we store the term frequency and document frequency
     // is that: we need the `len` property from the docs table which is only available during the
     // vertex compute.
-    auto numNodes = sharedState->graph->getNumNodesMap(executionContext->clientContext->getTx());
-    auto currentFrontier = std::make_shared<PathLengths>(numNodes,
-        executionContext->clientContext->getMemoryManager());
-    auto nextFrontier = std::make_shared<PathLengths>(numNodes,
-        executionContext->clientContext->getMemoryManager());
+    auto currentFrontier = getPathLengthsFrontier(executionContext);
+    auto nextFrontier = getPathLengthsFrontier(executionContext);
     auto frontierPair = std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier,
         nextFrontier, 1 /* numThreads */);
     auto edgeCompute = std::make_unique<QFTSEdgeCompute>(frontierPair.get(), &output->scores,
@@ -288,7 +275,8 @@ void QFTSAlgorithm::exec(processor::ExecutionContext* executionContext) {
     auto writerVC =
         std::make_unique<QFTSVertexCompute>(executionContext->clientContext->getMemoryManager(),
             sharedState.get(), outputWriter.copy());
-    runVertexComputeIteration(executionContext, sharedState->graph.get(), *writerVC);
+    auto docsTableID = sharedState->graph->getNodeTableIDs()[1];
+    GDSUtils::runVertexCompute(executionContext, sharedState->graph.get(), *writerVC, docsTableID, {QFTSAlgorithm::DOC_LEN_PROP_NAME});
     sharedState->mergeLocalTables();
 }
 

--- a/extension/fts/src/function/query_fts_gds.cpp
+++ b/extension/fts/src/function/query_fts_gds.cpp
@@ -276,7 +276,8 @@ void QFTSAlgorithm::exec(processor::ExecutionContext* executionContext) {
         std::make_unique<QFTSVertexCompute>(executionContext->clientContext->getMemoryManager(),
             sharedState.get(), outputWriter.copy());
     auto docsTableID = sharedState->graph->getNodeTableIDs()[1];
-    GDSUtils::runVertexCompute(executionContext, sharedState->graph.get(), *writerVC, docsTableID, {QFTSAlgorithm::DOC_LEN_PROP_NAME});
+    GDSUtils::runVertexCompute(executionContext, sharedState->graph.get(), *writerVC, docsTableID,
+        {QFTSAlgorithm::DOC_LEN_PROP_NAME});
     sharedState->mergeLocalTables();
 }
 

--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -248,7 +248,8 @@ private:
         auto numNodesMap = sharedState->graph->getNumNodesMap(clientContext->getTx());
         auto mm = clientContext->getMemoryManager();
         auto multiplicities = std::make_shared<PathMultiplicities>(numNodesMap, mm);
-        auto output = std::make_unique<AllSPDestinationsOutputs>(sourceNodeID, frontier, multiplicities);
+        auto output =
+            std::make_unique<AllSPDestinationsOutputs>(sourceNodeID, frontier, multiplicities);
         auto outputWriter = std::make_unique<AllSPDestinationsOutputWriter>(clientContext,
             output.get(), sharedState->getOutputNodeMaskMap());
         auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,

--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -25,9 +25,9 @@ class PathMultiplicities {
     using multiplicity_entry_t = std::atomic<uint64_t>;
 
 public:
-    PathMultiplicities(std::unordered_map<common::table_id_t, uint64_t> nodeTableIDAndNumNodes,
+    PathMultiplicities(std::unordered_map<common::table_id_t, uint64_t> numNodesMap,
         storage::MemoryManager* mm) {
-        for (auto& [tableID, numNodes] : nodeTableIDAndNumNodes) {
+        for (auto& [tableID, numNodes] : numNodesMap) {
             multiplicityArray.allocate(tableID, numNodes, mm);
             // Question to Trevor: Do I need to use atomics? If so, why?
             auto data = multiplicityArray.getData(tableID);
@@ -92,30 +92,29 @@ private:
 
 struct AllSPDestinationsOutputs : public SPOutputs {
 public:
-    AllSPDestinationsOutputs(std::unordered_map<table_id_t, uint64_t> nodeTableIDAndNumNodes,
-        nodeID_t sourceNodeID, MemoryManager* mm = nullptr)
-        : SPOutputs(nodeTableIDAndNumNodes, sourceNodeID, mm),
-          multiplicities{nodeTableIDAndNumNodes, mm} {}
+    AllSPDestinationsOutputs(nodeID_t sourceNodeID, std::shared_ptr<PathLengths> pathLengths,
+        std::shared_ptr<PathMultiplicities> multiplicities)
+        : SPOutputs{sourceNodeID, pathLengths}, multiplicities{multiplicities} {}
 
     void initRJFromSource(nodeID_t source) override {
-        multiplicities.incrementMultiplicity(source, 1);
+        multiplicities->incrementMultiplicity(source, 1);
     }
 
     void beginFrontierComputeBetweenTables(table_id_t curFrontierTableID,
         table_id_t nextFrontierTableID) override {
         // Note: We do not fix the node table for pathLengths, which is inherited from AllSPOutputs.
         // See the comment in SingleSPOutputs::beginFrontierComputeBetweenTables() for details.
-        multiplicities.fixBoundNodeTable(curFrontierTableID);
-        multiplicities.fixTargetNodeTable(nextFrontierTableID);
+        multiplicities->fixBoundNodeTable(curFrontierTableID);
+        multiplicities->fixTargetNodeTable(nextFrontierTableID);
     };
 
     void beginWritingOutputsForDstNodesInTable(table_id_t tableID) override {
         pathLengths->pinCurFrontierTableID(tableID);
-        multiplicities.fixTargetNodeTable(tableID);
+        multiplicities->fixTargetNodeTable(tableID);
     }
 
 public:
-    PathMultiplicities multiplicities;
+    std::shared_ptr<PathMultiplicities> multiplicities;
 };
 
 class AllSPDestinationsOutputWriter : public DestinationsOutputWriter {
@@ -130,7 +129,7 @@ public:
         auto length = outputs->pathLengths->getMaskValueFromCurFrontier(dstNodeID.offset);
         dstNodeIDVector->setValue<nodeID_t>(0, dstNodeID);
         lengthVector->setValue<uint16_t>(0, length);
-        auto multiplicity = outputs->multiplicities.getTargetMultiplicity(dstNodeID.offset);
+        auto multiplicity = outputs->multiplicities->getTargetMultiplicity(dstNodeID.offset);
         for (auto i = 0u; i < multiplicity; ++i) {
             fTable.append(vectors);
         }
@@ -245,15 +244,17 @@ public:
 private:
     RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
-        auto output = std::make_unique<AllSPDestinationsOutputs>(
-            sharedState->graph->getNumNodesMap(clientContext->getTx()), sourceNodeID,
-            clientContext->getMemoryManager());
+        auto frontier = getPathLengthsFrontier(context);
+        auto numNodesMap = sharedState->graph->getNumNodesMap(clientContext->getTx());
+        auto mm = clientContext->getMemoryManager();
+        auto multiplicities = std::make_shared<PathMultiplicities>(numNodesMap, mm);
+        auto output = std::make_unique<AllSPDestinationsOutputs>(sourceNodeID, frontier, multiplicities);
         auto outputWriter = std::make_unique<AllSPDestinationsOutputWriter>(clientContext,
             output.get(), sharedState->getOutputNodeMaskMap());
         auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,
             clientContext->getMaxNumThreadForExec());
         auto edgeCompute = std::make_unique<AllSPDestinationsEdgeCompute>(frontierPair.get(),
-            &output->multiplicities);
+            output->multiplicities.get());
         return RJCompState(std::move(frontierPair), std::move(edgeCompute), std::move(output),
             std::move(outputWriter));
     }
@@ -279,9 +280,9 @@ public:
 private:
     RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
-        auto output = std::make_unique<PathsOutputs>(
-            sharedState->graph->getNumNodesMap(clientContext->getTx()), sourceNodeID,
-            clientContext->getMemoryManager());
+        auto frontier = getPathLengthsFrontier(context);
+        auto bfsGraph = getBFSGraph(context);
+        auto output = std::make_unique<PathsOutputs>(sourceNodeID, frontier, std::move(bfsGraph));
         auto rjBindData = bindData->ptrCast<RJBindData>();
         auto writerInfo = rjBindData->getPathWriterInfo();
         writerInfo.pathNodeMask = sharedState->getPathNodeMaskMap();
@@ -290,7 +291,7 @@ private:
         auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,
             clientContext->getMaxNumThreadForExec());
         auto edgeCompute =
-            std::make_unique<AllSPPathsEdgeCompute>(frontierPair.get(), &output->bfsGraph);
+            std::make_unique<AllSPPathsEdgeCompute>(frontierPair.get(), output->bfsGraph.get());
         return RJCompState(std::move(frontierPair), std::move(edgeCompute), std::move(output),
             std::move(outputWriter));
     }

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -1,9 +1,9 @@
 #include "function/gds/gds.h"
 
 #include "binder/binder.h"
+#include "function/gds/gds_frontier.h"
 #include "function/gds/gds_utils.h"
 #include "processor/execution_context.h"
-#include "function/gds/gds_frontier.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::main;
@@ -20,7 +20,8 @@ std::shared_ptr<Expression> GDSAlgorithm::bindNodeOutput(Binder* binder,
     return node;
 }
 
-std::shared_ptr<PathLengths> GDSAlgorithm::getPathLengthsFrontier(processor::ExecutionContext* context) {
+std::shared_ptr<PathLengths> GDSAlgorithm::getPathLengthsFrontier(
+    processor::ExecutionContext* context) {
     auto tx = context->clientContext->getTx();
     auto mm = context->clientContext->getMemoryManager();
     auto graph = sharedState->graph.get();

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -1,6 +1,9 @@
 #include "function/gds/gds.h"
 
 #include "binder/binder.h"
+#include "function/gds/gds_utils.h"
+#include "processor/execution_context.h"
+#include "function/gds/gds_frontier.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::main;
@@ -15,6 +18,16 @@ std::shared_ptr<Expression> GDSAlgorithm::bindNodeOutput(Binder* binder,
     auto node = binder->createQueryNode(NODE_COLUMN_NAME, graphEntry.nodeEntries);
     binder->addToScope(NODE_COLUMN_NAME, node);
     return node;
+}
+
+std::shared_ptr<PathLengths> GDSAlgorithm::getPathLengthsFrontier(processor::ExecutionContext* context) {
+    auto tx = context->clientContext->getTx();
+    auto mm = context->clientContext->getMemoryManager();
+    auto graph = sharedState->graph.get();
+    auto pathLengths = std::make_shared<PathLengths>(graph->getNumNodesMap(tx), mm);
+    auto vc = std::make_unique<PathLengthsInitVertexCompute>(*pathLengths);
+    GDSUtils::runVertexCompute(context, graph, *vc);
+    return pathLengths;
 }
 
 } // namespace function

--- a/src/function/gds/gds_frontier.cpp
+++ b/src/function/gds/gds_frontier.cpp
@@ -65,7 +65,8 @@ bool PathLengthsInitVertexCompute::beginOnTable(common::table_id_t tableID) {
     return true;
 }
 
-void PathLengthsInitVertexCompute::vertexCompute(common::offset_t startOffset, common::offset_t endOffset, common::table_id_t) {
+void PathLengthsInitVertexCompute::vertexCompute(common::offset_t startOffset,
+    common::offset_t endOffset, common::table_id_t) {
     auto frontier = pathLengths.getCurFrontier();
     for (auto i = startOffset; i < endOffset; ++i) {
         frontier[i].store(PathLengths::UNVISITED);

--- a/src/function/gds/gds_frontier.cpp
+++ b/src/function/gds/gds_frontier.cpp
@@ -47,10 +47,6 @@ PathLengths::PathLengths(const common::table_id_map_t<common::offset_t>& numNode
     curIter.store(0);
     for (const auto& [tableID, numNodes] : numNodesMap_) {
         auto memBuffer = mm->allocateBuffer(false, numNodes * sizeof(frontier_entry_t));
-        auto memBufferPtr = reinterpret_cast<frontier_entry_t*>(memBuffer.get()->getData());
-        for (uint64_t i = 0; i < numNodes; ++i) {
-            memBufferPtr[i].store(UNVISITED, std::memory_order_relaxed);
-        }
         masks.insert({tableID, std::move(memBuffer)});
     }
 }
@@ -62,6 +58,18 @@ void PathLengths::pinCurFrontierTableID(common::table_id_t tableID) {
 
 void PathLengths::pinNextFrontierTableID(common::table_id_t tableID) {
     nextFrontier.store(getMaskData(tableID), std::memory_order_relaxed);
+}
+
+bool PathLengthsInitVertexCompute::beginOnTable(common::table_id_t tableID) {
+    pathLengths.pinTableID(tableID);
+    return true;
+}
+
+void PathLengthsInitVertexCompute::vertexCompute(common::offset_t startOffset, common::offset_t endOffset, common::table_id_t) {
+    auto frontier = pathLengths.getCurFrontier();
+    for (auto i = startOffset; i < endOffset; ++i) {
+        frontier[i].store(PathLengths::UNVISITED);
+    }
 }
 
 FrontierPair::FrontierPair(std::shared_ptr<GDSFrontier> curFrontier,

--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -54,8 +54,7 @@ void VertexComputeTask::run() {
     auto localVc = info.vc.copy();
     auto tableID = sharedState->morselDispatcher.getTableID();
     if (info.hasPropertiesToScan()) {
-        auto scanState =
-            graph->prepareVertexScan(tableID, info.propertiesToScan);
+        auto scanState = graph->prepareVertexScan(tableID, info.propertiesToScan);
         while (sharedState->morselDispatcher.getNextRangeMorsel(frontierMorsel)) {
             for (auto chunk : graph->scanVertices(frontierMorsel.getBeginOffset(),
                      frontierMorsel.getEndOffsetExclusive(), *scanState)) {
@@ -64,7 +63,8 @@ void VertexComputeTask::run() {
         }
     } else {
         while (sharedState->morselDispatcher.getNextRangeMorsel(frontierMorsel)) {
-            localVc->vertexCompute(frontierMorsel.getBeginOffset(), frontierMorsel.getEndOffsetExclusive(), tableID);
+            localVc->vertexCompute(frontierMorsel.getBeginOffset(),
+                frontierMorsel.getEndOffsetExclusive(), tableID);
         }
     }
 }

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -1,7 +1,6 @@
 #include "function/gds/gds_utils.h"
 
 #include "common/task_system/task_scheduler.h"
-#include "function/gds/gds_frontier.h"
 #include "function/gds/gds_task.h"
 #include "function/gds/rec_joins.h"
 #include "graph/graph.h"
@@ -9,6 +8,8 @@
 
 using namespace kuzu::common;
 using namespace kuzu::function;
+using namespace kuzu::processor;
+using namespace kuzu::graph;
 
 namespace kuzu {
 namespace function {
@@ -19,6 +20,10 @@ GDSComputeState::GDSComputeState(std::unique_ptr<function::FrontierPair> frontie
 
 GDSComputeState::~GDSComputeState() = default;
 
+static uint64_t getNumThreads(processor::ExecutionContext& context) {
+    return context.clientContext->getCurrentSetting(main::ThreadsSetting::name).getValue<uint64_t>();
+}
+
 void GDSUtils::scheduleFrontierTask(table_id_t relTableID, graph::Graph* graph,
     ExtendDirection extendDirection, GDSComputeState& gdsComputeState,
     processor::ExecutionContext* context, std::optional<uint64_t> numThreads,
@@ -27,10 +32,7 @@ void GDSUtils::scheduleFrontierTask(table_id_t relTableID, graph::Graph* graph,
     auto info = FrontierTaskInfo(relTableID, graph, extendDirection, *gdsComputeState.edgeCompute,
         edgePropertyIdx);
     auto sharedState = std::make_shared<FrontierTaskSharedState>(*gdsComputeState.frontierPair);
-    uint64_t maxThreads =
-        numThreads ?
-            numThreads.value() :
-            clientContext->getCurrentSetting(main::ThreadsSetting::name).getValue<uint64_t>();
+    uint64_t maxThreads = numThreads ? numThreads.value() : getNumThreads(*context);
     auto task = std::make_shared<FrontierTask>(maxThreads, info, sharedState);
     // GDSUtils::runFrontiersUntilConvergence is called from a GDSCall operator, which is
     // already executed by a worker thread Tm of the task scheduler. So this function is
@@ -86,31 +88,41 @@ void GDSUtils::runFrontiersUntilConvergence(processor::ExecutionContext* context
     }
 }
 
-void GDSUtils::runVertexComputeOnTable(common::table_id_t tableID, graph::Graph* graph,
-    std::shared_ptr<VertexComputeTaskSharedState> sharedState, const VertexComputeTaskInfo& info,
-    processor::ExecutionContext& context) {
-    auto maxThreads =
-        context.clientContext->getCurrentSetting(main::ThreadsSetting::name).getValue<uint64_t>();
-    sharedState->morselDispatcher.init(tableID,
-        graph->getNumNodes(context.clientContext->getTx(), tableID));
-    auto task = std::make_shared<VertexComputeTask>(maxThreads, info, sharedState);
-    context.clientContext->getTaskScheduler()->scheduleTaskAndWaitOrError(task, &context,
+static void runVertexComputeInternal(common::table_id_t tableID, graph::Graph* graph, std::shared_ptr<VertexComputeTask> task, processor::ExecutionContext* context) {
+    auto numNodes = graph->getNumNodes(context->clientContext->getTx(), tableID);
+    task->init(tableID, numNodes);
+    context->clientContext->getTaskScheduler()->scheduleTaskAndWaitOrError(task, context,
         true /* launchNewWorkerThread */);
 }
 
-void GDSUtils::runVertexComputeIteration(processor::ExecutionContext* executionContext,
+void GDSUtils::runVertexCompute(processor::ExecutionContext* context,
     graph::Graph* graph, VertexCompute& vc, std::vector<std::string> propertiesToScan) {
-    auto clientContext = executionContext->clientContext;
-    auto maxThreads =
-        clientContext->getCurrentSetting(main::ThreadsSetting::name).getValue<uint64_t>();
+    auto maxThreads = getNumThreads(*context);
     auto info = VertexComputeTaskInfo(vc, propertiesToScan);
     auto sharedState = std::make_shared<VertexComputeTaskSharedState>(maxThreads, graph);
     for (auto& tableID : graph->getNodeTableIDs()) {
         if (!vc.beginOnTable(tableID)) {
             continue;
         }
-        runVertexComputeOnTable(tableID, graph, sharedState, info, *executionContext);
+        auto task = std::make_shared<VertexComputeTask>(maxThreads, info, sharedState);
+        runVertexComputeInternal(tableID, graph, task, context);
     }
+}
+
+void GDSUtils::runVertexCompute(ExecutionContext* context, Graph* graph, VertexCompute& vc) {
+    runVertexCompute(context, graph, vc, std::vector<std::string>{});
+}
+
+void GDSUtils::runVertexCompute(ExecutionContext* context, Graph* graph, VertexCompute& vc,
+    table_id_t tableID, std::vector<std::string> propertiesToScan) {
+    auto maxThreads = getNumThreads(*context);
+    auto info = VertexComputeTaskInfo(vc, propertiesToScan);
+    auto sharedState = std::make_shared<VertexComputeTaskSharedState>(maxThreads, graph);
+    if (!vc.beginOnTable(tableID)) {
+        return;
+    }
+    auto task = std::make_shared<VertexComputeTask>(maxThreads, info, sharedState);
+    runVertexComputeInternal(tableID, graph, task, context);
 }
 
 } // namespace function

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -21,7 +21,8 @@ GDSComputeState::GDSComputeState(std::unique_ptr<function::FrontierPair> frontie
 GDSComputeState::~GDSComputeState() = default;
 
 static uint64_t getNumThreads(processor::ExecutionContext& context) {
-    return context.clientContext->getCurrentSetting(main::ThreadsSetting::name).getValue<uint64_t>();
+    return context.clientContext->getCurrentSetting(main::ThreadsSetting::name)
+        .getValue<uint64_t>();
 }
 
 void GDSUtils::scheduleFrontierTask(table_id_t relTableID, graph::Graph* graph,
@@ -88,15 +89,16 @@ void GDSUtils::runFrontiersUntilConvergence(processor::ExecutionContext* context
     }
 }
 
-static void runVertexComputeInternal(common::table_id_t tableID, graph::Graph* graph, std::shared_ptr<VertexComputeTask> task, processor::ExecutionContext* context) {
+static void runVertexComputeInternal(common::table_id_t tableID, graph::Graph* graph,
+    std::shared_ptr<VertexComputeTask> task, processor::ExecutionContext* context) {
     auto numNodes = graph->getNumNodes(context->clientContext->getTx(), tableID);
     task->init(tableID, numNodes);
     context->clientContext->getTaskScheduler()->scheduleTaskAndWaitOrError(task, context,
         true /* launchNewWorkerThread */);
 }
 
-void GDSUtils::runVertexCompute(processor::ExecutionContext* context,
-    graph::Graph* graph, VertexCompute& vc, std::vector<std::string> propertiesToScan) {
+void GDSUtils::runVertexCompute(processor::ExecutionContext* context, graph::Graph* graph,
+    VertexCompute& vc, std::vector<std::string> propertiesToScan) {
     auto maxThreads = getNumThreads(*context);
     auto info = VertexComputeTaskInfo(vc, propertiesToScan);
     auto sharedState = std::make_shared<VertexComputeTaskSharedState>(maxThreads, graph);

--- a/src/function/gds/output_writer.cpp
+++ b/src/function/gds/output_writer.cpp
@@ -9,15 +9,9 @@ using namespace kuzu::processor;
 namespace kuzu {
 namespace function {
 
-SPOutputs::SPOutputs(common::table_id_map_t<common::offset_t> numNodesMap, nodeID_t sourceNodeID,
-    storage::MemoryManager* mm)
-    : RJOutputs(sourceNodeID) {
-    pathLengths = std::make_shared<PathLengths>(numNodesMap, mm);
-}
-
 void PathsOutputs::beginWritingOutputsForDstNodesInTable(common::table_id_t tableID) {
     pathLengths->pinCurFrontierTableID(tableID);
-    bfsGraph.pinNodeTable(tableID);
+    bfsGraph->pinTableID(tableID);
 }
 
 RJOutputWriter::RJOutputWriter(main::ClientContext* context, RJOutputs* rjOutputs,
@@ -87,7 +81,7 @@ static ParentList* getTop(const std::vector<ParentList*>& path) {
 void PathsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNodeID,
     GDSOutputCounter* counter) {
     auto output = rjOutputs->ptrCast<PathsOutputs>();
-    auto& bfsGraph = output->bfsGraph;
+    auto& bfsGraph = *output->bfsGraph;
     auto sourceNodeID = output->sourceNodeID;
     dstNodeIDVector->setValue<common::nodeID_t>(0, dstNodeID);
     auto firstParent = findFirstParent(dstNodeID.offset, bfsGraph);

--- a/src/function/gds/rec_joins.cpp
+++ b/src/function/gds/rec_joins.cpp
@@ -149,7 +149,8 @@ public:
         return true;
     }
 
-    void vertexCompute(common::offset_t startOffset, common::offset_t endOffset, common::table_id_t tableID) override {
+    void vertexCompute(common::offset_t startOffset, common::offset_t endOffset,
+        common::table_id_t tableID) override {
         for (auto i = startOffset; i < endOffset; ++i) {
             if (sharedState->exceedLimit()) {
                 return;

--- a/src/function/gds/rec_joins.cpp
+++ b/src/function/gds/rec_joins.cpp
@@ -6,7 +6,6 @@
 #include "common/exception/runtime.h"
 #include "common/task_system/progress_bar.h"
 #include "function/gds/gds.h"
-#include "function/gds/gds_frontier.h"
 #include "function/gds/gds_utils.h"
 #include "graph/graph.h"
 #include "processor/execution_context.h"
@@ -150,11 +149,12 @@ public:
         return true;
     }
 
-    void vertexCompute(const graph::VertexScanState::Chunk& chunk) override {
-        for (auto nodeID : chunk.getNodeIDs()) {
+    void vertexCompute(common::offset_t startOffset, common::offset_t endOffset, common::table_id_t tableID) override {
+        for (auto i = startOffset; i < endOffset; ++i) {
             if (sharedState->exceedLimit()) {
                 return;
             }
+            auto nodeID = nodeID_t{i, tableID};
             if (writer->skip(nodeID)) {
                 continue;
             }
@@ -181,8 +181,8 @@ static double getRJProgress(common::offset_t totalNumNodes, common::offset_t com
     return (double)completedNumNodes / totalNumNodes;
 }
 
-void RJAlgorithm::exec(processor::ExecutionContext* executionContext) {
-    auto clientContext = executionContext->clientContext;
+void RJAlgorithm::exec(processor::ExecutionContext* context) {
+    auto clientContext = context->clientContext;
     auto graph = sharedState->graph.get();
     auto inputNodeMaskMap = sharedState->getInputNodeMaskMap();
     common::offset_t totalNumNodes = 0;
@@ -190,7 +190,7 @@ void RJAlgorithm::exec(processor::ExecutionContext* executionContext) {
         totalNumNodes = inputNodeMaskMap->getNumMaskedNode();
     } else {
         for (auto& tableID : graph->getNodeTableIDs()) {
-            totalNumNodes += graph->getNumNodes(executionContext->clientContext->getTx(), tableID);
+            totalNumNodes += graph->getNumNodes(clientContext->getTx(), tableID);
         }
     }
     common::offset_t completedNumNodes = 0;
@@ -198,27 +198,27 @@ void RJAlgorithm::exec(processor::ExecutionContext* executionContext) {
         if (!inputNodeMaskMap->containsTableID(tableID)) {
             continue;
         }
-        auto calcFunc = [tableID, graph, executionContext, clientContext, this](offset_t offset) {
+        auto calcFunc = [tableID, graph, context, clientContext, this](offset_t offset) {
             if (clientContext->interrupted()) {
                 throw InterruptException{};
             }
             auto sourceNodeID = nodeID_t{offset, tableID};
-            RJCompState rjCompState = getRJCompState(executionContext, sourceNodeID);
+            RJCompState rjCompState = getRJCompState(context, sourceNodeID);
             rjCompState.initSource(sourceNodeID);
             auto rjBindData = bindData->ptrCast<RJBindData>();
-            GDSUtils::runFrontiersUntilConvergence(executionContext, rjCompState, graph,
+            GDSUtils::runFrontiersUntilConvergence(context, rjCompState, graph,
                 rjBindData->extendDirection, rjBindData->upperBound);
             auto vertexCompute =
                 std::make_unique<RJVertexCompute>(clientContext->getMemoryManager(),
                     sharedState.get(), rjCompState.outputWriter->copy());
-            GDSUtils::runVertexComputeIteration(executionContext, graph, *vertexCompute);
+            GDSUtils::runVertexCompute(context, graph, *vertexCompute);
         };
-        auto numNodes = graph->getNumNodes(executionContext->clientContext->getTx(), tableID);
+        auto numNodes = graph->getNumNodes(clientContext->getTx(), tableID);
         auto mask = inputNodeMaskMap->getOffsetMask(tableID);
         if (mask->isEnabled()) {
             for (const auto& offset : mask->range(0, numNodes)) {
                 calcFunc(offset);
-                clientContext->getProgressBar()->updateProgress(executionContext->queryID,
+                clientContext->getProgressBar()->updateProgress(context->queryID,
                     getRJProgress(totalNumNodes, completedNumNodes++));
                 if (sharedState->exceedLimit()) {
                     break;
@@ -227,7 +227,7 @@ void RJAlgorithm::exec(processor::ExecutionContext* executionContext) {
         } else {
             for (auto offset = 0u; offset < numNodes; ++offset) {
                 calcFunc(offset);
-                clientContext->getProgressBar()->updateProgress(executionContext->queryID,
+                clientContext->getProgressBar()->updateProgress(context->queryID,
                     getRJProgress(totalNumNodes, completedNumNodes++));
                 if (sharedState->exceedLimit()) {
                     break;
@@ -236,6 +236,16 @@ void RJAlgorithm::exec(processor::ExecutionContext* executionContext) {
         }
     }
     sharedState->mergeLocalTables();
+}
+
+std::unique_ptr<BFSGraph> RJAlgorithm::getBFSGraph(processor::ExecutionContext* context) {
+    auto tx = context->clientContext->getTx();
+    auto mm = context->clientContext->getMemoryManager();
+    auto graph = sharedState->graph.get();
+    auto bfsGraph = std::make_unique<BFSGraph>(graph->getNumNodesMap(tx), mm);
+    auto vc = std::make_unique<BFSGraphInitVertexCompute>(*bfsGraph);
+    GDSUtils::runVertexCompute(context, graph, *vc);
+    return bfsGraph;
 }
 
 } // namespace function

--- a/src/function/gds/single_shortest_paths.cpp
+++ b/src/function/gds/single_shortest_paths.cpp
@@ -106,8 +106,7 @@ private:
     RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
         auto frontier = getPathLengthsFrontier(context);
-        auto output = std::make_unique<SingleSPDestinationsOutputs>(
-            sourceNodeID, frontier);
+        auto output = std::make_unique<SingleSPDestinationsOutputs>(sourceNodeID, frontier);
         auto outputWriter = std::make_unique<DestinationsOutputWriter>(clientContext, output.get(),
             sharedState->getOutputNodeMaskMap());
         auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,

--- a/src/function/gds/variable_length_path.cpp
+++ b/src/function/gds/variable_length_path.cpp
@@ -22,7 +22,7 @@ public:
 
     bool skipInternal(common::nodeID_t dstNodeID) const override {
         auto pathsOutputs = rjOutputs->ptrCast<PathsOutputs>();
-        auto head = pathsOutputs->bfsGraph.getParentListHead(dstNodeID.offset);
+        auto head = pathsOutputs->bfsGraph->getParentListHead(dstNodeID.offset);
         // For variable lengths joins, we skip a destination node d in the following conditions:
         //    (i) if no path has reached d from the source, except when the lower bound is 0.
         //    (ii) the longest path that has reached d, which is stored in the iter value of the
@@ -125,20 +125,20 @@ public:
 private:
     RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
-        auto mm = clientContext->getMemoryManager();
-        auto numNodesMap = sharedState->graph->getNumNodesMap(clientContext->getTx());
-        auto output = std::make_unique<PathsOutputs>(numNodesMap, sourceNodeID, mm);
+        auto frontier = getPathLengthsFrontier(context);
+        auto bfsGraph = getBFSGraph(context);
+        auto output = std::make_unique<PathsOutputs>(sourceNodeID, frontier, std::move(bfsGraph));
         auto rjBindData = bindData->ptrCast<RJBindData>();
         auto writerInfo = rjBindData->getPathWriterInfo();
         writerInfo.pathNodeMask = sharedState->getPathNodeMaskMap();
         auto outputWriter = std::make_unique<VarLenPathsOutputWriter>(clientContext, output.get(),
             sharedState->getOutputNodeMaskMap(), std::move(writerInfo));
-        auto currentFrontier = std::make_shared<PathLengths>(numNodesMap, mm);
-        auto nextFrontier = std::make_shared<PathLengths>(numNodesMap, mm);
+        auto currentFrontier = getPathLengthsFrontier(context);
+        auto nextFrontier = getPathLengthsFrontier(context);
         auto frontierPair = std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier,
             nextFrontier, clientContext->getMaxNumThreadForExec());
         auto edgeCompute =
-            std::make_unique<VarLenJoinsEdgeCompute>(frontierPair.get(), &output->bfsGraph);
+            std::make_unique<VarLenJoinsEdgeCompute>(frontierPair.get(), output->bfsGraph.get());
         return RJCompState(std::move(frontierPair), std::move(edgeCompute), std::move(output),
             std::move(outputWriter));
     }

--- a/src/include/function/gds/bfs_graph.h
+++ b/src/include/function/gds/bfs_graph.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "compute.h"
 #include "gds_object_manager.h"
 #include "storage/buffer_manager/memory_manager.h"
-#include "compute.h"
 
 namespace kuzu {
 namespace function {
@@ -139,7 +139,8 @@ public:
         return true;
     }
 
-    void vertexCompute(common::offset_t startOffset, common::offset_t endOffset, common::table_id_t) override {
+    void vertexCompute(common::offset_t startOffset, common::offset_t endOffset,
+        common::table_id_t) override {
         auto array = bfsGraph.currParentPtrs.load(std::memory_order_relaxed);
         KU_ASSERT(array != nullptr);
         for (auto i = startOffset; i < endOffset; ++i) {

--- a/src/include/function/gds/bfs_graph.h
+++ b/src/include/function/gds/bfs_graph.h
@@ -2,6 +2,7 @@
 
 #include "gds_object_manager.h"
 #include "storage/buffer_manager/memory_manager.h"
+#include "compute.h"
 
 namespace kuzu {
 namespace function {
@@ -52,6 +53,7 @@ private:
 };
 
 class BFSGraph {
+    friend class BFSGraphInitVertexCompute;
     static constexpr uint64_t ALL_PATHS_BLOCK_SIZE = (std::uint64_t)1 << 19;
     // Data type that is allocated to max num nodes per node table.
     using parent_entry_t = std::atomic<ParentList*>;
@@ -61,13 +63,6 @@ public:
         : mm{mm} {
         for (auto& [tableID, numNodes] : numNodesMap) {
             parentArray.allocate(tableID, numNodes, mm);
-            auto data = parentArray.getData(tableID);
-            for (uint64_t i = 0; i < numNodes; ++i) {
-                // Note: We are using memory_order_relaxed here because we are assuming that
-                // this code is running by a master thread which will run a memory barrier
-                // before worker threads start.
-                data[i].store(nullptr, std::memory_order_relaxed);
-            }
         }
     }
 
@@ -122,7 +117,7 @@ public:
         }
     }
 
-    void pinNodeTable(common::table_id_t tableID) {
+    void pinTableID(common::table_id_t tableID) {
         KU_ASSERT(parentArray.contains(tableID));
         currParentPtrs.store(parentArray.getData(tableID), std::memory_order_relaxed);
     }
@@ -133,6 +128,31 @@ private:
     ObjectArraysMap<parent_entry_t> parentArray;
     std::atomic<parent_entry_t*> currParentPtrs;
     std::vector<std::unique_ptr<ObjectBlock<ParentList>>> blocks;
+};
+
+class BFSGraphInitVertexCompute : public VertexCompute {
+public:
+    explicit BFSGraphInitVertexCompute(BFSGraph& bfsGraph) : bfsGraph{bfsGraph} {}
+
+    bool beginOnTable(common::table_id_t tableID) override {
+        bfsGraph.pinTableID(tableID);
+        return true;
+    }
+
+    void vertexCompute(common::offset_t startOffset, common::offset_t endOffset, common::table_id_t) override {
+        auto array = bfsGraph.currParentPtrs.load(std::memory_order_relaxed);
+        KU_ASSERT(array != nullptr);
+        for (auto i = startOffset; i < endOffset; ++i) {
+            array[i].store(nullptr);
+        }
+    }
+
+    std::unique_ptr<VertexCompute> copy() override {
+        return std::make_unique<BFSGraphInitVertexCompute>(bfsGraph);
+    }
+
+private:
+    BFSGraph& bfsGraph;
 };
 
 } // namespace function

--- a/src/include/function/gds/compute.h
+++ b/src/include/function/gds/compute.h
@@ -54,5 +54,5 @@ public:
     virtual std::unique_ptr<VertexCompute> copy() = 0;
 };
 
-}
-}
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/gds/compute.h
+++ b/src/include/function/gds/compute.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "common/types/types.h"
+#include "graph/graph.h"
+#include "processor/operator/gds_call_shared_state.h"
+
+namespace kuzu {
+namespace function {
+
+/**
+ * Base interface for algorithms that can be implemented in Pregel-like vertex-centric manner or
+ * more specifically Ligra's edgeCompute (called edgeUpdate in Ligra paper) function. Intended to be
+ * passed to the helper functions in GDSUtils that parallelize such Pregel-like computations.
+ */
+class EdgeCompute {
+public:
+    virtual ~EdgeCompute() = default;
+
+    // Does any work that is needed while extending the (boundNodeID, nbrNodeID, edgeID) edge.
+    // boundNodeID is the nodeID that is in the current frontier and currently executing.
+    // Returns a list of neighbors which should be put in the next frontier.
+    // So if the implementing class has access to the next frontier as a field,
+    // **do not** call setActive. Helper functions in GDSUtils will do that work.
+    virtual std::vector<common::nodeID_t> edgeCompute(common::nodeID_t boundNodeID,
+        graph::NbrScanState::Chunk& results, bool fwdEdge) = 0;
+
+    virtual void resetSingleThreadState() {}
+
+    virtual bool terminate(processor::NodeOffsetMaskMap&) { return false; }
+
+    virtual std::unique_ptr<EdgeCompute> copy() = 0;
+};
+
+class VertexCompute {
+public:
+    virtual ~VertexCompute() = default;
+
+    // This function is called once on the "main" copy of VertexCompute in the
+    // GDSUtils::runVertexCompute function. runVertexCompute loops through
+    // each node table T on the graph on which vertexCompute should run and then before
+    // parallelizing the computation on T calls this function.
+    virtual bool beginOnTable(common::table_id_t) { return true; }
+
+    // This function is called by each worker thread T on each node in the morsel that T grabs.
+    // Does any vertex-centric work that is needed while running on the curNodeID. This function
+    // should itself do the work of checking if any work should be done on the vertex or not. Note
+    // that this contrasts with how EdgeCompute::edgeCompute() should be implemented, where the
+    // GDSUtils helper functions call isActive on nodes to check if any work should be done for
+    // the edges of a node. Instead, here GDSUtils helper functions for VertexCompute blindly run
+    // the function on each node in a graph.
+    virtual void vertexCompute(const graph::VertexScanState::Chunk&) {}
+    virtual void vertexCompute(common::offset_t, common::offset_t, common::table_id_t) {}
+
+    virtual std::unique_ptr<VertexCompute> copy() = 0;
+};
+
+}
+}

--- a/src/include/function/gds/gds.h
+++ b/src/include/function/gds/gds.h
@@ -18,6 +18,7 @@ struct ExecutionContext;
 
 namespace function {
 
+class PathLengths;
 // Struct maintaining GDS specific information that needs to be obtained at compile time.
 struct GDSBindData {
     std::shared_ptr<binder::Expression> nodeOutput;
@@ -105,6 +106,8 @@ protected:
 protected:
     std::shared_ptr<binder::Expression> bindNodeOutput(binder::Binder* binder,
         const graph::GraphEntry& graphEntry);
+
+    std::shared_ptr<PathLengths> getPathLengthsFrontier(processor::ExecutionContext* context);
 
 protected:
     std::unique_ptr<GDSBindData> bindData;

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -4,7 +4,6 @@
 #include <mutex>
 
 #include "compute.h"
-
 #include "storage/buffer_manager/memory_manager.h"
 
 namespace kuzu {
@@ -100,7 +99,6 @@ protected:
     common::table_id_map_t<common::offset_t> numNodesMap;
 };
 
-
 /**
  * A GDSFrontier implementation that keeps the lengths of the paths from a source node to
  * destination nodes. This is a light-weight implementation that can keep lengths up to and
@@ -194,7 +192,8 @@ public:
 
     bool beginOnTable(common::table_id_t tableID) override;
 
-    void vertexCompute(common::offset_t startOffset, common::offset_t endOffset, common::table_id_t) override;
+    void vertexCompute(common::offset_t startOffset, common::offset_t endOffset,
+        common::table_id_t) override;
 
     std::unique_ptr<VertexCompute> copy() override {
         return std::make_unique<PathLengthsInitVertexCompute>(pathLengths);

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -3,59 +3,12 @@
 #include <atomic>
 #include <mutex>
 
-#include "common/types/types.h"
-#include "graph/graph.h"
-#include "processor/operator/gds_call_shared_state.h"
+#include "compute.h"
+
 #include "storage/buffer_manager/memory_manager.h"
 
 namespace kuzu {
 namespace function {
-
-/**
- * Base interface for algorithms that can be implemented in Pregel-like vertex-centric manner or
- * more specifically Ligra's edgeCompute (called edgeUpdate in Ligra paper) function. Intended to be
- * passed to the helper functions in GDSUtils that parallelize such Pregel-like computations.
- */
-class EdgeCompute {
-public:
-    virtual ~EdgeCompute() = default;
-
-    // Does any work that is needed while extending the (boundNodeID, nbrNodeID, edgeID) edge.
-    // boundNodeID is the nodeID that is in the current frontier and currently executing.
-    // Returns a list of neighbors which should be put in the next frontier.
-    // So if the implementing class has access to the next frontier as a field,
-    // **do not** call setActive. Helper functions in GDSUtils will do that work.
-    virtual std::vector<common::nodeID_t> edgeCompute(common::nodeID_t boundNodeID,
-        graph::NbrScanState::Chunk& results, bool fwdEdge) = 0;
-
-    virtual void resetSingleThreadState() {}
-
-    virtual bool terminate(processor::NodeOffsetMaskMap&) { return false; }
-
-    virtual std::unique_ptr<EdgeCompute> copy() = 0;
-};
-
-class VertexCompute {
-public:
-    virtual ~VertexCompute() = default;
-
-    // This function is called once on the "main" copy of VertexCompute in the
-    // GDSUtils::runVertexComputeIteration function. runVertexComputeIteration loops through
-    // each node table T on the graph on which vertexCompute should run and then before
-    // parallelizing the computation on T calls this function.
-    virtual bool beginOnTable(common::table_id_t) { return true; }
-
-    // This function is called by each worker thread T on each node in the morsel that T grabs.
-    // Does any vertex-centric work that is needed while running on the curNodeID. This function
-    // should itself do the work of checking if any work should be done on the vertex or not. Note
-    // that this contrasts with how EdgeCompute::edgeCompute() should be implemented, where the
-    // GDSUtils helper functions call isActive on nodes to check if any work should be done for
-    // the edges of a node. Instead, here GDSUtils helper functions for VertexCompute blindly run
-    // the function on each node in a graph.
-    virtual void vertexCompute(const graph::VertexScanState::Chunk& chunk) = 0;
-
-    virtual std::unique_ptr<VertexCompute> copy() = 0;
-};
 
 class FrontierMorsel {
     friend class FrontierMorselDispatcher;
@@ -147,6 +100,7 @@ protected:
     common::table_id_map_t<common::offset_t> numNodesMap;
 };
 
+
 /**
  * A GDSFrontier implementation that keeps the lengths of the paths from a source node to
  * destination nodes. This is a light-weight implementation that can keep lengths up to and
@@ -168,7 +122,7 @@ protected:
  * However, this is not necessary and the caller can also use this to represent a single frontier.
  */
 class KUZU_API PathLengths : public GDSFrontier {
-    friend class SingleSPDestinationsEdgeCompute;
+    friend class PathLengthsInitVertexCompute;
     using frontier_entry_t = std::atomic<uint16_t>;
 
 public:
@@ -232,6 +186,22 @@ private:
     std::atomic<common::table_id_t> curTableID;
     std::atomic<frontier_entry_t*> curFrontier;
     std::atomic<frontier_entry_t*> nextFrontier;
+};
+
+class PathLengthsInitVertexCompute : public VertexCompute {
+public:
+    explicit PathLengthsInitVertexCompute(PathLengths& pathLengths) : pathLengths{pathLengths} {}
+
+    bool beginOnTable(common::table_id_t tableID) override;
+
+    void vertexCompute(common::offset_t startOffset, common::offset_t endOffset, common::table_id_t) override;
+
+    std::unique_ptr<VertexCompute> copy() override {
+        return std::make_unique<PathLengthsInitVertexCompute>(pathLengths);
+    }
+
+private:
+    PathLengths& pathLengths;
 };
 
 /**

--- a/src/include/function/gds/gds_task.h
+++ b/src/include/function/gds/gds_task.h
@@ -49,8 +49,8 @@ struct VertexComputeTaskSharedState {
     FrontierMorselDispatcher morselDispatcher;
     graph::Graph* graph;
 
-    explicit VertexComputeTaskSharedState(uint64_t maxThreadsForExecution, graph::Graph* graph)
-        : morselDispatcher{maxThreadsForExecution}, graph{graph} {}
+    VertexComputeTaskSharedState(uint64_t maxNumThreads, graph::Graph* graph)
+        : morselDispatcher{maxNumThreads}, graph{graph} {}
 };
 
 struct VertexComputeTaskInfo {
@@ -61,6 +61,10 @@ struct VertexComputeTaskInfo {
         : vc{vc}, propertiesToScan{std::move(propertiesToScan)} {}
     VertexComputeTaskInfo(const VertexComputeTaskInfo& other)
         : vc{other.vc}, propertiesToScan{other.propertiesToScan} {}
+
+    bool hasPropertiesToScan() const {
+        return !propertiesToScan.empty();
+    }
 };
 
 class VertexComputeTask : public common::Task {
@@ -69,11 +73,16 @@ public:
         std::shared_ptr<VertexComputeTaskSharedState> sharedState)
         : common::Task{maxNumThreads}, info{info}, sharedState{std::move(sharedState)} {};
 
+    void init(common::table_id_t tableID, common::offset_t numNodes) {
+        sharedState->morselDispatcher.init(tableID, numNodes);
+    }
+
     void run() override;
 
 private:
     VertexComputeTaskInfo info;
     std::shared_ptr<VertexComputeTaskSharedState> sharedState;
 };
+
 } // namespace function
 } // namespace kuzu

--- a/src/include/function/gds/gds_task.h
+++ b/src/include/function/gds/gds_task.h
@@ -62,9 +62,7 @@ struct VertexComputeTaskInfo {
     VertexComputeTaskInfo(const VertexComputeTaskInfo& other)
         : vc{other.vc}, propertiesToScan{other.propertiesToScan} {}
 
-    bool hasPropertiesToScan() const {
-        return !propertiesToScan.empty();
-    }
+    bool hasPropertiesToScan() const { return !propertiesToScan.empty(); }
 };
 
 class VertexComputeTask : public common::Task {

--- a/src/include/function/gds/gds_utils.h
+++ b/src/include/function/gds/gds_utils.h
@@ -41,11 +41,17 @@ public:
     static void runFrontiersUntilConvergence(processor::ExecutionContext* executionContext,
         RJCompState& rjCompState, graph::Graph* graph, common::ExtendDirection extendDirection,
         uint64_t maxIters);
-    static void runVertexComputeOnTable(common::table_id_t tableID, graph::Graph* graph,
-        std::shared_ptr<VertexComputeTaskSharedState> sharedState,
-        const VertexComputeTaskInfo& info, processor::ExecutionContext& context);
-    static void runVertexComputeIteration(processor::ExecutionContext* executionContext,
-        graph::Graph* graph, VertexCompute& vc, std::vector<std::string> propertiesToScan = {});
+
+    // Run vertex compute without property scan
+    static void runVertexCompute(processor::ExecutionContext* context,
+        graph::Graph* graph, VertexCompute& vc);
+    // Run vertex compute with property scan
+    static void runVertexCompute(processor::ExecutionContext* context,
+        graph::Graph* graph, VertexCompute& vc, std::vector<std::string> propertiesToScan);
+    // Run vertex compute on specific table with property scan
+    static void runVertexCompute(processor::ExecutionContext* context,
+        graph::Graph* graph, VertexCompute& vc, common::table_id_t tableID,
+        std::vector<std::string> propertiesToScan);
 };
 
 } // namespace function

--- a/src/include/function/gds/gds_utils.h
+++ b/src/include/function/gds/gds_utils.h
@@ -43,15 +43,14 @@ public:
         uint64_t maxIters);
 
     // Run vertex compute without property scan
-    static void runVertexCompute(processor::ExecutionContext* context,
-        graph::Graph* graph, VertexCompute& vc);
+    static void runVertexCompute(processor::ExecutionContext* context, graph::Graph* graph,
+        VertexCompute& vc);
     // Run vertex compute with property scan
-    static void runVertexCompute(processor::ExecutionContext* context,
-        graph::Graph* graph, VertexCompute& vc, std::vector<std::string> propertiesToScan);
+    static void runVertexCompute(processor::ExecutionContext* context, graph::Graph* graph,
+        VertexCompute& vc, std::vector<std::string> propertiesToScan);
     // Run vertex compute on specific table with property scan
-    static void runVertexCompute(processor::ExecutionContext* context,
-        graph::Graph* graph, VertexCompute& vc, common::table_id_t tableID,
-        std::vector<std::string> propertiesToScan);
+    static void runVertexCompute(processor::ExecutionContext* context, graph::Graph* graph,
+        VertexCompute& vc, common::table_id_t tableID, std::vector<std::string> propertiesToScan);
 };
 
 } // namespace function

--- a/src/include/function/gds/output_writer.h
+++ b/src/include/function/gds/output_writer.h
@@ -33,29 +33,28 @@ public:
 
 struct SPOutputs : public RJOutputs {
 public:
-    SPOutputs(common::table_id_map_t<common::offset_t> numNodesMap, common::nodeID_t sourceNodeID,
-        storage::MemoryManager* mm);
+    SPOutputs(common::nodeID_t sourceNodeID, std::shared_ptr<PathLengths> pathLengths)
+        : RJOutputs{sourceNodeID}, pathLengths{std::move(pathLengths)} {}
 
 public:
     std::shared_ptr<PathLengths> pathLengths;
 };
 
 struct PathsOutputs : public SPOutputs {
-    PathsOutputs(common::table_id_map_t<common::offset_t> numNodesMap,
-        common::nodeID_t sourceNodeID, storage::MemoryManager* mm = nullptr)
-        : SPOutputs(numNodesMap, sourceNodeID, mm), bfsGraph{numNodesMap, mm} {}
+    PathsOutputs(common::nodeID_t sourceNodeID, std::shared_ptr<PathLengths> pathLengths, std::unique_ptr<BFSGraph> bfsGraph)
+        : SPOutputs(sourceNodeID, std::move(pathLengths)), bfsGraph{std::move(bfsGraph)} {}
 
     void beginFrontierComputeBetweenTables(common::table_id_t,
         common::table_id_t nextFrontierTableID) override {
         // Note: We do not fix the node table for pathLengths, which is inherited from AllSPOutputs.
         // See the comment in SingleSPOutputs::beginFrontierComputeBetweenTables() for details.
-        bfsGraph.pinNodeTable(nextFrontierTableID);
+        bfsGraph->pinTableID(nextFrontierTableID);
     };
 
     void beginWritingOutputsForDstNodesInTable(common::table_id_t tableID) override;
 
 public:
-    BFSGraph bfsGraph;
+    std::unique_ptr<BFSGraph> bfsGraph;
 };
 
 class RJOutputWriter {
@@ -179,7 +178,7 @@ protected:
         // For single/all shortest path computations, we do not output any results from source to
         // source. We also do not output any results if a destination node has not been reached.
         return dstNodeID == pathsOutputs->sourceNodeID ||
-               nullptr == pathsOutputs->bfsGraph.getParentListHead(dstNodeID.offset);
+               nullptr == pathsOutputs->bfsGraph->getParentListHead(dstNodeID.offset);
     }
 };
 

--- a/src/include/function/gds/output_writer.h
+++ b/src/include/function/gds/output_writer.h
@@ -41,7 +41,8 @@ public:
 };
 
 struct PathsOutputs : public SPOutputs {
-    PathsOutputs(common::nodeID_t sourceNodeID, std::shared_ptr<PathLengths> pathLengths, std::unique_ptr<BFSGraph> bfsGraph)
+    PathsOutputs(common::nodeID_t sourceNodeID, std::shared_ptr<PathLengths> pathLengths,
+        std::unique_ptr<BFSGraph> bfsGraph)
         : SPOutputs(sourceNodeID, std::move(pathLengths)), bfsGraph{std::move(bfsGraph)} {}
 
     void beginFrontierComputeBetweenTables(common::table_id_t,

--- a/src/include/function/gds/rec_joins.h
+++ b/src/include/function/gds/rec_joins.h
@@ -101,8 +101,8 @@ public:
     RJAlgorithm() = default;
     RJAlgorithm(const RJAlgorithm& other) : GDSAlgorithm{other} {}
 
-    void exec(processor::ExecutionContext* executionContext) override;
-    virtual RJCompState getRJCompState(processor::ExecutionContext* executionContext,
+    void exec(processor::ExecutionContext* context) override;
+    virtual RJCompState getRJCompState(processor::ExecutionContext* context,
         common::nodeID_t sourceNodeID) = 0;
     void setToNoPath();
     binder::expression_vector getResultColumnsNoPath();
@@ -112,6 +112,8 @@ protected:
 
     binder::expression_vector getBaseResultColumns() const;
     void bindColumnExpressions(binder::Binder* binder) const;
+
+    std::unique_ptr<BFSGraph> getBFSGraph(processor::ExecutionContext* context);
 };
 
 class SPAlgorithm : public RJAlgorithm {

--- a/test/test_files/tck/match/match5.test
+++ b/test/test_files/tck/match/match5.test
@@ -309,6 +309,7 @@ n0111
 
 # Handling a variable length relationship and a standard relationship in chain, longer 3
 -CASE Scenario25
+-SKIP_WASM
 -STATEMENT  MATCH (d:D)
             CREATE (e1:E {name: concat(d.name, '0')}),
                    (e2:E {name: concat(d.name, '1')})
@@ -338,6 +339,7 @@ n01111
 
 # Handling mixed relationship patterns and directions 1
 -CASE Scenario26
+-SKIP_WASM
 -STATEMENT MATCH (a:A)-[r]->(b:B)
            DELETE r
            CREATE (b)-[:LIKES_B_A]->(a);
@@ -436,6 +438,7 @@ n01111
 
 # Handling mixed relationship patterns 2
 -CASE Scenario29
+-SKIP_WASM
 -STATEMENT  MATCH (d:D)
             CREATE (e1:E {name: concat(d.name, '0')}),
                    (e2:E {name: concat(d.name, '1')})


### PR DESCRIPTION
# Description

Parallel init PathLengths and BFSGraph with VertexCompute.

On a graph with 500M nodes and 2 edges. The following query
```
MATCH (a)-[e*1..1]->(b) WHERE a.id = 0 RETURN COUNT(*);
```

Drops from 1s to 600ms

Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).