### PR TITLE
Add exception when trying to load from a directory (or a file name with extension)

### DIFF
--- a/src/binder/bind/bind_file_scan.cpp
+++ b/src/binder/bind/bind_file_scan.cpp
@@ -111,6 +111,17 @@ std::unique_ptr<BoundBaseScanSource> Binder::bindFileScanSource(const BaseScanSo
         fileTypeInfo = bindFileTypeInfo(filePaths);
     }
     auto config = std::make_unique<ReaderConfig>(std::move(fileTypeInfo), std::move(filePaths));
+    // If we defined a certain FileType, we have to ensure the path is a file, not something else
+    // (e.g. an existed directory)
+    if (fileTypeInfo.fileType != FileType::UNKNOWN) {
+        for (const auto& filePath : filePaths) {
+            if (!common::LocalFileSystem::fileExists(filePath) &&
+                common::LocalFileSystem::isLocalPath(filePath)) {
+                throw common::BinderException{
+                    common::stringFormat("Provided path is not a file: {}.", filePath)};
+            }
+        }
+    }
     config->options = std::move(parsingOptions);
     auto func = getScanFunction(config->fileTypeInfo, *config);
     auto bindInput = std::make_unique<ScanTableFuncBindInput>(config->copy(), columnNames,

--- a/src/binder/bind/bind_file_scan.cpp
+++ b/src/binder/bind/bind_file_scan.cpp
@@ -110,7 +110,6 @@ std::unique_ptr<BoundBaseScanSource> Binder::bindFileScanSource(const BaseScanSo
     } else {
         fileTypeInfo = bindFileTypeInfo(filePaths);
     }
-    auto config = std::make_unique<ReaderConfig>(std::move(fileTypeInfo), std::move(filePaths));
     // If we defined a certain FileType, we have to ensure the path is a file, not something else
     // (e.g. an existed directory)
     if (fileTypeInfo.fileType != FileType::UNKNOWN) {
@@ -122,6 +121,7 @@ std::unique_ptr<BoundBaseScanSource> Binder::bindFileScanSource(const BaseScanSo
             }
         }
     }
