### PR TITLE
Avoid double updating linesPerBlock in SharedFileErrorHandler if an exception is thrown

### DIFF
--- a/src/processor/operator/persistent/reader/file_error_handler.cpp
+++ b/src/processor/operator/persistent/reader/file_error_handler.cpp
@@ -221,8 +221,10 @@ void LocalFileErrorHandler::finalize(bool canThrowCachedError) {
 
 void LocalFileErrorHandler::flushCachedErrors(bool canThrowCachedError) {
     if (!linesPerBlock.empty()) {
-        sharedErrorHandler->updateLineNumberInfo(linesPerBlock, canThrowCachedError);
-        linesPerBlock.clear();
+        // clear linesPerBlock first so that it is empty even if updateLineNumberInfo() throws
+        decltype(linesPerBlock) oldLinesPerBlock;
+        oldLinesPerBlock.swap(linesPerBlock);
+        sharedErrorHandler->updateLineNumberInfo(oldLinesPerBlock, canThrowCachedError);
     }
 
     if (!cachedErrors.empty()) {


### PR DESCRIPTION
# Description

If `updateLineNumberInfo()` throws, we double-updated the line number info in the shared file error handler which can sometimes cause reported line numbers to be incorrect (this was causing the test `CastErrorPreviousBlockNotFinished` to fail). This PR fixes the bug.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).