### PR TITLE
refactor table function constructor

### DIFF
--- a/extension/delta/src/function/delta_scan.cpp
+++ b/extension/delta/src/function/delta_scan.cpp
@@ -73,9 +73,12 @@ std::unique_ptr<TableFuncLocalState> initEmptyLocalState(TableFunctionInitInput&
 
 function_set DeltaScanFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(
-        std::make_unique<TableFunction>(name, tableFunc, bindFunc, initDeltaScanSharedState,
-            initEmptyLocalState, std::vector<LogicalTypeID>{LogicalTypeID::STRING}));
+    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initDeltaScanSharedState;
+    function->initLocalStateFunc = initEmptyLocalState;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/extension/delta/src/function/delta_scan.cpp
+++ b/extension/delta/src/function/delta_scan.cpp
@@ -73,7 +73,8 @@ std::unique_ptr<TableFuncLocalState> initEmptyLocalState(TableFunctionInitInput&
 
 function_set DeltaScanFunction::getFunctionSet() {
     function_set functionSet;
-    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    auto function =
+        std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
     function->tableFunc = tableFunc;
     function->bindFunc = bindFunc;
     function->initSharedStateFunc = initDeltaScanSharedState;

--- a/extension/duckdb/src/function/clear_cache.cpp
+++ b/extension/duckdb/src/function/clear_cache.cpp
@@ -36,8 +36,7 @@ static std::unique_ptr<TableFuncBindData> clearCacheBindFunc(ClientContext* cont
         1 /* maxOffset */);
 }
 
-ClearCacheFunction::ClearCacheFunction()
-    : TableFunction{name, std::vector<LogicalTypeID>{}} {
+ClearCacheFunction::ClearCacheFunction() : TableFunction{name, std::vector<LogicalTypeID>{}} {
     tableFunc = clearCacheTableFunc;
     bindFunc = clearCacheBindFunc;
     initSharedStateFunc = SimpleTableFunction::initSharedState;

--- a/extension/duckdb/src/function/clear_cache.cpp
+++ b/extension/duckdb/src/function/clear_cache.cpp
@@ -37,9 +37,12 @@ static std::unique_ptr<TableFuncBindData> clearCacheBindFunc(ClientContext* cont
 }
 
 ClearCacheFunction::ClearCacheFunction()
-    : TableFunction{name, clearCacheTableFunc, clearCacheBindFunc,
-          function::SimpleTableFunction::initSharedState,
-          function::SimpleTableFunction::initEmptyLocalState, std::vector<LogicalTypeID>{}} {}
+    : TableFunction{name, std::vector<LogicalTypeID>{}} {
+    tableFunc = clearCacheTableFunc;
+    bindFunc = clearCacheBindFunc;
+    initSharedStateFunc = SimpleTableFunction::initSharedState;
+    initLocalStateFunc = SimpleTableFunction::initEmptyLocalState;
+}
 
 } // namespace duckdb_extension
 } // namespace kuzu

--- a/extension/duckdb/src/function/duckdb_scan.cpp
+++ b/extension/duckdb/src/function/duckdb_scan.cpp
@@ -112,10 +112,11 @@ std::unique_ptr<function::TableFuncBindData> DuckDBScanFunction::bindFunc(
 }
 
 TableFunction getScanFunction(DuckDBScanBindData bindData) {
-    auto function = TableFunction(DuckDBScanFunction::DUCKDB_SCAN_FUNC_NAME, std::vector<LogicalTypeID>{});
+    auto function =
+        TableFunction(DuckDBScanFunction::DUCKDB_SCAN_FUNC_NAME, std::vector<LogicalTypeID>{});
     function.tableFunc = DuckDBScanFunction::tableFunc;
-    function.bindFunc = std::bind(DuckDBScanFunction::bindFunc, std::move(bindData), std::placeholders::_1,
-        std::placeholders::_2);
+    function.bindFunc = std::bind(DuckDBScanFunction::bindFunc, std::move(bindData),
+        std::placeholders::_1, std::placeholders::_2);
     function.initSharedStateFunc = DuckDBScanFunction::initSharedState;
     function.initLocalStateFunc = DuckDBScanFunction::initLocalState;
     return function;

--- a/extension/duckdb/src/function/duckdb_scan.cpp
+++ b/extension/duckdb/src/function/duckdb_scan.cpp
@@ -112,11 +112,13 @@ std::unique_ptr<function::TableFuncBindData> DuckDBScanFunction::bindFunc(
 }
 
 TableFunction getScanFunction(DuckDBScanBindData bindData) {
-    return TableFunction(DuckDBScanFunction::DUCKDB_SCAN_FUNC_NAME, DuckDBScanFunction::tableFunc,
-        std::bind(DuckDBScanFunction::bindFunc, std::move(bindData), std::placeholders::_1,
-            std::placeholders::_2),
-        DuckDBScanFunction::initSharedState, DuckDBScanFunction::initLocalState,
-        std::vector<LogicalTypeID>{});
+    auto function = TableFunction(DuckDBScanFunction::DUCKDB_SCAN_FUNC_NAME, std::vector<LogicalTypeID>{});
+    function.tableFunc = DuckDBScanFunction::tableFunc;
+    function.bindFunc = std::bind(DuckDBScanFunction::bindFunc, std::move(bindData), std::placeholders::_1,
+        std::placeholders::_2);
+    function.initSharedStateFunc = DuckDBScanFunction::initSharedState;
+    function.initLocalStateFunc = DuckDBScanFunction::initLocalState;
+    return function;
 }
 
 } // namespace duckdb_extension

--- a/extension/fts/src/function/create_fts_index.cpp
+++ b/extension/fts/src/function/create_fts_index.cpp
@@ -228,9 +228,9 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& /*outp
 
 function_set CreateFTSFunction::getFunctionSet() {
     function_set functionSet;
-    auto func = std::make_unique<TableFunction>(name,
-        std::vector<LogicalTypeID>{LogicalTypeID::STRING, LogicalTypeID::STRING,
-            LogicalTypeID::LIST});
+    auto func =
+        std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING,
+                                                  LogicalTypeID::STRING, LogicalTypeID::LIST});
     func->tableFunc = tableFunc;
     func->bindFunc = bindFunc;
     func->initSharedStateFunc = initSharedState;

--- a/extension/fts/src/function/create_fts_index.cpp
+++ b/extension/fts/src/function/create_fts_index.cpp
@@ -228,10 +228,13 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& /*outp
 
 function_set CreateFTSFunction::getFunctionSet() {
     function_set functionSet;
-    auto func = std::make_unique<TableFunction>(name, tableFunc, bindFunc, initSharedState,
-        initEmptyLocalState,
+    auto func = std::make_unique<TableFunction>(name,
         std::vector<LogicalTypeID>{LogicalTypeID::STRING, LogicalTypeID::STRING,
             LogicalTypeID::LIST});
+    func->tableFunc = tableFunc;
+    func->bindFunc = bindFunc;
+    func->initSharedStateFunc = initSharedState;
+    func->initLocalStateFunc = initEmptyLocalState;
     func->rewriteFunc = createFTSIndexQuery;
     func->canParallelFunc = []() { return false; };
     functionSet.push_back(std::move(func));

--- a/extension/fts/src/function/drop_fts_index.cpp
+++ b/extension/fts/src/function/drop_fts_index.cpp
@@ -49,9 +49,12 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& /*outp
 
 function_set DropFTSFunction::getFunctionSet() {
     function_set functionSet;
-    auto func = std::make_unique<TableFunction>(name, tableFunc, bindFunc, initSharedState,
-        initEmptyLocalState,
+    auto func = std::make_unique<TableFunction>(name,
         std::vector<LogicalTypeID>{LogicalTypeID::STRING, LogicalTypeID::STRING});
+    func->tableFunc = tableFunc;
+    func->bindFunc = bindFunc;
+    func->initSharedStateFunc = initSharedState;
+    func->initLocalStateFunc = initEmptyLocalState;
     func->rewriteFunc = dropFTSIndexQuery;
     func->canParallelFunc = []() { return false; };
     functionSet.push_back(std::move(func));

--- a/extension/iceberg/src/function/iceberg_metadata.cpp
+++ b/extension/iceberg/src/function/iceberg_metadata.cpp
@@ -13,9 +13,12 @@ std::unique_ptr<TableFuncBindData> metadataBindFunc(main::ClientContext* context
 
 function_set IcebergMetadataFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(std::make_unique<TableFunction>(name, delta_extension::tableFunc,
-        metadataBindFunc, delta_extension::initDeltaScanSharedState,
-        delta_extension::initEmptyLocalState, std::vector<LogicalTypeID>{LogicalTypeID::STRING}));
+    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    function->tableFunc = delta_extension::tableFunc;
+    function->bindFunc = metadataBindFunc;
+    function->initSharedStateFunc = delta_extension::initDeltaScanSharedState;
+    function->initLocalStateFunc = delta_extension::initEmptyLocalState;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/extension/iceberg/src/function/iceberg_metadata.cpp
+++ b/extension/iceberg/src/function/iceberg_metadata.cpp
@@ -13,7 +13,8 @@ std::unique_ptr<TableFuncBindData> metadataBindFunc(main::ClientContext* context
 
 function_set IcebergMetadataFunction::getFunctionSet() {
     function_set functionSet;
-    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    auto function =
+        std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
     function->tableFunc = delta_extension::tableFunc;
     function->bindFunc = metadataBindFunc;
     function->initSharedStateFunc = delta_extension::initDeltaScanSharedState;

--- a/extension/iceberg/src/function/iceberg_scan.cpp
+++ b/extension/iceberg/src/function/iceberg_scan.cpp
@@ -13,9 +13,12 @@ std::unique_ptr<TableFuncBindData> scanBindFunc(main::ClientContext* context,
 
 function_set IcebergScanFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(std::make_unique<TableFunction>(name, delta_extension::tableFunc,
-        scanBindFunc, delta_extension::initDeltaScanSharedState,
-        delta_extension::initEmptyLocalState, std::vector<LogicalTypeID>{LogicalTypeID::STRING}));
+    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    function->tableFunc = delta_extension::tableFunc;
+    function->bindFunc = scanBindFunc;
+    function->initSharedStateFunc = delta_extension::initDeltaScanSharedState;
+    function->initLocalStateFunc = delta_extension::initEmptyLocalState;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/extension/iceberg/src/function/iceberg_scan.cpp
+++ b/extension/iceberg/src/function/iceberg_scan.cpp
@@ -13,7 +13,8 @@ std::unique_ptr<TableFuncBindData> scanBindFunc(main::ClientContext* context,
 
 function_set IcebergScanFunction::getFunctionSet() {
     function_set functionSet;
-    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    auto function =
+        std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
     function->tableFunc = delta_extension::tableFunc;
     function->bindFunc = scanBindFunc;
     function->initSharedStateFunc = delta_extension::initDeltaScanSharedState;

--- a/extension/iceberg/src/function/iceberg_snapshots.cpp
+++ b/extension/iceberg/src/function/iceberg_snapshots.cpp
@@ -13,7 +13,8 @@ static std::unique_ptr<TableFuncBindData> snapshotBindFunc(main::ClientContext* 
 
 function_set IcebergSnapshotsFunction::getFunctionSet() {
     function_set functionSet;
-    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    auto function =
+        std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
     function->tableFunc = delta_extension::tableFunc;
     function->bindFunc = snapshotBindFunc;
     function->initSharedStateFunc = delta_extension::initDeltaScanSharedState;

--- a/extension/iceberg/src/function/iceberg_snapshots.cpp
+++ b/extension/iceberg/src/function/iceberg_snapshots.cpp
@@ -13,9 +13,12 @@ static std::unique_ptr<TableFuncBindData> snapshotBindFunc(main::ClientContext* 
 
 function_set IcebergSnapshotsFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(std::make_unique<TableFunction>(name, delta_extension::tableFunc,
-        snapshotBindFunc, delta_extension::initDeltaScanSharedState,
-        delta_extension::initEmptyLocalState, std::vector<LogicalTypeID>{LogicalTypeID::STRING}));
+    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    function->tableFunc = delta_extension::tableFunc;
+    function->bindFunc = snapshotBindFunc;
+    function->initSharedStateFunc = delta_extension::initDeltaScanSharedState;
+    function->initLocalStateFunc = delta_extension::initEmptyLocalState;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/extension/json/src/functions/table_functions/json_scan.cpp
+++ b/extension/json/src/functions/table_functions/json_scan.cpp
@@ -899,8 +899,13 @@ static void finalizeFunc(processor::ExecutionContext* ctx, TableFuncSharedState*
 
 std::unique_ptr<TableFunction> JsonScan::getFunction() {
     auto func =
-        std::make_unique<TableFunction>(name, tableFunc, bindFunc, initSharedState, initLocalState,
-            progressFunc, std::vector<LogicalTypeID>{LogicalTypeID::STRING}, finalizeFunc);
+        std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    func->tableFunc = tableFunc;
+    func->bindFunc = bindFunc;
+    func->initSharedStateFunc = initSharedState;
+    func->initLocalStateFunc = initLocalState;
+    func->progressFunc = progressFunc;
+    func->finalizeFunc = finalizeFunc;
     return func;
 }
 

--- a/src/function/table/call/bm_info.cpp
+++ b/src/function/table/call/bm_info.cpp
@@ -46,8 +46,12 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
 
 function_set BMInfoFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(std::make_unique<TableFunction>(name, tableFunc, bindFunc,
-        initSharedState, initEmptyLocalState, std::vector<common::LogicalTypeID>{}));
+    auto function = std::make_unique<TableFunction>(name, std::vector<common::LogicalTypeID>{});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initEmptyLocalState;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/src/function/table/call/clear_warnings.cpp
+++ b/src/function/table/call/clear_warnings.cpp
@@ -19,8 +19,11 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* /*contex
 
 function_set ClearWarningsFunction::getFunctionSet() {
     function_set functionSet;
-    auto func = std::make_unique<TableFunction>(name, tableFunc, bindFunc, initSharedState,
-        initEmptyLocalState, std::vector<LogicalTypeID>{});
+    auto func = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{});
+    func->tableFunc = tableFunc;
+    func->bindFunc = bindFunc;
+    func->initSharedStateFunc = initSharedState;
+    func->initLocalStateFunc = initEmptyLocalState;
     func->canParallelFunc = []() { return false; };
     functionSet.push_back(std::move(func));
     return functionSet;

--- a/src/function/table/call/current_setting.cpp
+++ b/src/function/table/call/current_setting.cpp
@@ -47,8 +47,12 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
 
 function_set CurrentSettingFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(std::make_unique<TableFunction>(name, tableFunc, bindFunc,
-        initSharedState, initEmptyLocalState, std::vector<LogicalTypeID>{LogicalTypeID::STRING}));
+    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initEmptyLocalState;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/src/function/table/call/current_setting.cpp
+++ b/src/function/table/call/current_setting.cpp
@@ -47,7 +47,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
 
 function_set CurrentSettingFunction::getFunctionSet() {
     function_set functionSet;
-    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    auto function =
+        std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
     function->tableFunc = tableFunc;
     function->bindFunc = bindFunc;
     function->initSharedStateFunc = initSharedState;

--- a/src/function/table/call/db_version.cpp
+++ b/src/function/table/call/db_version.cpp
@@ -30,8 +30,12 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext*, TableFuncBind
 
 function_set DBVersionFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(std::make_unique<TableFunction>(name, tableFunc, bindFunc,
-        initSharedState, initEmptyLocalState, std::vector<LogicalTypeID>{}));
+    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initEmptyLocalState;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/src/function/table/call/show_attached_databases.cpp
+++ b/src/function/table/call/show_attached_databases.cpp
@@ -56,8 +56,12 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
 
 function_set ShowAttachedDatabasesFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(std::make_unique<TableFunction>(name, tableFunc, bindFunc,
-        initSharedState, initEmptyLocalState, std::vector<LogicalTypeID>{}));
+    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initEmptyLocalState;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/src/function/table/call/show_connection.cpp
+++ b/src/function/table/call/show_connection.cpp
@@ -113,8 +113,12 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
 
 function_set ShowConnectionFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(std::make_unique<TableFunction>(name, tableFunc, bindFunc,
-        initSharedState, initEmptyLocalState, std::vector<LogicalTypeID>{LogicalTypeID::STRING}));
+    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initEmptyLocalState;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/src/function/table/call/show_connection.cpp
+++ b/src/function/table/call/show_connection.cpp
@@ -113,7 +113,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
 
 function_set ShowConnectionFunction::getFunctionSet() {
     function_set functionSet;
-    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    auto function =
+        std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
     function->tableFunc = tableFunc;
     function->bindFunc = bindFunc;
     function->initSharedStateFunc = initSharedState;

--- a/src/function/table/call/show_functions.cpp
+++ b/src/function/table/call/show_functions.cpp
@@ -73,8 +73,12 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
 
 function_set ShowFunctionsFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(std::make_unique<TableFunction>(name, tableFunc, bindFunc,
-        initSharedState, initEmptyLocalState, std::vector<LogicalTypeID>{}));
+    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initEmptyLocalState;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/src/function/table/call/show_sequences.cpp
+++ b/src/function/table/call/show_sequences.cpp
@@ -108,8 +108,12 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
 
 function_set ShowSequencesFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(std::make_unique<TableFunction>(name, tableFunc, bindFunc,
-        initSharedState, initEmptyLocalState, std::vector<LogicalTypeID>{}));
+    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initEmptyLocalState;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/src/function/table/call/show_tables.cpp
+++ b/src/function/table/call/show_tables.cpp
@@ -97,8 +97,12 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
 
 function_set ShowTablesFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(std::make_unique<TableFunction>(name, tableFunc, bindFunc,
-        initSharedState, initEmptyLocalState, std::vector<LogicalTypeID>{}));
+    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initEmptyLocalState;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/src/function/table/call/show_warnings.cpp
+++ b/src/function/table/call/show_warnings.cpp
@@ -56,8 +56,12 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
 
 function_set ShowWarningsFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(std::make_unique<TableFunction>(name, tableFunc, bindFunc,
-        initSharedState, initEmptyLocalState, std::vector<LogicalTypeID>{}));
+    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initEmptyLocalState;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/src/function/table/call/stats_info.cpp
+++ b/src/function/table/call/stats_info.cpp
@@ -87,8 +87,12 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
 
 function_set StatsInfoFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(std::make_unique<TableFunction>(name, tableFunc, bindFunc,
-        initSharedState, initLocalState, std::vector{LogicalTypeID::STRING}));
+    auto function = std::make_unique<TableFunction>(name, std::vector{LogicalTypeID::STRING});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initLocalState;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/src/function/table/call/storage_info.cpp
+++ b/src/function/table/call/storage_info.cpp
@@ -359,7 +359,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
 
 function_set StorageInfoFunction::getFunctionSet() {
     function_set functionSet;
-    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    auto function =
+        std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
     function->tableFunc = tableFunc;
     function->bindFunc = bindFunc;
     function->initSharedStateFunc = initSharedState;

--- a/src/function/table/call/storage_info.cpp
+++ b/src/function/table/call/storage_info.cpp
@@ -359,8 +359,12 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
 
 function_set StorageInfoFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(std::make_unique<TableFunction>(name, tableFunc, bindFunc,
-        initSharedState, initLocalState, std::vector<LogicalTypeID>{LogicalTypeID::STRING}));
+    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initLocalState;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/src/function/table/call/table_info.cpp
+++ b/src/function/table/call/table_info.cpp
@@ -107,7 +107,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
 
 function_set TableInfoFunction::getFunctionSet() {
     function_set functionSet;
-    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    auto function =
+        std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
     function->tableFunc = tableFunc;
     function->bindFunc = bindFunc;
     function->initSharedStateFunc = initSharedState;

--- a/src/function/table/call/table_info.cpp
+++ b/src/function/table/call/table_info.cpp
@@ -107,8 +107,12 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
 
 function_set TableInfoFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(std::make_unique<TableFunction>(name, tableFunc, bindFunc,
-        initSharedState, initEmptyLocalState, std::vector<LogicalTypeID>{LogicalTypeID::STRING}));
+    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initEmptyLocalState;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/src/include/function/table_functions.h
+++ b/src/include/function/table_functions.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <optional>
-
 #include "common/data_chunk/data_chunk.h"
 #include "function.h"
 
@@ -96,36 +94,12 @@ struct KUZU_API TableFunction : public Function {
     table_func_can_parallel_t canParallelFunc = [] { return true; };
     table_func_progress_t progressFunc = [](TableFuncSharedState*) { return 0.0; };
     table_func_finalize_t finalizeFunc = [](auto, auto) {};
-    table_func_rewrite_t rewriteFunc;
+    table_func_rewrite_t rewriteFunc = nullptr;
 
-    TableFunction()
-        : Function{}, tableFunc{nullptr}, bindFunc{nullptr}, initSharedStateFunc{nullptr},
-          initLocalStateFunc{nullptr} {};
+    TableFunction() : Function{} {};
     TableFunction(std::string name, std::vector<common::LogicalTypeID> inputTypes)
         : Function{name, inputTypes} {}
-    TableFunction(std::string name, table_func_t tableFunc, table_func_bind_t bindFunc,
-        table_func_init_shared_t initSharedFunc, table_func_init_local_t initLocalFunc,
-        std::vector<common::LogicalTypeID> inputTypes,
-        std::optional<table_func_finalize_t> finalizeFunc = {})
-        : Function{std::move(name), std::move(inputTypes)}, tableFunc{tableFunc},
-          bindFunc{bindFunc}, initSharedStateFunc{initSharedFunc},
-          initLocalStateFunc{initLocalFunc} {
-        if (finalizeFunc.has_value()) {
-            this->finalizeFunc = finalizeFunc.value();
-        }
-    }
-    TableFunction(std::string name, table_func_t tableFunc, table_func_bind_t bindFunc,
-        table_func_init_shared_t initSharedFunc, table_func_init_local_t initLocalFunc,
-        table_func_progress_t progressFunc, std::vector<common::LogicalTypeID> inputTypes,
-        std::optional<table_func_finalize_t> finalizeFunc = {})
-        : Function{std::move(name), std::move(inputTypes)}, tableFunc{tableFunc},
-          bindFunc{bindFunc}, initSharedStateFunc{initSharedFunc},
-          initLocalStateFunc{initLocalFunc}, progressFunc(progressFunc) {
-        if (finalizeFunc.has_value()) {
-            this->finalizeFunc = finalizeFunc.value();
-        }
-    }
-
+    
     std::string signatureToString() const override {
         return common::LogicalTypeUtils::toString(parameterTypeIDs);
     }

--- a/src/include/function/table_functions.h
+++ b/src/include/function/table_functions.h
@@ -99,7 +99,7 @@ struct KUZU_API TableFunction : public Function {
     TableFunction() : Function{} {};
     TableFunction(std::string name, std::vector<common::LogicalTypeID> inputTypes)
         : Function{name, inputTypes} {}
-    
+
     std::string signatureToString() const override {
         return common::LogicalTypeUtils::toString(parameterTypeIDs);
     }

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
+#include <optional>
 
 #include "common/timer.h"
 #include "common/types/value/value.h"

--- a/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
@@ -317,9 +317,14 @@ static void finalizeFunc(ExecutionContext* ctx, TableFuncSharedState* sharedStat
 
 function_set ParallelCSVScan::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(
-        std::make_unique<TableFunction>(name, tableFunc, bindFunc, initSharedState, initLocalState,
-            progressFunc, std::vector<LogicalTypeID>{LogicalTypeID::STRING}, finalizeFunc));
+    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initLocalState;
+    function->progressFunc = progressFunc;
+    function->finalizeFunc = finalizeFunc;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
@@ -317,7 +317,8 @@ static void finalizeFunc(ExecutionContext* ctx, TableFuncSharedState* sharedStat
 
 function_set ParallelCSVScan::getFunctionSet() {
     function_set functionSet;
-    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    auto function =
+        std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
     function->tableFunc = tableFunc;
     function->bindFunc = bindFunc;
     function->initSharedStateFunc = initSharedState;

--- a/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
@@ -271,9 +271,14 @@ static double progressFunc(TableFuncSharedState* sharedState) {
 
 function_set SerialCSVScan::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(
-        std::make_unique<TableFunction>(name, tableFunc, bindFunc, initSharedState, initLocalState,
-            progressFunc, std::vector<LogicalTypeID>{LogicalTypeID::STRING}, finalizeFunc));
+    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initLocalState;
+    function->progressFunc = progressFunc;
+    function->finalizeFunc = finalizeFunc;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
@@ -271,7 +271,8 @@ static double progressFunc(TableFuncSharedState* sharedState) {
 
 function_set SerialCSVScan::getFunctionSet() {
     function_set functionSet;
-    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    auto function =
+        std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
     function->tableFunc = tableFunc;
     function->bindFunc = bindFunc;
     function->initSharedStateFunc = initSharedState;

--- a/src/processor/operator/persistent/reader/npy/npy_reader.cpp
+++ b/src/processor/operator/persistent/reader/npy/npy_reader.cpp
@@ -345,8 +345,8 @@ static std::unique_ptr<function::TableFuncLocalState> initLocalState(
 
 function_set NpyScanFunction::getFunctionSet() {
     function_set functionSet;
-    auto function = std::make_unique<TableFunction>(name,
-        std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    auto function =
+        std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
     function->tableFunc = tableFunc;
     function->bindFunc = bindFunc;
     function->initSharedStateFunc = initSharedState;

--- a/src/processor/operator/persistent/reader/npy/npy_reader.cpp
+++ b/src/processor/operator/persistent/reader/npy/npy_reader.cpp
@@ -345,9 +345,14 @@ static std::unique_ptr<function::TableFuncLocalState> initLocalState(
 
 function_set NpyScanFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(
-        std::make_unique<TableFunction>(name, tableFunc, bindFunc, initSharedState, initLocalState,
-            std::vector<LogicalTypeID>{LogicalTypeID::STRING}, finalizeFunc));
+    auto function = std::make_unique<TableFunction>(name,
+        std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initLocalState;
+    function->finalizeFunc = finalizeFunc;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -731,7 +731,8 @@ static void finalizeFunc(ExecutionContext* ctx, TableFuncSharedState*) {
 
 function_set ParquetScanFunction::getFunctionSet() {
     function_set functionSet;
-    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    auto function =
+        std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
     function->tableFunc = tableFunc;
     function->bindFunc = bindFunc;
     function->initSharedStateFunc = initSharedState;

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -731,9 +731,14 @@ static void finalizeFunc(ExecutionContext* ctx, TableFuncSharedState*) {
 
 function_set ParquetScanFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(
-        std::make_unique<TableFunction>(name, tableFunc, bindFunc, initSharedState, initLocalState,
-            progressFunc, std::vector<LogicalTypeID>{LogicalTypeID::STRING}, finalizeFunc));
+    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initLocalState;
+    function->progressFunc = progressFunc;
+    function->finalizeFunc = finalizeFunc;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/src/processor/operator/table_scan/ftable_scan_function.cpp
+++ b/src/processor/operator/table_scan/ftable_scan_function.cpp
@@ -64,8 +64,11 @@ static std::unique_ptr<TableFuncLocalState> initLocalState(TableFunctionInitInpu
 
 function_set FTableScan::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(std::make_unique<TableFunction>(name, tableFunc, nullptr /*bindFunc*/,
-        initSharedState, initLocalState, std::vector<LogicalTypeID>{}));
+    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{});
+    function->tableFunc = tableFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initLocalState;
+    functionSet.push_back(std::move(function));
     return functionSet;
 }
 

