### PR TITLE
Increase buffer pool size for LargeListTest

### DIFF
--- a/test/test_files/read_list/var_length_large_adj_list_extend.test
+++ b/test/test_files/read_list/var_length_large_adj_list_extend.test
@@ -10,6 +10,7 @@
 # So the nth level will contain 5K*(n+1) + 1 many number of nodes.
 
 -DATASET CSV read-list-tests/large-list
+-BUFFER_POOL_SIZE 268435456
 
 --
 


### PR DESCRIPTION
# Description

This test is sometimes running into BM exceptions on code coverage + in mem mode test, let's try increasing the buffer pool size to see if this resolves the issue.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).