### PR TITLE
Refactor table bind func input

### DIFF
--- a/extension/duckdb/src/function/clear_cache.cpp
+++ b/extension/duckdb/src/function/clear_cache.cpp
@@ -25,7 +25,7 @@ static offset_t clearCacheTableFunc(TableFuncInput& input, TableFuncOutput& outp
 }
 
 static std::unique_ptr<TableFuncBindData> clearCacheBindFunc(ClientContext* context,
-    ScanTableFuncBindInput*) {
+    TableFuncBindInput*) {
     std::vector<std::string> columnNames;
     std::vector<LogicalType> columnTypes;
     columnNames.emplace_back("message");

--- a/extension/duckdb/src/function/duckdb_scan.cpp
+++ b/extension/duckdb/src/function/duckdb_scan.cpp
@@ -28,7 +28,7 @@ struct DuckDBScanFunction {
         function::TableFuncOutput& output);
 
     static std::unique_ptr<function::TableFuncBindData> bindFunc(DuckDBScanBindData bindData,
-        main::ClientContext* /*context*/, function::ScanTableFuncBindInput* input);
+        main::ClientContext* /*context*/, function::TableFuncBindInput* input);
 
     static std::unique_ptr<function::TableFuncSharedState> initSharedState(
         function::TableFunctionInitInput& input);
@@ -104,7 +104,7 @@ common::offset_t DuckDBScanFunction::tableFunc(function::TableFuncInput& input,
 
 std::unique_ptr<function::TableFuncBindData> DuckDBScanFunction::bindFunc(
     DuckDBScanBindData bindData, main::ClientContext* /*clientContext*/,
-    function::ScanTableFuncBindInput* /*input*/) {
+    function::TableFuncBindInput* /*input*/) {
     return bindData.copy();
 }
 

--- a/extension/fts/src/function/create_fts_index.cpp
+++ b/extension/fts/src/function/create_fts_index.cpp
@@ -62,8 +62,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
     TableFuncBindInput* input) {
     FTSUtils::validateAutoTrx(*context, CreateFTSFunction::name);
     auto indexName = input->getParam(1).toString();
-    auto& nodeTableEntry =
-        FTSUtils::bindTable(input->getParam(0), context, indexName, FTSUtils::IndexOperation::CREATE);
+    auto& nodeTableEntry = FTSUtils::bindTable(input->getParam(0), context, indexName,
+        FTSUtils::IndexOperation::CREATE);
     auto properties = bindProperties(nodeTableEntry, input->getParam(2));
     validateIndexNotExist(*context, nodeTableEntry.getTableID(), indexName);
     auto createFTSConfig = FTSConfig{input->optionalParams};

--- a/extension/fts/src/function/create_fts_index.cpp
+++ b/extension/fts/src/function/create_fts_index.cpp
@@ -59,12 +59,12 @@ static void validateIndexNotExist(const main::ClientContext& context, common::ta
 }
 
 static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
-    ScanTableFuncBindInput* input) {
+    TableFuncBindInput* input) {
     FTSUtils::validateAutoTrx(*context, CreateFTSFunction::name);
-    auto indexName = input->inputs[1].toString();
+    auto indexName = input->getParam(1).toString();
     auto& nodeTableEntry =
-        FTSUtils::bindTable(input->inputs[0], context, indexName, FTSUtils::IndexOperation::CREATE);
-    auto properties = bindProperties(nodeTableEntry, input->inputs[2]);
+        FTSUtils::bindTable(input->getParam(0), context, indexName, FTSUtils::IndexOperation::CREATE);
+    auto properties = bindProperties(nodeTableEntry, input->getParam(2));
     validateIndexNotExist(*context, nodeTableEntry.getTableID(), indexName);
     auto createFTSConfig = FTSConfig{input->optionalParams};
     return std::make_unique<CreateFTSBindData>(nodeTableEntry.getName(),

--- a/extension/fts/src/function/drop_fts_index.cpp
+++ b/extension/fts/src/function/drop_fts_index.cpp
@@ -17,11 +17,11 @@ using namespace kuzu::main;
 using namespace kuzu::function;
 
 static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
-    ScanTableFuncBindInput* input) {
+    TableFuncBindInput* input) {
     FTSUtils::validateAutoTrx(*context, DropFTSFunction::name);
-    auto indexName = input->inputs[1].toString();
+    auto indexName = input->getParam(1).toString();
     auto& tableEntry =
-        FTSUtils::bindTable(input->inputs[0], context, indexName, FTSUtils::IndexOperation::DROP);
+        FTSUtils::bindTable(input->getParam(0), context, indexName, FTSUtils::IndexOperation::DROP);
     FTSUtils::validateIndexExistence(*context, tableEntry.getTableID(), indexName);
     return std::make_unique<FTSBindData>(tableEntry.getName(), tableEntry.getTableID(), indexName,
         std::vector<common::LogicalType>{}, std::vector<std::string>{});

--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -43,13 +43,13 @@ struct QueryFTSLocalState : public TableFuncLocalState {
 };
 
 static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
-    ScanTableFuncBindInput* input) {
+    TableFuncBindInput* input) {
     std::vector<std::string> columnNames;
     std::vector<LogicalType> columnTypes;
-    auto indexName = input->inputs[1].toString();
+    auto indexName = input->getParam(1).toString();
     auto& tableEntry =
-        FTSUtils::bindTable(input->inputs[0], context, indexName, FTSUtils::IndexOperation::QUERY);
-    auto query = input->inputs[2].toString();
+        FTSUtils::bindTable(input->getParam(0), context, indexName, FTSUtils::IndexOperation::QUERY);
+    auto query = input->getParam(2).toString();
     FTSUtils::validateIndexExistence(*context, tableEntry.getTableID(), indexName);
     auto ftsCatalogEntry =
         context->getCatalog()->getIndex(context->getTx(), tableEntry.getTableID(), indexName);

--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -47,8 +47,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
     std::vector<std::string> columnNames;
     std::vector<LogicalType> columnTypes;
     auto indexName = input->getParam(1).toString();
-    auto& tableEntry =
-        FTSUtils::bindTable(input->getParam(0), context, indexName, FTSUtils::IndexOperation::QUERY);
+    auto& tableEntry = FTSUtils::bindTable(input->getParam(0), context, indexName,
+        FTSUtils::IndexOperation::QUERY);
     auto query = input->getParam(2).toString();
     FTSUtils::validateIndexExistence(*context, tableEntry.getTableID(), indexName);
     auto ftsCatalogEntry =

--- a/extension/json/src/functions/table_functions/json_scan.cpp
+++ b/extension/json/src/functions/table_functions/json_scan.cpp
@@ -770,7 +770,8 @@ static JsonScanFormat autoDetect(main::ClientContext* context, const std::string
 }
 
 static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
-    ScanTableFuncBindInput* scanInput) {
+    TableFuncBindInput* input) {
+    auto scanInput = ku_dynamic_cast<ExtraScanTableFuncBindInput*>(input->extraInput.get());
     std::vector<LogicalType> columnTypes;
     std::vector<std::string> columnNames;
     JsonScanConfig scanConfig(scanInput->config.options);

--- a/src/binder/bind/bind_file_scan.cpp
+++ b/src/binder/bind/bind_file_scan.cpp
@@ -121,12 +121,20 @@ std::unique_ptr<BoundBaseScanSource> Binder::bindFileScanSource(const BaseScanSo
             }
         }
     }
