### PR TITLE
Trim Unnecessary Quote for CLI JSON output

### DIFF
--- a/test/test_files/cast/cast_error.test
+++ b/test/test_files/cast/cast_error.test
@@ -826,16 +826,3 @@ True
 -STATEMENT RETURN {'a':12, 'b':24} = {'c':12, 'd':24};
 ---- 1
 False
-
--CASE JSONModeOutput
--STATEMENT :mode json
----- ok
--STATEMENT RETURN [1,2,3] as should_be_an_array_not_a_string;
----- 1
-[{"should_be_an_array_not_a_string":[1,2,3]}]
--STATEMENT RETURN [[1],[2],[3]] as should_be_an_array_not_a_string;
----- 1
-[{"should_be_an_array_not_a_string":[[1],[2],[3]]}]
--STATEMENT RETURN [[[1],[2],[3]],[[1],[2],[3]]] as should_be_an_array_not_a_string;
----- 1
-[{"should_be_an_array_not_a_string":[[[1],[2],[3]],[[1],[2],[3]]]}]

--- a/test/test_files/cast/cast_error.test
+++ b/test/test_files/cast/cast_error.test
@@ -826,3 +826,16 @@ True
 -STATEMENT RETURN {'a':12, 'b':24} = {'c':12, 'd':24};
 ---- 1
 False
+
+-CASE JSONModeOutput
+-STATEMENT :mode json
+---- ok
+-STATEMENT RETURN [1,2,3] as should_be_an_array_not_a_string;
+---- 1
+[{"should_be_an_array_not_a_string":[1,2,3]}]
+-STATEMENT RETURN [[1],[2],[3]] as should_be_an_array_not_a_string;
+---- 1
+[{"should_be_an_array_not_a_string":[[1],[2],[3]]}]
+-STATEMENT RETURN [[[1],[2],[3]],[[1],[2],[3]]] as should_be_an_array_not_a_string;
+---- 1
+[{"should_be_an_array_not_a_string":[[[1],[2],[3]],[[1],[2],[3]]]}]

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -845,11 +845,13 @@ std::string EmbeddedShell::printJsonExecutionResult(QueryResult& queryResult) co
             printString += jsonDrawingCharacters->KeyValue;
             printString += jsonDrawingCharacters->KeyDelimiter;
             auto valueTypeID = tuple->getValue(i)->getDataType().getLogicalTypeID();
-            if (valueTypeID == common::LogicalTypeID::STRING || valueTypeID == common::LogicalTypeID::BLOB) {
+            if (valueTypeID == common::LogicalTypeID::STRING ||
+                valueTypeID == common::LogicalTypeID::BLOB) {
                 printString += jsonDrawingCharacters->KeyValue;
             }
             printString += escapeJsonString(tuple->getValue(i)->toString());
-            if (valueTypeID == common::LogicalTypeID::STRING || valueTypeID == common::LogicalTypeID::BLOB) {
+            if (valueTypeID == common::LogicalTypeID::STRING ||
+                valueTypeID == common::LogicalTypeID::BLOB) {
                 printString += jsonDrawingCharacters->KeyValue;
             }
             if (i != queryResult.getNumColumns() - 1) {

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -844,9 +844,14 @@ std::string EmbeddedShell::printJsonExecutionResult(QueryResult& queryResult) co
             printString += escapeJsonString(colNames[i]);
             printString += jsonDrawingCharacters->KeyValue;
             printString += jsonDrawingCharacters->KeyDelimiter;
-            printString += jsonDrawingCharacters->KeyValue;
+            auto valueTypeID = tuple->getValue(i)->getDataType().getLogicalTypeID();
+            if (valueTypeID == common::LogicalTypeID::STRING || valueTypeID == common::LogicalTypeID::BLOB) {
+                printString += jsonDrawingCharacters->KeyValue;
+            }
             printString += escapeJsonString(tuple->getValue(i)->toString());
-            printString += jsonDrawingCharacters->KeyValue;
+            if (valueTypeID == common::LogicalTypeID::STRING || valueTypeID == common::LogicalTypeID::BLOB) {
+                printString += jsonDrawingCharacters->KeyValue;
+            }
             if (i != queryResult.getNumColumns() - 1) {
                 printString += jsonDrawingCharacters->TupleDelimiter;
             }


### PR DESCRIPTION
# Description

Before, in `printJsonExecutionResult`, we always add quotes to the value, instead, we should only add these quotes when the value is a string or a blob.

Fixes #4634 

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).