--- a/tools/python_api/src_cpp/include/pandas/pandas_scan.h
+++ b/tools/python_api/src_cpp/include/pandas/pandas_scan.h
@@ -27,6 +27,7 @@ struct PandasScanFunction {
     static constexpr const char* name = "READ_PANDAS";
 
     static function::function_set getFunctionSet();
+    static function::TableFunction getFunction();
 };
 
 struct PandasScanFunctionData : public function::TableFuncBindData {
@@ -45,17 +46,16 @@ struct PandasScanFunctionData : public function::TableFuncBindData {
 
     std::vector<std::unique_ptr<PandasColumnBindData>> copyColumnBindData() const;
 
+    std::unique_ptr<function::TableFuncBindData> copy() const override {
+        return std::unique_ptr<PandasScanFunctionData>(new PandasScanFunctionData(*this));
+    }
+
 private:
     PandasScanFunctionData(const PandasScanFunctionData& other)
         : TableFuncBindData{other}, df{other.df} {
         for (const auto& i : other.columnBindData) {
             columnBindData.push_back(i->copy());
         }
-    }
-
-public:
-    std::unique_ptr<function::TableFuncBindData> copy() const override {
-        return std::unique_ptr<PandasScanFunctionData>(new PandasScanFunctionData(*this));
     }
 };
 

--- a/tools/python_api/src_cpp/pandas/pandas_scan.cpp
+++ b/tools/python_api/src_cpp/pandas/pandas_scan.cpp
@@ -128,8 +128,7 @@ function_set PandasScanFunction::getFunctionSet() {
 }
 
 function::TableFunction PandasScanFunction::getFunction() {
-    auto function = TableFunction(name,
-        std::vector<LogicalTypeID>{LogicalTypeID::POINTER});
+    auto function = TableFunction(name, std::vector<LogicalTypeID>{LogicalTypeID::POINTER});
     function.tableFunc = tableFunc;
     function.bindFunc = bindFunc;
     function.initSharedStateFunc = initSharedState;

--- a/tools/python_api/src_cpp/pyarrow/pyarrow_scan.cpp
+++ b/tools/python_api/src_cpp/pyarrow/pyarrow_scan.cpp
@@ -144,15 +144,18 @@ static double progressFunc(function::TableFuncSharedState* sharedState) {
 
 function::function_set PyArrowTableScanFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(
-        std::make_unique<TableFunction>(name, tableFunc, bindFunc, initSharedState, initLocalState,
-            progressFunc, std::vector<LogicalTypeID>{LogicalTypeID::POINTER}));
+    functionSet.push_back(getFunction().copy());
     return functionSet;
 }
 
 TableFunction PyArrowTableScanFunction::getFunction() {
-    return TableFunction(name, tableFunc, bindFunc, initSharedState, initLocalState, progressFunc,
-        std::vector<LogicalTypeID>{LogicalTypeID::POINTER});
+    auto function = TableFunction(name, std::vector<LogicalTypeID>{LogicalTypeID::POINTER});
+    function.tableFunc = tableFunc;
+    function.bindFunc = bindFunc;
+    function.initSharedStateFunc = initSharedState;
+    function.initLocalStateFunc = initLocalState;
+    function.progressFunc = progressFunc;
+    return function;
 }
 
 } // namespace kuzu


### PR DESCRIPTION
# Description

As we introduce more member fields in table function, the constructor is getting very bulky. I'm removing constructors and let each function sets its own field.

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).