+    auto config = std::make_unique<ReaderConfig>(std::move(fileTypeInfo), std::move(filePaths));
     config->options = std::move(parsingOptions);
     auto func = getScanFunction(config->fileTypeInfo, *config);
     auto bindInput = std::make_unique<ScanTableFuncBindInput>(config->copy(), columnNames,

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -209,7 +209,7 @@ function::TableFunction Binder::getScanFunction(FileTypeInfo typeInfo, const Rea
     // If we defined a certain FileType, we have to ensure the path is a file, not something else (e.g. an existed directory)
     if (typeInfo.fileType != FileType::UNKNOWN) {
         for (const auto& filePath : config.filePaths) {
-            if (!common::LocalFileSystem::fileExists(filePath)) {
+            if (!common::LocalFileSystem::fileExists(filePath) && common::LocalFileSystem::isLocalPath(filePath)) {
                 throw common::BinderException{common::stringFormat("Provided path is not a file: {}." , filePath)};
             }
         }

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -5,9 +5,9 @@
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "common/copier_config/csv_reader_config.h"
 #include "common/exception/binder.h"
+#include "common/file_system/local_file_system.h"
 #include "common/string_format.h"
 #include "common/string_utils.h"
-#include "common/file_system/local_file_system.h"
 #include "function/built_in_function_utils.h"
 #include "function/table_functions.h"
 #include "processor/operator/persistent/reader/csv/parallel_csv_reader.h"
@@ -206,11 +206,14 @@ function::TableFunction Binder::getScanFunction(FileTypeInfo typeInfo, const Rea
     std::vector<LogicalType> inputTypes;
     inputTypes.push_back(LogicalType::STRING());
     auto functions = clientContext->getCatalog()->getFunctions(clientContext->getTx());
-    // If we defined a certain FileType, we have to ensure the path is a file, not something else (e.g. an existed directory)
+    // If we defined a certain FileType, we have to ensure the path is a file, not something else
+    // (e.g. an existed directory)
     if (typeInfo.fileType != FileType::UNKNOWN) {
         for (const auto& filePath : config.filePaths) {
-            if (!common::LocalFileSystem::fileExists(filePath) && common::LocalFileSystem::isLocalPath(filePath)) {
-                throw common::BinderException{common::stringFormat("Provided path is not a file: {}." , filePath)};
+            if (!common::LocalFileSystem::fileExists(filePath) &&
+                common::LocalFileSystem::isLocalPath(filePath)) {
+                throw common::BinderException{
+                    common::stringFormat("Provided path is not a file: {}.", filePath)};
             }
         }
     }

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -206,17 +206,6 @@ function::TableFunction Binder::getScanFunction(FileTypeInfo typeInfo, const Rea
     std::vector<LogicalType> inputTypes;
     inputTypes.push_back(LogicalType::STRING());
     auto functions = clientContext->getCatalog()->getFunctions(clientContext->getTx());
-    // If we defined a certain FileType, we have to ensure the path is a file, not something else
-    // (e.g. an existed directory)
-    if (typeInfo.fileType != FileType::UNKNOWN) {
-        for (const auto& filePath : config.filePaths) {
-            if (!common::LocalFileSystem::fileExists(filePath) &&
-                common::LocalFileSystem::isLocalPath(filePath)) {
-                throw common::BinderException{
-                    common::stringFormat("Provided path is not a file: {}.", filePath)};
-            }
-        }
-    }
     switch (typeInfo.fileType) {
     case FileType::PARQUET: {
         func = function::BuiltInFunctionsUtils::matchFunction(clientContext->getTx(),

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -5,7 +5,6 @@
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "common/copier_config/csv_reader_config.h"
 #include "common/exception/binder.h"
-#include "common/file_system/local_file_system.h"
 #include "common/string_format.h"
 #include "common/string_utils.h"
 #include "function/built_in_function_utils.h"

--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -13,6 +13,7 @@
 #include <fileapi.h>
 #include <io.h>
 #include <windows.h>
+#include "common/windows_utils.h"
 #else
 #include "sys/stat.h"
 #include <unistd.h>
@@ -314,7 +315,7 @@ bool LocalFileSystem::fileExists(const std::string& filename) {
 }
 #else
 bool LocalFileSystem::fileExists(const std::string& filename) {
-	auto unicode_path = WindowsUtil::UTF8ToUnicode(filename.c_str());
+	auto unicode_path = WindowsUtils::utf8ToUnicode(filename.c_str());
 	const wchar_t *wpath = unicode_path.c_str();
 	if (_waccess(wpath, 0) == 0) {
 		struct _stati64 status = {};

--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -10,10 +10,10 @@
 #include "main/settings.h"
 
 #if defined(_WIN32)
+#include "common/windows_utils.h"
 #include <fileapi.h>
 #include <io.h>
 #include <windows.h>
-#include "common/windows_utils.h"
 #else
 #include "sys/stat.h"
 #include <unistd.h>
@@ -301,30 +301,30 @@ bool LocalFileSystem::fileOrPathExists(const std::string& path, main::ClientCont
 
 #ifndef _WIN32
 bool LocalFileSystem::fileExists(const std::string& filename) {
-	if (!filename.empty()) {
-		if (access(filename.c_str(), 0) == 0) {
-			struct stat status = {};
-			stat(filename.c_str(), &status);
-			if (S_ISREG(status.st_mode)) {
-				return true;
-			}
-		}
-	}
-	// if any condition fails
-	return false;
+    if (!filename.empty()) {
+        if (access(filename.c_str(), 0) == 0) {
+            struct stat status = {};
+            stat(filename.c_str(), &status);
+            if (S_ISREG(status.st_mode)) {
+                return true;
+            }
+        }
+    }
+    // if any condition fails
+    return false;
 }
 #else
 bool LocalFileSystem::fileExists(const std::string& filename) {
-	auto unicode_path = WindowsUtils::utf8ToUnicode(filename.c_str());
-	const wchar_t *wpath = unicode_path.c_str();
-	if (_waccess(wpath, 0) == 0) {
-		struct _stati64 status = {};
-		_wstati64(wpath, &status);
-		if (status.st_mode & S_IFREG) {
-			return true;
-		}
-	}
-	return false;
+    auto unicode_path = WindowsUtils::utf8ToUnicode(filename.c_str());
+    const wchar_t* wpath = unicode_path.c_str();
+    if (_waccess(wpath, 0) == 0) {
+        struct _stati64 status = {};
+        _wstati64(wpath, &status);
+        if (status.st_mode & S_IFREG) {
+            return true;
+        }
+    }
+    return false;
 }
 #endif
 

--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -302,7 +302,7 @@ bool LocalFileSystem::fileOrPathExists(const std::string& path, main::ClientCont
 bool LocalFileSystem::fileExists(const std::string& filename) {
 	if (!filename.empty()) {
 		if (access(filename.c_str(), 0) == 0) {
-			struct stat status;
+			struct stat status = {};
 			stat(filename.c_str(), &status);
 			if (S_ISREG(status.st_mode)) {
 				return true;
@@ -317,7 +317,7 @@ bool LocalFileSystem::fileExists(const std::string& filename) {
 	auto unicode_path = WindowsUtil::UTF8ToUnicode(filename.c_str());
 	const wchar_t *wpath = unicode_path.c_str();
 	if (_waccess(wpath, 0) == 0) {
-		struct _stati64 status;
+		struct _stati64 status = {};
 		_wstati64(wpath, &status);
 		if (status.st_mode & S_IFREG) {
 			return true;

--- a/src/include/common/file_system/local_file_system.h
+++ b/src/include/common/file_system/local_file_system.h
@@ -54,6 +54,8 @@ public:
 
     static bool isLocalPath(const std::string& path);
 
+    static bool fileExists(const std::string& filename);
+
 protected:
     void readFromFile(FileInfo& fileInfo, void* buffer, uint64_t numBytes,
         uint64_t position) const override;

--- a/test/test_files/load_from/load_from.test
+++ b/test/test_files/load_from/load_from.test
@@ -172,7 +172,7 @@ Binder exception: Cannot load from file type tsv.
 -LOG LoadFromIncorrectPath
 -STATEMENT LOAD FROM '${KUZU_ROOT_DIRECTORY}/dataset' (file_format='csv') RETURN *;
 ---- error
-Binder exception: No file found that matches the pattern: ${KUZU_ROOT_DIRECTORY}/dataset.
+Error: Binder exception: Provided path is not a file: ${KUZU_ROOT_DIRECTORY}/dataset.
 
 -LOG LoadFromNotExistPath
 -STATEMENT LOAD FROM '${KUZU_ROOT_DIRECTORY}/dataset/1.parquet' (file_format='csv') RETURN *;

--- a/test/test_files/load_from/load_from.test
+++ b/test/test_files/load_from/load_from.test
@@ -172,7 +172,7 @@ Binder exception: Cannot load from file type tsv.
 -LOG LoadFromIncorrectPath
 -STATEMENT LOAD FROM '${KUZU_ROOT_DIRECTORY}/dataset' (file_format='csv') RETURN *;
 ---- error
-Error: Binder exception: Provided path is not a file: ${KUZU_ROOT_DIRECTORY}/dataset.
+Binder exception: Provided path is not a file: ${KUZU_ROOT_DIRECTORY}/dataset.
 
 -LOG LoadFromNotExistPath
 -STATEMENT LOAD FROM '${KUZU_ROOT_DIRECTORY}/dataset/1.parquet' (file_format='csv') RETURN *;

--- a/test/test_files/load_from/load_from.test
+++ b/test/test_files/load_from/load_from.test
@@ -169,10 +169,10 @@ Binder exception: Cannot load from file type tsv.
 2|2
 
 -CASE LoadFromErrorTest
-# Fix after fixing issue #4610
-#-LOG LoadFromIncorrectPath
-#-STATEMENT LOAD FROM '${KUZU_ROOT_DIRECTORY}/dataset' (file_format='csv') RETURN *;
-#---- error
+-LOG LoadFromIncorrectPath
+-STATEMENT LOAD FROM '${KUZU_ROOT_DIRECTORY}/dataset' (file_format='csv') RETURN *;
+---- error
+Binder exception: No file found that matches the pattern: ${KUZU_ROOT_DIRECTORY}/dataset.
 
 -LOG LoadFromNotExistPath
 -STATEMENT LOAD FROM '${KUZU_ROOT_DIRECTORY}/dataset/1.parquet' (file_format='csv') RETURN *;


### PR DESCRIPTION
# Description

Added a fileExists function to check if a path is both 1.a file 2. existed . 

This check is performed in Binder::getScanFunction for all FileType except for UNKNOWN 

Fixes #4610 

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).