### PR TITLE
Add more complete order by key types check

### DIFF
--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -284,6 +284,7 @@ public:
     /*** validations ***/
     static void validateOrderByFollowedBySkipOrLimitInWithClause(
         const BoundProjectionBody& boundProjectionBody);
+    static bool isOrderByKeyTypeSupported(const common::LogicalType& dataType);
 
     void validateTableType(common::table_id_t tableID, common::TableType expectedTableType);
     void validateTableExist(const std::string& tableName);

--- a/src/processor/operator/order_by/order_by_key_encoder.cpp
+++ b/src/processor/operator/order_by/order_by_key_encoder.cpp
@@ -5,7 +5,6 @@
 
 #include "common/exception/runtime.h"
 #include "common/string_format.h"
-#include "common/string_utils.h"
 #include "common/utils.h"
 #include "storage/storage_utils.h"
 

--- a/src/processor/operator/order_by/order_by_key_encoder.cpp
+++ b/src/processor/operator/order_by/order_by_key_encoder.cpp
@@ -5,9 +5,9 @@
 
 #include "common/exception/runtime.h"
 #include "common/string_format.h"
+#include "common/string_utils.h"
 #include "common/utils.h"
 #include "storage/storage_utils.h"
-#include <common/string_utils.h>
 
 using namespace kuzu::common;
 using namespace kuzu::storage;

--- a/src/processor/operator/order_by/order_by_key_encoder.cpp
+++ b/src/processor/operator/order_by/order_by_key_encoder.cpp
@@ -7,6 +7,7 @@
 #include "common/string_format.h"
 #include "common/utils.h"
 #include "storage/storage_utils.h"
+#include <common/string_utils.h>
 
 using namespace kuzu::common;
 using namespace kuzu::storage;

--- a/test/test_files/exceptions/binder/binder_error.test
+++ b/test/test_files/exceptions/binder/binder_error.test
@@ -614,3 +614,43 @@ Binder exception: Table type mismatch.
 -STATEMENT CALL show_tables();
 ---- error
 Binder exception: Only standalone table functions can be called without return statement.
+
+-LOG UnsupportedOrderByNode
+-STATEMENT MATCH (a:person) RETURN a ORDER BY a;
+---- error
+Binder exception: Cannot order by a. Order by NODE is not supported.
+
+-LOG UnsupportedOrderByRel
+-STATEMENT MATCH (a:person)-[e:knows]->(b:person) RETURN a,e,b ORDER BY e;
+---- error
+Binder exception: Cannot order by e. Order by REL is not supported.
+
+-LOG UnsupportedOrderByInternalID
+-STATEMENT MATCH (a:person) RETURN a ORDER BY ID(a);
+---- error
+Binder exception: Cannot order by a._ID. Order by INTERNAL_ID is not supported.
+
+-LOG UnsupportedOrderByList
+-STATEMENT MATCH (a:person) RETURN a ORDER BY a.workedHours;
+---- error
+Binder exception: Cannot order by a.workedHours. Order by INT64[] is not supported.
+
+-LOG UnsupportedOrderByArray
+-STATEMENT MATCH (a:person) RETURN a ORDER BY a.grades;
+---- error
+Binder exception: Cannot order by a.grades. Order by INT64[4] is not supported.
+
+-LOG UnsupportedOrderByStruct
+-STATEMENT MATCH (a:movies) RETURN a ORDER BY a.description;
+---- error
+Binder exception: Cannot order by a.description. Order by STRUCT(rating DOUBLE, stars INT8, views INT64, release TIMESTAMP, release_ns TIMESTAMP_NS, release_ms TIMESTAMP_MS, release_sec TIMESTAMP_SEC, release_tz TIMESTAMP_TZ, film DATE, u8 UINT8, u16 UINT16, u32 UINT32, u64 UINT64, hugedata INT128) is not supported.
+
+-LOG UnsupportedOrderByMap
+-STATEMENT MATCH (a:movies) RETURN a ORDER BY a.audience;
+---- error
+Binder exception: Cannot order by a.audience. Order by MAP(STRING, INT64) is not supported.
+
+-LOG UnsupportedOrderByUnion
+-STATEMENT MATCH (a:movies) RETURN a ORDER BY a.grade;
+---- error
+Binder exception: Cannot order by a.grade. Order by UNION(credit BOOL, grade1 DOUBLE, grade2 INT64) is not supported.

--- a/test/test_files/order_by/multi_label.test
+++ b/test/test_files/order_by/multi_label.test
@@ -15,8 +15,11 @@
 325
 325
 
-# -LOG MultiLabelTest2
-# -STATEMENT MATCH (a:person)-[e:marries|:workAt]->(b:person) return a.ID, b.ID order by ID(e) desc LIMIT 4
+# TODO(Ziyi): Support order by INTERNAL_ID.
+-LOG MultiLabelTest2
+-STATEMENT MATCH (a:person)-[e:marries|:workAt]->(b:person) return a.ID, b.ID order by ID(e) desc LIMIT 4
+---- error
+Binder exception: Cannot order by e._ID. Order by INTERNAL_ID is not supported.
 # ---- 4
 # 7|8
 # 3|5


### PR DESCRIPTION
# Description

Add more binder type checks for order by key expression.
Follow-up from the conversion in #4669.