### PR TITLE
Support IGNORE_ERRORS when scanning from pyarrow/pandas

### DIFF
--- a/src/binder/bound_scan_source.cpp
+++ b/src/binder/bound_scan_source.cpp
@@ -13,14 +13,9 @@ expression_vector BoundTableScanSource::getWarningColumns() const {
     }
     return warningDataExprs;
 }
+
 bool BoundTableScanSource::getIgnoreErrorsOption() const {
-    bool ignoreErrors = common::CopyConstants::DEFAULT_IGNORE_ERRORS;
-    if (type == common::ScanSourceType::FILE) {
-        auto bindData = info.bindData->constPtrCast<function::ScanBindData>();
-        ignoreErrors = bindData->config.getOption(common::CopyConstants::IGNORE_ERRORS_OPTION_NAME,
-            ignoreErrors);
-    }
-    return ignoreErrors;
+    return info.bindData->getIgnoreErrorsOption();
 }
 
 } // namespace binder

--- a/src/function/table/bind_data.cpp
+++ b/src/function/table/bind_data.cpp
@@ -1,5 +1,7 @@
 #include "function/table/bind_data.h"
 
+#include "common/constants.h"
+
 namespace kuzu {
 namespace function {
 
@@ -12,6 +14,15 @@ std::vector<bool> TableFuncBindData::getColumnSkips() const {
         return skips;
     }
     return columnSkips;
+}
+
+bool TableFuncBindData::getIgnoreErrorsOption() const {
+    return common::CopyConstants::DEFAULT_IGNORE_ERRORS;
+}
+
+bool ScanBindData::getIgnoreErrorsOption() const {
+    return config.getOption(common::CopyConstants::IGNORE_ERRORS_OPTION_NAME,
+        common::CopyConstants::DEFAULT_IGNORE_ERRORS);
 }
 
 } // namespace function

