### PR TITLE
Implement anti-join

### DIFF
--- a/src/include/common/enums/join_type.h
+++ b/src/include/common/enums/join_type.h
@@ -10,6 +10,7 @@ enum class JoinType : uint8_t {
     LEFT = 1,
     MARK = 2,
     COUNT = 3,
+    ANTI = 4,
 };
 
 } // namespace common

--- a/src/include/optimizer/filter_push_down_optimizer.h
+++ b/src/include/optimizer/filter_push_down_optimizer.h
@@ -10,14 +10,19 @@ namespace optimizer {
 
 struct PredicateSet {
     binder::expression_vector equalityPredicates;
+    binder::expression_vector unEqualityPredicates;
     binder::expression_vector nonEqualityPredicates;
 
     PredicateSet() = default;
     EXPLICIT_COPY_DEFAULT_MOVE(PredicateSet);
 
-    bool isEmpty() const { return equalityPredicates.empty() && nonEqualityPredicates.empty(); }
+    bool isEmpty() const {
+        return equalityPredicates.empty() && unEqualityPredicates.empty() &&
+               nonEqualityPredicates.empty();
+    }
     void clear() {
         equalityPredicates.clear();
+        unEqualityPredicates.clear();
         nonEqualityPredicates.clear();
     }
 
@@ -29,6 +34,7 @@ struct PredicateSet {
 private:
     PredicateSet(const PredicateSet& other)
         : equalityPredicates{other.equalityPredicates},
+          unEqualityPredicates{other.unEqualityPredicates},
           nonEqualityPredicates{other.nonEqualityPredicates} {}
 };
 

--- a/src/include/processor/operator/hash_join/anti_join_hash_table.h
+++ b/src/include/processor/operator/hash_join/anti_join_hash_table.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "function/hash/vector_hash_functions.h"
+#include "join_hash_table.h"
+
+namespace kuzu {
+namespace processor {
+
+struct AntiJoinProbeState {
+    uint64_t nextHashSlotIdx = 0;
+    uint64_t maxNumHashSlots = 0;
+    uint64_t hashSlotIdx = 0;
+
+    AntiJoinProbeState() = default;
+
+    void initState(uint64_t maxNumHashSlots_, uint64_t hashSlotIdx_);
+
+    bool hasMoreToProbe() const;
+
+    bool checkKeys() const;
+};
+
+class AntiJoinHashTable : public JoinHashTable {
+public:
+    AntiJoinHashTable(storage::MemoryManager& memoryManager, common::logical_type_vec_t keyTypes,
+        FactorizedTableSchema tableSchema)
+        : JoinHashTable{memoryManager, std::move(keyTypes), std::move(tableSchema)} {}
+
+    void initProbeState(AntiJoinProbeState& probeState,
+        const std::vector<common::ValueVector*>& keyVectors, common::ValueVector& hashVector,
+        common::SelectionVector& hashSelVec, common::ValueVector& tmpHashResultVector) const;
+
+    void probe(AntiJoinProbeState& probeState, uint8_t** probedTuples) const;
+};
+
+} // namespace processor
+} // namespace kuzu

--- a/src/include/processor/operator/hash_join/anti_join_hash_table.h
+++ b/src/include/processor/operator/hash_join/anti_join_hash_table.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "function/hash/vector_hash_functions.h"
 #include "join_hash_table.h"
 
 namespace kuzu {

--- a/src/include/processor/operator/hash_join/anti_join_hash_table.h
+++ b/src/include/processor/operator/hash_join/anti_join_hash_table.h
@@ -12,11 +12,8 @@ struct AntiJoinProbeState {
     uint64_t hashSlotIdx = 0;
 
     AntiJoinProbeState() = default;
-
     void initState(uint64_t maxNumHashSlots_, uint64_t hashSlotIdx_);
-
     bool hasMoreToProbe() const;
-
     bool checkKeys() const;
 };
 

--- a/src/include/processor/operator/hash_join/anti_join_probe.h
+++ b/src/include/processor/operator/hash_join/anti_join_probe.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "anti_join_hash_table.h"
+#include "hash_join_probe.h"
+
+namespace kuzu {
+namespace processor {
+
+// Probe side on left, i.e. children[0] and build side on right, i.e. children[1]
+class AntiJoinProbe : public HashJoinProbe {
+    static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::ANTI_JOIN_PROBE;
+
+public:
+    AntiJoinProbe(std::shared_ptr<HashJoinSharedState> sharedState, common::JoinType joinType,
+        bool flatProbe, const ProbeDataInfo& probeDataInfo,
+        std::unique_ptr<PhysicalOperator> probeChild, std::unique_ptr<PhysicalOperator> buildChild,
+        uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
+        : HashJoinProbe{std::move(sharedState), joinType, flatProbe, probeDataInfo,
+              std::move(probeChild), std::move(buildChild), id, std::move(printInfo)} {}
+
+    // This constructor is used for cloning only.
+    AntiJoinProbe(std::shared_ptr<HashJoinSharedState> sharedState, common::JoinType joinType,
+        bool flatProbe, const ProbeDataInfo& probeDataInfo,
+        std::unique_ptr<PhysicalOperator> probeChild, uint32_t id,
+        std::unique_ptr<OPPrintInfo> printInfo)
+        : HashJoinProbe{std::move(sharedState), joinType, flatProbe, probeDataInfo,
+              std::move(probeChild), id, std::move(printInfo)} {}
+
+    std::unique_ptr<PhysicalOperator> clone() override {
+        return make_unique<AntiJoinProbe>(sharedState, joinType, flatProbe, probeDataInfo,
+            children[0]->clone(), id, printInfo->copy());
+    }
+
+protected:
+    bool getMatchedTuples(ExecutionContext* context) override;
+
+private:
+    void moveProbedTuplesToMatched();
+
+private:
+    AntiJoinProbeState antiJoinProbeState;
+};
+
+} // namespace processor
+} // namespace kuzu

--- a/src/include/processor/operator/hash_join/hash_join_probe.h
+++ b/src/include/processor/operator/hash_join/hash_join_probe.h
@@ -102,7 +102,7 @@ private:
     // We can probe a batch of input tuples if we know they have at most one match.
     bool getMatchedTuplesForUnFlatKey(ExecutionContext* context);
 
-    inline uint64_t getInnerJoinResult() {
+    uint64_t getInnerJoinResult() {
         return flatProbe ? getInnerJoinResultForFlatKey() : getInnerJoinResultForUnFlatKey();
     }
     uint64_t getInnerJoinResultForFlatKey();

--- a/src/include/processor/operator/hash_join/hash_join_probe.h
+++ b/src/include/processor/operator/hash_join/hash_join_probe.h
@@ -93,11 +93,13 @@ public:
             children[0]->clone(), id, printInfo->copy());
     }
 
-private:
-    inline bool getMatchedTuples(ExecutionContext* context) {
+protected:
+    virtual bool getMatchedTuples(ExecutionContext* context) {
         return flatProbe ? getMatchedTuplesForFlatKey(context) :
                            getMatchedTuplesForUnFlatKey(context);
     }
+
+private:
     bool getMatchedTuplesForFlatKey(ExecutionContext* context);
     // We can probe a batch of input tuples if we know they have at most one match.
     bool getMatchedTuplesForUnFlatKey(ExecutionContext* context);
@@ -112,21 +114,24 @@ private:
     uint64_t getCountJoinResult();
     uint64_t getJoinResult();
 
-private:
+protected:
     std::shared_ptr<HashJoinSharedState> sharedState;
     common::JoinType joinType;
     bool flatProbe;
 
     ProbeDataInfo probeDataInfo;
-    std::vector<common::ValueVector*> vectorsToReadInto;
-    std::vector<uint32_t> columnIdxsToReadFrom;
-    std::vector<common::ValueVector*> keyVectors;
-    common::ValueVector* markVector;
     std::unique_ptr<ProbeState> probeState;
+    std::vector<common::ValueVector*> keyVectors;
 
     std::unique_ptr<common::ValueVector> hashVector;
     std::unique_ptr<common::ValueVector> tmpHashVector;
     common::SelectionVector hashSelVec;
+
+private:
+    std::vector<common::ValueVector*> vectorsToReadInto;
+    std::vector<uint32_t> columnIdxsToReadFrom;
+
+    common::ValueVector* markVector;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/hash_join/join_hash_table.h
+++ b/src/include/processor/operator/hash_join/join_hash_table.h
@@ -29,10 +29,10 @@ public:
     // All key vectors must be flat. Thus input is a tuple, multiple matches can be found for the
     // given key tuple.
     common::sel_t matchFlatKeys(const std::vector<common::ValueVector*>& keyVectors,
-        uint8_t** probedTuples, uint8_t** matchedTuples);
+        uint8_t** probedTuples, uint8_t** matchedTuples, bool match);
     // Input is multiple tuples, at most one match exist for each key.
     common::sel_t matchUnFlatKey(common::ValueVector* keyVector, uint8_t** probedTuples,
-        uint8_t** matchedTuples, common::SelectionVector& matchedTuplesSelVector);
+        uint8_t** matchedTuples, common::SelectionVector& matchedTuplesSelVector, bool match);
 
     void lookup(std::vector<common::ValueVector*>& vectors, std::vector<uint32_t>& colIdxesToScan,
         uint8_t** tuplesToRead, uint64_t startPos, uint64_t numTuplesToRead) {
@@ -47,7 +47,7 @@ public:
         auto slotIdx = getSlotIdxForHash(hash);
         KU_ASSERT(slotIdx < maxNumHashSlots);
         return ((uint8_t**)(hashSlotsBlocks[slotIdx >> numSlotsPerBlockLog2]
-                                ->getData()))[slotIdx & slotIdxInBlockMask];
+                ->getData()))[slotIdx & slotIdxInBlockMask];
     }
     FactorizedTable* getFactorizedTable() { return factorizedTable.get(); }
     const FactorizedTableSchema* getTableSchema() { return factorizedTable->getTableSchema(); }

