### PR TITLE
Implement conjunctive full text search

### DIFF
--- a/extension/fts/src/function/fts_config.cpp
+++ b/extension/fts/src/function/fts_config.cpp
@@ -50,6 +50,9 @@ QueryFTSConfig::QueryFTSConfig(const function::optional_params_t& optionalParams
             value.validateType(B::TYPE);
             b = value.getValue<double>();
             B::validate(b);
+        } else if (Conjunctive::NAME == lowerCaseName) {
+            value.validateType(Conjunctive::TYPE);
+            isConjunctive = value.getValue<bool>();
         } else {
             throw common::BinderException{"Unrecognized optional parameter: " + name};
         }

--- a/extension/fts/src/function/query_fts_gds.cpp
+++ b/extension/fts/src/function/query_fts_gds.cpp
@@ -32,15 +32,18 @@ struct QFTSGDSBindData final : public function::GDSBindData {
     double_t b;
     uint64_t numDocs;
     double_t avgDocLen;
+    uint64_t numTermsInQuery;
+    bool isConjunctive;
 
     QFTSGDSBindData(std::shared_ptr<binder::Expression> terms,
         std::shared_ptr<binder::Expression> docs, double_t k, double_t b, uint64_t numDocs,
-        double_t avgDocLen)
+        double_t avgDocLen, uint64_t numTermsInQuery, bool isConjunctive)
         : GDSBindData{std::move(docs)}, terms{std::move(terms)}, k{k}, b{b}, numDocs{numDocs},
-          avgDocLen{avgDocLen} {}
+          avgDocLen{avgDocLen}, numTermsInQuery{numTermsInQuery}, isConjunctive{isConjunctive} {}
     QFTSGDSBindData(const QFTSGDSBindData& other)
         : GDSBindData{other}, terms{other.terms}, k{other.k}, b{other.b}, numDocs{other.numDocs},
-          avgDocLen{other.avgDocLen} {}
+          avgDocLen{other.avgDocLen}, numTermsInQuery{other.numTermsInQuery},
+          isConjunctive{other.isConjunctive} {}
 
     bool hasNodeInput() const override { return true; }
     std::shared_ptr<binder::Expression> getNodeInput() const override { return terms; }
