### PR TITLE
Remove unnecessary sink in copy from subquery

### DIFF
--- a/src/include/processor/operator/persistent/node_batch_insert.h
+++ b/src/include/processor/operator/persistent/node_batch_insert.h
@@ -3,7 +3,6 @@
 #include "common/enums/column_evaluate_type.h"
 #include "common/types/types.h"
 #include "expression_evaluator/expression_evaluator.h"
-#include "processor/operator/aggregate/hash_aggregate.h"
 #include "processor/operator/persistent/batch_insert.h"
 #include "processor/operator/persistent/index_builder.h"
 #include "processor/operator/table_function_call.h"
@@ -73,7 +72,6 @@ struct NodeBatchInsertSharedState final : BatchInsertSharedState {
     std::optional<IndexBuilder> globalIndexBuilder;
 
     TableFunctionCallSharedState* readerSharedState;
-    HashAggregateSharedState* distinctSharedState;
 
     std::vector<common::column_id_t> mainDataColumns;
 
@@ -86,7 +84,7 @@ struct NodeBatchInsertSharedState final : BatchInsertSharedState {
         storage::MemoryManager* mm)
         : BatchInsertSharedState{table, std::move(fTable), wal, mm}, pkColumnID{pkColumnID},
           pkType{std::move(pkType)}, globalIndexBuilder(std::nullopt), readerSharedState{nullptr},
-          distinctSharedState{nullptr}, sharedNodeGroup{nullptr} {}
+          sharedNodeGroup{nullptr} {}
 
     void initPKIndex(const ExecutionContext* context);
 };

--- a/src/planner/plan/plan_copy.cpp
+++ b/src/planner/plan/plan_copy.cpp
@@ -71,8 +71,12 @@ std::unique_ptr<LogicalPlan> Planner::planCopyNodeFrom(const BoundCopyFromInfo* 
     case ScanSourceType::QUERY: {
         auto& querySource = info->source->constCast<BoundQueryScanSource>();
         plan = getBestPlan(planQuery(*querySource.statement));
-        appendAccumulate(AccumulateType::REGULAR, plan->getSchema()->getExpressionsInScope(),
-            nullptr /* mark */, *plan);
+        if (plan->getSchema()->getNumGroups() > 1) {
+            // Copy operator assumes all input are in the same data chunk. If this is not the case,
+            // we first materialize input in flat form into a factorized table.
+            appendAccumulate(AccumulateType::REGULAR, plan->getSchema()->getExpressionsInScope(),
+                nullptr /* mark */, *plan);
+        }
     } break;
     default:
         KU_UNREACHABLE;
@@ -104,8 +108,12 @@ std::unique_ptr<LogicalPlan> Planner::planCopyRelFrom(const BoundCopyFromInfo* i
     case ScanSourceType::QUERY: {
         auto& querySource = info->source->constCast<BoundQueryScanSource>();
         plan = getBestPlan(planQuery(*querySource.statement));
-        appendAccumulate(AccumulateType::REGULAR, plan->getSchema()->getExpressionsInScope(),
-            nullptr /* mark */, *plan);
+        if (plan->getSchema()->getNumGroups() > 1) {
+            // Copy operator assumes all input are in the same data chunk. If this is not the case,
+            // we first materialize input in flat form into a factorized table.
+            appendAccumulate(AccumulateType::REGULAR, plan->getSchema()->getExpressionsInScope(),
+                nullptr /* mark */, *plan);
+        }
     } break;
     default:
         KU_UNREACHABLE;

--- a/src/processor/map/map_copy_from.cpp
+++ b/src/processor/map/map_copy_from.cpp
@@ -2,7 +2,6 @@
 #include "catalog/catalog_entry/rel_table_catalog_entry.h"
 #include "planner/operator/logical_partitioner.h"
 #include "planner/operator/persistent/logical_copy_from.h"
-#include "processor/operator/aggregate/hash_aggregate_scan.h"
 #include "processor/operator/index_lookup.h"
 #include "processor/operator/partitioner.h"
 #include "processor/operator/persistent/node_batch_insert.h"
@@ -75,10 +74,6 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyNodeFrom(LogicalOperator* l
     if (prevOperator->getOperatorType() == PhysicalOperatorType::TABLE_FUNCTION_CALL) {
         const auto call = prevOperator->ptrCast<TableFunctionCall>();
         sharedState->readerSharedState = call->getSharedState();
-    } else {
-        KU_ASSERT(prevOperator->getOperatorType() == PhysicalOperatorType::AGGREGATE_SCAN);
-        const auto hashScan = prevOperator->ptrCast<HashAggregateScan>();
-        sharedState->distinctSharedState = hashScan->getSharedState().get();
     }
     // Map copy node.
     std::vector<LogicalType> columnTypes;

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -6,7 +6,6 @@
 #include "function/table/scan_functions.h"
 #include "processor/execution_context.h"
 #include "processor/operator/persistent/index_builder.h"
-#include "processor/result/factorized_table.h"
 #include "processor/result/factorized_table_util.h"
 #include "storage/store/chunked_node_group.h"
 #include "storage/store/node_table.h"
@@ -27,13 +26,9 @@ std::string NodeBatchInsertPrintInfo::toString() const {
 void NodeBatchInsertSharedState::initPKIndex(const ExecutionContext* context) {
     uint64_t numRows = 0;
     if (readerSharedState != nullptr) {
-        KU_ASSERT(distinctSharedState == nullptr);
         const auto scanSharedState =
             readerSharedState->funcState->ptrCast<function::BaseScanSharedState>();
         numRows = scanSharedState->getNumRows();
-    } else {
-        KU_ASSERT(distinctSharedState);
-        numRows = distinctSharedState->getFactorizedTable()->getNumTuples();
     }
     auto* nodeTable = ku_dynamic_cast<NodeTable*>(table);
     nodeTable->getPKIndex()->bulkReserve(numRows);


### PR DESCRIPTION
# Description

Sanity check benchmark. On `wr1` when copying LDBC100 comment. The time goes from 38s to 28s

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).