--- a/src/include/processor/operator/hash_join/join_hash_table.h
+++ b/src/include/processor/operator/hash_join/join_hash_table.h
@@ -52,6 +52,11 @@ public:
     FactorizedTable* getFactorizedTable() { return factorizedTable.get(); }
     const FactorizedTableSchema* getTableSchema() { return factorizedTable->getTableSchema(); }
 
+protected:
+    void computeHashValue(const std::vector<common::ValueVector*>& keyVector,
+        common::ValueVector& hashVector, common::ValueVector& tmpHashResultVector,
+        common::SelectionVector& hashSelVec) const;
+
 private:
     uint8_t** findHashSlot(const uint8_t* tuple) const;
     // This function returns the pointer that previously stored in the same slot.

--- a/src/include/processor/operator/hash_join/join_hash_table.h
+++ b/src/include/processor/operator/hash_join/join_hash_table.h
@@ -29,10 +29,10 @@ public:
     // All key vectors must be flat. Thus input is a tuple, multiple matches can be found for the
     // given key tuple.
     common::sel_t matchFlatKeys(const std::vector<common::ValueVector*>& keyVectors,
-        uint8_t** probedTuples, uint8_t** matchedTuples, bool match);
+        uint8_t** probedTuples, uint8_t** matchedTuples, bool match = true);
     // Input is multiple tuples, at most one match exist for each key.
     common::sel_t matchUnFlatKey(common::ValueVector* keyVector, uint8_t** probedTuples,
-        uint8_t** matchedTuples, common::SelectionVector& matchedTuplesSelVector, bool match);
+        uint8_t** matchedTuples, common::SelectionVector& matchedTuplesSelVector);
 
     void lookup(std::vector<common::ValueVector*>& vectors, std::vector<uint32_t>& colIdxesToScan,
         uint8_t** tuplesToRead, uint64_t startPos, uint64_t numTuplesToRead) {

--- a/src/include/processor/operator/hash_join/join_hash_table.h
+++ b/src/include/processor/operator/hash_join/join_hash_table.h
@@ -47,7 +47,7 @@ public:
         auto slotIdx = getSlotIdxForHash(hash);
         KU_ASSERT(slotIdx < maxNumHashSlots);
         return ((uint8_t**)(hashSlotsBlocks[slotIdx >> numSlotsPerBlockLog2]
-                ->getData()))[slotIdx & slotIdxInBlockMask];
+                                ->getData()))[slotIdx & slotIdxInBlockMask];
     }
     FactorizedTable* getFactorizedTable() { return factorizedTable.get(); }
     const FactorizedTableSchema* getTableSchema() { return factorizedTable->getTableSchema(); }

