### PR TITLE
Fix incorrect set of sequence val after exporting database

### DIFF
--- a/src/catalog/catalog_entry/sequence_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/sequence_catalog_entry.cpp
@@ -157,9 +157,10 @@ std::unique_ptr<SequenceCatalogEntry> SequenceCatalogEntry::deserialize(
 
 std::string SequenceCatalogEntry::toCypher(main::ClientContext* /*clientContext*/) const {
     return stringFormat(
+        "DROP SEQUENCE IF EXISTS {};\n"
         "CREATE SEQUENCE IF NOT EXISTS {} START {} INCREMENT {} MINVALUE {} MAXVALUE {} {} CYCLE;\n"
         "RETURN nextval('{}');",
-        getName(), sequenceData.currVal, sequenceData.increment, sequenceData.minValue,
+        getName(), getName(), sequenceData.currVal, sequenceData.increment, sequenceData.minValue,
         sequenceData.maxValue, sequenceData.cycle ? "" : "NO", getName());
 }
 

--- a/test/test_files/copy/export_import_db.test
+++ b/test/test_files/copy/export_import_db.test
@@ -181,6 +181,22 @@ Imported database successfully.
 ---- 2
 0
 1
+-STATEMENT CREATE (o:twoserial {prop: "Dan2"})
+---- ok
+-STATEMENT CREATE (o:oneserial)
+---- ok
+-STATEMENT MATCH (o:twoserial) RETURN o.*;
+---- 5
+0|Alice
+1|Bob
+2|Carol
+3|Dan
+4|Dan2
+-STATEMENT MATCH (o:oneserial) RETURN o.*;
+---- 3
+0
+1
+2
 
 -CASE DocExportImportExampleCSV
 -SKIP_WASM


### PR DESCRIPTION
# Description

The bug is due to that generated `CREATE SEQUENCE IF NOT EXISTS` statement is not applied, as it runs after `CREATE NODE TABLE`.
`DROP SEQUENCE IF EXISTS` should be safe here as we don't expect users to manually create sequence for now, and there should be conflict handling in the future to prevent users from defining sequence with the same name as serial columns have.

Fix #4631.