### PR TITLE
Add setting `enable_plan_optimizer`

### DIFF
--- a/src/include/main/client_config.h
+++ b/src/include/main/client_config.h
@@ -21,6 +21,7 @@ struct ClientConfigDefault {
     static constexpr uint32_t RECURSIVE_PATTERN_FACTOR = 100;
     static constexpr bool DISABLE_MAP_KEY_CHECK = true;
     static constexpr uint64_t WARNING_LIMIT = 8 * 1024;
+    static constexpr bool ENABLE_PLAN_OPTIMIZER = true;
 };
 
 struct ClientConfig {
@@ -51,6 +52,7 @@ struct ClientConfig {
     // maximum number of cached warnings
     uint64_t warningLimit = ClientConfigDefault::WARNING_LIMIT;
     bool disableMapKeyCheck = ClientConfigDefault::DISABLE_MAP_KEY_CHECK;
+    bool enablePlanOptimizer = ClientConfigDefault::ENABLE_PLAN_OPTIMIZER;
 };
 
 } // namespace main

--- a/src/include/main/settings.h
+++ b/src/include/main/settings.h
@@ -229,5 +229,17 @@ struct SpillToDiskSetting {
     }
 };
 
+struct EnableOptimizerSetting {
+    static constexpr auto name = "enable_plan_optimizer";
+    static constexpr auto inputType = common::LogicalTypeID::BOOL;
+    static void setContext(ClientContext* context, const common::Value& parameter) {
+        parameter.validateType(inputType);
+        context->getClientConfigUnsafe()->enablePlanOptimizer = parameter.getValue<bool>();
+    }
+    static common::Value getSetting(const ClientContext* context) {
+        return common::Value::createValue(context->getClientConfig()->enablePlanOptimizer);
+    }
+};
+
 } // namespace main
 } // namespace kuzu

--- a/src/include/optimizer/schema_populator.h
+++ b/src/include/optimizer/schema_populator.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "optimizer/logical_operator_visitor.h"
+#include "planner/operator/logical_plan.h"
+namespace kuzu {
+namespace optimizer {
+class SchemaPopulator : public LogicalOperatorVisitor {
+public:
+    void rewrite(planner::LogicalPlan* plan);
+};
+} // namespace optimizer
+} // namespace kuzu

--- a/src/main/db_config.cpp
+++ b/src/main/db_config.cpp
@@ -22,7 +22,7 @@ static ConfigurationOption options[] = { // NOLINT(cert-err58-cpp):
     GET_CONFIGURATION(RecursivePatternFactorSetting), GET_CONFIGURATION(EnableMVCCSetting),
     GET_CONFIGURATION(CheckpointThresholdSetting), GET_CONFIGURATION(AutoCheckpointSetting),
     GET_CONFIGURATION(ForceCheckpointClosingDBSetting), GET_CONFIGURATION(SpillToDiskSetting),
-    GET_CONFIGURATION(EnableGDSSetting)};
+    GET_CONFIGURATION(EnableGDSSetting), GET_CONFIGURATION(EnableOptimizerSetting)};
 
 DBConfig::DBConfig(const SystemConfig& systemConfig)
     : bufferPoolSize{systemConfig.bufferPoolSize}, maxNumThreads{systemConfig.maxNumThreads},

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(kuzu_optimizer
         logical_operator_visitor.cpp
         optimizer.cpp
         projection_push_down_optimizer.cpp
+        schema_populator.cpp
         remove_factorization_rewriter.cpp
         remove_unnecessary_join_optimizer.cpp
         top_k_optimizer.cpp

--- a/src/optimizer/schema_populator.cpp
+++ b/src/optimizer/schema_populator.cpp
@@ -1,0 +1,15 @@
+#include "optimizer/schema_populator.h"
+
+namespace kuzu::optimizer {
+
+static void populateSchemaRecursive(planner::LogicalOperator* op) {
+    for (auto i = 0u; i < op->getNumChildren(); ++i) {
+        populateSchemaRecursive(op->getChild(i).get());
+    }
+    op->computeFactorizedSchema();
+}
+
+void SchemaPopulator::rewrite(planner::LogicalPlan* plan) {
+    populateSchemaRecursive(plan->getLastOperator().get());
+}
+} // namespace kuzu::optimizer

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -80,6 +80,36 @@ TEST_F(OptimizerTest, CrossJoinWithFilterWithoutPushDownTest) {
     ASSERT_STREQ(getEncodedPlan(q3).c_str(), "HJ(a.fName=b.fName){Filter()S(a)}{S(b)}");
 }
 
+TEST_F(OptimizerTest, DisableOptimizerTest) {
+    conn->query("CALL enable_plan_optimizer=false");
+
+    auto q1 = "MATCH (a:person)-[e]->(b) "
+              "WHERE a.ID < 0 AND a.fName='Alice' "
+              "RETURN a.gender;";
+    {
+        ASSERT_STREQ(getEncodedPlan(q1).c_str(), "HJ(b._ID){E(b)Filter()Filter()S(a)}{S(b)}");
+        // sanity check to see if the plan still outputs the correct result
+        auto result = conn->query(q1);
+        ASSERT_EQ(result->getNumTuples(), 0);
+    }
+
+    auto q2 = "MATCH (a:person)-[e:knows]->(b:person) "
+              "HINT (a JOIN e) JOIN b "
+              "RETURN e.date;";
+    {
+        ASSERT_STREQ(getEncodedPlan(q2).c_str(), "HJ(b._ID){E(b)S(a)}{S(b)}");
+        auto result = conn->query(q2);
+        ASSERT_EQ(result->getNumTuples(), 14);
+    }
+
+    conn->query("CALL enable_plan_optimizer=true");
+    {
+        ASSERT_STREQ(getEncodedPlan(q2).c_str(), "E(b)S(a)");
+        auto result = conn->query(q2);
+        ASSERT_EQ(result->getNumTuples(), 14);
+    }
+}
+
 TEST_F(OptimizerTest, FilterPushDownTest) {
     auto q1 = "MATCH (a:person)-[e]->(b) "
               "WHERE a.ID < 0 AND a.fName='Alice' "

--- a/test/test_files/call/call.test
+++ b/test/test_files/call/call.test
@@ -4,6 +4,18 @@
 
 -CASE CallSetGetConfig
 
+-LOG SetGetEnablePlanOptimizer
+-STATEMENT CALL enable_plan_optimizer=false
+---- ok
+-STATEMENT CALL current_setting('enable_plan_optimizer') RETURN *
+---- 1
+False
+-STATEMENT CALL enable_plan_optimizer=true
+---- ok
+-STATEMENT CALL current_setting('enable_plan_optimizer') RETURN *
+---- 1
+True
+
 -LOG SetGetThread
 -STATEMENT CALL THREADS=4
 ---- ok


### PR DESCRIPTION
# Description

Add setting `enable_plan_optimizer` that allows us to control whether we want the plan optimizer to be enabled/disabled. Disabling the optimizer may be useful in cases such as when we wish to view logical plans (e.g. with `EXPLAIN LOGICAL`) before optimizations occur (e.g. when debugging join order).

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).