--- a/src/include/processor/operator/physical_operator.h
+++ b/src/include/processor/operator/physical_operator.h
@@ -13,6 +13,7 @@ enum class PhysicalOperatorType : uint8_t {
     ALTER,
     AGGREGATE,
     AGGREGATE_SCAN,
+    ANTI_JOIN_PROBE,
     ATTACH_DATABASE,
     BATCH_INSERT,
     COPY_TO,

--- a/src/include/processor/result/base_hash_table.h
+++ b/src/include/processor/result/base_hash_table.h
@@ -15,6 +15,11 @@ public:
 
     virtual ~BaseHashTable() = default;
 
+    template<class TARGET>
+    const TARGET* constPtrCast() const {
+        return common::ku_dynamic_cast<const TARGET*>(this);
+    }
+
 protected:
     static constexpr uint64_t HASH_BLOCK_SIZE = common::TEMP_PAGE_SIZE;
 

--- a/src/include/processor/result/base_hash_table.h
+++ b/src/include/processor/result/base_hash_table.h
@@ -31,7 +31,7 @@ protected:
         const std::vector<common::ValueVector*>& unFlatKeyVectors);
     void initSlotConstant(uint64_t numSlotsPerBlock);
     bool matchFlatVecWithEntry(const std::vector<common::ValueVector*>& keyVectors,
-        const uint8_t* entry, bool match);
+        const uint8_t* entry, bool match = true);
 
 private:
     void initCompareFuncs();