@@ -194,6 +197,11 @@ void QFTSOutputWriter::write(processor::FactorizedTable& scoreFT, nodeID_t docNo
     if (hasScore) {
         auto scoreInfo = qFTSOutput->scores.at(docNodeID);
         double score = 0;
+        // If the query is conjunctive, the numbers of distinct terms in the doc and the number of
+        // distinct terms in the query must be equal to each other.
+        if (bindData.isConjunctive && scoreInfo.scoreData.size() != bindData.numTermsInQuery) {
+            return;
+        }
         for (auto& scoreData : scoreInfo.scoreData) {
             auto numDocs = bindData.numDocs;
             auto avgDocLen = bindData.avgDocLen;
@@ -308,14 +316,17 @@ binder::expression_vector QFTSAlgorithm::getResultColumns(binder::Binder* binder
 
 void QFTSAlgorithm::bind(const binder::expression_vector& params, binder::Binder* binder,
     graph::GraphEntry& graphEntry) {
-    KU_ASSERT(params.size() == 6);
+    KU_ASSERT(params.size() == 8);
     auto termNode = params[1];
     auto k = ExpressionUtil::getLiteralValue<double>(*params[2]);
     auto b = ExpressionUtil::getLiteralValue<double>(*params[3]);
     auto numDocs = ExpressionUtil::getLiteralValue<uint64_t>(*params[4]);
     auto avgDocLen = ExpressionUtil::getLiteralValue<double>(*params[5]);
+    auto numTermsInQuery = ExpressionUtil::getLiteralValue<int64_t>(*params[6]);
+    auto isConjunctive = ExpressionUtil::getLiteralValue<bool>(*params[7]);
     auto nodeOutput = bindNodeOutput(binder, graphEntry);
-    bindData = std::make_unique<QFTSGDSBindData>(termNode, nodeOutput, k, b, numDocs, avgDocLen);
+    bindData = std::make_unique<QFTSGDSBindData>(termNode, nodeOutput, k, b, numDocs, avgDocLen,
+        numTermsInQuery, isConjunctive);
 }
 
 function::function_set QFTSFunction::getFunctionSet() {

--- a/extension/fts/src/include/function/fts_config.h
+++ b/extension/fts/src/include/function/fts_config.h
@@ -38,9 +38,16 @@ struct B {
     static void validate(double value);
 };
 
+struct Conjunctive {
+    static constexpr const char* NAME = "conjunctive";
+    static constexpr common::LogicalTypeID TYPE = common::LogicalTypeID::BOOL;
+    static constexpr bool DEFAULT_VALUE = false;
+};
+
 struct QueryFTSConfig {
     double k = K::DEFAULT_VALUE;
     double b = B::DEFAULT_VALUE;
+    bool isConjunctive = Conjunctive::DEFAULT_VALUE;
 
     QueryFTSConfig() = default;
     explicit QueryFTSConfig(const function::optional_params_t& optionalParams);

--- a/extension/fts/src/include/function/query_fts_gds.h
+++ b/extension/fts/src/include/function/query_fts_gds.h
@@ -31,7 +31,8 @@ public:
     std::vector<common::LogicalTypeID> getParameterTypeIDs() const override {
         return {common::LogicalTypeID::ANY, common::LogicalTypeID::NODE,
             common::LogicalTypeID::DOUBLE, common::LogicalTypeID::DOUBLE,
-            common::LogicalTypeID::UINT64, common::LogicalTypeID::DOUBLE};
+            common::LogicalTypeID::UINT64, common::LogicalTypeID::DOUBLE,
+            common::LogicalTypeID::INT64, common::LogicalTypeID::BOOL};
     }
 
     void exec(processor::ExecutionContext* executionContext) override;

--- a/extension/fts/test/test_files/fts_small.test
+++ b/extension/fts/test/test_files/fts_small.test
@@ -9,118 +9,44 @@
 ---- ok
 -STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx', ['content', 'author', 'name'])
 ---- ok
--LOG SingleKeyWordUpperCase
--STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'Alice') RETURN node.ID, score
+
+-LOG QueryFTSConjunctiveSingleKeyword
+-STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'alice', conjunctive := true) RETURN node.ID, score
 ---- 2
 0|0.271133
 3|0.209476
--LOG SingleKeyWordLowerCase
--STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'alice') RETURN node.ID, score
+
+-LOG QueryFTSConjunctiveMultiKeywords
+-STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'alice studying', conjunctive := true) RETURN node.ID, score
+---- 2
+0|0.326304
+3|0.268989
+
+-LOG QueryFTSConjunctiveDuplicateKeywords
+-STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'alice studying alice', conjunctive := true) RETURN node.ID, score
+---- 2
+0|0.326304
+3|0.268989
+
+-LOG QueryFTSConjunctiveDuplicateSingleKeyword
+-STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'alice alice', conjunctive := true) RETURN node.ID, score
 ---- 2
 0|0.271133
 3|0.209476
--LOG QueryEmptyString
--STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', '') RETURN node.ID, score
----- 0
--LOG QueryStopWord
--STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'at') RETURN node.ID, score
----- 0
--LOG QuerySingular
--STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'studys') RETURN node.ID, score
----- 3
-0|0.055171
-20|0.059514
-3|0.059514
--LOG QueryPresentTense
--STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'studying') RETURN node.ID, score
----- 3
-0|0.055171
-20|0.059514
-3|0.059514
--LOG QueryWithSpecialChar
--STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'study ->') RETURN node.ID, score
----- 3
-0|0.055171
-20|0.059514
-3|0.059514
--LOG MultipleIndexes
--STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx1', ['content', 'author'])
----- ok
--STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx2', ['content'])
----- ok
--STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'toronto') RETURN node.ID, score
----- 1
-0|0.565815
--STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx1', 'toronto') RETURN node.ID, score
----- 1
-0|0.400747
--STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx2', 'toronto') RETURN node.ID, score
----- 1
-0|0.393753
--LOG DropAndRecreate
--STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx4', ['content', 'name'])
----- ok
--STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx4', 'waterloo') RETURN node.ID, score
----- 2
-0|0.192034
-20|0.210752
--STATEMENT CALL DROP_FTS_INDEX('doc', 'docIdx4')
----- ok
--STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx4', ['content', 'name'])
----- ok
--STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx4', 'waterloo') RETURN node.ID, score
----- 2
-0|0.192034
-20|0.210752
 
