### PR TITLE
Hash join flatten fix

### DIFF
--- a/src/include/planner/operator/logical_hash_join.h
+++ b/src/include/planner/operator/logical_hash_join.h
@@ -59,9 +59,6 @@ public:
     static bool isNodeIDOnlyJoin(const std::vector<join_condition_t>& joinConditions);
 
 private:
-    bool isJoinKeyUniqueOnBuildSide(const binder::Expression& joinNodeID);
-
-private:
     std::vector<join_condition_t> joinConditions;
     common::JoinType joinType;
     std::shared_ptr<binder::Expression> mark; // when joinType is Mark or Left


### PR DESCRIPTION
# Description

This PR fixes a bug in hash join planning exposed in PR #4625. Below is a description of the bug.

We append flatten to probe side if and only if join key is an internal ID and this ID is guaranteed to be unique on the build side. The check was done based on number of factorization group. This is not true if an aggregation happens, which will always reduce the number of factorization group to 1.

This PR checks by looking at operators along the build side subplan. 

### Testing

The bug cannot be revealed easily on master because we don't reorder multi-part queries. So aggregation does not happen on build side. I have tested by cherry-picking to #4625. 

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).