--- a/src/include/processor/result/base_hash_table.h
+++ b/src/include/processor/result/base_hash_table.h
@@ -26,7 +26,7 @@ protected:
         const std::vector<common::ValueVector*>& unFlatKeyVectors);
     void initSlotConstant(uint64_t numSlotsPerBlock);
     bool matchFlatVecWithEntry(const std::vector<common::ValueVector*>& keyVectors,
-        const uint8_t* entry);
+        const uint8_t* entry, bool match);
 
 private:
     void initCompareFuncs();

--- a/src/optimizer/filter_push_down_optimizer.cpp
+++ b/src/optimizer/filter_push_down_optimizer.cpp
@@ -127,8 +127,8 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitCrossProductRepla
     if (joinConditions.empty()) { // Nothing to push down. Terminate.
         return finishPushDown(op);
     }
-    auto hashJoin = std::make_shared<LogicalHashJoin>(joinConditions, type,
-        nullptr /* mark */, op->getChild(0), op->getChild(1), 0 /* cardinality */);
+    auto hashJoin = std::make_shared<LogicalHashJoin>(joinConditions, type, nullptr /* mark */,
+        op->getChild(0), op->getChild(1), 0 /* cardinality */);
     // For non-id based joins, we disable side way information passing.
     hashJoin->getSIPInfoUnsafe().position = SemiMaskPosition::PROHIBIT;
     hashJoin->computeFlatSchema();