--- a/src/include/common/vector/auxiliary_buffer.h
+++ b/src/include/common/vector/auxiliary_buffer.h
@@ -14,7 +14,7 @@ namespace common {
 class ValueVector;
 
 // AuxiliaryBuffer holds data which is only used by the targeting dataType.
-class AuxiliaryBuffer {
+class KUZU_API AuxiliaryBuffer {
 public:
     virtual ~AuxiliaryBuffer() = default;
 
@@ -43,7 +43,7 @@ private:
     std::unique_ptr<InMemOverflowBuffer> inMemOverflowBuffer;
 };
 
-class StructAuxiliaryBuffer : public AuxiliaryBuffer {
+class KUZU_API StructAuxiliaryBuffer : public AuxiliaryBuffer {
 public:
     StructAuxiliaryBuffer(const LogicalType& type, storage::MemoryManager* memoryManager);
 

--- a/src/include/function/export/export_function.h
+++ b/src/include/function/export/export_function.h
@@ -67,7 +67,7 @@ using export_sink_t = std::function<void(ExportFuncSharedState&, ExportFuncLocal
 using export_combine_t = std::function<void(ExportFuncSharedState&, ExportFuncLocalState&)>;
 using export_finalize_t = std::function<void(ExportFuncSharedState&)>;
 
-struct ExportFunction : public Function {
+struct KUZU_API ExportFunction : public Function {
     explicit ExportFunction(std::string name) : Function{std::move(name), {}} {}
 
     ExportFunction(std::string name, export_init_local_t initLocal,

--- a/src/include/function/function.h
+++ b/src/include/function/function.h
@@ -55,7 +55,7 @@ struct ScalarBindFuncInput {
 using scalar_bind_func =
     std::function<std::unique_ptr<FunctionBindData>(const ScalarBindFuncInput& bindInput)>;
 
-struct Function {
+struct KUZU_API Function {
     std::string name;
     std::vector<common::LogicalTypeID> parameterTypeIDs;
     // Currently we only one variable-length function which is list creation. The expectation is

--- a/src/include/function/gds_function.h
+++ b/src/include/function/gds_function.h
@@ -6,7 +6,7 @@
 namespace kuzu {
 namespace function {
 
-struct GDSFunction : public Function {
+struct KUZU_API GDSFunction : public Function {
     std::unique_ptr<GDSAlgorithm> gds;
 
     GDSFunction() = default;

--- a/src/include/function/scalar_function.h
+++ b/src/include/function/scalar_function.h
@@ -21,7 +21,7 @@ using scalar_func_exec_t = std::function<void(
 using scalar_func_select_t = std::function<bool(
     const std::vector<std::shared_ptr<common::ValueVector>>&, common::SelectionVector&)>;
 
-struct ScalarFunction : ScalarOrAggregateFunction {
+struct KUZU_API ScalarFunction : public ScalarOrAggregateFunction {
     scalar_func_exec_t execFunc = nullptr;
     scalar_func_select_t selectFunc = nullptr;
     scalar_func_compile_exec_t compileFunc = nullptr;

--- a/src/include/function/table/bind_input.h
+++ b/src/include/function/table/bind_input.h
@@ -35,7 +35,7 @@ struct ExtraTableFuncBindInput {
     }
 };
 
-struct TableFuncBindInput {
+struct KUZU_API TableFuncBindInput {
     binder::expression_vector params;
     optional_params_t optionalParams;
     std::unique_ptr<ExtraTableFuncBindInput> extraInput = nullptr;
@@ -51,7 +51,7 @@ struct TableFuncBindInput {
     T getLiteralVal(common::idx_t idx) const;
 };
 
-struct ExtraScanTableFuncBindInput : ExtraTableFuncBindInput {
+struct KUZU_API ExtraScanTableFuncBindInput : ExtraTableFuncBindInput {
     common::ReaderConfig config;
     std::vector<std::string> expectedColumnNames;
     std::vector<common::LogicalType> expectedColumnTypes;

--- a/src/include/function/table/scan_functions.h
+++ b/src/include/function/table/scan_functions.h
@@ -12,7 +12,7 @@ class FileSystem;
 
 namespace function {
 
-struct BaseScanSharedState : public TableFuncSharedState {
+struct KUZU_API BaseScanSharedState : public TableFuncSharedState {
     std::mutex lock;
 
     virtual uint64_t getNumRows() const = 0;

--- a/src/include/function/table/simple_table_functions.h
+++ b/src/include/function/table/simple_table_functions.h
@@ -21,7 +21,7 @@ struct SimpleTableFuncMorsel {
     }
 };
 
-struct SimpleTableFuncSharedState final : TableFuncSharedState {
+struct KUZU_API SimpleTableFuncSharedState final : TableFuncSharedState {
     common::offset_t maxOffset;
     common::offset_t curOffset;
     std::mutex mtx;
@@ -29,10 +29,10 @@ struct SimpleTableFuncSharedState final : TableFuncSharedState {
     explicit SimpleTableFuncSharedState(common::offset_t maxOffset)
         : maxOffset{maxOffset}, curOffset{0} {}
 
-    KUZU_API SimpleTableFuncMorsel getMorsel();
+    SimpleTableFuncMorsel getMorsel();
 };
 
-struct SimpleTableFuncBindData : TableFuncBindData {
+struct KUZU_API SimpleTableFuncBindData : TableFuncBindData {
     common::offset_t maxOffset;
 
     explicit SimpleTableFuncBindData(common::offset_t maxOffset)

--- a/src/include/function/table_functions.h
+++ b/src/include/function/table_functions.h
@@ -17,7 +17,7 @@ namespace function {
 struct TableFuncBindInput;
 struct TableFuncBindData;
 
-struct TableFuncSharedState {
+struct KUZU_API TableFuncSharedState {
     virtual ~TableFuncSharedState() = default;
 
     template<class TARGET>

--- a/tools/python_api/src_cpp/include/pyarrow/pyarrow_scan.h
+++ b/tools/python_api/src_cpp/include/pyarrow/pyarrow_scan.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "common/arrow/arrow.h"
 #include "function/scalar_function.h"
 #include "function/table/bind_data.h"
@@ -43,7 +45,7 @@ struct PyArrowTableScanFunctionData final : public function::TableFuncBindData {
         std::vector<std::shared_ptr<ArrowArrayWrapper>> arrowArrayBatches, uint64_t numRows,
         bool ignoreErrors)
         : TableFuncBindData{std::move(columns), 0 /* numWarningDataColumns */, numRows},
-          schema{std::move(schema)}, arrowArrayBatches{arrowArrayBatches},
+          schema{std::move(schema)}, arrowArrayBatches{std::move(arrowArrayBatches)},
           ignoreErrors(ignoreErrors) {}
 
     ~PyArrowTableScanFunctionData() override {}

--- a/tools/python_api/src_cpp/include/pyarrow/pyarrow_scan.h
+++ b/tools/python_api/src_cpp/include/pyarrow/pyarrow_scan.h
@@ -12,6 +12,7 @@ namespace kuzu {
 struct PyArrowScanConfig {
     uint64_t skipNum;
     uint64_t limitNum;
+    bool ignoreErrors;
     explicit PyArrowScanConfig(const common::case_insensitive_map_t<common::Value>& options);
 };
 
@@ -35,19 +36,22 @@ struct PyArrowTableScanSharedState final : public function::BaseScanSharedStateW
 struct PyArrowTableScanFunctionData final : public function::TableFuncBindData {
     std::shared_ptr<ArrowSchemaWrapper> schema;
     std::vector<std::shared_ptr<ArrowArrayWrapper>> arrowArrayBatches;
+    bool ignoreErrors;
 
     PyArrowTableScanFunctionData(binder::expression_vector columns,
         std::shared_ptr<ArrowSchemaWrapper> schema,
-        std::vector<std::shared_ptr<ArrowArrayWrapper>> arrowArrayBatches, uint64_t numRows)
+        std::vector<std::shared_ptr<ArrowArrayWrapper>> arrowArrayBatches, uint64_t numRows,
+        bool ignoreErrors)
         : TableFuncBindData{std::move(columns), 0 /* numWarningDataColumns */, numRows},
-          schema{std::move(schema)}, arrowArrayBatches{std::move(arrowArrayBatches)} {}
+          schema{std::move(schema)}, arrowArrayBatches{arrowArrayBatches},
+          ignoreErrors(ignoreErrors) {}
 
     ~PyArrowTableScanFunctionData() override {}
 
+    bool getIgnoreErrorsOption() const override { return ignoreErrors; }
+
 private:
-    PyArrowTableScanFunctionData(const PyArrowTableScanFunctionData& other)
-        : TableFuncBindData{other}, schema{other.schema},
-          arrowArrayBatches{other.arrowArrayBatches} {}
+    PyArrowTableScanFunctionData(const PyArrowTableScanFunctionData& other) = default;
 
 public:
     std::unique_ptr<function::TableFuncBindData> copy() const override {

--- a/tools/python_api/src_cpp/pandas/pandas_scan.cpp
+++ b/tools/python_api/src_cpp/pandas/pandas_scan.cpp
@@ -121,19 +121,13 @@ static double progressFunc(TableFuncSharedState* sharedState) {
     return static_cast<double>(pandasSharedState->numRowsRead) / pandasSharedState->numRows;
 }
 
-static void finalizeFunc(processor::ExecutionContext* ctx, TableFuncSharedState*) {
+static void finalizeFunc(const processor::ExecutionContext* ctx, TableFuncSharedState*) {
     ctx->clientContext->getWarningContextUnsafe().defaultPopulateAllWarnings(ctx->queryID);
 }
 
 function_set PandasScanFunction::getFunctionSet() {
     function_set functionSet;
-<<<<<<< HEAD
     functionSet.push_back(getFunction().copy());
-=======
-    functionSet.push_back(std::make_unique<TableFunction>(PandasScanFunction::name, tableFunc,
-        bindFunc, initSharedState, initLocalState, progressFunc,
-        std::vector<LogicalTypeID>{LogicalTypeID::POINTER}, finalizeFunc));
->>>>>>> ceac2f32d (Support IGNORE_ERRORS when scanning from pyarrow/pandas)
     return functionSet;
 }
 
@@ -144,6 +138,7 @@ TableFunction PandasScanFunction::getFunction() {
     function.initSharedStateFunc = initSharedState;
     function.initLocalStateFunc = initLocalState;
     function.progressFunc = progressFunc;
+    function.finalizeFunc = finalizeFunc;
     return function;
 }
 
@@ -172,13 +167,7 @@ std::unique_ptr<ScanReplacementData> tryReplacePD(py::dict& dict, py::str& objec
         if (isPyArrowBacked(entry)) {
             scanReplacementData->func = PyArrowTableScanFunction::getFunction();
         } else {
-<<<<<<< HEAD
             scanReplacementData->func = PandasScanFunction::getFunction();
-=======
-            scanReplacementData->func = TableFunction(PandasScanFunction::name, tableFunc, bindFunc,
-                initSharedState, initLocalState, progressFunc,
-                std::vector<LogicalTypeID>{LogicalTypeID::POINTER}, finalizeFunc);
->>>>>>> ceac2f32d (Support IGNORE_ERRORS when scanning from pyarrow/pandas)
         }
         auto bindInput = TableFuncBindInput();
         bindInput.addLiteralParam(Value::createValue(reinterpret_cast<uint8_t*>(entry.ptr())));


### PR DESCRIPTION
# Description

Adds support for the default `IGNORE_ERRORS` behaviour (skipping rows that trigger PK-related exceptions) when scanning from pandas/pyarrow.

Fixes #4534 

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).