-    auto config = std::make_unique<ReaderConfig>(std::move(fileTypeInfo), std::move(filePaths));
+    // Bind file configuration
+    auto config = std::make_unique<ReaderConfig>(std::move(fileTypeInfo), filePaths);
     config->options = std::move(parsingOptions);
     auto func = getScanFunction(config->fileTypeInfo, *config);
-    auto bindInput = std::make_unique<ScanTableFuncBindInput>(config->copy(), columnNames,
-        LogicalType::copy(columnTypes), clientContext, &func);
-    auto bindData = func.bindFunc(clientContext, bindInput.get());
+    // Bind table function
+    auto bindInput = TableFuncBindInput();
+    bindInput.addParam(Value::createValue(filePaths[0]));
+    auto extraInput = std::make_unique<ExtraScanTableFuncBindInput>();
+    extraInput->config = config->copy();
+    extraInput->expectedColumnNames = columnNames;
+    extraInput->expectedColumnTypes = LogicalType::copy(columnTypes);
+    extraInput->tableFunction = &func;
+    bindInput.extraInput = std::move(extraInput);
+    auto bindData = func.bindFunc(clientContext, &bindInput);
     expression_vector columns;
     auto i = 0u;
     for (; i < bindData->columnTypes.size() - bindData->numWarningDataColumns; ++i) {
@@ -181,14 +189,16 @@ std::unique_ptr<BoundBaseScanSource> Binder::bindObjectScanSource(const BaseScan
         // Bind external object as table
         objectName = objectSource->objectNames[0];
         auto replacementData = clientContext->tryReplace(objectName);
-        if (replacementData != nullptr) { // Replace as
+        if (replacementData != nullptr) { // Replace as python object
             func = replacementData->func;
-            replacementData->bindInput.config.options = bindParsingOptions(options);
+            auto extraInput = std::make_unique<ExtraScanTableFuncBindInput>();
+            extraInput->config.options = bindParsingOptions(options);
+            replacementData->bindInput.extraInput = std::move(extraInput);
             bindData = func.bindFunc(clientContext, &replacementData->bindInput);
         } else if (clientContext->getDatabaseManager()->hasDefaultDatabase()) {
             auto dbName = clientContext->getDatabaseManager()->getDefaultDatabase();
             func = getObjectScanFunc(dbName, objectSource->objectNames[0], clientContext);
-            auto bindInput = function::ScanTableFuncBindInput();
+            auto bindInput = TableFuncBindInput();
             bindData = func.bindFunc(clientContext, &bindInput);
         } else {
             throw BinderException(ExceptionMessage::variableNotInScope(objectName));
@@ -198,7 +208,7 @@ std::unique_ptr<BoundBaseScanSource> Binder::bindObjectScanSource(const BaseScan
         objectName = objectSource->objectNames[0] + "." + objectSource->objectNames[1];
         func = getObjectScanFunc(objectSource->objectNames[0], objectSource->objectNames[1],
             clientContext);
-        auto bindInput = function::ScanTableFuncBindInput();
+        auto bindInput = TableFuncBindInput();
         bindData = func.bindFunc(clientContext, &bindInput);
     } else {
         // LCOV_EXCL_START

--- a/src/binder/bind/bind_table_function.cpp
+++ b/src/binder/bind/bind_table_function.cpp
@@ -42,8 +42,8 @@ BoundTableFunction Binder::bindTableFunc(std::string tableFuncName,
         auto parameterTypeID = tableFunc->parameterTypeIDs[i];
         ExpressionUtil::validateDataType(*positionalParams[i], parameterTypeID);
     }
-    auto bindInput = function::ScanTableFuncBindInput();
-    bindInput.inputs = std::move(inputValues);
+    auto bindInput = TableFuncBindInput();
+    bindInput.params = std::move(inputValues);
     bindInput.optionalParams = std::move(optionalParams);
     auto bindData = tableFunc->bindFunc(clientContext, &bindInput);
     for (auto i = 0u; i < bindData->columnTypes.size(); i++) {

--- a/src/function/table/call/bm_info.cpp
+++ b/src/function/table/call/bm_info.cpp
@@ -35,7 +35,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
 }
 
 static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
-    ScanTableFuncBindInput*) {
+    TableFuncBindInput*) {
     auto memLimit = context->getMemoryManager()->getBufferManager()->getMemoryLimit();
     auto memUsage = context->getMemoryManager()->getBufferManager()->getUsedMemory();
     std::vector<common::LogicalType> returnTypes;

--- a/src/function/table/call/clear_warnings.cpp
+++ b/src/function/table/call/clear_warnings.cpp
@@ -13,7 +13,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& /*outp
 }
 
 static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* /*context*/,
-    ScanTableFuncBindInput*) {
+    TableFuncBindInput*) {
     return std::make_unique<SimpleTableFuncBindData>(0);
 }
 

--- a/src/function/table/call/current_setting.cpp
+++ b/src/function/table/call/current_setting.cpp
@@ -35,8 +35,8 @@ static common::offset_t tableFunc(TableFuncInput& data, TableFuncOutput& output)
 }
 
 static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
-    ScanTableFuncBindInput* input) {
-    auto optionName = input->inputs[0].getValue<std::string>();
+    TableFuncBindInput* input) {
+    auto optionName = input->getParam(0).getValue<std::string>();
     std::vector<std::string> columnNames;
     std::vector<LogicalType> columnTypes;
     columnNames.emplace_back(optionName);

--- a/src/function/table/call/db_version.cpp
+++ b/src/function/table/call/db_version.cpp
@@ -18,7 +18,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
     return 1;
 }
 
-static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext*, ScanTableFuncBindInput*) {
+static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext*, TableFuncBindInput*) {
     std::vector<std::string> returnColumnNames;
     std::vector<LogicalType> returnTypes;
     returnColumnNames.emplace_back("version");

--- a/src/function/table/call/show_attached_databases.cpp
+++ b/src/function/table/call/show_attached_databases.cpp
@@ -41,7 +41,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
 }
 
 static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
-    ScanTableFuncBindInput*) {
+    TableFuncBindInput*) {
     std::vector<std::string> columnNames;
     std::vector<LogicalType> columnTypes;
     columnNames.emplace_back("name");

--- a/src/function/table/call/show_connection.cpp
+++ b/src/function/table/call/show_connection.cpp
@@ -84,10 +84,10 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
 }
 
 static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
