### PR TITLE
refactor table bind func

### DIFF
--- a/extension/delta/src/function/delta_scan.cpp
+++ b/extension/delta/src/function/delta_scan.cpp
@@ -1,11 +1,11 @@
 #include "function/delta_scan.h"
 
+#include "binder/binder.h"
 #include "connector/connector_factory.h"
 #include "connector/delta_connector.h"
 #include "connector/duckdb_result_converter.h"
 #include "connector/duckdb_type_converter.h"
 #include "function/table/scan_functions.h"
-#include "binder/binder.h"
 
 namespace kuzu {
 namespace delta_extension {
@@ -19,10 +19,10 @@ struct DeltaScanBindData : public ScanBindData {
     duckdb_extension::DuckDBResultConverter converter;
 
     DeltaScanBindData(std::string query, std::shared_ptr<DeltaConnector> connector,
-        duckdb_extension::DuckDBResultConverter converter, binder::expression_vector columns, ReaderConfig config, main::ClientContext* ctx)
-        : ScanBindData{std::move(columns), std::move(config), ctx},
-          query{std::move(query)}, connector{std::move(connector)},
-          converter{std::move(converter)} {}
+        duckdb_extension::DuckDBResultConverter converter, binder::expression_vector columns,
+        ReaderConfig config, main::ClientContext* ctx)
+        : ScanBindData{std::move(columns), std::move(config), ctx}, query{std::move(query)},
+          connector{std::move(connector)}, converter{std::move(converter)} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
         return std::make_unique<DeltaScanBindData>(*this);

--- a/extension/duckdb/src/function/clear_cache.cpp
+++ b/extension/duckdb/src/function/clear_cache.cpp
@@ -2,6 +2,7 @@
 
 #include "catalog/duckdb_catalog.h"
 #include "storage/duckdb_storage.h"
+#include "binder/binder.h"
 
 using namespace kuzu::function;
 using namespace kuzu::main;
@@ -25,13 +26,14 @@ static offset_t clearCacheTableFunc(TableFuncInput& input, TableFuncOutput& outp
 }
 
 static std::unique_ptr<TableFuncBindData> clearCacheBindFunc(ClientContext* context,
-    TableFuncBindInput*) {
+    TableFuncBindInput* input) {
     std::vector<std::string> columnNames;
     std::vector<LogicalType> columnTypes;
     columnNames.emplace_back("message");
     columnTypes.emplace_back(LogicalType::STRING());
+    auto columns = input->binder->createVariables(columnNames, columnTypes);
     return std::make_unique<ClearCacheBindData>(context->getDatabaseManager(),
-        std::move(columnTypes), std::move(columnNames), 1 /* maxOffset */);
+        columns, 1 /* maxOffset */);
 }
 
 ClearCacheFunction::ClearCacheFunction()

--- a/extension/duckdb/src/function/clear_cache.cpp
+++ b/extension/duckdb/src/function/clear_cache.cpp
@@ -1,8 +1,8 @@
 #include "function/clear_cache.h"
 
+#include "binder/binder.h"
 #include "catalog/duckdb_catalog.h"
 #include "storage/duckdb_storage.h"
-#include "binder/binder.h"
 
 using namespace kuzu::function;
 using namespace kuzu::main;
@@ -32,8 +32,8 @@ static std::unique_ptr<TableFuncBindData> clearCacheBindFunc(ClientContext* cont
     columnNames.emplace_back("message");
     columnTypes.emplace_back(LogicalType::STRING());
     auto columns = input->binder->createVariables(columnNames, columnTypes);
-    return std::make_unique<ClearCacheBindData>(context->getDatabaseManager(),
-        columns, 1 /* maxOffset */);
+    return std::make_unique<ClearCacheBindData>(context->getDatabaseManager(), columns,
+        1 /* maxOffset */);
 }
 
 ClearCacheFunction::ClearCacheFunction()

--- a/extension/duckdb/src/function/duckdb_scan.cpp
+++ b/extension/duckdb/src/function/duckdb_scan.cpp
@@ -1,9 +1,9 @@
 #include "function/duckdb_scan.h"
 
+#include "binder/binder.h"
 #include "common/exception/runtime.h"
 #include "connector/duckdb_connector.h"
 #include "function/table/bind_input.h"
-#include "binder/binder.h"
 
 using namespace kuzu::function;
 using namespace kuzu::common;
@@ -14,8 +14,8 @@ namespace duckdb_extension {
 DuckDBScanBindData::DuckDBScanBindData(std::string query,
     std::vector<common::LogicalType> columnTypes, std::vector<std::string> columnNames,
     const DuckDBConnector& connector)
-    : TableFuncBindData{}, query{std::move(query)}, columnTypes{LogicalType::copy(columnTypes)}, columnNames{columnNames},
-      converter{columnTypes}, connector{connector} {}
+    : TableFuncBindData{}, query{std::move(query)}, columnTypes{LogicalType::copy(columnTypes)},
+      columnNames{columnNames}, converter{columnTypes}, connector{connector} {}
 
 DuckDBScanSharedState::DuckDBScanSharedState(
     std::unique_ptr<duckdb::MaterializedQueryResult> queryResult)

--- a/extension/duckdb/src/include/function/clear_cache.h
+++ b/extension/duckdb/src/include/function/clear_cache.h
@@ -13,12 +13,11 @@ struct ClearCacheBindData : public function::SimpleTableFuncBindData {
 
     ClearCacheBindData(main::DatabaseManager* databaseManager, binder::expression_vector columns,
         common::offset_t maxOffset)
-        : SimpleTableFuncBindData{std::move(columns), maxOffset},
-          databaseManager{databaseManager} {}
+        : SimpleTableFuncBindData{std::move(columns), maxOffset}, databaseManager{databaseManager} {
+    }
 
     std::unique_ptr<TableFuncBindData> copy() const override {
-        return std::make_unique<ClearCacheBindData>(databaseManager,
-            columns, maxOffset);
+        return std::make_unique<ClearCacheBindData>(databaseManager, columns, maxOffset);
     }
 };
 

--- a/extension/duckdb/src/include/function/clear_cache.h
+++ b/extension/duckdb/src/include/function/clear_cache.h
@@ -11,15 +11,14 @@ namespace duckdb_extension {
 struct ClearCacheBindData : public function::SimpleTableFuncBindData {
     main::DatabaseManager* databaseManager;
 
-    ClearCacheBindData(main::DatabaseManager* databaseManager,
-        std::vector<common::LogicalType> returnTypes, std::vector<std::string> returnColumnNames,
+    ClearCacheBindData(main::DatabaseManager* databaseManager, binder::expression_vector columns,
         common::offset_t maxOffset)
-        : SimpleTableFuncBindData{std::move(returnTypes), std::move(returnColumnNames), maxOffset},
+        : SimpleTableFuncBindData{std::move(columns), maxOffset},
           databaseManager{databaseManager} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
         return std::make_unique<ClearCacheBindData>(databaseManager,
-            common::LogicalType::copy(columnTypes), columnNames, maxOffset);
+            columns, maxOffset);
     }
 };
 

--- a/extension/duckdb/src/include/function/duckdb_scan.h
+++ b/extension/duckdb/src/include/function/duckdb_scan.h
@@ -14,14 +14,17 @@ using init_duckdb_conn_t = std::function<std::pair<duckdb::DuckDB, duckdb::Conne
 
 struct DuckDBScanBindData : public function::TableFuncBindData {
     std::string query;
+    std::vector<common::LogicalType> columnTypes;
+    std::vector<std::string> columnNames;
     DuckDBResultConverter converter;
     const DuckDBConnector& connector;
 
     DuckDBScanBindData(std::string query, std::vector<common::LogicalType> columnTypes,
         std::vector<std::string> columnNames, const DuckDBConnector& connector);
     DuckDBScanBindData(const DuckDBScanBindData& other)
-        : function::TableFuncBindData{other}, query{other.query}, converter{other.converter},
-          connector{other.connector} {}
+        : function::TableFuncBindData{other}, query{other.query},
+          columnTypes{copyVector(other.columnTypes)}, columnNames{other.columnNames},
+          converter{other.converter}, connector{other.connector} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
         return std::make_unique<DuckDBScanBindData>(*this);

--- a/extension/fts/src/function/create_fts_index.cpp
+++ b/extension/fts/src/function/create_fts_index.cpp
@@ -29,7 +29,7 @@ struct CreateFTSBindData final : public FTSBindData {
 
     CreateFTSBindData(std::string tableName, common::table_id_t tableID, std::string indexName,
         std::vector<std::string> properties, FTSConfig createFTSConfig)
-        : FTSBindData{std::move(tableName), tableID, std::move(indexName)},
+        : FTSBindData{std::move(tableName), tableID, std::move(indexName), binder::expression_vector{}},
           properties{std::move(properties)}, ftsConfig{std::move(createFTSConfig)} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {

--- a/extension/fts/src/function/create_fts_index.cpp
+++ b/extension/fts/src/function/create_fts_index.cpp
@@ -29,7 +29,8 @@ struct CreateFTSBindData final : public FTSBindData {
 
     CreateFTSBindData(std::string tableName, common::table_id_t tableID, std::string indexName,
         std::vector<std::string> properties, FTSConfig createFTSConfig)
-        : FTSBindData{std::move(tableName), tableID, std::move(indexName), binder::expression_vector{}},
+        : FTSBindData{std::move(tableName), tableID, std::move(indexName),
+              binder::expression_vector{}},
           properties{std::move(properties)}, ftsConfig{std::move(createFTSConfig)} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {

--- a/extension/fts/src/function/drop_fts_index.cpp
+++ b/extension/fts/src/function/drop_fts_index.cpp
@@ -24,7 +24,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
         FTSUtils::IndexOperation::DROP);
     FTSUtils::validateIndexExistence(*context, tableEntry.getTableID(), indexName);
     return std::make_unique<FTSBindData>(tableEntry.getName(), tableEntry.getTableID(), indexName,
-        std::vector<common::LogicalType>{}, std::vector<std::string>{});
+        binder::expression_vector{});
 }
 
 std::string dropFTSIndexQuery(ClientContext& /*context*/, const TableFuncBindData& bindData) {

--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -1,5 +1,6 @@
 #include "function/query_fts_index.h"
 
+#include "binder/binder.h"
 #include "binder/expression/expression_util.h"
 #include "binder/expression/literal_expression.h"
 #include "binder/expression/parameter_expression.h"
@@ -13,7 +14,6 @@
 #include "processor/result/factorized_table.h"
 #include "storage/storage_manager.h"
 #include "storage/store/node_table.h"
-#include "binder/binder.h"
 
 namespace kuzu {
 namespace fts_extension {
@@ -29,8 +29,7 @@ struct QueryFTSBindData final : public FTSBindData {
 
     QueryFTSBindData(std::string tableName, common::table_id_t tableID, std::string indexName,
         std::shared_ptr<binder::Expression> query, const FTSIndexCatalogEntry& entry,
-        binder::expression_vector columns,
-        QueryFTSConfig config)
+        binder::expression_vector columns, QueryFTSConfig config)
         : FTSBindData{std::move(tableName), tableID, std::move(indexName), columns},
           query{std::move(query)}, entry{entry}, config{std::move(config)} {}
 

--- a/extension/fts/src/include/function/fts_bind_data.h
+++ b/extension/fts/src/include/function/fts_bind_data.h
@@ -13,7 +13,7 @@ struct FTSBindData : public function::SimpleTableFuncBindData {
     std::string indexName;
 
     FTSBindData(std::string tableName, common::table_id_t tableID, std::string indexName,
-         binder::expression_vector columns)
+        binder::expression_vector columns)
         : function::SimpleTableFuncBindData{std::move(columns), 1 /* maxOffset */},
           tableName{std::move(tableName)}, tableID{tableID}, indexName{std::move(indexName)} {}
 

--- a/extension/fts/src/include/function/fts_bind_data.h
+++ b/extension/fts/src/include/function/fts_bind_data.h
@@ -13,10 +13,8 @@ struct FTSBindData : public function::SimpleTableFuncBindData {
     std::string indexName;
 
     FTSBindData(std::string tableName, common::table_id_t tableID, std::string indexName,
-        std::vector<common::LogicalType> returnTypes = {},
-        std::vector<std::string> returnColumnNames = {})
-        : function::SimpleTableFuncBindData{std::move(returnTypes), std::move(returnColumnNames),
-              1 /* maxOffset */},
+         binder::expression_vector columns)
+        : function::SimpleTableFuncBindData{std::move(columns), 1 /* maxOffset */},
           tableName{std::move(tableName)}, tableID{tableID}, indexName{std::move(indexName)} {}
 
     std::string getTablePrefix() const { return common::stringFormat("{}_{}", tableID, indexName); }

--- a/extension/json/src/functions/table_functions/json_scan.cpp
+++ b/extension/json/src/functions/table_functions/json_scan.cpp
@@ -2,6 +2,7 @@
 
 #include <regex>
 
+#include "binder/binder.h"
 #include "common/case_insensitive_map.h"
 #include "common/exception/binder.h"
 #include "common/exception/runtime.h"
@@ -15,7 +16,6 @@
 #include "processor/operator/persistent/reader/file_error_handler.h"
 #include "processor/warning_context.h"
 #include "reader/buffered_json_reader.h"
-#include "binder/binder.h"
 
 namespace kuzu {
 namespace json_extension {
@@ -805,7 +805,6 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
         return scanConfig.format == JsonScanFormat::NEWLINE_DELIMITED;
     };
 
-
     auto columns = input->binder->createVariables(columnNames, columnTypes);
 
     const bool ignoreErrors = scanInput->config.getOption(CopyConstants::IGNORE_ERRORS_OPTION_NAME,
@@ -821,13 +820,13 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
             warningColumnTypes.emplace_back(JsonConstant::JSON_WARNING_DATA_COLUMN_TYPES[i]);
         }
     }
-    auto warningColumns = input->binder->createInvisibleVariables(warningColumnNames, warningColumnTypes);
+    auto warningColumns =
+        input->binder->createInvisibleVariables(warningColumnNames, warningColumnTypes);
     for (auto& column : warningColumns) {
         columns.push_back(column);
     }
-    return std::make_unique<JsonScanBindData>(columns,
-        numWarningDataColumns, scanInput->config.copy(), context, std::move(colNameToIdx),
-        scanConfig.format);
+    return std::make_unique<JsonScanBindData>(columns, numWarningDataColumns,
+        scanInput->config.copy(), context, std::move(colNameToIdx), scanConfig.format);
 }
 
 static decltype(auto) getWarningDataVectors(const DataChunk& chunk, column_id_t numWarningColumns) {

--- a/extension/json/src/functions/table_functions/json_scan.cpp
+++ b/extension/json/src/functions/table_functions/json_scan.cpp
@@ -15,6 +15,7 @@
 #include "processor/operator/persistent/reader/file_error_handler.h"
 #include "processor/warning_context.h"
 #include "reader/buffered_json_reader.h"
+#include "binder/binder.h"
 
 namespace kuzu {
 namespace json_extension {
@@ -685,12 +686,10 @@ struct JsonScanBindData : public ScanBindData {
     case_insensitive_map_t<idx_t> colNameToIdx;
     JsonScanFormat format;
 
-    JsonScanBindData(std::vector<common::LogicalType> columnTypes,
-        std::vector<std::string> columnNames, column_id_t numWarningDataColumns,
+    JsonScanBindData(binder::expression_vector columns, column_id_t numWarningDataColumns,
         ReaderConfig config, main::ClientContext* ctx, case_insensitive_map_t<idx_t> colNameToIdx,
         JsonScanFormat format)
-        : ScanBindData(std::move(columnTypes), std::move(columnNames), std::move(config), ctx, 0,
-              numWarningDataColumns),
+        : ScanBindData(columns, std::move(config), ctx, numWarningDataColumns, 0),
           colNameToIdx{std::move(colNameToIdx)}, format{format} {}
 
     uint64_t getFieldIdx(const std::string& fieldName) const;
@@ -806,18 +805,27 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
         return scanConfig.format == JsonScanFormat::NEWLINE_DELIMITED;
     };
 
+
+    auto columns = input->binder->createVariables(columnNames, columnTypes);
+
     const bool ignoreErrors = scanInput->config.getOption(CopyConstants::IGNORE_ERRORS_OPTION_NAME,
         CopyConstants::DEFAULT_IGNORE_ERRORS);
+
+    std::vector<std::string> warningColumnNames;
+    std::vector<common::LogicalType> warningColumnTypes;
     column_id_t numWarningDataColumns = 0;
     if (ignoreErrors) {
         numWarningDataColumns = JsonConstant::JSON_WARNING_DATA_NUM_COLUMNS;
         for (idx_t i = 0; i < JsonConstant::JSON_WARNING_DATA_NUM_COLUMNS; ++i) {
-            columnNames.emplace_back(JsonConstant::JSON_WARNING_DATA_COLUMN_NAMES[i]);
-            columnTypes.emplace_back(JsonConstant::JSON_WARNING_DATA_COLUMN_TYPES[i]);
+            warningColumnNames.emplace_back(JsonConstant::JSON_WARNING_DATA_COLUMN_NAMES[i]);
+            warningColumnTypes.emplace_back(JsonConstant::JSON_WARNING_DATA_COLUMN_TYPES[i]);
         }
     }
-
-    return std::make_unique<JsonScanBindData>(std::move(columnTypes), std::move(columnNames),
+    auto warningColumns = input->binder->createInvisibleVariables(warningColumnNames, warningColumnTypes);
+    for (auto& column : warningColumns) {
+        columns.push_back(column);
+    }
+    return std::make_unique<JsonScanBindData>(columns,
         numWarningDataColumns, scanInput->config.copy(), context, std::move(colNameToIdx),
         scanConfig.format);
 }

--- a/src/binder/bind/bind_file_scan.cpp
+++ b/src/binder/bind/bind_file_scan.cpp
@@ -218,7 +218,8 @@ std::unique_ptr<BoundBaseScanSource> Binder::bindObjectScanSource(const BaseScan
                 objectName, bindData->getNumColumns(), columnTypes.size()));
         }
         for (auto i = 0u; i < bindData->getNumColumns(); ++i) {
-            auto column = createInvisibleVariable(columnNames[i], bindData->columns[i]->getDataType());
+            auto column =
+                createInvisibleVariable(columnNames[i], bindData->columns[i]->getDataType());
             scope.replaceExpression(bindData->columns[i]->toString(), columnNames[i], column);
             columns.push_back(column);
         }

--- a/src/binder/bind/bind_table_function.cpp
+++ b/src/binder/bind/bind_table_function.cpp
@@ -20,8 +20,9 @@ static void validateParameterType(expression_vector positionalParams) {
 
 BoundTableFunction Binder::bindTableFunc(std::string tableFuncName,
     const parser::ParsedExpression& expr, expression_vector& columns) {
+    auto functions = clientContext->getCatalog()->getFunctions(clientContext->getTx());
     auto entry = BuiltInFunctionsUtils::getFunctionCatalogEntry(clientContext->getTx(),
-        tableFuncName, clientContext->getCatalog()->getFunctions(clientContext->getTx()));
+        tableFuncName, functions);
     expression_vector positionalParams;
     std::vector<LogicalType> positionalParamTypes;
     optional_params_t optionalParams;
@@ -49,10 +50,9 @@ BoundTableFunction Binder::bindTableFunc(std::string tableFuncName,
     auto bindInput = TableFuncBindInput();
     bindInput.params = std::move(positionalParams);
     bindInput.optionalParams = std::move(optionalParams);
+    bindInput.binder = this;
     auto bindData = tableFunc->bindFunc(clientContext, &bindInput);
-    for (auto i = 0u; i < bindData->columnTypes.size(); i++) {
-        columns.push_back(createVariable(bindData->columnNames[i], bindData->columnTypes[i]));
-    }
+    columns = bindData->columns;
     auto offset = expressionBinder.createVariableExpression(LogicalType::INT64(),
         std::string(InternalKeyword::ROW_OFFSET));
     return BoundTableFunction{tableFunc->copy(), std::move(bindData), std::move(offset)};

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -117,13 +117,15 @@ std::shared_ptr<Expression> Binder::createVariable(const std::string& name,
     return expression;
 }
 
-std::shared_ptr<Expression> Binder::createInvisibleVariable(const std::string& name, const LogicalType& dataType) {
+std::shared_ptr<Expression> Binder::createInvisibleVariable(const std::string& name,
+    const LogicalType& dataType) {
     auto expression = expressionBinder.createVariableExpression(dataType.copy(), name);
     expression->setAlias(name);
     return expression;
 }
 
-binder::expression_vector Binder::createVariables(std::vector<std::string> names, const std::vector<LogicalType>& types) {
+binder::expression_vector Binder::createVariables(std::vector<std::string> names,
+    const std::vector<LogicalType>& types) {
     KU_ASSERT(names.size() == types.size());
     expression_vector variables;
     for (auto i = 0u; i < names.size(); ++i) {
@@ -132,7 +134,8 @@ binder::expression_vector Binder::createVariables(std::vector<std::string> names
     return variables;
 }
 
-expression_vector Binder::createInvisibleVariables(std::vector<std::string> names, const std::vector<LogicalType>& types) {
+expression_vector Binder::createInvisibleVariables(std::vector<std::string> names,
+    const std::vector<LogicalType>& types) {
     KU_ASSERT(names.size() == types.size());
     expression_vector variables;
     for (auto i = 0u; i < names.size(); ++i) {

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -117,6 +117,30 @@ std::shared_ptr<Expression> Binder::createVariable(const std::string& name,
     return expression;
 }
 
+std::shared_ptr<Expression> Binder::createInvisibleVariable(const std::string& name, const LogicalType& dataType) {
+    auto expression = expressionBinder.createVariableExpression(dataType.copy(), name);
+    expression->setAlias(name);
+    return expression;
+}
+
+binder::expression_vector Binder::createVariables(std::vector<std::string> names, const std::vector<LogicalType>& types) {
+    KU_ASSERT(names.size() == types.size());
+    expression_vector variables;
+    for (auto i = 0u; i < names.size(); ++i) {
+        variables.push_back(createVariable(names[i], types[i]));
+    }
+    return variables;
+}
+
+expression_vector Binder::createInvisibleVariables(std::vector<std::string> names, const std::vector<LogicalType>& types) {
+    KU_ASSERT(names.size() == types.size());
+    expression_vector variables;
+    for (auto i = 0u; i < names.size(); ++i) {
+        variables.push_back(createInvisibleVariable(names[i], types[i]));
+    }
+    return variables;
+}
+
 void Binder::validateOrderByFollowedBySkipOrLimitInWithClause(
     const BoundProjectionBody& boundProjectionBody) {
     auto hasSkipOrLimit = boundProjectionBody.hasSkip() || boundProjectionBody.hasLimit();

--- a/src/binder/binder_scope.cpp
+++ b/src/binder/binder_scope.cpp
@@ -9,6 +9,14 @@ void BinderScope::addExpression(const std::string& varName,
     expressions.push_back(std::move(expression));
 }
 
+void BinderScope::replaceExpression(const std::string& oldName, const std::string& newName, std::shared_ptr<Expression> expression) {
+    KU_ASSERT(nameToExprIdx.contains(oldName));
+    auto idx = nameToExprIdx.at(oldName);
+    expressions[idx] = expression;
+    nameToExprIdx.erase(oldName);
+    nameToExprIdx.insert({newName, idx});
+}
+
 void BinderScope::clear() {
     expressions.clear();
     nameToExprIdx.clear();

--- a/src/binder/binder_scope.cpp
+++ b/src/binder/binder_scope.cpp
@@ -9,7 +9,8 @@ void BinderScope::addExpression(const std::string& varName,
     expressions.push_back(std::move(expression));
 }
 
-void BinderScope::replaceExpression(const std::string& oldName, const std::string& newName, std::shared_ptr<Expression> expression) {
+void BinderScope::replaceExpression(const std::string& oldName, const std::string& newName,
+    std::shared_ptr<Expression> expression) {
     KU_ASSERT(nameToExprIdx.contains(oldName));
     auto idx = nameToExprIdx.at(oldName);
     expressions[idx] = expression;

--- a/src/function/table/call/bm_info.cpp
+++ b/src/function/table/call/bm_info.cpp
@@ -1,8 +1,8 @@
+#include "binder/binder.h"
 #include "function/table/simple_table_functions.h"
 #include "main/database.h"
 #include "storage/buffer_manager/buffer_manager.h"
 #include "storage/buffer_manager/memory_manager.h"
-#include "binder/binder.h"
 
 namespace kuzu {
 namespace function {
@@ -11,10 +11,8 @@ struct BMInfoBindData final : SimpleTableFuncBindData {
     uint64_t memLimit;
     uint64_t memUsage;
 
-    BMInfoBindData(uint64_t memLimit, uint64_t memUsage,
-        binder::expression_vector columns)
-        : SimpleTableFuncBindData{std::move(columns), 1},
-          memLimit{memLimit}, memUsage{memUsage} {}
+    BMInfoBindData(uint64_t memLimit, uint64_t memUsage, binder::expression_vector columns)
+        : SimpleTableFuncBindData{std::move(columns), 1}, memLimit{memLimit}, memUsage{memUsage} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
         return std::make_unique<BMInfoBindData>(memLimit, memUsage, columns);

--- a/src/function/table/call/current_setting.cpp
+++ b/src/function/table/call/current_setting.cpp
@@ -1,6 +1,6 @@
+#include "binder/binder.h"
 #include "function/table/bind_input.h"
 #include "function/table/simple_table_functions.h"
-#include "binder/binder.h"
 
 using namespace kuzu::common;
 using namespace kuzu::main;
@@ -11,9 +11,9 @@ namespace function {
 struct CurrentSettingBindData final : public SimpleTableFuncBindData {
     std::string result;
 
-    CurrentSettingBindData(std::string result, binder::expression_vector columns, offset_t maxOffset)
-        : SimpleTableFuncBindData{std::move(columns), maxOffset},
-          result{std::move(result)} {}
+    CurrentSettingBindData(std::string result, binder::expression_vector columns,
+        offset_t maxOffset)
+        : SimpleTableFuncBindData{std::move(columns), maxOffset}, result{std::move(result)} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
         return std::make_unique<CurrentSettingBindData>(result, columns, maxOffset);

--- a/src/function/table/call/current_setting.cpp
+++ b/src/function/table/call/current_setting.cpp
@@ -1,5 +1,6 @@
 #include "function/table/bind_input.h"
 #include "function/table/simple_table_functions.h"
+#include "binder/binder.h"
 
 using namespace kuzu::common;
 using namespace kuzu::main;
@@ -10,14 +11,12 @@ namespace function {
 struct CurrentSettingBindData final : public SimpleTableFuncBindData {
     std::string result;
 
-    CurrentSettingBindData(std::string result, std::vector<LogicalType> returnTypes,
-        std::vector<std::string> returnColumnNames, offset_t maxOffset)
-        : SimpleTableFuncBindData{std::move(returnTypes), std::move(returnColumnNames), maxOffset},
+    CurrentSettingBindData(std::string result, binder::expression_vector columns, offset_t maxOffset)
+        : SimpleTableFuncBindData{std::move(columns), maxOffset},
           result{std::move(result)} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
-        return std::make_unique<CurrentSettingBindData>(result, LogicalType::copy(columnTypes),
-            columnNames, maxOffset);
+        return std::make_unique<CurrentSettingBindData>(result, columns, maxOffset);
     }
 };
 
@@ -41,9 +40,9 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
     std::vector<LogicalType> columnTypes;
     columnNames.emplace_back(optionName);
     columnTypes.push_back(LogicalType::STRING());
+    auto columns = input->binder->createVariables(columnNames, columnTypes);
     return std::make_unique<CurrentSettingBindData>(
-        context->getCurrentSetting(optionName).toString(), std::move(columnTypes),
-        std::move(columnNames), 1 /* one row result */);
+        context->getCurrentSetting(optionName).toString(), columns, 1 /* one row result */);
 }
 
 function_set CurrentSettingFunction::getFunctionSet() {

--- a/src/function/table/call/db_version.cpp
+++ b/src/function/table/call/db_version.cpp
@@ -1,5 +1,5 @@
-#include "function/table/simple_table_functions.h"
 #include "binder/binder.h"
+#include "function/table/simple_table_functions.h"
 
 using namespace kuzu::common;
 using namespace kuzu::main;

--- a/src/function/table/call/db_version.cpp
+++ b/src/function/table/call/db_version.cpp
@@ -1,4 +1,5 @@
 #include "function/table/simple_table_functions.h"
+#include "binder/binder.h"
 
 using namespace kuzu::common;
 using namespace kuzu::main;
@@ -18,13 +19,13 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
     return 1;
 }
 
-static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext*, TableFuncBindInput*) {
+static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext*, TableFuncBindInput* input) {
     std::vector<std::string> returnColumnNames;
     std::vector<LogicalType> returnTypes;
     returnColumnNames.emplace_back("version");
     returnTypes.emplace_back(LogicalType::STRING());
-    return std::make_unique<SimpleTableFuncBindData>(std::move(returnTypes),
-        std::move(returnColumnNames), 1 /* one row result */);
+    auto columns = input->binder->createVariables(returnColumnNames, returnTypes);
+    return std::make_unique<SimpleTableFuncBindData>(std::move(columns), 1 /* one row result */);
 }
 
 function_set DBVersionFunction::getFunctionSet() {

--- a/src/function/table/call/show_attached_databases.cpp
+++ b/src/function/table/call/show_attached_databases.cpp
@@ -1,6 +1,6 @@
+#include "binder/binder.h"
 #include "function/table/simple_table_functions.h"
 #include "main/database_manager.h"
-#include "binder/binder.h"
 
 using namespace kuzu::common;
 using namespace kuzu::catalog;
@@ -17,8 +17,8 @@ struct ShowAttachedDatabasesBindData : public SimpleTableFuncBindData {
           attachedDatabases{std::move(attachedDatabases)} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
-        return std::make_unique<ShowAttachedDatabasesBindData>(attachedDatabases,
-            columns, maxOffset);
+        return std::make_unique<ShowAttachedDatabasesBindData>(attachedDatabases, columns,
+            maxOffset);
     }
 };
 
@@ -50,8 +50,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     columnTypes.emplace_back(LogicalType::STRING());
     auto attachedDatabases = context->getDatabaseManager()->getAttachedDatabases();
     auto columns = input->binder->createVariables(columnNames, columnTypes);
-    return std::make_unique<ShowAttachedDatabasesBindData>(attachedDatabases,
-        columns, attachedDatabases.size());
+    return std::make_unique<ShowAttachedDatabasesBindData>(attachedDatabases, columns,
+        attachedDatabases.size());
 }
 
 function_set ShowAttachedDatabasesFunction::getFunctionSet() {

--- a/src/function/table/call/show_attached_databases.cpp
+++ b/src/function/table/call/show_attached_databases.cpp
@@ -1,5 +1,6 @@
 #include "function/table/simple_table_functions.h"
 #include "main/database_manager.h"
+#include "binder/binder.h"
 
 using namespace kuzu::common;
 using namespace kuzu::catalog;
@@ -11,14 +12,13 @@ struct ShowAttachedDatabasesBindData : public SimpleTableFuncBindData {
     std::vector<main::AttachedDatabase*> attachedDatabases;
 
     ShowAttachedDatabasesBindData(std::vector<main::AttachedDatabase*> attachedDatabases,
-        std::vector<LogicalType> returnTypes, std::vector<std::string> returnColumnNames,
-        offset_t maxOffset)
-        : SimpleTableFuncBindData{std::move(returnTypes), std::move(returnColumnNames), maxOffset},
+        binder::expression_vector columns, offset_t maxOffset)
+        : SimpleTableFuncBindData{std::move(columns), maxOffset},
           attachedDatabases{std::move(attachedDatabases)} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
         return std::make_unique<ShowAttachedDatabasesBindData>(attachedDatabases,
-            LogicalType::copy(columnTypes), columnNames, maxOffset);
+            columns, maxOffset);
     }
 };
 
@@ -41,7 +41,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
 }
 
 static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
-    TableFuncBindInput*) {
+    TableFuncBindInput* input) {
     std::vector<std::string> columnNames;
     std::vector<LogicalType> columnTypes;
     columnNames.emplace_back("name");
@@ -49,8 +49,9 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     columnNames.emplace_back("database type");
     columnTypes.emplace_back(LogicalType::STRING());
     auto attachedDatabases = context->getDatabaseManager()->getAttachedDatabases();
+    auto columns = input->binder->createVariables(columnNames, columnTypes);
     return std::make_unique<ShowAttachedDatabasesBindData>(attachedDatabases,
-        std::move(columnTypes), std::move(columnNames), attachedDatabases.size());
+        columns, attachedDatabases.size());
 }
 
 function_set ShowAttachedDatabasesFunction::getFunctionSet() {

--- a/src/function/table/call/show_connection.cpp
+++ b/src/function/table/call/show_connection.cpp
@@ -1,3 +1,4 @@
+#include "binder/binder.h"
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
@@ -5,7 +6,6 @@
 #include "common/exception/binder.h"
 #include "function/table/bind_input.h"
 #include "function/table/simple_table_functions.h"
-#include "binder/binder.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;
@@ -20,12 +20,11 @@ struct ShowConnectionBindData : public SimpleTableFuncBindData {
 
     ShowConnectionBindData(ClientContext* context, TableCatalogEntry* tableEntry,
         binder::expression_vector columns, offset_t maxOffset)
-        : SimpleTableFuncBindData{std::move(columns), maxOffset},
-          context{context}, tableEntry{tableEntry} {}
+        : SimpleTableFuncBindData{std::move(columns), maxOffset}, context{context},
+          tableEntry{tableEntry} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
-        return std::make_unique<ShowConnectionBindData>(context, tableEntry,
-            columns, maxOffset);
+        return std::make_unique<ShowConnectionBindData>(context, tableEntry, columns, maxOffset);
     }
 };
 

--- a/src/function/table/call/show_functions.cpp
+++ b/src/function/table/call/show_functions.cpp
@@ -1,6 +1,6 @@
+#include "binder/binder.h"
 #include "catalog/catalog.h"
 #include "function/table/simple_table_functions.h"
-#include "binder/binder.h"
 
 using namespace kuzu::common;
 using namespace kuzu::catalog;
@@ -67,7 +67,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
         }
     }
     auto columns = input->binder->createVariables(columnNames, columnTypes);
-    return std::make_unique<ShowFunctionsBindData>(std::move(FunctionInfos), columns, FunctionInfos.size());
+    return std::make_unique<ShowFunctionsBindData>(std::move(FunctionInfos), columns,
+        FunctionInfos.size());
 }
 
 function_set ShowFunctionsFunction::getFunctionSet() {

--- a/src/function/table/call/show_sequences.cpp
+++ b/src/function/table/call/show_sequences.cpp
@@ -1,6 +1,7 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/sequence_catalog_entry.h"
 #include "function/table/simple_table_functions.h"
+#include "binder/binder.h"
 
 using namespace kuzu::common;
 using namespace kuzu::catalog;
@@ -26,14 +27,13 @@ struct SequenceInfo {
 struct ShowSequencesBindData : public SimpleTableFuncBindData {
     std::vector<SequenceInfo> sequences;
 
-    ShowSequencesBindData(std::vector<SequenceInfo> sequences, std::vector<LogicalType> returnTypes,
-        std::vector<std::string> returnColumnNames, offset_t maxOffset)
-        : SimpleTableFuncBindData{std::move(returnTypes), std::move(returnColumnNames), maxOffset},
+    ShowSequencesBindData(std::vector<SequenceInfo> sequences,
+        binder::expression_vector columns, offset_t maxOffset)
+        : SimpleTableFuncBindData{std::move(columns), maxOffset},
           sequences{std::move(sequences)} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
-        return std::make_unique<ShowSequencesBindData>(sequences, LogicalType::copy(columnTypes),
-            columnNames, maxOffset);
+        return std::make_unique<ShowSequencesBindData>(sequences, columns, maxOffset);
     }
 };
 
@@ -60,7 +60,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
 }
 
 static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
-    TableFuncBindInput*) {
+    TableFuncBindInput* input) {
     std::vector<std::string> columnNames;
     std::vector<LogicalType> columnTypes;
     columnNames.emplace_back("name");
@@ -102,8 +102,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     //         sequenceInfos.push_back(std::move(sequenceInfo));
     //     }
     // }
-    return std::make_unique<ShowSequencesBindData>(std::move(sequenceInfos), std::move(columnTypes),
-        std::move(columnNames), sequenceInfos.size());
+    auto columns = input->binder->createVariables(columnNames, columnTypes);
+    return std::make_unique<ShowSequencesBindData>(std::move(sequenceInfos), columns, sequenceInfos.size());
 }
 
 function_set ShowSequencesFunction::getFunctionSet() {

--- a/src/function/table/call/show_sequences.cpp
+++ b/src/function/table/call/show_sequences.cpp
@@ -1,7 +1,7 @@
+#include "binder/binder.h"
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/sequence_catalog_entry.h"
 #include "function/table/simple_table_functions.h"
-#include "binder/binder.h"
 
 using namespace kuzu::common;
 using namespace kuzu::catalog;
@@ -27,10 +27,9 @@ struct SequenceInfo {
 struct ShowSequencesBindData : public SimpleTableFuncBindData {
     std::vector<SequenceInfo> sequences;
 
-    ShowSequencesBindData(std::vector<SequenceInfo> sequences,
-        binder::expression_vector columns, offset_t maxOffset)
-        : SimpleTableFuncBindData{std::move(columns), maxOffset},
-          sequences{std::move(sequences)} {}
+    ShowSequencesBindData(std::vector<SequenceInfo> sequences, binder::expression_vector columns,
+        offset_t maxOffset)
+        : SimpleTableFuncBindData{std::move(columns), maxOffset}, sequences{std::move(sequences)} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
         return std::make_unique<ShowSequencesBindData>(sequences, columns, maxOffset);
@@ -103,7 +102,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     //     }
     // }
     auto columns = input->binder->createVariables(columnNames, columnTypes);
-    return std::make_unique<ShowSequencesBindData>(std::move(sequenceInfos), columns, sequenceInfos.size());
+    return std::make_unique<ShowSequencesBindData>(std::move(sequenceInfos), columns,
+        sequenceInfos.size());
 }
 
 function_set ShowSequencesFunction::getFunctionSet() {

--- a/src/function/table/call/show_tables.cpp
+++ b/src/function/table/call/show_tables.cpp
@@ -1,8 +1,8 @@
+#include "binder/binder.h"
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "function/table/simple_table_functions.h"
 #include "main/database_manager.h"
-#include "binder/binder.h"
 
 using namespace kuzu::common;
 using namespace kuzu::catalog;
@@ -26,7 +26,8 @@ struct TableInfo {
 struct ShowTablesBindData : public SimpleTableFuncBindData {
     std::vector<TableInfo> tables;
 
-    ShowTablesBindData(std::vector<TableInfo> tables, binder::expression_vector columns, offset_t maxOffset)
+    ShowTablesBindData(std::vector<TableInfo> tables, binder::expression_vector columns,
+        offset_t maxOffset)
         : SimpleTableFuncBindData{std::move(columns), maxOffset}, tables{std::move(tables)} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
@@ -91,7 +92,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     }
     auto columns = input->binder->createVariables(columnNames, columnTypes);
     return std::make_unique<ShowTablesBindData>(std::move(tableInfos), std::move(columns),
-         tableInfos.size());
+        tableInfos.size());
 }
 
 function_set ShowTablesFunction::getFunctionSet() {

--- a/src/function/table/call/show_tables.cpp
+++ b/src/function/table/call/show_tables.cpp
@@ -2,6 +2,7 @@
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "function/table/simple_table_functions.h"
 #include "main/database_manager.h"
+#include "binder/binder.h"
 
 using namespace kuzu::common;
 using namespace kuzu::catalog;
@@ -25,14 +26,11 @@ struct TableInfo {
 struct ShowTablesBindData : public SimpleTableFuncBindData {
     std::vector<TableInfo> tables;
 
-    ShowTablesBindData(std::vector<TableInfo> tables, std::vector<LogicalType> returnTypes,
-        std::vector<std::string> returnColumnNames, offset_t maxOffset)
-        : SimpleTableFuncBindData{std::move(returnTypes), std::move(returnColumnNames), maxOffset},
-          tables{std::move(tables)} {}
+    ShowTablesBindData(std::vector<TableInfo> tables, binder::expression_vector columns, offset_t maxOffset)
+        : SimpleTableFuncBindData{std::move(columns), maxOffset}, tables{std::move(tables)} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
-        return std::make_unique<ShowTablesBindData>(tables, LogicalType::copy(columnTypes),
-            columnNames, maxOffset);
+        return std::make_unique<ShowTablesBindData>(tables, columns, maxOffset);
     }
 };
 
@@ -57,7 +55,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
 }
 
 static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
-    TableFuncBindInput*) {
+    TableFuncBindInput* input) {
     std::vector<std::string> columnNames;
     std::vector<LogicalType> columnTypes;
     columnNames.emplace_back("id");
@@ -91,8 +89,9 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
             tableInfos.push_back(std::move(tableInfo));
         }
     }
-    return std::make_unique<ShowTablesBindData>(std::move(tableInfos), std::move(columnTypes),
-        std::move(columnNames), tableInfos.size());
+    auto columns = input->binder->createVariables(columnNames, columnTypes);
+    return std::make_unique<ShowTablesBindData>(std::move(tableInfos), std::move(columns),
+         tableInfos.size());
 }
 
 function_set ShowTablesFunction::getFunctionSet() {

--- a/src/function/table/call/show_warnings.cpp
+++ b/src/function/table/call/show_warnings.cpp
@@ -1,6 +1,6 @@
+#include "binder/binder.h"
 #include "function/table/simple_table_functions.h"
 #include "processor/warning_context.h"
-#include "binder/binder.h"
 
 using namespace kuzu::common;
 
@@ -12,8 +12,7 @@ struct ShowWarningsBindData : public SimpleTableFuncBindData {
 
     ShowWarningsBindData(std::vector<processor::WarningInfo> warnings,
         binder::expression_vector columns, offset_t maxOffset)
-        : SimpleTableFuncBindData{std::move(columns), maxOffset},
-          warnings{std::move(warnings)} {}
+        : SimpleTableFuncBindData{std::move(columns), maxOffset}, warnings{std::move(warnings)} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
         return std::make_unique<ShowWarningsBindData>(warnings, columns, maxOffset);
@@ -51,7 +50,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
         warningInfos.emplace_back(warning);
     }
     auto columns = input->binder->createVariables(columnNames, columnTypes);
-    return std::make_unique<ShowWarningsBindData>(std::move(warningInfos), columns, warningInfos.size());
+    return std::make_unique<ShowWarningsBindData>(std::move(warningInfos), columns,
+        warningInfos.size());
 }
 
 function_set ShowWarningsFunction::getFunctionSet() {

--- a/src/function/table/call/stats_info.cpp
+++ b/src/function/table/call/stats_info.cpp
@@ -3,6 +3,7 @@
 #include "function/table/simple_table_functions.h"
 #include "storage/storage_manager.h"
 #include "storage/store/node_table.h"
+#include "binder/binder.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;
@@ -21,14 +22,13 @@ struct StatsInfoBindData final : SimpleTableFuncBindData {
     storage::Table* table;
     ClientContext* context;
 
-    StatsInfoBindData(std::vector<LogicalType> columnTypes, std::vector<std::string> columnNames,
+    StatsInfoBindData(binder::expression_vector columns,
         TableCatalogEntry* tableEntry, storage::Table* table, ClientContext* context)
-        : SimpleTableFuncBindData{std::move(columnTypes), std::move(columnNames), 1 /*maxOffset*/},
+        : SimpleTableFuncBindData{std::move(columns), 1 /*maxOffset*/},
           tableEntry{tableEntry}, table{table}, context{context} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
-        return std::make_unique<StatsInfoBindData>(LogicalType::copy(columnTypes), columnNames,
-            tableEntry, table, context);
+        return std::make_unique<StatsInfoBindData>(columns, tableEntry, table, context);
     }
 };
 
@@ -81,8 +81,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
     }
     const auto storageManager = context->getStorageManager();
     auto table = storageManager->getTable(tableID);
-    return std::make_unique<StatsInfoBindData>(std::move(columnTypes), std::move(columnNames),
-        tableEntry, table, context);
+    auto columns = input->binder->createVariables(columnNames, columnTypes);
+    return std::make_unique<StatsInfoBindData>(columns, tableEntry, table, context);
 }
 
 function_set StatsInfoFunction::getFunctionSet() {

--- a/src/function/table/call/stats_info.cpp
+++ b/src/function/table/call/stats_info.cpp
@@ -1,9 +1,9 @@
+#include "binder/binder.h"
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "common/exception/binder.h"
 #include "function/table/simple_table_functions.h"
 #include "storage/storage_manager.h"
 #include "storage/store/node_table.h"
-#include "binder/binder.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;
@@ -22,10 +22,10 @@ struct StatsInfoBindData final : SimpleTableFuncBindData {
     storage::Table* table;
     ClientContext* context;
 
-    StatsInfoBindData(binder::expression_vector columns,
-        TableCatalogEntry* tableEntry, storage::Table* table, ClientContext* context)
-        : SimpleTableFuncBindData{std::move(columns), 1 /*maxOffset*/},
-          tableEntry{tableEntry}, table{table}, context{context} {}
+    StatsInfoBindData(binder::expression_vector columns, TableCatalogEntry* tableEntry,
+        storage::Table* table, ClientContext* context)
+        : SimpleTableFuncBindData{std::move(columns), 1 /*maxOffset*/}, tableEntry{tableEntry},
+          table{table}, context{context} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
         return std::make_unique<StatsInfoBindData>(columns, tableEntry, table, context);

--- a/src/function/table/call/storage_info.cpp
+++ b/src/function/table/call/storage_info.cpp
@@ -15,6 +15,7 @@
 #include "storage/store/string_column.h"
 #include "storage/store/struct_chunk_data.h"
 #include "storage/store/struct_column.h"
+#include "binder/binder.h"
 #include <concepts>
 
 using namespace kuzu::common;
@@ -72,14 +73,13 @@ struct StorageInfoBindData final : public SimpleTableFuncBindData {
     storage::Table* table;
     ClientContext* context;
 
-    StorageInfoBindData(std::vector<LogicalType> columnTypes, std::vector<std::string> columnNames,
+    StorageInfoBindData(binder::expression_vector columns,
         TableCatalogEntry* tableEntry, storage::Table* table, ClientContext* context)
-        : SimpleTableFuncBindData{std::move(columnTypes), columnNames, 1 /*maxOffset*/},
+        : SimpleTableFuncBindData{columns, 1 /*maxOffset*/},
           tableEntry{tableEntry}, table{table}, context{context} {}
 
-    inline std::unique_ptr<TableFuncBindData> copy() const override {
-        return std::make_unique<StorageInfoBindData>(common::LogicalType::copy(columnTypes),
-            columnNames, tableEntry, table, context);
+    std::unique_ptr<TableFuncBindData> copy() const override {
+        return std::make_unique<StorageInfoBindData>(columns, tableEntry, table, context);
     }
 };
 
@@ -353,8 +353,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
     auto tableEntry = catalog->getTableCatalogEntry(context->getTx(), tableID);
     auto storageManager = context->getStorageManager();
     auto table = storageManager->getTable(tableID);
-    return std::make_unique<StorageInfoBindData>(std::move(columnTypes), std::move(columnNames),
-        tableEntry, table, context);
+    auto columns = input->binder->createVariables(columnNames, columnTypes);
+    return std::make_unique<StorageInfoBindData>(columns, tableEntry, table, context);
 }
 
 function_set StorageInfoFunction::getFunctionSet() {

--- a/src/function/table/call/storage_info.cpp
+++ b/src/function/table/call/storage_info.cpp
@@ -1,3 +1,4 @@
+#include "binder/binder.h"
 #include "common/data_chunk/data_chunk_collection.h"
 #include "common/exception/binder.h"
 #include "common/type_utils.h"
@@ -15,7 +16,6 @@
 #include "storage/store/string_column.h"
 #include "storage/store/struct_chunk_data.h"
 #include "storage/store/struct_column.h"
-#include "binder/binder.h"
 #include <concepts>
 
 using namespace kuzu::common;
@@ -73,10 +73,10 @@ struct StorageInfoBindData final : public SimpleTableFuncBindData {
     storage::Table* table;
     ClientContext* context;
 
-    StorageInfoBindData(binder::expression_vector columns,
-        TableCatalogEntry* tableEntry, storage::Table* table, ClientContext* context)
-        : SimpleTableFuncBindData{columns, 1 /*maxOffset*/},
-          tableEntry{tableEntry}, table{table}, context{context} {}
+    StorageInfoBindData(binder::expression_vector columns, TableCatalogEntry* tableEntry,
+        storage::Table* table, ClientContext* context)
+        : SimpleTableFuncBindData{columns, 1 /*maxOffset*/}, tableEntry{tableEntry}, table{table},
+          context{context} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
         return std::make_unique<StorageInfoBindData>(columns, tableEntry, table, context);

--- a/src/function/table/call/table_info.cpp
+++ b/src/function/table/call/table_info.cpp
@@ -1,3 +1,4 @@
+#include "binder/binder.h"
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "common/exception/runtime.h"
@@ -5,7 +6,6 @@
 #include "function/table/bind_input.h"
 #include "function/table/simple_table_functions.h"
 #include "main/database_manager.h"
-#include "binder/binder.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;
@@ -16,9 +16,10 @@ namespace function {
 struct TableInfoBindData : public SimpleTableFuncBindData {
     std::unique_ptr<TableCatalogEntry> catalogEntry;
 
-    TableInfoBindData(std::unique_ptr<TableCatalogEntry> catalogEntry, binder::expression_vector columns,
-        offset_t maxOffset)
-        : SimpleTableFuncBindData{std::move(columns), maxOffset}, catalogEntry{std::move(catalogEntry)} {}
+    TableInfoBindData(std::unique_ptr<TableCatalogEntry> catalogEntry,
+        binder::expression_vector columns, offset_t maxOffset)
+        : SimpleTableFuncBindData{std::move(columns), maxOffset},
+          catalogEntry{std::move(catalogEntry)} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
         return std::make_unique<TableInfoBindData>(catalogEntry->copy(), columns, maxOffset);
@@ -100,7 +101,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
         columnTypes.push_back(LogicalType::BOOL());
     }
     auto columns = input->binder->createVariables(columnNames, columnTypes);
-    return std::make_unique<TableInfoBindData>(std::move(catalogEntry), columns, tableEntry->getNumProperties());
+    return std::make_unique<TableInfoBindData>(std::move(catalogEntry), columns,
+        tableEntry->getNumProperties());
 }
 
 function_set TableInfoFunction::getFunctionSet() {

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -79,13 +79,14 @@ public:
     bool bindExportTableData(ExportedTableData& tableData, const catalog::TableCatalogEntry& entry,
         const catalog::Catalog& catalog, transaction::Transaction* tx);
 
-
     KUZU_API std::shared_ptr<Expression> createVariable(const std::string& name,
         const common::LogicalType& dataType);
     KUZU_API std::shared_ptr<Expression> createInvisibleVariable(const std::string& name,
         const common::LogicalType& dataType);
-    KUZU_API expression_vector createVariables(std::vector<std::string> names, const std::vector<common::LogicalType>& types);
-    KUZU_API expression_vector createInvisibleVariables(std::vector<std::string> names, const std::vector<common::LogicalType>& types);
+    KUZU_API expression_vector createVariables(std::vector<std::string> names,
+        const std::vector<common::LogicalType>& types);
+    KUZU_API expression_vector createInvisibleVariables(std::vector<std::string> names,
+        const std::vector<common::LogicalType>& types);
 
     std::shared_ptr<Expression> bindWhereExpression(
         const parser::ParsedExpression& parsedExpression);

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -78,8 +78,14 @@ public:
 
     bool bindExportTableData(ExportedTableData& tableData, const catalog::TableCatalogEntry& entry,
         const catalog::Catalog& catalog, transaction::Transaction* tx);
+
+
     KUZU_API std::shared_ptr<Expression> createVariable(const std::string& name,
         const common::LogicalType& dataType);
+    KUZU_API std::shared_ptr<Expression> createInvisibleVariable(const std::string& name,
+        const common::LogicalType& dataType);
+    KUZU_API expression_vector createVariables(std::vector<std::string> names, const std::vector<common::LogicalType>& types);
+    KUZU_API expression_vector createInvisibleVariables(std::vector<std::string> names, const std::vector<common::LogicalType>& types);
 
     std::shared_ptr<Expression> bindWhereExpression(
         const parser::ParsedExpression& parsedExpression);
@@ -158,6 +164,7 @@ public:
     std::unique_ptr<BoundStatement> bindStandaloneCallFunction(const parser::Statement& statement);
 
     /*** bind table function ***/
+    // TODO: change signature
     BoundTableFunction bindTableFunc(std::string tableFuncName,
         const parser::ParsedExpression& expr, expression_vector& columns);
 

--- a/src/include/binder/binder_scope.h
+++ b/src/include/binder/binder_scope.h
@@ -19,7 +19,8 @@ public:
     }
     expression_vector getExpressions() const { return expressions; }
     void addExpression(const std::string& varName, std::shared_ptr<Expression> expression);
-    void replaceExpression(const std::string& oldName, const std::string& newName, std::shared_ptr<Expression> expression);
+    void replaceExpression(const std::string& oldName, const std::string& newName,
+        std::shared_ptr<Expression> expression);
 
     void memorizeTableEntries(const std::string& name,
         std::vector<catalog::TableCatalogEntry*> entries) {

--- a/src/include/binder/binder_scope.h
+++ b/src/include/binder/binder_scope.h
@@ -19,6 +19,7 @@ public:
     }
     expression_vector getExpressions() const { return expressions; }
     void addExpression(const std::string& varName, std::shared_ptr<Expression> expression);
+    void replaceExpression(const std::string& oldName, const std::string& newName, std::shared_ptr<Expression> expression);
 
     void memorizeTableEntries(const std::string& name,
         std::vector<catalog::TableCatalogEntry*> entries) {

--- a/src/include/function/table/bind_data.h
+++ b/src/include/function/table/bind_data.h
@@ -21,8 +21,10 @@ struct TableFuncBindData {
     TableFuncBindData() : numWarningDataColumns{0}, cardinality{0} {}
     explicit TableFuncBindData(binder::expression_vector columns)
         : columns{std::move(columns)}, numWarningDataColumns{0}, cardinality{0} {}
-    TableFuncBindData(binder::expression_vector columns, common::column_id_t numWarningColumns, common::cardinality_t cardinality)
-        : columns{std::move(columns)}, numWarningDataColumns{numWarningColumns}, cardinality{cardinality} {}
+    TableFuncBindData(binder::expression_vector columns, common::column_id_t numWarningColumns,
+        common::cardinality_t cardinality)
+        : columns{std::move(columns)}, numWarningDataColumns{numWarningColumns},
+          cardinality{cardinality} {}
     TableFuncBindData(const TableFuncBindData& other)
         : columns{other.columns}, numWarningDataColumns(other.numWarningDataColumns),
           cardinality{other.cardinality}, columnSkips{other.columnSkips},
@@ -61,14 +63,13 @@ struct ScanBindData : public TableFuncBindData {
     common::ReaderConfig config;
     main::ClientContext* context;
 
-    ScanBindData(binder::expression_vector columns,
-        common::ReaderConfig config, main::ClientContext* context)
+    ScanBindData(binder::expression_vector columns, common::ReaderConfig config,
+        main::ClientContext* context)
         : TableFuncBindData{std::move(columns)}, config{std::move(config)}, context{context} {}
-    ScanBindData(binder::expression_vector columns,
-        common::ReaderConfig config, main::ClientContext* context,
-        common::column_id_t numWarningDataColumns, common::row_idx_t estCardinality)
-        : TableFuncBindData{std::move(columns), numWarningDataColumns,
-              estCardinality},
+    ScanBindData(binder::expression_vector columns, common::ReaderConfig config,
+        main::ClientContext* context, common::column_id_t numWarningDataColumns,
+        common::row_idx_t estCardinality)
+        : TableFuncBindData{std::move(columns), numWarningDataColumns, estCardinality},
           config{std::move(config)}, context{context} {}
     ScanBindData(const ScanBindData& other)
         : TableFuncBindData{other}, config{other.config.copy()}, context{other.context} {}

--- a/src/include/function/table/bind_data.h
+++ b/src/include/function/table/bind_data.h
@@ -13,31 +13,23 @@ class FileSystem;
 namespace function {
 
 struct TableFuncBindData {
-    std::vector<common::LogicalType> columnTypes;
-    std::vector<std::string> columnNames;
-
+    binder::expression_vector columns;
     // the last {numWarningDataColumns} columns are for temporary internal use
     common::column_id_t numWarningDataColumns;
-
     common::cardinality_t cardinality;
 
-    TableFuncBindData() : numWarningDataColumns{0}, cardinality(0) {}
-    TableFuncBindData(std::vector<common::LogicalType> columnTypes,
-        std::vector<std::string> columnNames)
-        : columnTypes{std::move(columnTypes)}, columnNames{std::move(columnNames)},
-          numWarningDataColumns(0), cardinality(0) {}
-    TableFuncBindData(std::vector<common::LogicalType> columnTypes,
-        std::vector<std::string> columnNames, common::column_id_t numWarningDataColumns,
-        common::cardinality_t cardinality)
-        : columnTypes{std::move(columnTypes)}, columnNames{std::move(columnNames)},
-          numWarningDataColumns{numWarningDataColumns}, cardinality(cardinality) {}
+    TableFuncBindData() : numWarningDataColumns{0}, cardinality{0} {}
+    explicit TableFuncBindData(binder::expression_vector columns)
+        : columns{std::move(columns)}, numWarningDataColumns{0}, cardinality{0} {}
+    TableFuncBindData(binder::expression_vector columns, common::column_id_t numWarningColumns, common::cardinality_t cardinality)
+        : columns{std::move(columns)}, numWarningDataColumns{numWarningColumns}, cardinality{cardinality} {}
     TableFuncBindData(const TableFuncBindData& other)
-        : columnTypes{common::LogicalType::copy(other.columnTypes)}, columnNames{other.columnNames},
-          numWarningDataColumns(other.numWarningDataColumns), cardinality(other.cardinality),
-          columnSkips{other.columnSkips}, columnPredicates{copyVector(other.columnPredicates)} {}
+        : columns{other.columns}, numWarningDataColumns(other.numWarningDataColumns),
+          cardinality{other.cardinality}, columnSkips{other.columnSkips},
+          columnPredicates{copyVector(other.columnPredicates)} {}
     virtual ~TableFuncBindData() = default;
 
-    common::idx_t getNumColumns() const { return columnTypes.size(); }
+    common::idx_t getNumColumns() const { return columns.size(); }
     void setColumnSkips(std::vector<bool> skips) { columnSkips = std::move(skips); }
     KUZU_API std::vector<bool> getColumnSkips() const;
 
@@ -69,10 +61,13 @@ struct ScanBindData : public TableFuncBindData {
     common::ReaderConfig config;
     main::ClientContext* context;
 
-    ScanBindData(std::vector<common::LogicalType> columnTypes, std::vector<std::string> columnNames,
+    ScanBindData(binder::expression_vector columns,
+        common::ReaderConfig config, main::ClientContext* context)
+        : TableFuncBindData{std::move(columns)}, config{std::move(config)}, context{context} {}
+    ScanBindData(binder::expression_vector columns,
         common::ReaderConfig config, main::ClientContext* context,
-        common::row_idx_t estCardinality = 0, common::column_id_t numWarningDataColumns = 0)
-        : TableFuncBindData{std::move(columnTypes), std::move(columnNames), numWarningDataColumns,
+        common::column_id_t numWarningDataColumns, common::row_idx_t estCardinality)
+        : TableFuncBindData{std::move(columns), numWarningDataColumns,
               estCardinality},
           config{std::move(config)}, context{context} {}
     ScanBindData(const ScanBindData& other)

--- a/src/include/function/table/bind_input.h
+++ b/src/include/function/table/bind_input.h
@@ -11,7 +11,7 @@ namespace kuzu {
 namespace binder {
 class LiteralExpression;
 class Binder;
-}
+} // namespace binder
 namespace main {
 class ClientContext;
 }

--- a/src/include/function/table/bind_input.h
+++ b/src/include/function/table/bind_input.h
@@ -10,6 +10,7 @@
 namespace kuzu {
 namespace binder {
 class LiteralExpression;
+class Binder;
 }
 namespace main {
 class ClientContext;
@@ -33,6 +34,7 @@ struct TableFuncBindInput {
     binder::expression_vector params;
     optional_params_t optionalParams;
     std::unique_ptr<ExtraTableFuncBindInput> extraInput = nullptr;
+    binder::Binder* binder = nullptr;
 
     TableFuncBindInput() = default;
 

--- a/src/include/function/table/simple_table_functions.h
+++ b/src/include/function/table/simple_table_functions.h
@@ -36,16 +36,12 @@ struct SimpleTableFuncBindData : TableFuncBindData {
     common::offset_t maxOffset;
 
     explicit SimpleTableFuncBindData(common::offset_t maxOffset)
-        : SimpleTableFuncBindData{std::vector<common::LogicalType>{}, std::vector<std::string>{},
-              maxOffset} {}
-    SimpleTableFuncBindData(std::vector<common::LogicalType> columnTypes,
-        std::vector<std::string> returnColumnNames, common::offset_t maxOffset)
-        : TableFuncBindData{std::move(columnTypes), std::move(returnColumnNames)},
-          maxOffset{maxOffset} {}
+        : SimpleTableFuncBindData{binder::expression_vector{}, maxOffset} {}
+    SimpleTableFuncBindData(binder::expression_vector columns, common::offset_t maxOffset)
+        : TableFuncBindData{std::move(columns)}, maxOffset{maxOffset} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
-        return std::make_unique<SimpleTableFuncBindData>(common::LogicalType::copy(columnTypes),
-            columnNames, maxOffset);
+        return std::make_unique<SimpleTableFuncBindData>(columns, maxOffset);
     }
 };
 

--- a/src/planner/plan/plan_read.cpp
+++ b/src/planner/plan/plan_read.cpp
@@ -118,6 +118,9 @@ void Planner::planTableFunctionCall(const BoundReadingClause& readingClause,
     splitPredicates(call.getColumns(), call.getConjunctivePredicates(), predicatesToPull,
         predicatesToPush);
     for (auto& plan : plans) {
+
+        auto op = getTableFunctionCall(readingClause);
+
         planReadOp(getTableFunctionCall(readingClause), predicatesToPush, *plan);
         if (!predicatesToPull.empty()) {
             appendFilters(predicatesToPull, *plan);

--- a/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
@@ -1,10 +1,10 @@
 #include "processor/operator/persistent/reader/csv/parallel_csv_reader.h"
 
+#include "binder/binder.h"
 #include "function/table/bind_data.h"
 #include "processor/execution_context.h"
 #include "processor/operator/persistent/reader/csv/serial_csv_reader.h"
 #include "processor/operator/persistent/reader/reader_bind_utils.h"
-#include "binder/binder.h"
 
 #if defined(_WIN32)
 #include <io.h>
@@ -254,12 +254,13 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     std::vector<LogicalType> warningColumnTypes;
     const column_id_t numWarningDataColumns = BaseCSVReader::appendWarningDataColumns(
         warningColumnNames, warningColumnTypes, scanInput->config);
-    auto warningColumns = input->binder->createInvisibleVariables(warningColumnNames, warningColumnTypes);
+    auto warningColumns =
+        input->binder->createInvisibleVariables(warningColumnNames, warningColumnTypes);
     for (auto& column : warningColumns) {
         resultColumns.push_back(column);
     }
-    return std::make_unique<ScanBindData>(std::move(resultColumns), scanInput->config.copy(), context, numWarningDataColumns, 0 /* estCardinality */);
-
+    return std::make_unique<ScanBindData>(std::move(resultColumns), scanInput->config.copy(),
+        context, numWarningDataColumns, 0 /* estCardinality */);
 }
 
 static std::unique_ptr<TableFuncSharedState> initSharedState(TableFunctionInitInput& input) {

--- a/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
@@ -1,10 +1,10 @@
 #include "processor/operator/persistent/reader/csv/serial_csv_reader.h"
 
+#include "binder/binder.h"
 #include "function/table/bind_data.h"
 #include "processor/execution_context.h"
 #include "processor/operator/persistent/reader/csv/driver.h"
 #include "processor/operator/persistent/reader/reader_bind_utils.h"
-#include "binder/binder.h"
 
 using namespace kuzu::common;
 using namespace kuzu::function;
@@ -222,12 +222,13 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     std::vector<LogicalType> warningColumnTypes;
     const column_id_t numWarningDataColumns = BaseCSVReader::appendWarningDataColumns(
         warningColumnNames, warningColumnTypes, scanInput->config);
-    auto warningColumns = input->binder->createInvisibleVariables(warningColumnNames, warningColumnTypes);
+    auto warningColumns =
+        input->binder->createInvisibleVariables(warningColumnNames, warningColumnTypes);
     for (auto& column : warningColumns) {
         resultColumns.push_back(column);
     }
-    return std::make_unique<ScanBindData>(std::move(resultColumns), scanInput->config.copy(), context,
-        numWarningDataColumns, 0 /* estCardinality */);
+    return std::make_unique<ScanBindData>(std::move(resultColumns), scanInput->config.copy(),
+        context, numWarningDataColumns, 0 /* estCardinality */);
 }
 
 static std::unique_ptr<TableFuncSharedState> initSharedState(TableFunctionInitInput& input) {

--- a/src/processor/operator/persistent/reader/npy/npy_reader.cpp
+++ b/src/processor/operator/persistent/reader/npy/npy_reader.cpp
@@ -6,6 +6,7 @@
 #include "common/exception/binder.h"
 #include "processor/execution_context.h"
 #include "processor/operator/persistent/reader/reader_bind_utils.h"
+#include "binder/binder.h"
 
 #ifdef _WIN32
 #include "common/exception/buffer_manager.h"
@@ -320,11 +321,9 @@ static std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext
         }
         reader->validate(resultColumnTypes[i], numRows);
     }
-    const row_idx_t numTotalRows = numRows * config.getNumFiles();
-    auto bindData = std::make_unique<function::ScanBindData>(std::move(resultColumnTypes),
-        std::move(resultColumnNames), scanInput->config.copy(), context);
-    bindData->cardinality = numTotalRows;
-    return bindData;
+    auto columns = input->binder->createVariables(resultColumnNames, resultColumnTypes);
+    return std::make_unique<function::ScanBindData>(columns, scanInput->config.copy(), context,
+        0 /* numWarningColumns*/, numRows);
 }
 
 static std::unique_ptr<function::TableFuncSharedState> initSharedState(

--- a/src/processor/operator/persistent/reader/npy/npy_reader.cpp
+++ b/src/processor/operator/persistent/reader/npy/npy_reader.cpp
@@ -3,10 +3,10 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 
+#include "binder/binder.h"
 #include "common/exception/binder.h"
 #include "processor/execution_context.h"
 #include "processor/operator/persistent/reader/reader_bind_utils.h"
-#include "binder/binder.h"
 
 #ifdef _WIN32
 #include "common/exception/buffer_manager.h"

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -1,5 +1,6 @@
 #include "processor/operator/persistent/reader/parquet/parquet_reader.h"
 
+#include "binder/binder.h"
 #include "common/exception/binder.h"
 #include "common/exception/copy.h"
 #include "common/file_system/virtual_file_system.h"
@@ -10,7 +11,6 @@
 #include "processor/operator/persistent/reader/parquet/struct_column_reader.h"
 #include "processor/operator/persistent/reader/parquet/thrift_tools.h"
 #include "processor/operator/persistent/reader/reader_bind_utils.h"
-#include "binder/binder.h"
 
 using namespace kuzu_parquet::format;
 

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -10,6 +10,7 @@
 #include "processor/operator/persistent/reader/parquet/struct_column_reader.h"
 #include "processor/operator/persistent/reader/parquet/thrift_tools.h"
 #include "processor/operator/persistent/reader/reader_bind_utils.h"
+#include "binder/binder.h"
 
 using namespace kuzu_parquet::format;
 
@@ -686,8 +687,10 @@ static std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext
             detectedColumnNames.size());
         detectedColumnNames = scanInput->expectedColumnNames;
     }
-    auto bindData = std::make_unique<function::ScanBindData>(std::move(detectedColumnTypes),
-        std::move(detectedColumnNames), scanInput->config.copy(), context);
+
+    auto resultColumns = input->binder->createVariables(detectedColumnNames, detectedColumnTypes);
+    auto bindData = std::make_unique<function::ScanBindData>(std::move(resultColumns),
+        scanInput->config.copy(), context);
     bindData->cardinality = getNumRows(bindData.get());
     return bindData;
 }

--- a/tools/python_api/src_cpp/include/pandas/pandas_scan.h
+++ b/tools/python_api/src_cpp/include/pandas/pandas_scan.h
@@ -33,11 +33,9 @@ struct PandasScanFunctionData : public function::TableFuncBindData {
     py::handle df;
     std::vector<std::unique_ptr<PandasColumnBindData>> columnBindData;
 
-    PandasScanFunctionData(std::vector<common::LogicalType> columnTypes,
-        std::vector<std::string> columnNames, py::handle df, uint64_t numRows,
+    PandasScanFunctionData(binder::expression_vector columns, py::handle df, uint64_t numRows,
         std::vector<std::unique_ptr<PandasColumnBindData>> columnBindData)
-        : TableFuncBindData{std::move(columnTypes), std::move(columnNames),
-              0 /* numWarningDataColumns */, numRows},
+        : TableFuncBindData{std::move(columns), 0 /* numWarningDataColumns */, numRows},
           df{df}, columnBindData{std::move(columnBindData)} {}
 
     ~PandasScanFunctionData() override {

--- a/tools/python_api/src_cpp/include/pandas/pandas_scan.h
+++ b/tools/python_api/src_cpp/include/pandas/pandas_scan.h
@@ -35,8 +35,8 @@ struct PandasScanFunctionData : public function::TableFuncBindData {
 
     PandasScanFunctionData(binder::expression_vector columns, py::handle df, uint64_t numRows,
         std::vector<std::unique_ptr<PandasColumnBindData>> columnBindData)
-        : TableFuncBindData{std::move(columns), 0 /* numWarningDataColumns */, numRows},
-          df{df}, columnBindData{std::move(columnBindData)} {}
+        : TableFuncBindData{std::move(columns), 0 /* numWarningDataColumns */, numRows}, df{df},
+          columnBindData{std::move(columnBindData)} {}
 
     ~PandasScanFunctionData() override {
         py::gil_scoped_acquire acquire;

--- a/tools/python_api/src_cpp/include/pyarrow/pyarrow_scan.h
+++ b/tools/python_api/src_cpp/include/pyarrow/pyarrow_scan.h
@@ -37,11 +37,10 @@ struct PyArrowTableScanFunctionData final : public function::TableFuncBindData {
     std::shared_ptr<ArrowSchemaWrapper> schema;
     std::vector<std::shared_ptr<ArrowArrayWrapper>> arrowArrayBatches;
 
-    PyArrowTableScanFunctionData(std::vector<common::LogicalType> columnTypes,
-        std::shared_ptr<ArrowSchemaWrapper> schema, std::vector<std::string> columnNames,
+    PyArrowTableScanFunctionData(binder::expression_vector columns,
+        std::shared_ptr<ArrowSchemaWrapper> schema,
         std::vector<std::shared_ptr<ArrowArrayWrapper>> arrowArrayBatches, uint64_t numRows)
-        : TableFuncBindData{std::move(columnTypes), std::move(columnNames),
-              0 /* numWarningDataColumns */, numRows},
+        : TableFuncBindData{std::move(columns), 0 /* numWarningDataColumns */, numRows},
           schema{std::move(schema)}, arrowArrayBatches{arrowArrayBatches} {}
 
     ~PyArrowTableScanFunctionData() override {}

--- a/tools/python_api/src_cpp/pandas/pandas_scan.cpp
+++ b/tools/python_api/src_cpp/pandas/pandas_scan.cpp
@@ -1,5 +1,6 @@
 #include "pandas/pandas_scan.h"
 
+#include "binder/binder.h"
 #include "cached_import/py_cached_import.h"
 #include "common/exception/runtime.h"
 #include "function/table/bind_input.h"
@@ -7,7 +8,6 @@
 #include "py_connection.h"
 #include "pyarrow/pyarrow_scan.h"
 #include "pybind11/pytypes.h"
-#include "binder/binder.h"
 
 using namespace kuzu::function;
 using namespace kuzu::common;
@@ -31,8 +31,8 @@ std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext* /*con
     auto getFunc = df.attr("__getitem__");
     auto numRows = py::len(getFunc(columns[0]));
     auto returnColumns = input->binder->createVariables(names, returnTypes);
-    return std::make_unique<PandasScanFunctionData>(std::move(returnColumns), df,
-        numRows, std::move(columnBindData));
+    return std::make_unique<PandasScanFunctionData>(std::move(returnColumns), df, numRows,
+        std::move(columnBindData));
 }
 
 bool sharedStateNext(const TableFuncBindData* /*bindData*/, PandasScanLocalState* localState,

--- a/tools/python_api/src_cpp/pyarrow/pyarrow_scan.cpp
+++ b/tools/python_api/src_cpp/pyarrow/pyarrow_scan.cpp
@@ -6,6 +6,7 @@
 #include "function/table/bind_input.h"
 #include "py_connection.h"
 #include "pybind11/pytypes.h"
+#include "binder/binder.h"
 
 using namespace kuzu::function;
 using namespace kuzu::common;
@@ -78,8 +79,9 @@ static std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext
         i.attr("_export_to_c")(reinterpret_cast<uint64_t>(arrowArrayBatches.back().get()));
     }
 
-    return std::make_unique<PyArrowTableScanFunctionData>(std::move(returnTypes), std::move(schema),
-        std::move(names), arrowArrayBatches, numRows);
+    auto columns = input->binder->createVariables(names, returnTypes);
+    return std::make_unique<PyArrowTableScanFunctionData>(std::move(columns), std::move(schema),
+        arrowArrayBatches, numRows);
 }
 
 ArrowArrayWrapper* PyArrowTableScanSharedState::getNextChunk() {
@@ -120,7 +122,7 @@ static common::offset_t tableFunc(function::TableFuncInput& input,
         return 0;
     }
     auto skipCols = arrowScanData->getColumnSkips();
-    for (auto i = 0u; i < arrowScanData->columnTypes.size(); i++) {
+    for (auto i = 0u; i < arrowScanData->getNumColumns(); i++) {
         if (!skipCols[i]) {
             common::ArrowConverter::fromArrowArray(arrowScanData->schema->children[i],
                 arrowLocalState->arrowArray->children[i],

--- a/tools/python_api/src_cpp/pyarrow/pyarrow_scan.cpp
+++ b/tools/python_api/src_cpp/pyarrow/pyarrow_scan.cpp
@@ -1,12 +1,12 @@
 #include "pyarrow/pyarrow_scan.h"
 
+#include "binder/binder.h"
 #include "cached_import/py_cached_import.h"
 #include "common/arrow/arrow_converter.h"
 #include "function/cast/functions/numeric_limits.h"
 #include "function/table/bind_input.h"
 #include "py_connection.h"
 #include "pybind11/pytypes.h"
-#include "binder/binder.h"
 
 using namespace kuzu::function;
 using namespace kuzu::common;


### PR DESCRIPTION
# Description

This PR refactor table function bindFunc so that it directly returns columns instead of columnNames & columnTypes. This lays the foundation for vector index, because the return columns of vector index is no longer variable. To handle such case, the expression binding logic should happen instead table function bindFunc.

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).