--- a/src/planner/operator/logical_hash_join.cpp
+++ b/src/planner/operator/logical_hash_join.cpp
@@ -38,7 +38,8 @@ void LogicalHashJoin::computeFactorizedSchema() {
     switch (joinType) {
     case JoinType::INNER:
     case JoinType::LEFT:
-    case JoinType::COUNT: {
+    case JoinType::COUNT:
+    case JoinType::ANTI: {
         // Populate group position mapping
         std::unordered_map<f_group_pos, f_group_pos> buildToProbeKeyGroupPositionMap;
         for (auto& [probeKey, buildKey] : joinConditions) {
@@ -95,7 +96,8 @@ void LogicalHashJoin::computeFlatSchema() {
     switch (joinType) {
     case JoinType::INNER:
     case JoinType::LEFT:
-    case JoinType::COUNT: {
+    case JoinType::COUNT:
+    case JoinType::ANTI: {
         for (auto& expression : buildSchema->getExpressionsInScope()) {
             // Join key may repeat for internal ID based joins.
             schema->insertToGroupAndScopeMayRepeat(expression, 0);
@@ -123,7 +125,8 @@ binder::expression_vector LogicalHashJoin::getExpressionsToMaterialize() const {
     switch (joinType) {
     case JoinType::INNER:
     case JoinType::LEFT:
-    case JoinType::COUNT: {
+    case JoinType::COUNT:
+    case JoinType::ANTI: {
         return children[1]->getSchema()->getExpressionsInScope();
     }
     case JoinType::MARK: {

--- a/src/processor/operator/aggregate/aggregate_hash_table.cpp
+++ b/src/processor/operator/aggregate/aggregate_hash_table.cpp
@@ -174,7 +174,7 @@ uint8_t* AggregateHashTable::findEntryInDistinctHT(
         auto slot = (HashSlot*)getHashSlot(slotIdx);
         if (slot->entry == nullptr) {
             return nullptr;
-        } else if ((slot->hash == hash) && matchFlatVecWithEntry(groupByKeyVectors, slot->entry, true)) {
+        } else if ((slot->hash == hash) && matchFlatVecWithEntry(groupByKeyVectors, slot->entry)) {
             return slot->entry;
         }
         increaseSlotIdx(slotIdx);

--- a/src/processor/operator/aggregate/aggregate_hash_table.cpp
+++ b/src/processor/operator/aggregate/aggregate_hash_table.cpp
@@ -174,7 +174,7 @@ uint8_t* AggregateHashTable::findEntryInDistinctHT(
         auto slot = (HashSlot*)getHashSlot(slotIdx);
         if (slot->entry == nullptr) {
             return nullptr;
-        } else if ((slot->hash == hash) && matchFlatVecWithEntry(groupByKeyVectors, slot->entry)) {
+        } else if ((slot->hash == hash) && matchFlatVecWithEntry(groupByKeyVectors, slot->entry, true)) {
             return slot->entry;
         }
         increaseSlotIdx(slotIdx);

--- a/src/processor/operator/hash_join/CMakeLists.txt
+++ b/src/processor/operator/hash_join/CMakeLists.txt
@@ -2,7 +2,9 @@ add_library(kuzu_processor_operator_hash_join
         OBJECT
         hash_join_build.cpp
         hash_join_probe.cpp
-        join_hash_table.cpp)
+        join_hash_table.cpp
+        anti_join_probe.cpp
+        anti_join_hash_table.cpp)
 
 set(ALL_OBJECT_FILES
         ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_processor_operator_hash_join>

--- a/src/processor/operator/hash_join/anti_join_hash_table.cpp
+++ b/src/processor/operator/hash_join/anti_join_hash_table.cpp
@@ -1,0 +1,38 @@
+#include "processor/operator/hash_join/anti_join_hash_table.h"
+
+namespace kuzu {
+namespace processor {
+
+void AntiJoinProbeState::initState(uint64_t maxNumHashSlots_, uint64_t hashSlotIdx_) {
+    nextHashSlotIdx = 0;
+    maxNumHashSlots = maxNumHashSlots_;
+    hashSlotIdx = hashSlotIdx_;
+}
+
+bool AntiJoinProbeState::hasMoreToProbe() const {
+    return nextHashSlotIdx < maxNumHashSlots;
+}
+
+bool AntiJoinProbeState::checkKeys() const {
+    return nextHashSlotIdx - 1 == hashSlotIdx;
+}
+
+void AntiJoinHashTable::initProbeState(kuzu::processor::AntiJoinProbeState& probeState,
+    const std::vector<common::ValueVector*>& keyVectors, common::ValueVector& hashVector,
+    common::SelectionVector& hashSelVec, common::ValueVector& tmpHashResultVector) const {
+    KU_ASSERT(keyVectors.size() == keyTypes.size());
+    KU_ASSERT(keyVectors[0]->state->isFlat());
+    computeHashValue(keyVectors, hashVector, tmpHashResultVector, hashSelVec);
+    probeState.initState(maxNumHashSlots,
+        getSlotIdxForHash(hashVector.getValue<common::hash_t>(0)));
+}
+
+void AntiJoinHashTable::probe(AntiJoinProbeState& probeState, uint8_t** probedTuples) const {
+    probedTuples[0] =
+        ((uint8_t**)(hashSlotsBlocks[probeState.nextHashSlotIdx >> numSlotsPerBlockLog2]
+                ->getData()))[probeState.nextHashSlotIdx & slotIdxInBlockMask];
+    probeState.nextHashSlotIdx++;
+}
+
+} // namespace processor
+} // namespace kuzu

--- a/src/processor/operator/hash_join/anti_join_hash_table.cpp
+++ b/src/processor/operator/hash_join/anti_join_hash_table.cpp
@@ -30,7 +30,7 @@ void AntiJoinHashTable::initProbeState(kuzu::processor::AntiJoinProbeState& prob
 void AntiJoinHashTable::probe(AntiJoinProbeState& probeState, uint8_t** probedTuples) const {
     probedTuples[0] =
         ((uint8_t**)(hashSlotsBlocks[probeState.nextHashSlotIdx >> numSlotsPerBlockLog2]
-                ->getData()))[probeState.nextHashSlotIdx & slotIdxInBlockMask];
+                         ->getData()))[probeState.nextHashSlotIdx & slotIdxInBlockMask];
     probeState.nextHashSlotIdx++;
 }
 

--- a/src/processor/operator/hash_join/anti_join_probe.cpp
+++ b/src/processor/operator/hash_join/anti_join_probe.cpp
@@ -1,0 +1,65 @@
+#include "processor/operator/hash_join/anti_join_probe.h"
+
+#include "processor/operator/hash_join/anti_join_hash_table.h"
+
+using namespace kuzu::common;
+
+namespace kuzu {
+namespace processor {
+
+bool AntiJoinProbe::getMatchedTuples(kuzu::processor::ExecutionContext* context) {
+    KU_ASSERT(flatProbe);
+    if (probeState->nextMatchedTupleIdx < probeState->matchedSelVector.getSelSize()) {
+        // Not all matched tuples have been shipped. Continue shipping.
+        return true;
+    }
+
+    auto antiJoinHT = sharedState->getHashTable()->constPtrCast<AntiJoinHashTable>();
+    auto probedTuples = probeState->probedTuples.get();
+    if (probedTuples[0] == nullptr) {
+        if (!antiJoinProbeState.hasMoreToProbe()) {
+            restoreSelVector(*keyVectors[0]->state);
+            if (!children[0]->getNextTuple(context)) {
+                return false;
+            }
+            saveSelVector(*keyVectors[0]->state);
+            antiJoinHT->initProbeState(antiJoinProbeState, keyVectors, *hashVector, hashSelVec,
+                *tmpHashVector);
+        }
+
+        while (antiJoinProbeState.hasMoreToProbe()) {
+            antiJoinHT->probe(antiJoinProbeState, probedTuples);
+            if (probeState->probedTuples[0] != nullptr) {
+                break;
+            }
+        }
+    }
+
+    moveProbedTuplesToMatched();
+    return true;
+}
+
+void AntiJoinProbe::moveProbedTuplesToMatched() {
+    uint64_t numMatchedTuples = 0;
+    auto probedTuples = probeState->probedTuples.get();
+    if (antiJoinProbeState.checkKeys()) {
+        numMatchedTuples =
+            sharedState->getHashTable()->matchFlatKeys(keyVectors, probeState->probedTuples.get(),
+                probeState->matchedTuples.get(), joinType != common::JoinType::ANTI);
+    } else {
+        while (probedTuples[0]) {
+            if (numMatchedTuples == DEFAULT_VECTOR_CAPACITY) {
+                break;
+            }
+            auto currentTuple = probedTuples[0];
+            probeState->matchedTuples[numMatchedTuples] = currentTuple;
+            numMatchedTuples++;
+            probedTuples[0] = *sharedState->getHashTable()->getPrevTuple(currentTuple);
+        }
+    }
+    probeState->matchedSelVector.setSelSize(numMatchedTuples);
+    probeState->nextMatchedTupleIdx = 0;
+}
+
+} // namespace processor
+} // namespace kuzu

--- a/src/processor/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/operator/hash_join/hash_join_probe.cpp
@@ -58,8 +58,9 @@ bool HashJoinProbe::getMatchedTuplesForFlatKey(ExecutionContext* context) {
         sharedState->getHashTable()->probe(keyVectors, *hashVector, hashSelVec, *tmpHashVector,
             probeState->probedTuples.get());
     }
-    auto numMatchedTuples = sharedState->getHashTable()->matchFlatKeys(keyVectors,
-        probeState->probedTuples.get(), probeState->matchedTuples.get());
+    auto numMatchedTuples =
+        sharedState->getHashTable()->matchFlatKeys(keyVectors, probeState->probedTuples.get(),
+            probeState->matchedTuples.get(), joinType != common::JoinType::ANTI);
     probeState->matchedSelVector.setSelSize(numMatchedTuples);
     probeState->nextMatchedTupleIdx = 0;
     return true;
@@ -75,9 +76,9 @@ bool HashJoinProbe::getMatchedTuplesForUnFlatKey(ExecutionContext* context) {
     saveSelVector(*keyVector->state);
     sharedState->getHashTable()->probe(keyVectors, *hashVector, hashSelVec, *tmpHashVector,
         probeState->probedTuples.get());
-    auto numMatchedTuples =
-        sharedState->getHashTable()->matchUnFlatKey(keyVector, probeState->probedTuples.get(),
-            probeState->matchedTuples.get(), probeState->matchedSelVector);
+    auto numMatchedTuples = sharedState->getHashTable()->matchUnFlatKey(keyVector,
+        probeState->probedTuples.get(), probeState->matchedTuples.get(),
+        probeState->matchedSelVector, joinType != common::JoinType::ANTI);
     probeState->matchedSelVector.setSelSize(numMatchedTuples);
     probeState->nextMatchedTupleIdx = 0;
     return true;
@@ -181,6 +182,7 @@ uint64_t HashJoinProbe::getJoinResult() {
     case JoinType::MARK: {
         return getMarkJoinResult();
     }
+    case JoinType::ANTI:
     case JoinType::INNER: {
         return getInnerJoinResult();
     }

--- a/src/processor/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/operator/hash_join/hash_join_probe.cpp
@@ -58,9 +58,8 @@ bool HashJoinProbe::getMatchedTuplesForFlatKey(ExecutionContext* context) {
         sharedState->getHashTable()->probe(keyVectors, *hashVector, hashSelVec, *tmpHashVector,
             probeState->probedTuples.get());
     }
-    auto numMatchedTuples =
-        sharedState->getHashTable()->matchFlatKeys(keyVectors, probeState->probedTuples.get(),
-            probeState->matchedTuples.get(), joinType != common::JoinType::ANTI);
+    auto numMatchedTuples = sharedState->getHashTable()->matchFlatKeys(keyVectors,
+        probeState->probedTuples.get(), probeState->matchedTuples.get());
     probeState->matchedSelVector.setSelSize(numMatchedTuples);
     probeState->nextMatchedTupleIdx = 0;
     return true;
@@ -76,9 +75,9 @@ bool HashJoinProbe::getMatchedTuplesForUnFlatKey(ExecutionContext* context) {
     saveSelVector(*keyVector->state);
     sharedState->getHashTable()->probe(keyVectors, *hashVector, hashSelVec, *tmpHashVector,
         probeState->probedTuples.get());
-    auto numMatchedTuples = sharedState->getHashTable()->matchUnFlatKey(keyVector,
-        probeState->probedTuples.get(), probeState->matchedTuples.get(),
-        probeState->matchedSelVector, joinType != common::JoinType::ANTI);
+    auto numMatchedTuples =
+        sharedState->getHashTable()->matchUnFlatKey(keyVector, probeState->probedTuples.get(),
+            probeState->matchedTuples.get(), probeState->matchedSelVector);
     probeState->matchedSelVector.setSelSize(numMatchedTuples);
     probeState->nextMatchedTupleIdx = 0;
     return true;

--- a/src/processor/operator/hash_join/join_hash_table.cpp
+++ b/src/processor/operator/hash_join/join_hash_table.cpp
@@ -152,7 +152,7 @@ void JoinHashTable::probe(const std::vector<ValueVector*>& keyVectors, ValueVect
 }
 
 sel_t JoinHashTable::matchFlatKeys(const std::vector<ValueVector*>& keyVectors,
-    uint8_t** probedTuples, uint8_t** matchedTuples) {
+    uint8_t** probedTuples, uint8_t** matchedTuples, bool match) {
     auto numMatchedTuples = 0;
     while (probedTuples[0]) {
         if (numMatchedTuples == DEFAULT_VECTOR_CAPACITY) {
@@ -160,21 +160,21 @@ sel_t JoinHashTable::matchFlatKeys(const std::vector<ValueVector*>& keyVectors,
         }
         auto currentTuple = probedTuples[0];
         matchedTuples[numMatchedTuples] = currentTuple;
-        numMatchedTuples += matchFlatVecWithEntry(keyVectors, currentTuple);
+        numMatchedTuples += matchFlatVecWithEntry(keyVectors, currentTuple, match);
         probedTuples[0] = *getPrevTuple(currentTuple);
     }
     return numMatchedTuples;
 }
 
 sel_t JoinHashTable::matchUnFlatKey(ValueVector* keyVector, uint8_t** probedTuples,
-    uint8_t** matchedTuples, SelectionVector& matchedTuplesSelVector) {
+    uint8_t** matchedTuples, SelectionVector& matchedTuplesSelVector, bool match) {
     auto numMatchedTuples = 0;
     for (auto i = 0u; i < keyVector->state->getSelVector().getSelSize(); ++i) {
         auto pos = keyVector->state->getSelVector()[i];
         while (probedTuples[i]) {
             auto currentTuple = probedTuples[i];
             auto entryCompareResult = compareEntryFuncs[0](keyVector, pos, currentTuple);
-            if (entryCompareResult) {
+            if (match == entryCompareResult) {
                 matchedTuples[numMatchedTuples] = currentTuple;
                 matchedTuplesSelVector[numMatchedTuples] = pos;
                 numMatchedTuples++;

--- a/src/processor/operator/hash_join/join_hash_table.cpp
+++ b/src/processor/operator/hash_join/join_hash_table.cpp
@@ -158,14 +158,14 @@ sel_t JoinHashTable::matchFlatKeys(const std::vector<ValueVector*>& keyVectors,
 }
 
 sel_t JoinHashTable::matchUnFlatKey(ValueVector* keyVector, uint8_t** probedTuples,
-    uint8_t** matchedTuples, SelectionVector& matchedTuplesSelVector, bool match) {
+    uint8_t** matchedTuples, SelectionVector& matchedTuplesSelVector) {
     auto numMatchedTuples = 0;
     for (auto i = 0u; i < keyVector->state->getSelVector().getSelSize(); ++i) {
         auto pos = keyVector->state->getSelVector()[i];
         while (probedTuples[i]) {
             auto currentTuple = probedTuples[i];
             auto entryCompareResult = compareEntryFuncs[0](keyVector, pos, currentTuple);
-            if (match == entryCompareResult) {
+            if (entryCompareResult) {
                 matchedTuples[numMatchedTuples] = currentTuple;
                 matchedTuplesSelVector[numMatchedTuples] = pos;
                 numMatchedTuples++;

--- a/test/test_files/anti_join/basic.test
+++ b/test/test_files/anti_join/basic.test
@@ -1,0 +1,43 @@
+-DATASET CSV tinysnb
+
+--
+
+-CASE BasicAntiJoin
+
+-STATEMENT MATCH (a:person), (b:person) WHERE a.ID <> b.ID AND a.fName = 'Alice' RETURN a.fName, b.fName
+---- 7
+Alice|Bob
+Alice|Carol
+Alice|Dan
+Alice|Elizabeth
+Alice|Farooq
+Alice|Greg
+Alice|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
+
+-STATEMENT MATCH (a:person), (b:person) WHERE a.ID <> b.ID AND a.ID < 3 AND b.ID > 5 RETURN a.fName, b.fName
+---- 8
+Alice|Elizabeth
+Alice|Farooq
+Alice|Greg
+Alice|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
+Bob|Elizabeth
+Bob|Farooq
+Bob|Greg
+Bob|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
+
+-STATEMENT MATCH (a:person), (b:person) WHERE a.ID <> b.ID RETURN COUNT(*)
+---- 1
+56
+
+-STATEMENT MATCH (a), (b) WHERE a.ID <> b.ID RETURN COUNT(*)
+---- 1
+110
+
+-STATEMENT MATCH (a:person)-[e1:knows]->(b:person) , (c:person)-[e2:knows]->(d:person) WHERE a.ID = 0 AND c.ID = 2 AND e1.date <> e2.date RETURN id(e1), e1.date, id(e2), e2.date
+---- 6
+3:0|2021-06-30|3:4|1950-05-14
+3:0|2021-06-30|3:5|1950-05-14
+3:1|2021-06-30|3:4|1950-05-14
+3:1|2021-06-30|3:5|1950-05-14
+3:2|2021-06-30|3:4|1950-05-14
+3:2|2021-06-30|3:5|1950-05-14


### PR DESCRIPTION
This PR implements anti-join which makes the cross-product with unequality faster.
E.g.
```
MATCH (a:person) (b:person)
WHERE a.ID <> b.ID
RETURN *
```
will use the anti-join operator to gain better performance.