-    ScanTableFuncBindInput* input) {
+    TableFuncBindInput* input) {
     std::vector<std::string> columnNames;
     std::vector<LogicalType> columnTypes;
-    auto tableName = input->inputs[0].getValue<std::string>();
+    auto tableName = input->getParam(0).getValue<std::string>();
     auto catalog = context->getCatalog();
     auto tableID = catalog->getTableID(context->getTx(), tableName);
     auto tableEntry = catalog->getTableCatalogEntry(context->getTx(), tableID);

--- a/src/function/table/call/show_functions.cpp
+++ b/src/function/table/call/show_functions.cpp
@@ -49,7 +49,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
 }
 
 static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
-    ScanTableFuncBindInput*) {
+    TableFuncBindInput*) {
     std::vector<std::string> columnNames;
     std::vector<LogicalType> columnTypes;
     columnNames.emplace_back("name");

--- a/src/function/table/call/show_sequences.cpp
+++ b/src/function/table/call/show_sequences.cpp
@@ -60,7 +60,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
 }
 
 static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
-    ScanTableFuncBindInput*) {
+    TableFuncBindInput*) {
     std::vector<std::string> columnNames;
     std::vector<LogicalType> columnTypes;
     columnNames.emplace_back("name");

--- a/src/function/table/call/show_tables.cpp
+++ b/src/function/table/call/show_tables.cpp
@@ -57,7 +57,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
 }
 
 static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
-    ScanTableFuncBindInput*) {
+    TableFuncBindInput*) {
     std::vector<std::string> columnNames;
     std::vector<LogicalType> columnTypes;
     columnNames.emplace_back("id");

--- a/src/function/table/call/show_warnings.cpp
+++ b/src/function/table/call/show_warnings.cpp
@@ -42,7 +42,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
 }
 
 static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
