### PR TITLE
Remove unnecessary lock in isVisibleNoLock check

### DIFF
--- a/src/include/storage/store/node_group_collection.h
+++ b/src/include/storage/store/node_group_collection.h
@@ -36,6 +36,9 @@ public:
         const auto lock = nodeGroups.lock();
         return nodeGroups.getNumGroups(lock);
     }
+    common::node_group_idx_t getNumNodeGroupsNoLock() const {
+        return nodeGroups.getNumGroupsNoLock();
+    }
     NodeGroup* getNodeGroupNoLock(const common::node_group_idx_t groupIdx) {
         KU_ASSERT(nodeGroups.getGroupNoLock(groupIdx)->getNodeGroupIdx() == groupIdx);
         return nodeGroups.getGroupNoLock(groupIdx);

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -485,7 +485,7 @@ void NodeTable::commit(Transaction* transaction, LocalTable* localTable) {
     // 2. Set deleted flag for tuples that are deleted in local storage.
     row_idx_t numLocalRows = 0u;
     for (auto localNodeGroupIdx = 0u; localNodeGroupIdx < localNodeTable.getNumNodeGroups();
-         localNodeGroupIdx++) {
+        localNodeGroupIdx++) {
         const auto localNodeGroup = localNodeTable.getNodeGroup(localNodeGroupIdx);
         if (localNodeGroup->hasDeletions(transaction)) {
             // TODO(Guodong): Assume local storage is small here. Should optimize the loop away by
@@ -593,7 +593,7 @@ bool NodeTable::isVisible(const Transaction* transaction, offset_t offset) const
 
 bool NodeTable::isVisibleNoLock(const Transaction* transaction, offset_t offset) const {
     auto [nodeGroupIdx, offsetInGroup] = StorageUtils::getNodeGroupIdxAndOffsetInChunk(offset);
-    if (nodeGroupIdx >= nodeGroups->getNumNodeGroups()) {
+    if (nodeGroupIdx >= nodeGroups->getNumNodeGroupsNoLock()) {
         return false;
     }
     auto* nodeGroup = getNodeGroupNoLock(nodeGroupIdx);

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -485,7 +485,7 @@ void NodeTable::commit(Transaction* transaction, LocalTable* localTable) {
     // 2. Set deleted flag for tuples that are deleted in local storage.
     row_idx_t numLocalRows = 0u;
     for (auto localNodeGroupIdx = 0u; localNodeGroupIdx < localNodeTable.getNumNodeGroups();
-        localNodeGroupIdx++) {
+         localNodeGroupIdx++) {
         const auto localNodeGroup = localNodeTable.getNodeGroup(localNodeGroupIdx);
         if (localNodeGroup->hasDeletions(transaction)) {
             // TODO(Guodong): Assume local storage is small here. Should optimize the loop away by


### PR DESCRIPTION
# Description

Remove the unnecessary lock in `NodeTable::isVisibleNoLock`, which was introduced in #4467.

The lock caused large regression on COPY REL performance.
On a Mac Studio with M1 Max Pro and 64GB RAM, copying of ldbc-1000 knows table is improved from 115862ms to 41669ms.