--CASE FTSWithParams
--STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
----- ok
+-LOG QueryFTSConjunctiveNotExistSingleKeyword
+-STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'carol', conjunctive := true) RETURN node.ID, score
+---- 0
 
--LOG StemmerOption
--STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx', ['content', 'author', 'name'], stemmer := 'german1')
----- error
-Binder exception: Unrecognized stemmer 'german1'. Supported stemmers are: ['arabic, basque, catalan, danish, dutch, english, finnish, french, german, greek, hindi, hungarian, indonesian, irish, italian, lithuanian, nepali, norwegian, porter, portuguese, romanian, russian, serbian, spanish, swedish, tamil, turkish'], or use 'none' for no stemming.
--STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx', ['content', 'author', 'name'], stemmer := 'araBic')
----- ok
-#Note: arabic stemmer doesn't reduce studys/studying->study
--STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'study') RETURN node.ID, score
+-LOG QueryFTSConjunctiveNotExistMultiKeywords
+-STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'carol dog', conjunctive := true) RETURN node.ID, score
+---- 0
+
+-LOG QueryFTSConjunctivePartialExistKeyword
+-STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'alice carol', conjunctive := true) RETURN node.ID, score
+---- 0
+
+-LOG QueryFTSConjunctivePartialExistKeyword
+-STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'alice waterloo', conjunctive := true) RETURN node.ID, score
 ---- 1
-20|0.437146
--STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx1', ['content', 'author', 'name'], stemmer := 'frEnch')
----- ok
-#Note: french stemmer doesn't reduce studying->study
--STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx1', 'study') RETURN node.ID, score
----- 2
-0|0.194190
-20|0.209476
--STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx2', ['content', 'author', 'name'], stemmer := 'nOne')
----- ok
--STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx2', 'studying') RETURN node.ID, score
----- 1
-3|0.437146
--LOG CreateFTSIncorrectParam
--STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx5', ['content', 'author', 'name'], test := 'nOne')
----- error
-Binder exception: Unrecognized optional parameter: test
--LOG CreateFTSIncorrectParamType
--STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx5', ['content', 'author', 'name'], stemmer := 25)
----- error
-Binder exception: 25 has data type INT64 but STRING was expected.
--LOG QueryFTSOptionalParam
--STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx1', 'study', k := 0.3, B:= 0.5) RETURN node.ID, score
----- 2
-0|0.201218
-20|0.205603
--LOG QueryFTSOptionalParamError
--STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx1', 'study', k := 0.3, c:= 0.5) RETURN node.ID, score
----- error
-Binder exception: Unrecognized optional parameter: c
--LOG QueryFTSBOutOfRange
--STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx1', 'study', k := 0.3, B:= 3.88) RETURN node.ID, score
----- error
-Binder exception: BM25 model requires the Document Length Normalization(b) value to be in the range [0,1].
--LOG QueryFTSKOutOfRange
--STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx1', 'study', k := -5.3, B:= 0.7) RETURN node.ID, score
----- error
-Binder exception: BM25 model requires the Term Frequency Saturation(k) value to be a positive number.
+0|0.465323


### PR DESCRIPTION
This PR implements the conjunctive case for full text search.
In conjunctive full text search, only docs containing all the keywords in the query will be selected.
For example:
```
CALL QUERY_FTS_INDEX('doc', 'docIdx', 'alice studying', conjunctive := true)
```
Only docs with keywords: `alice` and `study` are selected.