-    ScanTableFuncBindInput*) {
+    TableFuncBindInput*) {
     std::vector<std::string> columnNames{WarningConstants::WARNING_TABLE_COLUMN_NAMES.begin(),
         WarningConstants::WARNING_TABLE_COLUMN_NAMES.end()};
     std::vector<LogicalType> columnTypes{WarningConstants::WARNING_TABLE_COLUMN_DATA_TYPES.begin(),

--- a/src/function/table/call/stats_info.cpp
+++ b/src/function/table/call/stats_info.cpp
@@ -59,8 +59,8 @@ static offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output) {
 }
 
 static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
-    ScanTableFuncBindInput* input) {
-    const auto tableName = input->inputs[0].getValue<std::string>();
+    TableFuncBindInput* input) {
+    const auto tableName = input->getParam(0).getValue<std::string>();
     const auto catalog = context->getCatalog();
     if (!catalog->containsTable(context->getTx(), tableName)) {
         throw BinderException{"Table " + tableName + " does not exist!"};

--- a/src/function/table/call/storage_info.cpp
+++ b/src/function/table/call/storage_info.cpp
@@ -327,7 +327,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
 }
 
 static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
-    ScanTableFuncBindInput* input) {
+    TableFuncBindInput* input) {
     std::vector<std::string> columnNames = {"table_type", "node_group_id", "node_chunk_id",
         "residency", "column_name", "data_type", "start_page_idx", "num_pages", "num_values", "min",
         "max", "compression"};
@@ -344,7 +344,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
     columnTypes.emplace_back(LogicalType::STRING());
     columnTypes.emplace_back(LogicalType::STRING());
     columnTypes.emplace_back(LogicalType::STRING());
-    auto tableName = input->inputs[0].getValue<std::string>();
+    auto tableName = input->getParam(0).getValue<std::string>();
     auto catalog = context->getCatalog();
     if (!catalog->containsTable(context->getTx(), tableName)) {
         throw BinderException{"Table " + tableName + " does not exist!"};

--- a/src/function/table/call/table_info.cpp
+++ b/src/function/table/call/table_info.cpp
@@ -84,10 +84,10 @@ static std::unique_ptr<TableCatalogEntry> getTableCatalogEntry(main::ClientConte
 }
 
 static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
-    ScanTableFuncBindInput* input) {
+    TableFuncBindInput* input) {
     std::vector<std::string> columnNames;
     std::vector<LogicalType> columnTypes;
-    auto catalogEntry = getTableCatalogEntry(context, input->inputs[0].getValue<std::string>());
+    auto catalogEntry = getTableCatalogEntry(context, input->getParam(0).getValue<std::string>());
     auto tableEntry = catalogEntry->constPtrCast<TableCatalogEntry>();
     columnNames.emplace_back("property id");
     columnTypes.push_back(LogicalType::INT32());

--- a/src/include/function/table/bind_input.h
+++ b/src/include/function/table/bind_input.h
@@ -33,9 +33,7 @@ struct TableFuncBindInput {
     TableFuncBindInput() = default;
 
     void addParam(common::Value value) { params.push_back(std::move(value)); }
-    const common::Value& getParam(common::idx_t idx) const {
-        return params[idx];
-    }
+    const common::Value& getParam(common::idx_t idx) const { return params[idx]; }
 };
 
 struct ExtraScanTableFuncBindInput : ExtraTableFuncBindInput {

--- a/src/include/function/table/bind_input.h
+++ b/src/include/function/table/bind_input.h
@@ -20,36 +20,29 @@ namespace function {
 using optional_params_t = common::case_insensitive_map_t<common::Value>;
 
 struct TableFunction;
-struct ScanTableFuncBindInput {
-    std::vector<common::Value> inputs;
+
+struct ExtraTableFuncBindInput {
+    virtual ~ExtraTableFuncBindInput() = default;
+};
+
+struct TableFuncBindInput {
+    std::vector<common::Value> params;
+    optional_params_t optionalParams;
+    std::unique_ptr<ExtraTableFuncBindInput> extraInput = nullptr;
+
+    TableFuncBindInput() = default;
+
+    void addParam(common::Value value) { params.push_back(std::move(value)); }
+    const common::Value& getParam(common::idx_t idx) const {
+        return params[idx];
+    }
+};
+
+struct ExtraScanTableFuncBindInput : ExtraTableFuncBindInput {
     common::ReaderConfig config;
     std::vector<std::string> expectedColumnNames;
     std::vector<common::LogicalType> expectedColumnTypes;
-    main::ClientContext* context;
-    function::TableFunction* tableFunction;
-    optional_params_t optionalParams;
-
-    ScanTableFuncBindInput() : context(nullptr), tableFunction(nullptr) {}
-    explicit ScanTableFuncBindInput(common::ReaderConfig config)
-        : config{std::move(config)}, context(nullptr), tableFunction(nullptr){};
-    ScanTableFuncBindInput(common::ReaderConfig config,
-        std::vector<std::string> expectedColumnNames,
-        std::vector<common::LogicalType> expectedColumnTypes, main::ClientContext* context,
-        function::TableFunction* tableFunction)
-        : config{std::move(config)}, expectedColumnNames{std::move(expectedColumnNames)},
-          expectedColumnTypes{std::move(expectedColumnTypes)}, context{context},
-          tableFunction{tableFunction} {
-        inputs.push_back(common::Value::createValue(this->config.filePaths[0]));
-    }
-    EXPLICIT_COPY_DEFAULT_MOVE(ScanTableFuncBindInput);
-
-private:
-    ScanTableFuncBindInput(const ScanTableFuncBindInput& other)
-        : inputs{other.inputs}, config{other.config.copy()},
-          expectedColumnNames{other.expectedColumnNames},
-          expectedColumnTypes{common::LogicalType::copy(other.expectedColumnTypes)},
-          context{other.context}, tableFunction{other.tableFunction},
-          optionalParams{other.optionalParams} {}
+    function::TableFunction* tableFunction = nullptr;
 };
 
 } // namespace function

--- a/src/include/function/table/scan_replacement.h
+++ b/src/include/function/table/scan_replacement.h
@@ -8,7 +8,7 @@ namespace function {
 
 struct ScanReplacementData {
     TableFunction func;
-    ScanTableFuncBindInput bindInput;
+    TableFuncBindInput bindInput;
 };
 
 using scan_replace_func_t = std::function<std::unique_ptr<ScanReplacementData>(const std::string&)>;

--- a/src/include/function/table_functions.h
+++ b/src/include/function/table_functions.h
@@ -16,8 +16,8 @@ struct ExecutionContext;
 
 namespace function {
 
+struct TableFuncBindInput;
 struct TableFuncBindData;
-struct ScanTableFuncBindInput;
 
 struct TableFuncSharedState {
     virtual ~TableFuncSharedState() = default;
@@ -75,7 +75,7 @@ struct TableFunctionInitInput {
 };
 
 using table_func_bind_t = std::function<std::unique_ptr<TableFuncBindData>(main::ClientContext*,
-    function::ScanTableFuncBindInput*)>;
+    function::TableFuncBindInput*)>;
 using table_func_t = std::function<common::offset_t(TableFuncInput&, TableFuncOutput&)>;
 using table_func_init_shared_t =
     std::function<std::unique_ptr<TableFuncSharedState>(TableFunctionInitInput&)>;

--- a/src/include/processor/operator/persistent/reader/csv/driver.h
+++ b/src/include/processor/operator/persistent/reader/csv/driver.h
@@ -94,8 +94,7 @@ protected:
 
 class SniffCSVDialectDriver : public SerialParsingDriver {
 public:
-    SniffCSVDialectDriver(SerialCSVReader* reader,
-        const function::ScanTableFuncBindInput* bindInput);
+    explicit SniffCSVDialectDriver(SerialCSVReader* reader);
 
     bool done(uint64_t rowNum) const;
     bool addValue(uint64_t rowNum, common::column_id_t columnIdx, std::string_view value) override;
@@ -125,7 +124,7 @@ private:
 class SniffCSVNameAndTypeDriver : public SerialParsingDriver {
 public:
     SniffCSVNameAndTypeDriver(SerialCSVReader* reader,
-        const function::ScanTableFuncBindInput* bindInput);
+        const function::ExtraScanTableFuncBindInput* bindInput);
 
     bool done(uint64_t rowNum);
     bool addValue(uint64_t rowNum, common::column_id_t columnIdx, std::string_view value) override;
@@ -139,7 +138,7 @@ public:
 
 class SniffCSVHeaderDriver : public SerialParsingDriver {
 public:
-    SniffCSVHeaderDriver(SerialCSVReader* reader, const function::ScanTableFuncBindInput* bindInput,
+    SniffCSVHeaderDriver(SerialCSVReader* reader,
         const std::vector<std::pair<std::string, common::LogicalType>>& TypeDetected);
 
     bool done(uint64_t rowNum) const {

--- a/src/include/processor/operator/persistent/reader/csv/serial_csv_reader.h
+++ b/src/include/processor/operator/persistent/reader/csv/serial_csv_reader.h
@@ -15,7 +15,7 @@ class SerialCSVReader final : public BaseCSVReader {
 public:
     SerialCSVReader(const std::string& filePath, common::idx_t fileIdx, common::CSVOption option,
         CSVColumnInfo columnInfo, main::ClientContext* context, LocalFileErrorHandler* errorHandler,
-        const function::ScanTableFuncBindInput* bindInput = nullptr);
+        const function::ExtraScanTableFuncBindInput* bindInput = nullptr);
 
     //! Sniffs CSV dialect and determines skip rows, header row, column types and column names
     std::vector<std::pair<std::string, common::LogicalType>> sniffCSV(
@@ -26,7 +26,7 @@ protected:
     bool handleQuotedNewline() override { return true; }
 
 private:
-    const function::ScanTableFuncBindInput* bindInput;
+    const function::ExtraScanTableFuncBindInput* bindInput;
     void resetReaderState();
     DialectOption detectDialect();
     bool detectHeader(std::vector<std::pair<std::string, common::LogicalType>>& detectedTypes);
@@ -58,9 +58,9 @@ struct SerialCSVScan {
     static constexpr const char* name = "READ_CSV_SERIAL";
 
     static function::function_set getFunctionSet();
-    static void bindColumns(const function::ScanTableFuncBindInput* bindInput,
+    static void bindColumns(const function::ExtraScanTableFuncBindInput* bindInput,
         std::vector<std::string>& columnNames, std::vector<common::LogicalType>& columnTypes,
-        DialectOption& detectedDialect, bool& detectedHeader);
+        DialectOption& detectedDialect, bool& detectedHeader, main::ClientContext* context);
 };
 
 } // namespace processor

--- a/src/processor/operator/persistent/reader/csv/driver.cpp
+++ b/src/processor/operator/persistent/reader/csv/driver.cpp
@@ -113,8 +113,7 @@ common::DataChunk& getDummyDataChunk() {
     return dummyChunk;
 }
 
-SniffCSVDialectDriver::SniffCSVDialectDriver(SerialCSVReader* reader,
-    const function::ScanTableFuncBindInput* /*bindInput*/)
+SniffCSVDialectDriver::SniffCSVDialectDriver(SerialCSVReader* reader)
     : SerialParsingDriver(getDummyDataChunk(), reader, DriverType::SNIFF_CSV_DIALECT) {
     auto& csvOption = reader->getCSVOption();
     columnCounts = std::vector<idx_t>(csvOption.sampleSize, 0);
@@ -170,7 +169,7 @@ void SniffCSVDialectDriver::reset() {
 }
 
 SniffCSVNameAndTypeDriver::SniffCSVNameAndTypeDriver(SerialCSVReader* reader,
-    const function::ScanTableFuncBindInput* bindInput)
+    const function::ExtraScanTableFuncBindInput* bindInput)
     : SerialParsingDriver(getDummyDataChunk(), reader, DriverType::SNIFF_CSV_NAME_AND_TYPE) {
     if (bindInput != nullptr) {
         for (auto i = 0u; i < bindInput->expectedColumnNames.size(); i++) {
@@ -255,7 +254,6 @@ bool SniffCSVNameAndTypeDriver::addValue(uint64_t rowNum, common::column_id_t co
 }
 
 SniffCSVHeaderDriver::SniffCSVHeaderDriver(SerialCSVReader* reader,
-    const function::ScanTableFuncBindInput* /*bindInput*/,
     const std::vector<std::pair<std::string, common::LogicalType>>& typeDetected)
     : SerialParsingDriver(getDummyDataChunk(), reader, DriverType::SNIFF_CSV_HEADER) {
     for (auto i = 0u; i < typeDetected.size(); i++) {

--- a/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
@@ -216,8 +216,10 @@ static offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output) {
     } while (true);
 }
 
-static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* /*context*/,
-    ScanTableFuncBindInput* scanInput) {
+static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
+    TableFuncBindInput* input) {
+    auto scanInput = ku_dynamic_cast<ExtraScanTableFuncBindInput*>(input->extraInput.get());
+
     bool detectedHeader = false;
 
     DialectOption detectedDialect;
@@ -227,7 +229,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* /*contex
     std::vector<std::string> detectedColumnNames;
     std::vector<LogicalType> detectedColumnTypes;
     SerialCSVScan::bindColumns(scanInput, detectedColumnNames, detectedColumnTypes, detectedDialect,
-        detectedHeader);
+        detectedHeader, context);
 
     std::vector<std::string> resultColumnNames;
     std::vector<LogicalType> resultColumnTypes;
@@ -251,7 +253,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* /*contex
         resultColumnNames, resultColumnTypes, scanInput->config);
 
     return std::make_unique<ScanBindData>(std::move(resultColumnTypes),
-        std::move(resultColumnNames), scanInput->config.copy(), scanInput->context,
+        std::move(resultColumnNames), scanInput->config.copy(), context,
         numWarningDataColumns);
 }
 

--- a/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
@@ -253,8 +253,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
         resultColumnNames, resultColumnTypes, scanInput->config);
 
     return std::make_unique<ScanBindData>(std::move(resultColumnTypes),
-        std::move(resultColumnNames), scanInput->config.copy(), context,
-        numWarningDataColumns);
+        std::move(resultColumnNames), scanInput->config.copy(), context, numWarningDataColumns);
 }
 
 static std::unique_ptr<TableFuncSharedState> initSharedState(TableFunctionInitInput& input) {

--- a/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
@@ -147,8 +147,7 @@ static void bindColumnsFromFile(const ExtraScanTableFuncBindInput* bindInput, ui
     SharedFileErrorHandler sharedErrorHandler{fileIdx, nullptr};
     // We don't want to cache CSV errors encountered during sniffing, they will be re-encountered
     // when actually parsing
-    LocalFileErrorHandler errorHandler{&sharedErrorHandler, csvOption.ignoreErrors,
-        context, false};
+    LocalFileErrorHandler errorHandler{&sharedErrorHandler, csvOption.ignoreErrors, context, false};
     auto csvReader = SerialCSVReader(bindInput->config.filePaths[fileIdx], fileIdx,
         csvOption.copy(), columnInfo.copy(), context, &errorHandler, bindInput);
     sharedErrorHandler.setPopulateErrorFunc(
@@ -169,7 +168,8 @@ void SerialCSVScan::bindColumns(const ExtraScanTableFuncBindInput* bindInput,
     std::vector<std::string>& columnNames, std::vector<LogicalType>& columnTypes,
     DialectOption& detectedDialect, bool& detectedHeader, main::ClientContext* context) {
     KU_ASSERT(bindInput->config.getNumFiles() > 0);
-    bindColumnsFromFile(bindInput, 0, columnNames, columnTypes, detectedDialect, detectedHeader, context);
+    bindColumnsFromFile(bindInput, 0, columnNames, columnTypes, detectedDialect, detectedHeader,
+        context);
     for (auto i = 1u; i < bindInput->config.getNumFiles(); ++i) {
         std::vector<std::string> tmpColumnNames;
         std::vector<LogicalType> tmpColumnTypes;
@@ -220,8 +220,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
         resultColumnNames, resultColumnTypes, scanInput->config);
 
     return std::make_unique<ScanBindData>(std::move(resultColumnTypes),
-        std::move(resultColumnNames), scanInput->config.copy(), context,
-        numWarningDataColumns);
+        std::move(resultColumnNames), scanInput->config.copy(), context, numWarningDataColumns);
 }
 
 static std::unique_ptr<TableFuncSharedState> initSharedState(TableFunctionInitInput& input) {

--- a/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
@@ -13,7 +13,7 @@ namespace processor {
 
 SerialCSVReader::SerialCSVReader(const std::string& filePath, common::idx_t fileIdx,
     common::CSVOption option, CSVColumnInfo columnInfo, main::ClientContext* context,
-    LocalFileErrorHandler* errorHandler, const function::ScanTableFuncBindInput* bindInput)
+    LocalFileErrorHandler* errorHandler, const function::ExtraScanTableFuncBindInput* bindInput)
     : BaseCSVReader{filePath, fileIdx, std::move(option), std::move(columnInfo), context,
           errorHandler},
       bindInput{bindInput} {}
@@ -138,9 +138,9 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
     return output.dataChunk.state->getSelVector().getSelSize();
 }
 
-static void bindColumnsFromFile(const ScanTableFuncBindInput* bindInput, uint32_t fileIdx,
+static void bindColumnsFromFile(const ExtraScanTableFuncBindInput* bindInput, uint32_t fileIdx,
     std::vector<std::string>& columnNames, std::vector<LogicalType>& columnTypes,
-    DialectOption& detectedDialect, bool& detectedHeader) {
+    DialectOption& detectedDialect, bool& detectedHeader, main::ClientContext* context) {
     auto csvOption = CSVReaderConfig::construct(bindInput->config.options).option;
     auto columnInfo = CSVColumnInfo(bindInput->expectedColumnNames.size() /* numColumns */,
         {} /* columnSkips */, {} /*warningDataColumns*/);
@@ -148,9 +148,9 @@ static void bindColumnsFromFile(const ScanTableFuncBindInput* bindInput, uint32_
     // We don't want to cache CSV errors encountered during sniffing, they will be re-encountered
     // when actually parsing
     LocalFileErrorHandler errorHandler{&sharedErrorHandler, csvOption.ignoreErrors,
-        bindInput->context, false};
+        context, false};
     auto csvReader = SerialCSVReader(bindInput->config.filePaths[fileIdx], fileIdx,
-        csvOption.copy(), columnInfo.copy(), bindInput->context, &errorHandler, bindInput);
+        csvOption.copy(), columnInfo.copy(), context, &errorHandler, bindInput);
     sharedErrorHandler.setPopulateErrorFunc(
         [&sharedErrorHandler, &csvReader, bindInput](CopyFromFileError error,
             idx_t fileIdx) -> PopulatedCopyFromError {
@@ -165,22 +165,23 @@ static void bindColumnsFromFile(const ScanTableFuncBindInput* bindInput, uint32_
     }
 }
 
-void SerialCSVScan::bindColumns(const ScanTableFuncBindInput* bindInput,
+void SerialCSVScan::bindColumns(const ExtraScanTableFuncBindInput* bindInput,
     std::vector<std::string>& columnNames, std::vector<LogicalType>& columnTypes,
-    DialectOption& detectedDialect, bool& detectedHeader) {
+    DialectOption& detectedDialect, bool& detectedHeader, main::ClientContext* context) {
     KU_ASSERT(bindInput->config.getNumFiles() > 0);
-    bindColumnsFromFile(bindInput, 0, columnNames, columnTypes, detectedDialect, detectedHeader);
+    bindColumnsFromFile(bindInput, 0, columnNames, columnTypes, detectedDialect, detectedHeader, context);
     for (auto i = 1u; i < bindInput->config.getNumFiles(); ++i) {
         std::vector<std::string> tmpColumnNames;
         std::vector<LogicalType> tmpColumnTypes;
         bindColumnsFromFile(bindInput, i, tmpColumnNames, tmpColumnTypes, detectedDialect,
-            detectedHeader);
+            detectedHeader, context);
         ReaderBindUtils::validateNumColumns(columnTypes.size(), tmpColumnTypes.size());
     }
 }
 
-static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* /*context*/,
-    ScanTableFuncBindInput* scanInput) {
+static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
+    TableFuncBindInput* input) {
+    auto scanInput = ku_dynamic_cast<ExtraScanTableFuncBindInput*>(input->extraInput.get());
     if (scanInput->expectedColumnTypes.size() > 0) {
         scanInput->config.options.insert_or_assign("SAMPLE_SIZE",
             Value((int64_t)0)); // only scan headers
@@ -195,7 +196,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* /*contex
     std::vector<std::string> detectedColumnNames;
     std::vector<LogicalType> detectedColumnTypes;
     SerialCSVScan::bindColumns(scanInput, detectedColumnNames, detectedColumnTypes, detectedDialect,
-        detectedHeader);
+        detectedHeader, context);
 
     std::vector<std::string> resultColumnNames;
     std::vector<LogicalType> resultColumnTypes;
@@ -219,7 +220,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* /*contex
         resultColumnNames, resultColumnTypes, scanInput->config);
 
     return std::make_unique<ScanBindData>(std::move(resultColumnTypes),
-        std::move(resultColumnNames), scanInput->config.copy(), scanInput->context,
+        std::move(resultColumnNames), scanInput->config.copy(), context,
         numWarningDataColumns);
 }
 
@@ -289,7 +290,7 @@ void SerialCSVReader::resetReaderState() {
 
 DialectOption SerialCSVReader::detectDialect() {
     // Extract a sample of rows from the file for dialect detection.
-    SniffCSVDialectDriver driver{this, bindInput};
+    SniffCSVDialectDriver driver{this};
 
     // Generate dialect options based on the non-user-specified options.
     auto dialectSearchSpace = generateDialectOptions(option);
@@ -436,7 +437,7 @@ bool SerialCSVReader::detectHeader(
     std::vector<std::pair<std::string, common::LogicalType>>& detectedTypes) {
     // Reset the file position and buffer to start reading from the beginning after detection.
     resetReaderState();
-    SniffCSVHeaderDriver sniffHeaderDriver{this, bindInput, detectedTypes};
+    SniffCSVHeaderDriver sniffHeaderDriver{this, detectedTypes};
     readBOM();
     parseCSV(sniffHeaderDriver);
     resetReaderState();

--- a/src/processor/operator/persistent/reader/npy/npy_reader.cpp
+++ b/src/processor/operator/persistent/reader/npy/npy_reader.cpp
@@ -295,8 +295,9 @@ static void bindColumns(const common::ReaderConfig& readerConfig,
     }
 }
 
-static std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext* /*context*/,
-    function::ScanTableFuncBindInput* scanInput) {
+static std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext* context,
+    function::TableFuncBindInput* input) {
+    auto scanInput = ku_dynamic_cast<ExtraScanTableFuncBindInput*>(input->extraInput.get());
     if (scanInput->config.options.size() > 1 ||
         (scanInput->config.options.size() == 1 &&
             !scanInput->config.options.contains(CopyConstants::IGNORE_ERRORS_OPTION_NAME))) {
@@ -320,7 +321,7 @@ static std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext
         reader->validate(resultColumnTypes[i], numRows);
     }
     return std::make_unique<function::ScanBindData>(std::move(resultColumnTypes),
-        std::move(resultColumnNames), scanInput->config.copy(), scanInput->context);
+        std::move(resultColumnNames), scanInput->config.copy(), context);
 }
 
 static std::unique_ptr<function::TableFuncSharedState> initSharedState(

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -635,7 +635,8 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
 }
 
 static void bindColumns(const ExtraScanTableFuncBindInput* bindInput, uint32_t fileIdx,
-    std::vector<std::string>& columnNames, std::vector<common::LogicalType>& columnTypes, main::ClientContext* context) {
+    std::vector<std::string>& columnNames, std::vector<common::LogicalType>& columnTypes,
+    main::ClientContext* context) {
     auto reader = ParquetReader(bindInput->config.filePaths[fileIdx], {}, context);
     auto state = std::make_unique<processor::ParquetReaderScanState>();
     reader.initializeScan(*state, std::vector<uint64_t>{}, context->getVFSUnsafe());
@@ -646,7 +647,8 @@ static void bindColumns(const ExtraScanTableFuncBindInput* bindInput, uint32_t f
 }
 
 static void bindColumns(const ExtraScanTableFuncBindInput* bindInput,
-    std::vector<std::string>& columnNames, std::vector<common::LogicalType>& columnTypes, main::ClientContext* context) {
+    std::vector<std::string>& columnNames, std::vector<common::LogicalType>& columnTypes,
+    main::ClientContext* context) {
     KU_ASSERT(bindInput->config.getNumFiles() > 0);
     bindColumns(bindInput, 0 /* fileIdx */, columnNames, columnTypes, context);
     for (auto i = 1u; i < bindInput->config.getNumFiles(); ++i) {

--- a/tools/python_api/src_cpp/pandas/pandas_scan.cpp
+++ b/tools/python_api/src_cpp/pandas/pandas_scan.cpp
@@ -15,9 +15,9 @@ using namespace kuzu::catalog;
 namespace kuzu {
 
 std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext* /*context*/,
-    ScanTableFuncBindInput* input) {
+    TableFuncBindInput* input) {
     py::gil_scoped_acquire acquire;
-    py::handle df(reinterpret_cast<PyObject*>(input->inputs[0].getValue<uint8_t*>()));
+    py::handle df(reinterpret_cast<PyObject*>(input->getParam(0).getValue<uint8_t*>()));
     std::vector<std::unique_ptr<PandasColumnBindData>> columnBindData;
     std::vector<LogicalType> returnTypes;
     std::vector<std::string> names;
@@ -156,8 +156,8 @@ std::unique_ptr<ScanReplacementData> tryReplacePD(py::dict& dict, py::str& objec
                 initSharedState, initLocalState, progressFunc,
                 std::vector<LogicalTypeID>{LogicalTypeID::POINTER});
         }
-        auto bindInput = ScanTableFuncBindInput();
-        bindInput.inputs.push_back(Value::createValue(reinterpret_cast<uint8_t*>(entry.ptr())));
+        auto bindInput = TableFuncBindInput();
+        bindInput.addParam(Value::createValue(reinterpret_cast<uint8_t*>(entry.ptr())));
         scanReplacementData->bindInput = std::move(bindInput);
         return scanReplacementData;
     } else {

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -52,8 +52,8 @@ static std::unique_ptr<function::ScanReplacementData> tryReplacePolars(py::dict&
     if (PyConnection::isPolarsDataframe(entry)) {
         auto scanReplacementData = std::make_unique<function::ScanReplacementData>();
         scanReplacementData->func = PyArrowTableScanFunction::getFunction();
-        auto bindInput = function::ScanTableFuncBindInput();
-        bindInput.inputs.push_back(Value::createValue(reinterpret_cast<uint8_t*>(entry.ptr())));
+        auto bindInput = function::TableFuncBindInput();
+        bindInput.addParam(Value::createValue(reinterpret_cast<uint8_t*>(entry.ptr())));
         scanReplacementData->bindInput = std::move(bindInput);
         return scanReplacementData;
     } else {
@@ -70,8 +70,8 @@ static std::unique_ptr<function::ScanReplacementData> tryReplacePyArrow(py::dict
     if (PyConnection::isPyArrowTable(entry)) {
         auto scanReplacementData = std::make_unique<function::ScanReplacementData>();
         scanReplacementData->func = PyArrowTableScanFunction::getFunction();
-        auto bindInput = function::ScanTableFuncBindInput();
-        bindInput.inputs.push_back(Value::createValue(reinterpret_cast<uint8_t*>(entry.ptr())));
+        auto bindInput = function::TableFuncBindInput();
+        bindInput.addParam(Value::createValue(reinterpret_cast<uint8_t*>(entry.ptr())));
         scanReplacementData->bindInput = std::move(bindInput);
         return scanReplacementData;
     } else {

--- a/tools/python_api/src_cpp/pyarrow/pyarrow_scan.cpp
+++ b/tools/python_api/src_cpp/pyarrow/pyarrow_scan.cpp
@@ -42,13 +42,14 @@ static bool moduleIsLoaded() {
 }
 
 static std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext* /*context*/,
-    ScanTableFuncBindInput* input) {
+    TableFuncBindInput* input) {
+    auto scanInput = ku_dynamic_cast<ExtraScanTableFuncBindInput*>(input->extraInput.get());
     // TODO: This binding step could use some drastic improvements.
     // Particularly when scanning from pandas or polars.
     // Possibly look into using the pycapsule interface.
     py::gil_scoped_acquire acquire;
     py::object table(py::reinterpret_borrow<py::object>(
-        reinterpret_cast<PyObject*>(input->inputs[0].getValue<uint8_t*>())));
+        reinterpret_cast<PyObject*>(input->getParam(0).getValue<uint8_t*>())));
     if (PyConnection::isPandasDataframe(table)) {
         table = importCache->pyarrow.lib.Table.from_pandas()(table);
     } else if (moduleIsLoaded<PolarsCachedItem>() &&
@@ -62,7 +63,7 @@ static std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext
     }
     auto numRows = py::len(table);
     auto schema = Pyarrow::bind(table, returnTypes, names);
-    auto config = PyArrowScanConfig(input->config.options);
+    auto config = PyArrowScanConfig(scanInput->config.options);
     // The following python operations are zero copy as defined in pyarrow docs.
     if (config.skipNum != 0) {
         table = table.attr("slice")(config.skipNum);
@@ -140,7 +141,6 @@ static double progressFunc(function::TableFuncSharedState* sharedState) {
 }
 
 function::function_set PyArrowTableScanFunction::getFunctionSet() {
-
     function_set functionSet;
     functionSet.push_back(
         std::make_unique<TableFunction>(name, tableFunc, bindFunc, initSharedState, initLocalState,


### PR DESCRIPTION
# Description

Rename ScanTableFunBindInput to TableFuncBindInput because that's really what it is. Also fields that specifically related to scan is now moved to `ExtraScanTableFuncBindInput`

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).