### PR TITLE
Add null checks to zone map

### DIFF
--- a/benchmark/queries/ldbc-sf100/filter/zonemap-node-null.benchmark
+++ b/benchmark/queries/ldbc-sf100/filter/zonemap-node-null.benchmark
@@ -1,0 +1,3 @@
+-NAME zonemap-node-null
+-QUERY MATCH (c:Comment) WHERE c.length IS NULL RETURN *;
+---- 0

--- a/src/common/expression_type.cpp
+++ b/src/common/expression_type.cpp
@@ -122,6 +122,10 @@ std::string ExpressionTypeUtil::toParsableString(ExpressionType type) {
         return "<";
     case ExpressionType::LESS_THAN_EQUALS:
         return "<=";
+    case ExpressionType::IS_NULL:
+        return "IS NULL";
+    case ExpressionType::IS_NOT_NULL:
+        return "IS NOT NULL";
     default:
         throw RuntimeException(stringFormat(
             "ExpressionTypeUtil::toParsableString not implemented for {}", toString(type)));

--- a/src/include/storage/predicate/column_predicate.h
+++ b/src/include/storage/predicate/column_predicate.h
@@ -15,9 +15,10 @@ public:
     ColumnPredicateSet() = default;
     EXPLICIT_COPY_DEFAULT_MOVE(ColumnPredicateSet);
 
-    void addPredicate(std::unique_ptr<ColumnPredicate> predicate) {
+    void addColumnPredicate(std::unique_ptr<ColumnPredicate> predicate) {
         predicates.push_back(std::move(predicate));
     }
+    void tryAddPredicate(const binder::Expression& column, const binder::Expression& predicate);
     bool isEmpty() const { return predicates.empty(); }
 
     common::ZoneMapCheckResult checkZoneMap(const ColumnChunkStats& stats) const;
@@ -34,13 +35,14 @@ private:
 
 class KUZU_API ColumnPredicate {
 public:
-    explicit ColumnPredicate(std::string columnName) : columnName{std::move(columnName)} {}
+    ColumnPredicate(std::string columnName, common::ExpressionType expressionType)
+        : columnName{std::move(columnName)}, expressionType(expressionType) {}
 
     virtual ~ColumnPredicate() = default;
 
     virtual common::ZoneMapCheckResult checkZoneMap(const ColumnChunkStats& stats) const = 0;
 
-    virtual std::string toString() = 0;
+    virtual std::string toString();
 
     virtual std::unique_ptr<ColumnPredicate> copy() const = 0;
 
@@ -51,11 +53,7 @@ public:
 
 protected:
     std::string columnName;
-};
-
-struct ColumnPredicateUtil {
-    static std::unique_ptr<ColumnPredicate> tryConvert(const binder::Expression& column,
-        const binder::Expression& predicate);
+    common::ExpressionType expressionType;
 };
 
 } // namespace storage

--- a/src/include/storage/predicate/column_predicate.h
+++ b/src/include/storage/predicate/column_predicate.h
@@ -7,7 +7,7 @@
 namespace kuzu {
 namespace storage {
 
-struct ColumnChunkStats;
+struct MergedColumnChunkStats;
 
 class ColumnPredicate;
 class KUZU_API ColumnPredicateSet {
@@ -21,7 +21,7 @@ public:
     void tryAddPredicate(const binder::Expression& column, const binder::Expression& predicate);
     bool isEmpty() const { return predicates.empty(); }
 
-    common::ZoneMapCheckResult checkZoneMap(const ColumnChunkStats& stats) const;
+    common::ZoneMapCheckResult checkZoneMap(const MergedColumnChunkStats& stats) const;
 
     std::string toString() const;
 
@@ -40,7 +40,7 @@ public:
 
     virtual ~ColumnPredicate() = default;
 
-    virtual common::ZoneMapCheckResult checkZoneMap(const ColumnChunkStats& stats) const = 0;
+    virtual common::ZoneMapCheckResult checkZoneMap(const MergedColumnChunkStats& stats) const = 0;
 
     virtual std::string toString();
 

--- a/src/include/storage/predicate/column_predicate.h
+++ b/src/include/storage/predicate/column_predicate.h
@@ -59,7 +59,6 @@ protected:
 struct ColumnPredicateUtil {
     static std::unique_ptr<ColumnPredicate> tryConvert(const binder::Expression& column,
         const binder::Expression& predicate);
-    common::ExpressionType expressionType;
 };
 
 } // namespace storage

--- a/src/include/storage/predicate/column_predicate.h
+++ b/src/include/storage/predicate/column_predicate.h
@@ -15,7 +15,7 @@ public:
     ColumnPredicateSet() = default;
     EXPLICIT_COPY_DEFAULT_MOVE(ColumnPredicateSet);
 
-    void addColumnPredicate(std::unique_ptr<ColumnPredicate> predicate) {
+    void addPredicate(std::unique_ptr<ColumnPredicate> predicate) {
         predicates.push_back(std::move(predicate));
     }
     void tryAddPredicate(const binder::Expression& column, const binder::Expression& predicate);
@@ -53,6 +53,12 @@ public:
 
 protected:
     std::string columnName;
+    common::ExpressionType expressionType;
+};
+
+struct ColumnPredicateUtil {
+    static std::unique_ptr<ColumnPredicate> tryConvert(const binder::Expression& column,
+        const binder::Expression& predicate);
     common::ExpressionType expressionType;
 };
 

--- a/src/include/storage/predicate/constant_predicate.h
+++ b/src/include/storage/predicate/constant_predicate.h
@@ -11,8 +11,7 @@ class ColumnConstantPredicate : public ColumnPredicate {
 public:
     ColumnConstantPredicate(std::string columnName, common::ExpressionType expressionType,
         common::Value value)
-        : ColumnPredicate{std::move(columnName)}, expressionType{expressionType},
-          value{std::move(value)} {}
+        : ColumnPredicate{std::move(columnName), expressionType}, value{std::move(value)} {}
 
     common::ZoneMapCheckResult checkZoneMap(const ColumnChunkStats& stats) const override;
 
@@ -23,7 +22,6 @@ public:
     }
 
 private:
-    common::ExpressionType expressionType;
     common::Value value;
 };
 

--- a/src/include/storage/predicate/constant_predicate.h
+++ b/src/include/storage/predicate/constant_predicate.h
@@ -13,7 +13,7 @@ public:
         common::Value value)
         : ColumnPredicate{std::move(columnName), expressionType}, value{std::move(value)} {}
 
-    common::ZoneMapCheckResult checkZoneMap(const ColumnChunkStats& stats) const override;
+    common::ZoneMapCheckResult checkZoneMap(const MergedColumnChunkStats& stats) const override;
 
     std::string toString() override;
 

--- a/src/include/storage/predicate/null_predicate.h
+++ b/src/include/storage/predicate/null_predicate.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "column_predicate.h"
+#include "common/enums/expression_type.h"
+
+namespace kuzu {
+namespace storage {
+
+class ColumnIsNullPredicate : public ColumnPredicate {
+public:
+    explicit ColumnIsNullPredicate(std::string columnName)
+        : ColumnPredicate{std::move(columnName), common::ExpressionType::IS_NULL} {}
+
+    common::ZoneMapCheckResult checkZoneMap(const ColumnChunkStats& stats) const override;
+
+    std::unique_ptr<ColumnPredicate> copy() const override {
+        return std::make_unique<ColumnIsNullPredicate>(columnName);
+    }
+};
+
+class ColumnIsNotNullPredicate : public ColumnPredicate {
+public:
+    explicit ColumnIsNotNullPredicate(std::string columnName)
+        : ColumnPredicate{std::move(columnName), common::ExpressionType::IS_NOT_NULL} {}
+
+    common::ZoneMapCheckResult checkZoneMap(const ColumnChunkStats& stats) const override;
+
+    std::unique_ptr<ColumnPredicate> copy() const override {
+        return std::make_unique<ColumnIsNotNullPredicate>(columnName);
+    }
+};
+
+} // namespace storage
+} // namespace kuzu

--- a/src/include/storage/predicate/null_predicate.h
+++ b/src/include/storage/predicate/null_predicate.h
@@ -6,27 +6,18 @@
 namespace kuzu {
 namespace storage {
 
-class ColumnIsNullPredicate : public ColumnPredicate {
+class ColumnNullPredicate : public ColumnPredicate {
 public:
-    explicit ColumnIsNullPredicate(std::string columnName)
-        : ColumnPredicate{std::move(columnName), common::ExpressionType::IS_NULL} {}
-
-    common::ZoneMapCheckResult checkZoneMap(const MergedColumnChunkStats& stats) const override;
-
-    std::unique_ptr<ColumnPredicate> copy() const override {
-        return std::make_unique<ColumnIsNullPredicate>(columnName);
+    explicit ColumnNullPredicate(std::string columnName, common::ExpressionType type)
+        : ColumnPredicate{std::move(columnName), type} {
+        KU_ASSERT(
+            type == common::ExpressionType::IS_NULL || type == common::ExpressionType::IS_NOT_NULL);
     }
-};
-
-class ColumnIsNotNullPredicate : public ColumnPredicate {
-public:
-    explicit ColumnIsNotNullPredicate(std::string columnName)
-        : ColumnPredicate{std::move(columnName), common::ExpressionType::IS_NOT_NULL} {}
 
     common::ZoneMapCheckResult checkZoneMap(const MergedColumnChunkStats& stats) const override;
 
     std::unique_ptr<ColumnPredicate> copy() const override {
-        return std::make_unique<ColumnIsNotNullPredicate>(columnName);
+        return std::make_unique<ColumnNullPredicate>(columnName, expressionType);
     }
 };
 

--- a/src/include/storage/predicate/null_predicate.h
+++ b/src/include/storage/predicate/null_predicate.h
@@ -11,7 +11,7 @@ public:
     explicit ColumnIsNullPredicate(std::string columnName)
         : ColumnPredicate{std::move(columnName), common::ExpressionType::IS_NULL} {}
 
-    common::ZoneMapCheckResult checkZoneMap(const ColumnChunkStats& stats) const override;
+    common::ZoneMapCheckResult checkZoneMap(const MergedColumnChunkStats& stats) const override;
 
     std::unique_ptr<ColumnPredicate> copy() const override {
         return std::make_unique<ColumnIsNullPredicate>(columnName);
@@ -23,7 +23,7 @@ public:
     explicit ColumnIsNotNullPredicate(std::string columnName)
         : ColumnPredicate{std::move(columnName), common::ExpressionType::IS_NOT_NULL} {}
 
-    common::ZoneMapCheckResult checkZoneMap(const ColumnChunkStats& stats) const override;
+    common::ZoneMapCheckResult checkZoneMap(const MergedColumnChunkStats& stats) const override;
 
     std::unique_ptr<ColumnPredicate> copy() const override {
         return std::make_unique<ColumnIsNotNullPredicate>(columnName);

--- a/src/include/storage/store/column_chunk.h
+++ b/src/include/storage/store/column_chunk.h
@@ -102,6 +102,9 @@ public:
     void loadFromDisk() { data->loadFromDisk(); }
     uint64_t spillToDisk() { return data->spillToDisk(); }
 
+    MergedColumnChunkStats getMergedColumnChunkStats(
+        const transaction::Transaction* transaction) const;
+
 private:
     void scanCommittedUpdates(const transaction::Transaction* transaction, ColumnChunkData& output,
         common::offset_t startOffsetInOutput, common::row_idx_t startRowScanned,

--- a/src/include/storage/store/column_chunk_data.h
+++ b/src/include/storage/store/column_chunk_data.h
@@ -337,6 +337,7 @@ public:
     void setNull(common::offset_t pos, bool isNull);
 
     bool mayHaveNull() const { return mayHaveNullValue; }
+    bool mayHaveNullOnDisk() const;
 
     void resetToEmpty() override {
         resetToNoNull();

--- a/src/include/storage/store/column_chunk_data.h
+++ b/src/include/storage/store/column_chunk_data.h
@@ -229,7 +229,7 @@ public:
     void loadFromDisk();
     uint64_t spillToDisk();
 
-    ColumnChunkStats getMergedColumnChunkStats() const;
+    MergedColumnChunkStats getMergedColumnChunkStats() const;
 
     void updateStats(const common::ValueVector* vector, const common::SelectionVector& selVector);
 

--- a/src/include/storage/store/column_chunk_stats.h
+++ b/src/include/storage/store/column_chunk_stats.h
@@ -6,13 +6,16 @@ namespace kuzu::storage {
 struct ColumnChunkStats {
     std::optional<StorageValue> max;
     std::optional<StorageValue> min;
+    bool mayHaveNulls = false;
 
-    void update(std::optional<StorageValue> min, std::optional<StorageValue> max,
+    void update(std::optional<StorageValue> min, std::optional<StorageValue> max, bool mayHaveNulls,
         common::PhysicalTypeID dataType);
     void update(StorageValue val, common::PhysicalTypeID dataType);
-    void update(uint8_t* data, uint64_t offset, uint64_t numValues,
+    void update(uint8_t* data, uint64_t offset, uint64_t numValues, bool mayHaveNulls,
         common::PhysicalTypeID physicalType);
     void reset();
+
+    void updateMayHaveNulls(bool newMayHaveNulls);
 };
 
 } // namespace kuzu::storage

--- a/src/include/storage/store/column_chunk_stats.h
+++ b/src/include/storage/store/column_chunk_stats.h
@@ -6,16 +6,23 @@ namespace kuzu::storage {
 struct ColumnChunkStats {
     std::optional<StorageValue> max;
     std::optional<StorageValue> min;
-    bool mayHaveNulls = false;
 
-    void update(std::optional<StorageValue> min, std::optional<StorageValue> max, bool mayHaveNulls,
+    void update(std::optional<StorageValue> min, std::optional<StorageValue> max,
         common::PhysicalTypeID dataType);
     void update(StorageValue val, common::PhysicalTypeID dataType);
-    void update(uint8_t* data, uint64_t offset, uint64_t numValues, bool mayHaveNulls,
+    void update(uint8_t* data, uint64_t offset, uint64_t numValues,
         common::PhysicalTypeID physicalType);
     void reset();
+};
 
-    void updateMayHaveNulls(bool newMayHaveNulls);
+struct MergedColumnChunkStats {
+    MergedColumnChunkStats(ColumnChunkStats stats, bool mayContainNulls)
+        : stats(stats), mayHaveNulls(mayContainNulls) {}
+
+    ColumnChunkStats stats;
+    bool mayHaveNulls;
+
+    void merge(const MergedColumnChunkStats& o, common::PhysicalTypeID dataType);
 };
 
 } // namespace kuzu::storage

--- a/src/include/storage/store/column_chunk_stats.h
+++ b/src/include/storage/store/column_chunk_stats.h
@@ -16,11 +16,13 @@ struct ColumnChunkStats {
 };
 
 struct MergedColumnChunkStats {
-    MergedColumnChunkStats(ColumnChunkStats stats, bool mayContainNulls)
-        : stats(stats), mayHaveNulls(mayContainNulls) {}
+    MergedColumnChunkStats(ColumnChunkStats stats, bool guaranteedNoNulls, bool guaranteedAllNulls)
+        : stats(stats), guaranteedNoNulls(guaranteedNoNulls),
+          guaranteedAllNulls(guaranteedAllNulls) {}
 
     ColumnChunkStats stats;
-    bool mayHaveNulls;
+    bool guaranteedNoNulls;
+    bool guaranteedAllNulls;
 
     void merge(const MergedColumnChunkStats& o, common::PhysicalTypeID dataType);
 };

--- a/src/include/storage/store/column_chunk_stats.h
+++ b/src/include/storage/store/column_chunk_stats.h
@@ -11,7 +11,7 @@ struct ColumnChunkStats {
         common::PhysicalTypeID dataType);
     void update(StorageValue val, common::PhysicalTypeID dataType);
     void update(uint8_t* data, uint64_t offset, uint64_t numValues,
-        common::PhysicalTypeID physicalType);
+        const common::NullMask* nullMask, common::PhysicalTypeID physicalType);
     void reset();
 };
 

--- a/src/optimizer/filter_push_down_optimizer.cpp
+++ b/src/optimizer/filter_push_down_optimizer.cpp
@@ -138,7 +138,11 @@ static ColumnPredicateSet getPredicateSet(const Expression& column,
     const binder::expression_vector& predicates) {
     auto predicateSet = ColumnPredicateSet();
     for (auto& predicate : predicates) {
-        predicateSet.tryAddPredicate(column, *predicate);
+        auto columnPredicate = ColumnPredicateUtil::tryConvert(column, *predicate);
+        if (columnPredicate == nullptr) {
+            continue;
+        }
+        predicateSet.addPredicate(std::move(columnPredicate));
     }
     return predicateSet;
 }

--- a/src/optimizer/filter_push_down_optimizer.cpp
+++ b/src/optimizer/filter_push_down_optimizer.cpp
@@ -138,11 +138,7 @@ static ColumnPredicateSet getPredicateSet(const Expression& column,
     const binder::expression_vector& predicates) {
     auto predicateSet = ColumnPredicateSet();
     for (auto& predicate : predicates) {
-        auto columnPredicate = ColumnPredicateUtil::tryConvert(column, *predicate);
-        if (columnPredicate == nullptr) {
-            continue;
-        }
-        predicateSet.addPredicate(std::move(columnPredicate));
+        predicateSet.tryAddPredicate(column, *predicate);
     }
     return predicateSet;
 }

--- a/src/storage/predicate/CMakeLists.txt
+++ b/src/storage/predicate/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(kuzu_storage_predicate
         OBJECT
+        null_predicate.cpp
         column_predicate.cpp
         constant_predicate.cpp)
 

--- a/src/storage/predicate/column_predicate.cpp
+++ b/src/storage/predicate/column_predicate.cpp
@@ -14,7 +14,7 @@ namespace storage {
 static void tryAddConjunction(const Expression& column, const Expression& predicate,
     std::vector<std::unique_ptr<ColumnPredicate>>& predicateSetToAddTo);
 
-ZoneMapCheckResult ColumnPredicateSet::checkZoneMap(const ColumnChunkStats& stats) const {
+ZoneMapCheckResult ColumnPredicateSet::checkZoneMap(const MergedColumnChunkStats& stats) const {
     for (auto& predicate : predicates) {
         if (predicate->checkZoneMap(stats) == ZoneMapCheckResult::SKIP_SCAN) {
             return ZoneMapCheckResult::SKIP_SCAN;

--- a/src/storage/predicate/column_predicate.cpp
+++ b/src/storage/predicate/column_predicate.cpp
@@ -46,12 +46,12 @@ static bool isCastedColumnRef(const Expression& expr) {
     return false;
 }
 
-static bool isSimpleExpr(const Expression& expr) {
+static bool isColumnOrCastedColumnRef(const Expression& expr) {
     return isColumnRef(expr.expressionType) || isCastedColumnRef(expr);
 }
 
 static bool isColumnRefConstantPair(const Expression& left, const Expression& right) {
-    return isSimpleExpr(left) && right.expressionType == ExpressionType::LITERAL;
+    return isColumnOrCastedColumnRef(left) && right.expressionType == ExpressionType::LITERAL;
 }
 
 static bool columnMatchesExprChild(const Expression& column, const Expression& expr) {
@@ -85,7 +85,7 @@ static std::unique_ptr<ColumnPredicate> tryConvertToConstColumnPredicate(const E
 static std::unique_ptr<ColumnPredicate> tryConvertToIsNull(const Expression& column,
     const Expression& predicate) {
     // we only convert simple predicates
-    if (isSimpleExpr(*predicate.getChild(0))) {
+    if (isColumnOrCastedColumnRef(*predicate.getChild(0))) {
         return std::make_unique<ColumnNullPredicate>(column.toString(), ExpressionType::IS_NULL);
     }
     return nullptr;
@@ -93,7 +93,7 @@ static std::unique_ptr<ColumnPredicate> tryConvertToIsNull(const Expression& col
 
 static std::unique_ptr<ColumnPredicate> tryConvertToIsNotNull(const Expression& column,
     const Expression& predicate) {
-    if (isSimpleExpr(*predicate.getChild(0))) {
+    if (isColumnOrCastedColumnRef(*predicate.getChild(0))) {
         return std::make_unique<ColumnNullPredicate>(column.toString(),
             ExpressionType::IS_NOT_NULL);
     }

--- a/src/storage/predicate/column_predicate.cpp
+++ b/src/storage/predicate/column_predicate.cpp
@@ -86,7 +86,7 @@ static std::unique_ptr<ColumnPredicate> tryConvertToIsNull(const Expression& col
     const Expression& predicate) {
     // we only convert simple predicates
     if (isSimpleExpr(*predicate.getChild(0))) {
-        return std::make_unique<ColumnIsNullPredicate>(column.toString());
+        return std::make_unique<ColumnNullPredicate>(column.toString(), ExpressionType::IS_NULL);
     }
     return nullptr;
 }
@@ -94,7 +94,8 @@ static std::unique_ptr<ColumnPredicate> tryConvertToIsNull(const Expression& col
 static std::unique_ptr<ColumnPredicate> tryConvertToIsNotNull(const Expression& column,
     const Expression& predicate) {
     if (isSimpleExpr(*predicate.getChild(0))) {
-        return std::make_unique<ColumnIsNotNullPredicate>(column.toString());
+        return std::make_unique<ColumnNullPredicate>(column.toString(),
+            ExpressionType::IS_NOT_NULL);
     }
     return nullptr;
 }

--- a/src/storage/predicate/constant_predicate.cpp
+++ b/src/storage/predicate/constant_predicate.cpp
@@ -19,11 +19,11 @@ bool inRange(T min, T max, T val) {
 }
 
 template<typename T>
-ZoneMapCheckResult checkZoneMapSwitch(const ColumnChunkStats& stats, ExpressionType expressionType,
-    const Value& value) {
-    KU_ASSERT(stats.min.has_value() && stats.max.has_value());
-    auto max = stats.max->get<T>();
-    auto min = stats.min->get<T>();
+ZoneMapCheckResult checkZoneMapSwitch(const MergedColumnChunkStats& mergedStats,
+    ExpressionType expressionType, const Value& value) {
+    KU_ASSERT(mergedStats.stats.min.has_value() && mergedStats.stats.max.has_value());
+    auto max = mergedStats.stats.max->get<T>();
+    auto min = mergedStats.stats.min->get<T>();
     auto constant = value.getValue<T>();
     switch (expressionType) {
     case ExpressionType::EQUALS: {
@@ -62,7 +62,8 @@ ZoneMapCheckResult checkZoneMapSwitch(const ColumnChunkStats& stats, ExpressionT
     return ZoneMapCheckResult::ALWAYS_SCAN;
 }
 
-ZoneMapCheckResult ColumnConstantPredicate::checkZoneMap(const ColumnChunkStats& stats) const {
+ZoneMapCheckResult ColumnConstantPredicate::checkZoneMap(
+    const MergedColumnChunkStats& stats) const {
     auto physicalType = value.getDataType().getPhysicalType();
     return TypeUtils::visit(
         physicalType,

--- a/src/storage/predicate/constant_predicate.cpp
+++ b/src/storage/predicate/constant_predicate.cpp
@@ -84,8 +84,7 @@ std::string ColumnConstantPredicate::toString() {
     } else {
         valStr = value.toString();
     }
-    return stringFormat("{} {} {}", columnName,
-        ExpressionTypeUtil::toParsableString(expressionType), valStr);
+    return stringFormat("{} {}", ColumnPredicate::toString(), valStr);
 }
 
 } // namespace storage

--- a/src/storage/predicate/null_predicate.cpp
+++ b/src/storage/predicate/null_predicate.cpp
@@ -3,15 +3,13 @@
 #include "storage/store/column_chunk_stats.h"
 
 namespace kuzu::storage {
-common::ZoneMapCheckResult ColumnIsNullPredicate::checkZoneMap(
+common::ZoneMapCheckResult ColumnNullPredicate::checkZoneMap(
     const MergedColumnChunkStats& mergedStats) const {
-    return mergedStats.guaranteedNoNulls ? common::ZoneMapCheckResult::SKIP_SCAN :
-                                           common::ZoneMapCheckResult::ALWAYS_SCAN;
+    const bool statToCheck = (expressionType == common::ExpressionType::IS_NULL) ?
+                                 mergedStats.guaranteedNoNulls :
+                                 mergedStats.guaranteedAllNulls;
+    return statToCheck ? common::ZoneMapCheckResult::SKIP_SCAN :
+                         common::ZoneMapCheckResult::ALWAYS_SCAN;
 }
 
-common::ZoneMapCheckResult ColumnIsNotNullPredicate::checkZoneMap(
-    const MergedColumnChunkStats& mergedStats) const {
-    return mergedStats.guaranteedAllNulls ? common::ZoneMapCheckResult::SKIP_SCAN :
-                                            common::ZoneMapCheckResult::ALWAYS_SCAN;
-}
 } // namespace kuzu::storage

--- a/src/storage/predicate/null_predicate.cpp
+++ b/src/storage/predicate/null_predicate.cpp
@@ -1,0 +1,15 @@
+#include "storage/predicate/null_predicate.h"
+
+#include "storage/store/column_chunk_stats.h"
+
+namespace kuzu::storage {
+common::ZoneMapCheckResult ColumnIsNullPredicate::checkZoneMap(
+    const ColumnChunkStats& stats) const {
+    return stats.mayHaveNulls ? common::ZoneMapCheckResult::ALWAYS_SCAN :
+                                common::ZoneMapCheckResult::SKIP_SCAN;
+}
+
+common::ZoneMapCheckResult ColumnIsNotNullPredicate::checkZoneMap(const ColumnChunkStats&) const {
+    return common::ZoneMapCheckResult::ALWAYS_SCAN;
+}
+} // namespace kuzu::storage

--- a/src/storage/predicate/null_predicate.cpp
+++ b/src/storage/predicate/null_predicate.cpp
@@ -4,12 +4,13 @@
 
 namespace kuzu::storage {
 common::ZoneMapCheckResult ColumnIsNullPredicate::checkZoneMap(
-    const ColumnChunkStats& stats) const {
-    return stats.mayHaveNulls ? common::ZoneMapCheckResult::ALWAYS_SCAN :
-                                common::ZoneMapCheckResult::SKIP_SCAN;
+    const MergedColumnChunkStats& mergedStats) const {
+    return mergedStats.mayHaveNulls ? common::ZoneMapCheckResult::ALWAYS_SCAN :
+                                      common::ZoneMapCheckResult::SKIP_SCAN;
 }
 
-common::ZoneMapCheckResult ColumnIsNotNullPredicate::checkZoneMap(const ColumnChunkStats&) const {
+common::ZoneMapCheckResult ColumnIsNotNullPredicate::checkZoneMap(
+    const MergedColumnChunkStats&) const {
     return common::ZoneMapCheckResult::ALWAYS_SCAN;
 }
 } // namespace kuzu::storage

--- a/src/storage/predicate/null_predicate.cpp
+++ b/src/storage/predicate/null_predicate.cpp
@@ -5,12 +5,13 @@
 namespace kuzu::storage {
 common::ZoneMapCheckResult ColumnIsNullPredicate::checkZoneMap(
     const MergedColumnChunkStats& mergedStats) const {
-    return mergedStats.mayHaveNulls ? common::ZoneMapCheckResult::ALWAYS_SCAN :
-                                      common::ZoneMapCheckResult::SKIP_SCAN;
+    return mergedStats.guaranteedNoNulls ? common::ZoneMapCheckResult::SKIP_SCAN :
+                                           common::ZoneMapCheckResult::ALWAYS_SCAN;
 }
 
 common::ZoneMapCheckResult ColumnIsNotNullPredicate::checkZoneMap(
-    const MergedColumnChunkStats&) const {
-    return common::ZoneMapCheckResult::ALWAYS_SCAN;
+    const MergedColumnChunkStats& mergedStats) const {
+    return mergedStats.guaranteedAllNulls ? common::ZoneMapCheckResult::SKIP_SCAN :
+                                            common::ZoneMapCheckResult::ALWAYS_SCAN;
 }
 } // namespace kuzu::storage

--- a/src/storage/store/chunked_node_group.cpp
+++ b/src/storage/store/chunked_node_group.cpp
@@ -207,11 +207,6 @@ static ZoneMapCheckResult getZoneMapResult(const Transaction* transaction,
             KU_ASSERT(i < scanState.columnPredicateSets.size());
             const auto columnZoneMapResult = scanState.columnPredicateSets[i].checkZoneMap(
                 chunks[columnID]->getMergedColumnChunkStats(transaction));
-            RUNTIME_CHECK(const bool columnHasStorageValueType =
-                              TypeUtils::visit(chunks[columnID]->getDataType().getPhysicalType(),
-                                  []<typename T>(T) { return StorageValueType<T>; }));
-            KU_ASSERT(columnHasStorageValueType ||
-                      columnZoneMapResult == common::ZoneMapCheckResult::ALWAYS_SCAN);
             if (columnZoneMapResult == common::ZoneMapCheckResult::SKIP_SCAN) {
                 return common::ZoneMapCheckResult::SKIP_SCAN;
             }

--- a/src/storage/store/chunked_node_group.cpp
+++ b/src/storage/store/chunked_node_group.cpp
@@ -195,8 +195,8 @@ void ChunkedNodeGroup::write(const ChunkedNodeGroup& data, column_id_t offsetCol
     }
 }
 
-static ZoneMapCheckResult getZoneMapResult(const TableScanState& scanState,
-    const std::vector<std::unique_ptr<ColumnChunk>>& chunks) {
+static ZoneMapCheckResult getZoneMapResult(const Transaction* transaction,
+    const TableScanState& scanState, const std::vector<std::unique_ptr<ColumnChunk>>& chunks) {
     if (!scanState.columnPredicateSets.empty()) {
         for (auto i = 0u; i < scanState.columnIDs.size(); i++) {
             const auto columnID = scanState.columnIDs[i];
@@ -206,7 +206,7 @@ static ZoneMapCheckResult getZoneMapResult(const TableScanState& scanState,
 
             KU_ASSERT(i < scanState.columnPredicateSets.size());
             const auto columnZoneMapResult = scanState.columnPredicateSets[i].checkZoneMap(
-                chunks[columnID]->getData().getMergedColumnChunkStats());
+                chunks[columnID]->getMergedColumnChunkStats(transaction));
             RUNTIME_CHECK(const bool columnHasStorageValueType =
                               TypeUtils::visit(chunks[columnID]->getDataType().getPhysicalType(),
                                   []<typename T>(T) { return StorageValueType<T>; }));
@@ -225,7 +225,7 @@ void ChunkedNodeGroup::scan(const Transaction* transaction, const TableScanState
     length_t numRowsToScan) const {
     KU_ASSERT(rowIdxInGroup + numRowsToScan <= numRows);
     auto& anchorSelVector = scanState.outState->getSelVectorUnsafe();
-    if (getZoneMapResult(scanState, chunks) == common::ZoneMapCheckResult::SKIP_SCAN) {
+    if (getZoneMapResult(transaction, scanState, chunks) == common::ZoneMapCheckResult::SKIP_SCAN) {
         anchorSelVector.setToFiltered(0);
         return;
     }

--- a/src/storage/store/column_chunk_stats.cpp
+++ b/src/storage/store/column_chunk_stats.cpp
@@ -37,7 +37,8 @@ void ColumnChunkStats::reset() {
 void MergedColumnChunkStats::merge(const MergedColumnChunkStats& o,
     common::PhysicalTypeID dataType) {
     stats.update(o.stats.min, o.stats.max, dataType);
-    mayHaveNulls = mayHaveNulls || o.mayHaveNulls;
+    guaranteedNoNulls = guaranteedNoNulls && o.guaranteedNoNulls;
+    guaranteedAllNulls = guaranteedAllNulls && o.guaranteedAllNulls;
 }
 
 } // namespace storage

--- a/src/storage/store/column_chunk_stats.cpp
+++ b/src/storage/store/column_chunk_stats.cpp
@@ -6,12 +6,12 @@ namespace kuzu {
 namespace storage {
 
 void ColumnChunkStats::update(uint8_t* data, uint64_t offset, uint64_t numValues,
-    common::PhysicalTypeID physicalType) {
+    const common::NullMask* nullMask, common::PhysicalTypeID physicalType) {
     const bool isStorageValueType =
         common::TypeUtils::visit(physicalType, []<typename T>(T) { return StorageValueType<T>; });
     if (isStorageValueType) {
         auto [minVal, maxVal] =
-            getMinMaxStorageValue(data, offset, numValues, physicalType, nullptr);
+            getMinMaxStorageValue(data, offset, numValues, physicalType, nullMask);
         update(minVal, maxVal, physicalType);
     }
 }

--- a/src/storage/store/column_chunk_stats.cpp
+++ b/src/storage/store/column_chunk_stats.cpp
@@ -5,33 +5,40 @@
 namespace kuzu {
 namespace storage {
 
-void ColumnChunkStats::update(uint8_t* data, uint64_t offset, uint64_t numValues,
+void ColumnChunkStats::update(uint8_t* data, uint64_t offset, uint64_t numValues, bool mayHaveNulls,
     common::PhysicalTypeID physicalType) {
     const bool isStorageValueType =
         common::TypeUtils::visit(physicalType, []<typename T>(T) { return StorageValueType<T>; });
     if (isStorageValueType) {
         auto [minVal, maxVal] =
             getMinMaxStorageValue(data, offset, numValues, physicalType, nullptr);
-        update(minVal, maxVal, physicalType);
+        update(minVal, maxVal, mayHaveNulls, physicalType);
+    } else {
+        updateMayHaveNulls(mayHaveNulls);
     }
 }
 
 void ColumnChunkStats::update(std::optional<StorageValue> newMin,
-    std::optional<StorageValue> newMax, common::PhysicalTypeID dataType) {
+    std::optional<StorageValue> newMax, bool mayHaveNulls, common::PhysicalTypeID dataType) {
     if (!min.has_value() || (newMin.has_value() && min->gt(*newMin, dataType))) {
         min = newMin;
     }
     if (!max.has_value() || (newMax.has_value() && newMax->gt(*max, dataType))) {
         max = newMax;
     }
+    updateMayHaveNulls(mayHaveNulls);
 }
 
 void ColumnChunkStats::update(StorageValue val, common::PhysicalTypeID dataType) {
-    update(val, val, dataType);
+    update(val, val, false, dataType);
+}
+
+void ColumnChunkStats::updateMayHaveNulls(bool newMayHaveNulls) {
+    mayHaveNulls = mayHaveNulls || newMayHaveNulls;
 }
 
 void ColumnChunkStats::reset() {
-    *this = {};
+    *this = ColumnChunkStats{};
 }
 
 } // namespace storage

--- a/src/storage/store/string_chunk_data.cpp
+++ b/src/storage/store/string_chunk_data.cpp
@@ -108,7 +108,7 @@ void StringChunkData::scan(ValueVector& output, offset_t offset, length_t length
     sel_t posInOutputVector) const {
     KU_ASSERT(offset + length <= numValues && nullData);
     nullData->scan(output, offset, length, posInOutputVector);
-    if (nullData->mayHaveNull()) {
+    if (!nullData->noNullsGuaranteedInMem()) {
         for (auto i = 0u; i < length; i++) {
             if (!nullData->isNull(offset + i)) {
                 output.setValue<std::string_view>(posInOutputVector + i,

--- a/test/test_files/call/call.test
+++ b/test/test_files/call/call.test
@@ -134,17 +134,17 @@ True
 ---- 1
 False
 
-# -LOG ZoneMapConfig
-# -STATEMENT CALL enable_zone_map=true
-# ---- ok
-# -STATEMENT CALL current_setting('enable_zone_map') RETURN *
-# ---- 1
-# True
-# -STATEMENT CALL enable_zone_map=false
-# ---- ok
-# -STATEMENT CALL current_setting('enable_zone_map') RETURN *
-# ---- 1
-# False
+-LOG ZoneMapConfig
+-STATEMENT CALL enable_zone_map=true
+---- ok
+-STATEMENT CALL current_setting('enable_zone_map') RETURN *
+---- 1
+True
+-STATEMENT CALL enable_zone_map=false
+---- ok
+-STATEMENT CALL current_setting('enable_zone_map') RETURN *
+---- 1
+False
 
 -LOG NodeTableInfo
 -STATEMENT CALL table_info('person') RETURN *

--- a/test/test_files/filter/node.test
+++ b/test/test_files/filter/node.test
@@ -33,12 +33,6 @@
 100|100
 
 -LOG NullCheckBool
--STATEMENT MATCH (a:person) WHERE a.isStudent IS NULL RETURN COUNT(*)
----- 1
-0
--STATEMENT MATCH (a:person) WHERE a.isStudent IS NOT NULL RETURN COUNT(*)
----- 1
-9
 -STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.isStudent=null
 ---- ok
 -STATEMENT MATCH (a:person) WHERE a.isStudent IS NULL RETURN COUNT(*)

--- a/test/test_files/filter/node.test
+++ b/test/test_files/filter/node.test
@@ -16,6 +16,7 @@
 77|123456789.123000
 
 -CASE ZoneMapUpdateThenQueryWithoutCheckpoint
+-LOG Comparison
 -STATEMENT CALL enable_zone_map=true;
 ---- ok
 -STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.age=40 + 50
@@ -25,11 +26,42 @@
 0|90
 -STATEMENT MATCH (a:person) WHERE a.age > 95 RETURN a.ID, a.age
 ---- 0
--STATEMENT CREATE (a:person {id: 100, age: 100})
+-STATEMENT CREATE (a:person {id: 100, age: 100, isStudent: true})
 ---- ok
 -STATEMENT MATCH (a:person) WHERE a.age > 95 RETURN a.ID, a.age
 ---- 1
 100|100
+
+-LOG NullCheck
+-STATEMENT MATCH (a:person) WHERE a.isStudent IS NULL RETURN COUNT(*)
+---- 1
+0
+-STATEMENT MATCH (a:person) WHERE a.isStudent IS NOT NULL RETURN COUNT(*)
+---- 1
+9
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.isStudent=null
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.isStudent IS NULL RETURN COUNT(*)
+---- 1
+1
+-STATEMENT MATCH (a:person) WHERE a.isStudent IS NOT NULL RETURN COUNT(*)
+---- 1
+8
+-RELOADDB
+-STATEMENT MATCH (a:person) WHERE a.isStudent IS NULL RETURN COUNT(*)
+---- 1
+1
+-STATEMENT MATCH (a:person) WHERE a.isStudent IS NOT NULL RETURN COUNT(*)
+---- 1
+8
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.isStudent=true
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.isStudent IS NULL RETURN COUNT(*)
+---- 1
+0
+-STATEMENT MATCH (a:person) WHERE a.isStudent IS NOT NULL RETURN COUNT(*)
+---- 1
+9
 
 -CASE FilterNode
 

--- a/test/test_files/filter/node.test
+++ b/test/test_files/filter/node.test
@@ -32,7 +32,7 @@
 ---- 1
 100|100
 
--LOG NullCheck
+-LOG NullCheckBool
 -STATEMENT MATCH (a:person) WHERE a.isStudent IS NULL RETURN COUNT(*)
 ---- 1
 0
@@ -62,6 +62,37 @@
 -STATEMENT MATCH (a:person) WHERE a.isStudent IS NOT NULL RETURN COUNT(*)
 ---- 1
 9
+
+-LOG NullCheckStruct
+-STATEMENT MATCH (a:organisation) WHERE a.state IS NULL RETURN COUNT(*)
+---- 1
+0
+-STATEMENT MATCH (a:organisation) WHERE a.state IS NOT NULL RETURN COUNT(*)
+---- 1
+3
+-STATEMENT MATCH (a:organisation) WHERE a.ID=4 SET a.state=null
+---- ok
+-STATEMENT MATCH (a:organisation) WHERE a.state IS NULL RETURN COUNT(*)
+---- 1
+1
+-STATEMENT MATCH (a:organisation) WHERE a.state IS NOT NULL RETURN COUNT(*)
+---- 1
+2
+-RELOADDB
+-STATEMENT MATCH (a:organisation) WHERE a.state IS NULL RETURN COUNT(*)
+---- 1
+1
+-STATEMENT MATCH (a:organisation) WHERE a.state IS NOT NULL RETURN COUNT(*)
+---- 1
+2
+-STATEMENT MATCH (a:organisation) WHERE a.ID=4 SET a.state={revenue: CAST(1, "INT16"), location: ["aaa"], stock: {price: [1], volumn: 1}}
+---- ok
+-STATEMENT MATCH (a:organisation) WHERE a.state IS NULL RETURN COUNT(*)
+---- 1
+0
+-STATEMENT MATCH (a:organisation) WHERE a.state IS NOT NULL RETURN COUNT(*)
+---- 1
+3
 
 -CASE FilterNode
 


### PR DESCRIPTION
# Description
Add support for skipping chunked group scans based on zone map for `IS NULL` and `IS NOT NULL` predicates

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).