### PR TITLE
Skip query result from rewritten queries

### DIFF
--- a/extension/fts/test/test_files/fts_small.test
+++ b/extension/fts/test/test_files/fts_small.test
@@ -8,7 +8,7 @@
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
 ---- ok
 -STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx', ['content', 'author', 'name'])
----- ok
+---- 0
 
 -LOG QueryFTSConjunctiveSingleKeyword
 -STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'alice', conjunctive := true) RETURN _node.ID, score

--- a/extension/httpfs/src/http_config.cpp
+++ b/extension/httpfs/src/http_config.cpp
@@ -14,7 +14,7 @@ HTTPConfig::HTTPConfig(main::ClientContext* context) {
 
 void HTTPConfigEnvProvider::setOptionValue(main::ClientContext* context) {
     const auto cacheFileOptionStrVal =
-        context->getEnvVariable(HTTPCacheFileConfig::HTTP_CACHE_FILE_ENV_VAR);
+        main::ClientContext::getEnvVariable(HTTPCacheFileConfig::HTTP_CACHE_FILE_ENV_VAR);
     if (cacheFileOptionStrVal != "") {
         bool enableCacheFile = false;
         function::CastString::operation(

--- a/extension/httpfs/src/s3_download_options.cpp
+++ b/extension/httpfs/src/s3_download_options.cpp
@@ -18,11 +18,11 @@ void S3DownloadOptions::registerExtensionOptions(main::Database* db) {
 }
 
 void S3DownloadOptions::setEnvValue(main::ClientContext* context) {
-    auto accessKeyID = context->getEnvVariable(S3AccessKeyID::NAME);
-    auto secretAccessKey = context->getEnvVariable(S3SecretAccessKey::NAME);
-    auto endpoint = context->getEnvVariable(S3EndPoint::NAME);
-    auto urlStyle = context->getEnvVariable(S3URLStyle::NAME);
-    auto region = context->getEnvVariable(S3Region::NAME);
+    auto accessKeyID = main::ClientContext::getEnvVariable(S3AccessKeyID::NAME);
+    auto secretAccessKey = main::ClientContext::getEnvVariable(S3SecretAccessKey::NAME);
+    auto endpoint = main::ClientContext::getEnvVariable(S3EndPoint::NAME);
+    auto urlStyle = main::ClientContext::getEnvVariable(S3URLStyle::NAME);
+    auto region = main::ClientContext::getEnvVariable(S3Region::NAME);
     if (accessKeyID != "") {
         context->setExtensionOption(S3AccessKeyID::NAME, Value::createValue(accessKeyID));
     }

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -106,21 +106,18 @@ public:
     extension::ExtensionOptions* getExtensionOptions() const;
     std::string getExtensionDir() const;
 
-    // Environment.
-    std::string getEnvVariable(const std::string& name);
-
     // Database component getters.
     std::string getDatabasePath() const;
     Database* getDatabase() const { return localDatabase; }
     common::TaskScheduler* getTaskScheduler() const;
     DatabaseManager* getDatabaseManager() const;
     storage::StorageManager* getStorageManager() const;
-    storage::MemoryManager* getMemoryManager();
+    storage::MemoryManager* getMemoryManager() const;
     storage::WAL* getWAL() const;
     catalog::Catalog* getCatalog() const;
     transaction::TransactionManager* getTransactionManagerUnsafe() const;
     common::VirtualFileSystem* getVFSUnsafe() const;
-    common::RandomEngine* getRandomEngine();
+    common::RandomEngine* getRandomEngine() const;
 
     // Query.
     std::unique_ptr<PreparedStatement> prepare(std::string_view query);
@@ -131,7 +128,7 @@ public:
         std::optional<uint64_t> queryID = std::nullopt);
 
     void setDefaultDatabase(AttachedKuzuDatabase* defaultDatabase_);
-    bool hasDefaultDatabase();
+    bool hasDefaultDatabase() const;
 
     void addScalarFunction(std::string name, function::function_set definitions);
     void removeScalarFunction(std::string name);
@@ -146,10 +143,12 @@ public:
     std::unique_ptr<QueryResult> queryInternal(std::string_view query,
         std::optional<uint64_t> queryID = std::nullopt);
 
+    static std::string getEnvVariable(const std::string& name);
+
 private:
     std::vector<std::shared_ptr<parser::Statement>> parseQuery(std::string_view query);
 
-    std::unique_ptr<QueryResult> queryResultWithError(std::string_view errMsg);
+    static std::unique_ptr<QueryResult> queryResultWithError(std::string_view errMsg);
 
     std::unique_ptr<PreparedStatement> preparedStatementWithError(std::string_view errMsg);
 
@@ -178,7 +177,7 @@ private:
     std::unique_ptr<QueryResult> executeNoLock(PreparedStatement* preparedStatement,
         std::optional<uint64_t> queryID = std::nullopt);
 
-    bool canExecuteWriteQuery();
+    bool canExecuteWriteQuery() const;
 
     void runFuncInTransaction(const std::function<void(void)>& fun);
 

--- a/src/include/parser/statement.h
+++ b/src/include/parser/statement.h
@@ -8,13 +8,16 @@ namespace parser {
 
 class Statement {
 public:
-    explicit Statement(common::StatementType statementType) : statementType{statementType} {}
+    explicit Statement(common::StatementType statementType)
+        : statementType{statementType}, internal{false} {}
 
     virtual ~Statement() = default;
 
     common::StatementType getStatementType() const { return statementType; }
+    void setToInternal() { internal = true; }
+    bool isInternal() const { return internal; }
 
-    bool requireTx() {
+    bool requireTx() const {
         switch (statementType) {
         case common::StatementType::TRANSACTION:
             return false;
@@ -38,6 +41,11 @@ public:
 
 private:
     common::StatementType statementType;
+    // By setting the statement to internal, we still execute the statement, but will not return the
+    // executio result as part of the query result returned to users.
+    // The use case for this is when a query internally generates other queries to finish first,
+    // e.g., `TableFunction::rewriteFunc`.
+    bool internal;
 };
 
 } // namespace parser

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -169,9 +169,11 @@ void TestRunner::checkPlanResult(Connection& conn, QueryResult* result, TestStat
 }
 
 void TestRunner::outputFailedPlan(Connection& conn, const TestStatement* statement) {
-    const auto plan = getLogicalPlan(statement->query, conn);
     spdlog::error("QUERY FAILED.");
-    spdlog::info("PLAN: \n{}", plan->toString());
+    const auto plan = getLogicalPlan(statement->query, conn);
+    if (plan) {
+        spdlog::info("PLAN: \n{}", plan->toString());
+    }
 }
 
 bool TestRunner::checkResultNumeric(QueryResult& queryResult, const TestStatement* statement,


### PR DESCRIPTION
# Description

Query results from rewritten queries should only be kept as internal one, but not exposed as query result to users.