### PR TITLE
Add call function for bm info

### DIFF
--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -36,23 +36,22 @@ namespace kuzu {
 namespace function {
 
 #define SCALAR_FUNCTION_BASE(_PARAM, _NAME)                                                        \
-    { _PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
 #define SCALAR_FUNCTION(_PARAM) SCALAR_FUNCTION_BASE(_PARAM, _PARAM::name)
 #define SCALAR_FUNCTION_ALIAS(_PARAM) SCALAR_FUNCTION_BASE(_PARAM::alias, _PARAM::name)
 #define REWRITE_FUNCTION(_PARAM)                                                                   \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY}
 #define AGGREGATE_FUNCTION(_PARAM)                                                                 \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY}
 #define EXPORT_FUNCTION(_PARAM)                                                                    \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY}
 #define TABLE_FUNCTION(_PARAM)                                                                     \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY}
 #define STANDALONE_TABLE_FUNCTION(_PARAM)                                                          \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY}
 #define ALGORITHM_FUNCTION(_PARAM)                                                                 \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY }
-#define FINAL_FUNCTION                                                                             \
-    { nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY}
+#define FINAL_FUNCTION {nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
 
 FunctionCollection* FunctionCollection::getFunctions() {
     static FunctionCollection functions[] = {
@@ -216,7 +215,7 @@ FunctionCollection* FunctionCollection::getFunctions() {
         TABLE_FUNCTION(TableInfoFunction), TABLE_FUNCTION(ShowConnectionFunction),
         TABLE_FUNCTION(StatsInfoFunction), TABLE_FUNCTION(StorageInfoFunction),
         TABLE_FUNCTION(ShowAttachedDatabasesFunction), TABLE_FUNCTION(ShowSequencesFunction),
-        TABLE_FUNCTION(ShowFunctionsFunction),
+        TABLE_FUNCTION(ShowFunctionsFunction), TABLE_FUNCTION(BMInfoFunction),
 
         // Standalone Table functions
         STANDALONE_TABLE_FUNCTION(ClearWarningsFunction),

--- a/src/function/table/call/CMakeLists.txt
+++ b/src/function/table/call/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(kuzu_table_call
         OBJECT
+        bm_info.cpp
         current_setting.cpp
         db_version.cpp
         show_connection.cpp

--- a/src/function/table/call/bm_info.cpp
+++ b/src/function/table/call/bm_info.cpp
@@ -1,0 +1,57 @@
+#include "function/table/call_functions.h"
+#include "main/database.h"
+#include "storage/buffer_manager/buffer_manager.h"
+#include "storage/buffer_manager/memory_manager.h"
+
+namespace kuzu {
+namespace function {
+
+struct BMInfoBindData final : CallTableFuncBindData {
+    uint64_t memLimit;
+    uint64_t memUsage;
+
+    BMInfoBindData(uint64_t memLimit, uint64_t memUsage,
+        std::vector<common::LogicalType> returnTypes, std::vector<std::string> returnColumnNames)
+        : CallTableFuncBindData{std::move(returnTypes), std::move(returnColumnNames), 1},
+          memLimit{memLimit}, memUsage{memUsage} {}
+
+    std::unique_ptr<TableFuncBindData> copy() const override {
+        return std::make_unique<BMInfoBindData>(memLimit, memUsage,
+            common::LogicalType::copy(columnTypes), columnNames);
+    }
+};
+
+static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output) {
+    KU_ASSERT(output.dataChunk.getNumValueVectors() == 2);
+    const auto sharedState = input.sharedState->ptrCast<CallFuncSharedState>();
+    const auto morsel = sharedState->getMorsel();
+    if (!morsel.hasMoreToOutput()) {
+        return 0;
+    }
+    const auto bindData = input.bindData->constPtrCast<BMInfoBindData>();
+    output.dataChunk.getValueVectorMutable(0).setValue<uint64_t>(0, bindData->memLimit);
+    output.dataChunk.getValueVectorMutable(1).setValue<uint64_t>(0, bindData->memUsage);
+    return 1;
+}
+
+static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
+    ScanTableFuncBindInput*) {
+    auto memLimit = context->getMemoryManager()->getBufferManager()->getMemoryLimit();
+    auto memUsage = context->getMemoryManager()->getBufferManager()->getUsedMemory();
+    std::vector<common::LogicalType> returnTypes;
+    returnTypes.emplace_back(common::LogicalType::UINT64());
+    returnTypes.emplace_back(common::LogicalType::UINT64());
+    auto returnColumnNames = std::vector<std::string>{"mem_limit", "mem_usage"};
+    return std::make_unique<BMInfoBindData>(memLimit, memUsage, std::move(returnTypes),
+        std::move(returnColumnNames));
+}
+
+function_set BMInfoFunction::getFunctionSet() {
+    function_set functionSet;
+    functionSet.push_back(std::make_unique<TableFunction>(name, tableFunc, bindFunc,
+        initSharedState, initEmptyLocalState, std::vector<common::LogicalTypeID>{}));
+    return functionSet;
+}
+
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/table/call_functions.h
+++ b/src/include/function/table/call_functions.h
@@ -121,6 +121,12 @@ struct StatsInfoFunction final : CallFunction {
     static function_set getFunctionSet();
 };
 
+struct BMInfoFunction final : CallFunction {
+    static constexpr const char* name = "BM_INFO";
+
+    static function_set getFunctionSet();
+};
+
 struct ShowAttachedDatabasesFunction final : CallFunction {
     static constexpr const char* name = "SHOW_ATTACHED_DATABASES";
 

--- a/src/include/storage/buffer_manager/buffer_manager.h
+++ b/src/include/storage/buffer_manager/buffer_manager.h
@@ -205,6 +205,7 @@ public:
         return fileHandles.back().get();
     }
 
+    uint64_t getMemoryLimit() const { return bufferPoolSize; }
     uint64_t getUsedMemory() const { return usedMemory; }
 
     void getSpillerOrSkip(std::function<void(Spiller&)> func) {

--- a/test/test_files/call/call.test
+++ b/test/test_files/call/call.test
@@ -258,3 +258,8 @@ Binder exception: Show connection can only be called on a rel table!
 -STATEMENT MATCH (a:person) CALL show_connection(a.fName) RETURN *
 ---- error
 Binder exception: a.fName has type PROPERTY but LITERAL was expected.
+
+-LOG BMInfo
+-STATEMENT CALL bm_info() RETURN mem_limit
+---- 1
+67108864


### PR DESCRIPTION
# Description

Return bm max limit and current usage in bytes.

```
kuzu> call bm_info() return *;
┌─────────────┬───────────┐
│ mem_limit   │ mem_usage │
│ UINT64      │ UINT64    │
├─────────────┼───────────┤
│ 54975581388 │ 107374176 │
└─────────────┴───────────┘
(1 tuple)
(2 columns)
Time: 0.78ms (compiling), 0.68ms (executing)
```