### PR TITLE
Rework auto begin/commit/rollback transaction during query lifetime

### DIFF
--- a/extension/fts/src/function/drop_fts_index.cpp
+++ b/extension/fts/src/function/drop_fts_index.cpp
@@ -41,7 +41,7 @@ std::string dropFTSIndexQuery(const ClientContext& /*context*/, const TableFuncB
 static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput& /*output*/) {
     auto& ftsBindData = *input.bindData->constPtrCast<FTSBindData>();
     auto& context = *input.context;
-    context.clientContext->getCatalog()->dropIndex(input.context->clientContext->getTx(),
+    context.clientContext->getCatalog()->dropIndex(input.context->clientContext->getTransaction(),
         ftsBindData.tableID, ftsBindData.indexName);
     return 0;
 }

--- a/extension/fts/src/function/fts_utils.cpp
+++ b/extension/fts/src/function/fts_utils.cpp
@@ -9,10 +9,11 @@ namespace fts_extension {
 
 catalog::NodeTableCatalogEntry& FTSUtils::bindTable(const std::string& tableName,
     main::ClientContext* context, std::string indexName, IndexOperation operation) {
-    if (!context->getCatalog()->containsTable(context->getTx(), tableName)) {
+    if (!context->getCatalog()->containsTable(context->getTransaction(), tableName)) {
         throw common::BinderException{common::stringFormat("Table {} does not exist.", tableName)};
     }
-    auto tableEntry = context->getCatalog()->getTableCatalogEntry(context->getTx(), tableName);
+    auto tableEntry =
+        context->getCatalog()->getTableCatalogEntry(context->getTransaction(), tableName);
     if (tableEntry->getTableType() != common::TableType::NODE) {
         switch (operation) {
         case IndexOperation::CREATE:
@@ -34,8 +35,8 @@ catalog::NodeTableCatalogEntry& FTSUtils::bindTable(const std::string& tableName
 
 void FTSUtils::validateIndexExistence(const main::ClientContext& context,
     common::table_id_t tableID, std::string indexName) {
-    if (!context.getCatalog()->containsIndex(context.getTx(), tableID, indexName)) {
-        auto tableName = context.getCatalog()->getTableName(context.getTx(), tableID);
+    if (!context.getCatalog()->containsIndex(context.getTransaction(), tableID, indexName)) {
+        auto tableName = context.getCatalog()->getTableName(context.getTransaction(), tableID);
         throw common::BinderException{common::stringFormat(
             "Table: {} doesn't have an index with name: {}.", tableName, indexName)};
     }

--- a/extension/fts/test/test_files/error.test
+++ b/extension/fts/test/test_files/error.test
@@ -58,6 +58,8 @@ Binder exception: Table: person doesn't have an index with name: personIdx.
 Binder exception: CREATE_FTS_INDEX is only supported in auto transaction mode.
 
 -LOG DropFTSInManualTrx
+-STATEMENT BEGIN TRANSACTION
+---- ok
 -STATEMENT CALL DROP_FTS_INDEX('person1', 'contentIdx')
 ---- error
 Binder exception: DROP_FTS_INDEX is only supported in auto transaction mode.

--- a/extension/httpfs/src/cached_file_manager.cpp
+++ b/extension/httpfs/src/cached_file_manager.cpp
@@ -33,7 +33,7 @@ std::unique_ptr<FileInfo> CachedFileManager::getCachedFileInfo(HTTPFileInfo* htt
 }
 
 void CachedFileManager::cleanUP(main::ClientContext* context) {
-    auto cacheDirForTrx = getCachedDirForTrx(context->getTx()->getID());
+    auto cacheDirForTrx = getCachedDirForTrx(context->getTransaction()->getID());
     vfs->removeFileIfExists(cacheDirForTrx);
 }
 

--- a/extension/httpfs/src/httpfs.cpp
+++ b/extension/httpfs/src/httpfs.cpp
@@ -110,7 +110,7 @@ void HTTPFileInfo::initialize(main::ClientContext* context) {
     if (httpConfig.cacheFile) {
         auto hfs = fileSystem->ptrCast<HTTPFileSystem>();
         cachedFileInfo =
-            hfs->getCachedFileManager().getCachedFileInfo(this, context->getTx()->getID());
+            hfs->getCachedFileManager().getCachedFileInfo(this, context->getTransaction()->getID());
         return;
     }
     initMetadata();

--- a/src/binder/bind/bind_create_macro.cpp
+++ b/src/binder/bind/bind_create_macro.cpp
@@ -17,7 +17,7 @@ std::unique_ptr<BoundStatement> Binder::bindCreateMacro(const Statement& stateme
     auto& createMacro = ku_dynamic_cast<const CreateMacro&>(statement);
     auto macroName = createMacro.getMacroName();
     StringUtils::toUpper(macroName);
-    if (clientContext->getCatalog()->containsMacro(clientContext->getTx(), macroName)) {
+    if (clientContext->getCatalog()->containsMacro(clientContext->getTransaction(), macroName)) {
         throw BinderException{stringFormat("Macro {} already exists.", macroName)};
     }
     parser::default_macro_args defaultArgs;

--- a/src/binder/bind/bind_export_database.cpp
+++ b/src/binder/bind/bind_export_database.cpp
@@ -90,7 +90,7 @@ bool Binder::bindExportTableData(ExportedTableData& tableData, const TableCatalo
     if (!bindExportQuery(exportQuery, entry, catalog, tx)) {
         return false;
     }
-    auto parsedStatement = Parser::parseQuery(exportQuery, clientContext);
+    auto parsedStatement = Parser::parseQuery(exportQuery);
     KU_ASSERT(parsedStatement.size() == 1);
     auto parsedQuery = parsedStatement[0]->constPtrCast<RegularQuery>();
     auto query = bindQuery(*parsedQuery);
@@ -108,7 +108,8 @@ std::unique_ptr<BoundStatement> Binder::bindExportDatabaseClause(const Statement
     auto& exportDB = statement.constCast<ExportDB>();
     auto boundFilePath =
         clientContext->getVFSUnsafe()->expandPath(clientContext, exportDB.getFilePath());
-    auto exportData = getExportInfo(*clientContext->getCatalog(), clientContext->getTx(), this);
+    auto exportData =
+        getExportInfo(*clientContext->getCatalog(), clientContext->getTransaction(), this);
     auto parsedOptions = bindParsingOptions(exportDB.getParsingOptionsRef());
     auto fileTypeInfo = getFileType(parsedOptions);
     switch (fileTypeInfo.fileType) {

--- a/src/binder/bind/bind_file_scan.cpp
+++ b/src/binder/bind/bind_file_scan.cpp
@@ -165,8 +165,8 @@ static TableFunction getObjectScanFunc(const std::string& dbName, const std::str
         throw BinderException{stringFormat("No database named {} has been attached.", dbName)};
     }
     auto attachedCatalog = attachedDB->getCatalog();
-    auto tableID = attachedCatalog->getTableID(clientContext->getTx(), tableName);
-    auto entry = attachedCatalog->getTableCatalogEntry(clientContext->getTx(), tableID);
+    auto tableID = attachedCatalog->getTableID(clientContext->getTransaction(), tableName);
+    auto entry = attachedCatalog->getTableCatalogEntry(clientContext->getTransaction(), tableID);
     return entry->ptrCast<TableCatalogEntry>()->getScanFunction();
 }
 

--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -287,7 +287,7 @@ std::shared_ptr<RelExpression> Binder::createRecursiveQueryRel(const parser::Rel
     std::shared_ptr<NodeExpression> srcNode, std::shared_ptr<NodeExpression> dstNode,
     RelDirectionType directionType) {
     auto catalog = clientContext->getCatalog();
-    auto transaction = clientContext->getTx();
+    auto transaction = clientContext->getTransaction();
     auto relTableEntries = getRelTableEntries(entries);
     table_catalog_entry_set_t entrySet;
     for (auto entry : relTableEntries) {
@@ -575,7 +575,7 @@ void Binder::bindQueryNodeProperties(NodeExpression& node) {
 
 std::vector<TableCatalogEntry*> Binder::bindTableEntries(const std::vector<std::string>& tableNames,
     bool nodePattern) const {
-    auto tx = clientContext->getTx();
+    auto tx = clientContext->getTransaction();
     auto catalog = clientContext->getCatalog();
     table_catalog_entry_set_t entrySet;
     if (tableNames.empty()) { // Rewrite empty table names as all tables.
@@ -605,7 +605,7 @@ std::vector<TableCatalogEntry*> Binder::bindTableEntries(const std::vector<std::
 
 catalog::TableCatalogEntry* Binder::bindTableEntry(const std::string& tableName) const {
     auto catalog = clientContext->getCatalog();
-    auto transaction = clientContext->getTx();
+    auto transaction = clientContext->getTransaction();
     if (!catalog->containsTable(transaction, tableName)) {
         throw BinderException(common::stringFormat("Table {} does not exist.", tableName));
     }
@@ -666,7 +666,7 @@ std::vector<TableCatalogEntry*> Binder::getNodeTableEntries(TableCatalogEntry* e
 
 std::vector<TableCatalogEntry*> Binder::getRelTableEntries(TableCatalogEntry* entry) const {
     auto catalog = clientContext->getCatalog();
-    auto transaction = clientContext->getTx();
+    auto transaction = clientContext->getTransaction();
     switch (entry->getTableType()) {
     case TableType::REL_GROUP: {
         auto& relGroupEntry = entry->constCast<RelGroupCatalogEntry>();
@@ -687,7 +687,7 @@ std::vector<TableCatalogEntry*> Binder::getRelTableEntries(TableCatalogEntry* en
 
 std::vector<TableCatalogEntry*> Binder::getTableEntries(const table_id_vector_t& tableIDs) {
     auto catalog = clientContext->getCatalog();
-    auto transaction = clientContext->getTx();
+    auto transaction = clientContext->getTransaction();
     std::vector<TableCatalogEntry*> result;
     for (auto id : tableIDs) {
         result.push_back(catalog->getTableCatalogEntry(transaction, id));

--- a/src/binder/bind/bind_import_database.cpp
+++ b/src/binder/bind/bind_import_database.cpp
@@ -73,7 +73,7 @@ std::unique_ptr<BoundStatement> Binder::bindImportDatabaseClause(const Statement
     auto copyQuery =
         getQueryFromFile(fs, boundFilePath, ImportDBConstants::COPY_NAME, clientContext);
     if (!copyQuery.empty()) {
-        auto parsedStatements = Parser::parseQuery(copyQuery, clientContext);
+        auto parsedStatements = Parser::parseQuery(copyQuery);
         for (auto& parsedStatement : parsedStatements) {
             KU_ASSERT(parsedStatement->getStatementType() == StatementType::COPY_FROM);
             auto& copyFromStatement = parsedStatement->constCast<CopyFrom>();

--- a/src/binder/bind/bind_standalone_call_function.cpp
+++ b/src/binder/bind/bind_standalone_call_function.cpp
@@ -18,9 +18,9 @@ std::unique_ptr<BoundStatement> Binder::bindStandaloneCallFunction(
     auto& funcExpr =
         callStatement.getFunctionExpression()->constCast<parser::ParsedFunctionExpression>();
     auto funcName = funcExpr.getFunctionName();
-    auto catalogSet = clientContext->getCatalog()->getFunctions(clientContext->getTx());
-    auto entry = function::BuiltInFunctionsUtils::getFunctionCatalogEntry(clientContext->getTx(),
-        funcName, catalogSet);
+    auto catalogSet = clientContext->getCatalog()->getFunctions(clientContext->getTransaction());
+    auto entry = function::BuiltInFunctionsUtils::getFunctionCatalogEntry(
+        clientContext->getTransaction(), funcName, catalogSet);
     if (entry->getType() != catalog::CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY) {
         throw common::BinderException(
             "Only standalone table functions can be called without return statement.");

--- a/src/binder/bind/bind_table_function.cpp
+++ b/src/binder/bind/bind_table_function.cpp
@@ -20,8 +20,8 @@ static void validateParameterType(expression_vector positionalParams) {
 
 BoundTableFunction Binder::bindTableFunc(std::string tableFuncName,
     const parser::ParsedExpression& expr, expression_vector& columns) {
-    auto functions = clientContext->getCatalog()->getFunctions(clientContext->getTx());
-    auto entry = BuiltInFunctionsUtils::getFunctionCatalogEntry(clientContext->getTx(),
+    auto functions = clientContext->getCatalog()->getFunctions(clientContext->getTransaction());
+    auto entry = BuiltInFunctionsUtils::getFunctionCatalogEntry(clientContext->getTransaction(),
         tableFuncName, functions);
     expression_vector positionalParams;
     std::vector<LogicalType> positionalParamTypes;

--- a/src/binder/bind/copy/bind_copy_from.cpp
+++ b/src/binder/bind/copy/bind_copy_from.cpp
@@ -24,8 +24,8 @@ std::unique_ptr<BoundStatement> Binder::bindCopyFromClause(const Statement& stat
     validateTableExist(tableName);
     // Bind to table schema.
     auto catalog = clientContext->getCatalog();
-    auto tableID = catalog->getTableID(clientContext->getTx(), tableName);
-    auto tableEntry = catalog->getTableCatalogEntry(clientContext->getTx(), tableID);
+    auto tableID = catalog->getTableID(clientContext->getTransaction(), tableName);
+    auto tableEntry = catalog->getTableCatalogEntry(clientContext->getTransaction(), tableID);
     switch (tableEntry->getTableType()) {
     case TableType::REL_GROUP: {
         throw BinderException(stringFormat("Cannot copy into {} table with type {}.", tableName,
@@ -221,7 +221,7 @@ void bindExpectedRelColumns(RelTableCatalogEntry* relTableEntry,
     std::vector<LogicalType>& columnTypes, main::ClientContext* context) {
     KU_ASSERT(columnNames.empty() && columnTypes.empty());
     auto catalog = context->getCatalog();
-    auto transaction = context->getTx();
+    auto transaction = context->getTransaction();
     auto srcTable = catalog->getTableCatalogEntry(transaction, relTableEntry->getSrcTableID())
                         ->ptrCast<NodeTableCatalogEntry>();
     auto dstTable = catalog->getTableCatalogEntry(transaction, relTableEntry->getDstTableID())

--- a/src/binder/bind/copy/bind_copy_to.cpp
+++ b/src/binder/bind/copy/bind_copy_to.cpp
@@ -19,12 +19,12 @@ std::unique_ptr<BoundStatement> Binder::bindCopyToClause(const Statement& statem
     auto parsedQuery = copyToStatement.getStatement()->constPtrCast<RegularQuery>();
     auto query = bindQuery(*parsedQuery);
     auto columns = query->getStatementResult()->getColumns();
-    auto functions = clientContext->getCatalog()->getFunctions(clientContext->getTx());
+    auto functions = clientContext->getCatalog()->getFunctions(clientContext->getTransaction());
     auto fileTypeStr = fileTypeInfo.fileTypeStr;
     auto name = common::stringFormat("COPY_{}", fileTypeStr);
-    auto exportFunc =
-        function::BuiltInFunctionsUtils::matchFunction(clientContext->getTx(), name, functions)
-            ->constPtrCast<function::ExportFunction>();
+    auto exportFunc = function::BuiltInFunctionsUtils::matchFunction(
+        clientContext->getTransaction(), name, functions)
+                          ->constPtrCast<function::ExportFunction>();
     for (auto& column : columns) {
         auto columnName = column->hasAlias() ? column->getAlias() : column->toString();
         columnNames.push_back(columnName);

--- a/src/binder/bind/read/bind_in_query_call.cpp
+++ b/src/binder/bind/read/bind_in_query_call.cpp
@@ -26,8 +26,8 @@ std::unique_ptr<BoundReadingClause> Binder::bindInQueryCall(const ReadingClause&
     auto functionName = functionExpr->getFunctionName();
     std::unique_ptr<BoundReadingClause> boundReadingClause;
     expression_vector columns;
-    auto catalogSet = clientContext->getCatalog()->getFunctions(clientContext->getTx());
-    auto entry = BuiltInFunctionsUtils::getFunctionCatalogEntry(clientContext->getTx(),
+    auto catalogSet = clientContext->getCatalog()->getFunctions(clientContext->getTransaction());
+    auto entry = BuiltInFunctionsUtils::getFunctionCatalogEntry(clientContext->getTransaction(),
         functionName, catalogSet);
     switch (entry->getType()) {
     case CatalogEntryType::TABLE_FUNCTION_ENTRY: {

--- a/src/binder/bind_expression/bind_comparison_expression.cpp
+++ b/src/binder/bind_expression/bind_comparison_expression.cpp
@@ -27,7 +27,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindComparisonExpression(
 std::shared_ptr<Expression> ExpressionBinder::bindComparisonExpression(
     ExpressionType expressionType, const expression_vector& children) {
     auto catalog = context->getCatalog();
-    auto transaction = context->getTx();
+    auto transaction = context->getTransaction();
     auto functions = catalog->getFunctions(transaction);
     auto functionName = ExpressionTypeUtil::toString(expressionType);
     LogicalType combinedType(LogicalTypeID::ANY);

--- a/src/binder/bind_expression/bind_subquery_expression.cpp
+++ b/src/binder/bind_expression/bind_subquery_expression.cpp
@@ -34,7 +34,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindSubqueryExpression(
         std::move(boundGraphPattern.queryGraphCollection), uniqueName, std::move(rawName));
     boundSubqueryExpr->setWhereExpression(boundGraphPattern.where);
     // Bind projection
-    auto functions = context->getCatalog()->getFunctions(context->getTx());
+    auto functions = context->getCatalog()->getFunctions(context->getTransaction());
     auto function = BuiltInFunctionsUtils::matchAggregateFunction(CountStarFunction::name,
         std::vector<LogicalType>{}, false, functions);
     auto bindData = std::make_unique<FunctionBindData>(LogicalType(function->returnTypeID));

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -154,14 +154,14 @@ void Binder::validateOrderByFollowedBySkipOrLimitInWithClause(
 
 void Binder::validateTableType(table_id_t tableID, TableType expectedTableType) {
     auto tableEntry =
-        clientContext->getCatalog()->getTableCatalogEntry(clientContext->getTx(), tableID);
+        clientContext->getCatalog()->getTableCatalogEntry(clientContext->getTransaction(), tableID);
     if (tableEntry->getTableType() != expectedTableType) {
         throw BinderException("Table type mismatch.");
     }
 }
 
 void Binder::validateTableExist(const std::string& tableName) {
-    if (!clientContext->getCatalog()->containsTable(clientContext->getTx(), tableName)) {
+    if (!clientContext->getCatalog()->containsTable(clientContext->getTransaction(), tableName)) {
         throw BinderException("Table " + tableName + " does not exist.");
     }
 }
@@ -232,25 +232,25 @@ function::TableFunction Binder::getScanFunction(FileTypeInfo typeInfo,
     function::Function* func = nullptr;
     std::vector<LogicalType> inputTypes;
     inputTypes.push_back(LogicalType::STRING());
-    auto functions = clientContext->getCatalog()->getFunctions(clientContext->getTx());
+    auto functions = clientContext->getCatalog()->getFunctions(clientContext->getTransaction());
     switch (typeInfo.fileType) {
     case FileType::PARQUET: {
-        func = function::BuiltInFunctionsUtils::matchFunction(clientContext->getTx(),
+        func = function::BuiltInFunctionsUtils::matchFunction(clientContext->getTransaction(),
             ParquetScanFunction::name, inputTypes, functions);
     } break;
     case FileType::NPY: {
-        func = function::BuiltInFunctionsUtils::matchFunction(clientContext->getTx(),
+        func = function::BuiltInFunctionsUtils::matchFunction(clientContext->getTransaction(),
             NpyScanFunction::name, inputTypes, functions);
     } break;
     case FileType::CSV: {
         auto csvConfig = CSVReaderConfig::construct(fileScanInfo.options);
-        func = function::BuiltInFunctionsUtils::matchFunction(clientContext->getTx(),
+        func = function::BuiltInFunctionsUtils::matchFunction(clientContext->getTransaction(),
             csvConfig.parallel ? ParallelCSVScan::name : SerialCSVScan::name, inputTypes,
             functions);
     } break;
     case FileType::UNKNOWN: {
         try {
-            func = function::BuiltInFunctionsUtils::matchFunction(clientContext->getTx(),
+            func = function::BuiltInFunctionsUtils::matchFunction(clientContext->getTransaction(),
                 common::stringFormat("{}_SCAN", typeInfo.fileTypeStr), inputTypes, functions);
         } catch (...) {
             if (typeInfo.fileTypeStr == "") {

--- a/src/binder/query/query_graph_label_analyzer.cpp
+++ b/src/binder/query/query_graph_label_analyzer.cpp
@@ -32,7 +32,7 @@ void QueryGraphLabelAnalyzer::pruneNode(const QueryGraph& graph, NodeExpression&
         std::unordered_set<std::string> candidateNamesSet;
         auto isSrcConnect = *queryRel->getSrcNode() == node;
         auto isDstConnect = *queryRel->getDstNode() == node;
-        auto tx = clientContext.getTx();
+        auto tx = clientContext.getTransaction();
         if (queryRel->getDirectionType() == RelDirectionType::BOTH) {
             if (isSrcConnect || isDstConnect) {
                 for (auto entry : queryRel->getEntries()) {

--- a/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
@@ -76,7 +76,7 @@ RelGroupCatalogEntry::getBoundExtraCreateInfo(transaction::Transaction* transact
 
 static std::string getFromToStr(common::table_id_t tableID, ClientContext* context) {
     auto catalog = context->getCatalog();
-    auto transaction = context->getTx();
+    auto transaction = context->getTransaction();
     auto& entry =
         catalog->getTableCatalogEntry(transaction, tableID)->constCast<RelTableCatalogEntry>();
     auto srcTableName = catalog->getTableName(transaction, entry.getSrcTableID());
@@ -92,8 +92,8 @@ std::string RelGroupCatalogEntry::toCypher(ClientContext* clientContext) const {
     for (auto i = 1u; i < relTableIDs.size(); ++i) {
         ss << stringFormat(", {}", getFromToStr(relTableIDs[i], clientContext));
     }
-    auto childRelEntry =
-        clientContext->getCatalog()->getTableCatalogEntry(clientContext->getTx(), relTableIDs[0]);
+    auto childRelEntry = clientContext->getCatalog()->getTableCatalogEntry(
+        clientContext->getTransaction(), relTableIDs[0]);
     if (childRelEntry->getNumProperties() > 1) { // skip internal id property.
         auto propertyStr = stringFormat(", {}", childRelEntry->propertiesToCypher());
         propertyStr.resize(propertyStr.size() - 1);

--- a/src/catalog/catalog_entry/rel_table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_table_catalog_entry.cpp
@@ -81,8 +81,8 @@ std::unique_ptr<TableCatalogEntry> RelTableCatalogEntry::copy() const {
 std::string RelTableCatalogEntry::toCypher(main::ClientContext* clientContext) const {
     std::stringstream ss;
     auto catalog = clientContext->getCatalog();
-    auto srcTableName = catalog->getTableName(clientContext->getTx(), srcTableID);
-    auto dstTableName = catalog->getTableName(clientContext->getTx(), dstTableID);
+    auto srcTableName = catalog->getTableName(clientContext->getTransaction(), srcTableID);
+    auto dstTableName = catalog->getTableName(clientContext->getTransaction(), dstTableID);
     auto srcMultiStr = srcMultiplicity == common::RelMultiplicity::MANY ? "MANY" : "ONE";
     auto dstMultiStr = dstMultiplicity == common::RelMultiplicity::MANY ? "MANY" : "ONE";
     std::string tableInfo =

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -726,7 +726,7 @@ LogicalType LogicalType::convertFromString(const std::string& str, main::ClientC
     } else if (tryGetIDFromString(upperDataTypeString, type.typeID)) {
         type.physicalType = LogicalType::getPhysicalType(type.typeID, type.extraTypeInfo);
     } else if (context != nullptr) {
-        type = context->getCatalog()->getType(context->getTx(), upperDataTypeString);
+        type = context->getCatalog()->getType(context->getTransaction(), upperDataTypeString);
     } else {
         throw common::RuntimeException{"Invalid datatype string: " + str};
     }

--- a/src/function/date/date_functions.cpp
+++ b/src/function/date/date_functions.cpp
@@ -6,14 +6,16 @@ namespace kuzu {
 namespace function {
 
 void CurrentDate::operation(common::date_t& result, void* dataPtr) {
-    auto currentTS =
-        reinterpret_cast<FunctionBindData*>(dataPtr)->clientContext->getTx()->getCurrentTS();
+    auto currentTS = reinterpret_cast<FunctionBindData*>(dataPtr)
+                         ->clientContext->getTransaction()
+                         ->getCurrentTS();
     result = common::Timestamp::getDate(common::timestamp_tz_t(currentTS));
 }
 
 void CurrentTimestamp::operation(common::timestamp_tz_t& result, void* dataPtr) {
-    auto currentTS =
-        reinterpret_cast<FunctionBindData*>(dataPtr)->clientContext->getTx()->getCurrentTS();
+    auto currentTS = reinterpret_cast<FunctionBindData*>(dataPtr)
+                         ->clientContext->getTransaction()
+                         ->getCurrentTS();
     result = common::timestamp_tz_t(currentTS);
 }
 

--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -246,7 +246,7 @@ private:
     RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
         auto frontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
-        auto numNodesMap = sharedState->graph->getNumNodesMap(clientContext->getTx());
+        auto numNodesMap = sharedState->graph->getNumNodesMap(clientContext->getTransaction());
         auto mm = clientContext->getMemoryManager();
         auto multiplicities = std::make_shared<PathMultiplicities>(numNodesMap, mm);
         auto output =

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -32,7 +32,7 @@ std::shared_ptr<Expression> GDSAlgorithm::bindNodeOutput(Binder* binder,
 
 std::shared_ptr<PathLengths> GDSAlgorithm::getPathLengthsFrontier(
     processor::ExecutionContext* context, uint16_t val) {
-    auto tx = context->clientContext->getTx();
+    auto tx = context->clientContext->getTransaction();
     auto mm = context->clientContext->getMemoryManager();
     auto graph = sharedState->graph.get();
     auto pathLengths = std::make_shared<PathLengths>(graph->getNumNodesMap(tx), mm);

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -103,7 +103,7 @@ void GDSUtils::runFrontiersUntilConvergence(processor::ExecutionContext* context
 
 static void runVertexComputeInternal(common::table_id_t tableID, graph::Graph* graph,
     std::shared_ptr<VertexComputeTask> task, processor::ExecutionContext* context) {
-    auto numNodes = graph->getNumNodes(context->clientContext->getTx(), tableID);
+    auto numNodes = graph->getNumNodes(context->clientContext->getTransaction(), tableID);
     task->init(tableID, numNodes);
     context->clientContext->getTaskScheduler()->scheduleTaskAndWaitOrError(task, context,
         true /* launchNewWorkerThread */);

--- a/src/function/gds/page_rank.cpp
+++ b/src/function/gds/page_rank.cpp
@@ -50,7 +50,7 @@ public:
     void materialize(main::ClientContext* context, Graph* graph,
         const common::node_id_map_t<double>& ranks, FactorizedTable& table) const {
         for (auto tableID : graph->getNodeTableIDs()) {
-            for (auto offset = 0u; offset < graph->getNumNodes(context->getTx(), tableID);
+            for (auto offset = 0u; offset < graph->getNumNodes(context->getTransaction(), tableID);
                  ++offset) {
                 auto nodeID = nodeID_t{offset, tableID};
                 nodeIDVector->setValue<nodeID_t>(0, nodeID);
@@ -113,10 +113,11 @@ public:
         auto graph = sharedState->graph.get();
         // Initialize state.
         common::node_id_map_t<double> ranks;
-        auto numNodes = graph->getNumNodes(context->clientContext->getTx());
+        auto numNodes = graph->getNumNodes(context->clientContext->getTransaction());
         for (auto tableID : graph->getNodeTableIDs()) {
             for (auto offset = 0u;
-                 offset < graph->getNumNodes(context->clientContext->getTx(), tableID); ++offset) {
+                 offset < graph->getNumNodes(context->clientContext->getTransaction(), tableID);
+                 ++offset) {
                 auto nodeID = nodeID_t{offset, tableID};
                 ranks.insert({nodeID, 1.0 / numNodes});
             }
@@ -128,12 +129,12 @@ public:
         // We're using multiple overlapping iterators, both of which need access to a scan state, so
         // we need multiple scan states
         auto innerScanState = graph->prepareMultiTableScanFwd(nodeTableIDs);
-        auto numNodesInGraph = graph->getNumNodes(context->clientContext->getTx());
+        auto numNodesInGraph = graph->getNumNodes(context->clientContext->getTransaction());
         for (auto i = 0u; i < extraData->maxIteration; ++i) {
             auto change = 0.0;
             for (auto tableID : nodeTableIDs) {
                 for (auto offset = 0u;
-                     offset < graph->getNumNodes(context->clientContext->getTx(), tableID);
+                     offset < graph->getNumNodes(context->clientContext->getTransaction(), tableID);
                      ++offset) {
                     auto nodeID = nodeID_t{offset, tableID};
                     auto rank = 0.0;

--- a/src/function/gds/rec_joins.cpp
+++ b/src/function/gds/rec_joins.cpp
@@ -193,7 +193,7 @@ void RJAlgorithm::exec(processor::ExecutionContext* context) {
         totalNumNodes = inputNodeMaskMap->getNumMaskedNode();
     } else {
         for (auto& tableID : graph->getNodeTableIDs()) {
-            totalNumNodes += graph->getNumNodes(clientContext->getTx(), tableID);
+            totalNumNodes += graph->getNumNodes(clientContext->getTransaction(), tableID);
         }
     }
     common::offset_t completedNumNodes = 0;
@@ -222,7 +222,7 @@ void RJAlgorithm::exec(processor::ExecutionContext* context) {
                 GDSUtils::runVertexCompute(context, graph, *vertexCompute);
             }
         };
-        auto numNodes = graph->getNumNodes(clientContext->getTx(), tableID);
+        auto numNodes = graph->getNumNodes(clientContext->getTransaction(), tableID);
         auto mask = inputNodeMaskMap->getOffsetMask(tableID);
         if (mask->isEnabled()) {
             for (const auto& offset : mask->range(0, numNodes)) {
@@ -248,7 +248,7 @@ void RJAlgorithm::exec(processor::ExecutionContext* context) {
 }
 
 std::unique_ptr<BFSGraph> RJAlgorithm::getBFSGraph(processor::ExecutionContext* context) {
-    auto tx = context->clientContext->getTx();
+    auto tx = context->clientContext->getTransaction();
     auto mm = context->clientContext->getMemoryManager();
     auto graph = sharedState->graph.get();
     auto bfsGraph = std::make_unique<BFSGraph>(graph->getNumNodesMap(tx), mm);

--- a/src/function/gds/weakly_connected_components.cpp
+++ b/src/function/gds/weakly_connected_components.cpp
@@ -208,7 +208,7 @@ public:
     void exec(processor::ExecutionContext* context) override {
         auto clientContext = context->clientContext;
         auto graph = sharedState->graph.get();
-        auto numNodesMap = graph->getNumNodesMap(clientContext->getTx());
+        auto numNodesMap = graph->getNumNodesMap(clientContext->getTransaction());
         auto numThreads = clientContext->getMaxNumThreadForExec();
         auto currentFrontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
         auto nextFrontier = getPathLengthsFrontier(context, 0);

--- a/src/function/sequence/sequence_functions.cpp
+++ b/src/function/sequence/sequence_functions.cpp
@@ -15,8 +15,8 @@ struct CurrVal {
         auto ctx = reinterpret_cast<FunctionBindData*>(dataPtr)->clientContext;
         auto catalog = ctx->getCatalog();
         auto sequenceName = input.getAsString();
-        auto sequenceID = catalog->getSequenceID(ctx->getTx(), sequenceName);
-        auto sequenceEntry = catalog->getSequenceCatalogEntry(ctx->getTx(), sequenceID);
+        auto sequenceID = catalog->getSequenceID(ctx->getTransaction(), sequenceName);
+        auto sequenceEntry = catalog->getSequenceCatalogEntry(ctx->getTransaction(), sequenceID);
         result.setValue(0, sequenceEntry->currVal());
     }
 };
@@ -27,9 +27,9 @@ struct NextVal {
         auto cnt = reinterpret_cast<FunctionBindData*>(dataPtr)->count;
         auto catalog = ctx->getCatalog();
         auto sequenceName = input.getAsString();
-        auto sequenceID = catalog->getSequenceID(ctx->getTx(), sequenceName);
-        auto sequenceEntry = catalog->getSequenceCatalogEntry(ctx->getTx(), sequenceID);
-        sequenceEntry->nextKVal(ctx->getTx(), cnt, result);
+        auto sequenceID = catalog->getSequenceID(ctx->getTransaction(), sequenceName);
+        auto sequenceEntry = catalog->getSequenceCatalogEntry(ctx->getTransaction(), sequenceID);
+        sequenceEntry->nextKVal(ctx->getTransaction(), cnt, result);
         result.state->getSelVectorUnsafe().setSelSize(cnt);
     }
 };

--- a/src/function/table/call/create_project_graph.cpp
+++ b/src/function/table/call/create_project_graph.cpp
@@ -51,7 +51,8 @@ static std::vector<TableCatalogEntry*> getTableEntries(const std::vector<std::st
     CatalogEntryType expectedType, const main::ClientContext& context) {
     std::vector<TableCatalogEntry*> entries;
     for (auto& tableName : tableNames) {
-        auto entry = context.getCatalog()->getTableCatalogEntry(context.getTx(), tableName);
+        auto entry =
+            context.getCatalog()->getTableCatalogEntry(context.getTransaction(), tableName);
         if (entry->getType() != expectedType) {
             throw BinderException(stringFormat("Expect catalog entry type {} but got {}.",
                 CatalogEntryTypeUtils::toString(expectedType),

--- a/src/function/table/call/show_connection.cpp
+++ b/src/function/table/call/show_connection.cpp
@@ -31,17 +31,17 @@ struct ShowConnectionBindData final : SimpleTableFuncBindData {
 static void outputRelTableConnection(const DataChunk& outputDataChunk, uint64_t outputPos,
     const ClientContext* context, table_id_t tableID) {
     const auto catalog = context->getCatalog();
-    const auto tableEntry = catalog->getTableCatalogEntry(context->getTx(), tableID);
+    const auto tableEntry = catalog->getTableCatalogEntry(context->getTransaction(), tableID);
     const auto relTableEntry = ku_dynamic_cast<RelTableCatalogEntry*>(tableEntry);
     KU_ASSERT(tableEntry->getTableType() == TableType::REL);
     // Get src and dst name
     const auto srcTableID = relTableEntry->getSrcTableID();
     const auto dstTableID = relTableEntry->getDstTableID();
-    const auto srcTableName = catalog->getTableName(context->getTx(), srcTableID);
-    const auto dstTableName = catalog->getTableName(context->getTx(), dstTableID);
+    const auto srcTableName = catalog->getTableName(context->getTransaction(), srcTableID);
+    const auto dstTableName = catalog->getTableName(context->getTransaction(), dstTableID);
     // Get src and dst primary key
-    const auto srcTableEntry = catalog->getTableCatalogEntry(context->getTx(), srcTableID);
-    const auto dstTableEntry = catalog->getTableCatalogEntry(context->getTx(), dstTableID);
+    const auto srcTableEntry = catalog->getTableCatalogEntry(context->getTransaction(), srcTableID);
+    const auto dstTableEntry = catalog->getTableCatalogEntry(context->getTransaction(), dstTableID);
     const auto srcTablePrimaryKey =
         srcTableEntry->constCast<NodeTableCatalogEntry>().getPrimaryKeyName();
     const auto dstTablePrimaryKey =
@@ -90,8 +90,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const ClientContext* context,
     std::vector<LogicalType> columnTypes;
     const auto tableName = input->getLiteralVal<std::string>(0);
     const auto catalog = context->getCatalog();
-    const auto tableID = catalog->getTableID(context->getTx(), tableName);
-    auto tableEntry = catalog->getTableCatalogEntry(context->getTx(), tableID);
+    const auto tableID = catalog->getTableID(context->getTransaction(), tableName);
+    auto tableEntry = catalog->getTableCatalogEntry(context->getTransaction(), tableID);
     const auto tableType = tableEntry->getTableType();
     if (tableType != TableType::REL && tableType != TableType::REL_GROUP) {
         throw BinderException{"Show connection can only be called on a rel table!"};

--- a/src/function/table/call/show_functions.cpp
+++ b/src/function/table/call/show_functions.cpp
@@ -58,7 +58,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* co
     columnNames.emplace_back("signature");
     columnTypes.emplace_back(LogicalType::STRING());
     std::vector<FunctionInfo> FunctionInfos;
-    for (const auto& entry : context->getCatalog()->getFunctionEntries(context->getTx())) {
+    for (const auto& entry : context->getCatalog()->getFunctionEntries(context->getTransaction())) {
         const auto& functionSet = entry->getFunctionSet();
         const auto type = FunctionEntryTypeUtils::toString(entry->getType());
         for (auto& function : functionSet) {

--- a/src/function/table/call/show_sequences.cpp
+++ b/src/function/table/call/show_sequences.cpp
@@ -77,7 +77,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* co
     columnNames.emplace_back("cycle");
     columnTypes.emplace_back(LogicalType::BOOL());
     std::vector<SequenceInfo> sequenceInfos;
-    for (const auto& entry : context->getCatalog()->getSequenceEntries(context->getTx())) {
+    for (const auto& entry : context->getCatalog()->getSequenceEntries(context->getTransaction())) {
         const auto sequenceData = entry->getSequenceData();
         auto sequenceInfo = SequenceInfo{entry->getName(), LOCAL_DB_NAME, sequenceData.startValue,
             sequenceData.increment, sequenceData.minValue, sequenceData.maxValue,

--- a/src/function/table/call/show_tables.cpp
+++ b/src/function/table/call/show_tables.cpp
@@ -71,7 +71,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* co
     columnTypes.emplace_back(LogicalType::STRING());
     std::vector<TableInfo> tableInfos;
     if (!context->hasDefaultDatabase()) {
-        for (auto& entry : context->getCatalog()->getTableEntries(context->getTx())) {
+        for (auto& entry : context->getCatalog()->getTableEntries(context->getTransaction())) {
             auto tableInfo = TableInfo{entry->getName(), entry->getTableID(),
                 TableTypeUtils::toString(entry->getTableType()), LOCAL_DB_NAME,
                 entry->getComment()};
@@ -83,7 +83,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* co
     for (auto attachedDatabase : databaseManager->getAttachedDatabases()) {
         auto databaseName = attachedDatabase->getDBName();
         auto databaseType = attachedDatabase->getDBType();
-        for (auto& entry : attachedDatabase->getCatalog()->getTableEntries(context->getTx())) {
+        for (auto& entry :
+            attachedDatabase->getCatalog()->getTableEntries(context->getTransaction())) {
             auto tableInfo = TableInfo{entry->getName(), entry->getTableID(),
                 TableTypeUtils::toString(entry->getTableType()),
                 stringFormat("{}({})", databaseName, databaseType), entry->getComment()};

--- a/src/function/table/call/stats_info.cpp
+++ b/src/function/table/call/stats_info.cpp
@@ -44,7 +44,7 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput& output) 
     switch (table->getTableType()) {
     case TableType::NODE: {
         const auto& nodeTable = table->cast<storage::NodeTable>();
-        const auto stats = nodeTable.getStats(bindData->context->getTx());
+        const auto stats = nodeTable.getStats(bindData->context->getTransaction());
         dataChunk.getValueVectorMutable(0).setValue<cardinality_t>(0, stats.getTableCard());
         for (auto i = 0u; i < nodeTable.getNumColumns(); ++i) {
             dataChunk.getValueVectorMutable(i + 1).setValue(0, stats.getNumDistinctValues(i));
@@ -62,11 +62,11 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const ClientContext* context,
     const TableFuncBindInput* input) {
     const auto tableName = input->getLiteralVal<std::string>(0);
     const auto catalog = context->getCatalog();
-    if (!catalog->containsTable(context->getTx(), tableName)) {
+    if (!catalog->containsTable(context->getTransaction(), tableName)) {
         throw BinderException{"Table " + tableName + " does not exist!"};
     }
-    const auto tableID = catalog->getTableID(context->getTx(), tableName);
-    auto tableEntry = catalog->getTableCatalogEntry(context->getTx(), tableID);
+    const auto tableID = catalog->getTableID(context->getTransaction(), tableName);
+    auto tableEntry = catalog->getTableCatalogEntry(context->getTransaction(), tableID);
     if (tableEntry->getTableType() != TableType::NODE) {
         throw BinderException{
             "Stats from a non-node table " + tableName + " is not supported yet!"};

--- a/src/function/table/call/storage_info.cpp
+++ b/src/function/table/call/storage_info.cpp
@@ -348,11 +348,11 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const ClientContext* context,
     columnTypes.emplace_back(LogicalType::STRING());
     auto tableName = input->getLiteralVal<std::string>(0);
     auto catalog = context->getCatalog();
-    if (!catalog->containsTable(context->getTx(), tableName)) {
+    if (!catalog->containsTable(context->getTransaction(), tableName)) {
         throw BinderException{"Table " + tableName + " does not exist!"};
     }
-    auto tableID = catalog->getTableID(context->getTx(), tableName);
-    auto tableEntry = catalog->getTableCatalogEntry(context->getTx(), tableID);
+    auto tableID = catalog->getTableID(context->getTransaction(), tableName);
+    auto tableEntry = catalog->getTableCatalogEntry(context->getTransaction(), tableID);
     auto storageManager = context->getStorageManager();
     auto table = storageManager->getTable(tableID);
     auto columns = input->binder->createVariables(columnNames, columnTypes);

--- a/src/function/table/call/table_info.cpp
+++ b/src/function/table/call/table_info.cpp
@@ -64,7 +64,7 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput& output) 
 
 static std::unique_ptr<TableCatalogEntry> getTableCatalogEntry(const main::ClientContext* context,
     const std::string& tableName) {
-    auto transaction = context->getTx();
+    auto transaction = context->getTransaction();
     auto tableInfo = common::StringUtils::split(tableName, ".");
     if (tableInfo.size() == 1) {
         auto tableID = context->getCatalog()->getTableID(transaction, tableName);

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -1058,11 +1058,11 @@ static std::unique_ptr<FunctionBindData> castBindFunc(ScalarBindFuncInput input)
         std::vector<LogicalType> typeVec;
         typeVec.push_back(input.arguments[0]->getDataType().copy());
         try {
-            func->execFunc =
-                BuiltInFunctionsUtils::matchFunction(input.context->getTx(), func->name, typeVec,
-                    input.context->getCatalog()->getFunctions(input.context->getTx()))
-                    ->constPtrCast<ScalarFunction>()
-                    ->execFunc;
+            func->execFunc = BuiltInFunctionsUtils::matchFunction(input.context->getTransaction(),
+                func->name, typeVec,
+                input.context->getCatalog()->getFunctions(input.context->getTransaction()))
+                                 ->constPtrCast<ScalarFunction>()
+                                 ->execFunc;
             return std::make_unique<function::CastFunctionBindData>(targetType.copy());
         } catch (...) { // NOLINT
             // If there's no user defined casting function for the corresponding user defined type,

--- a/src/include/binder/ddl/property_definition.h
+++ b/src/include/binder/ddl/property_definition.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "binder/expression/expression.h"
 #include "common/types/types.h"
 #include "parser/expression/parsed_expression.h"
 

--- a/src/include/binder/ddl/property_definition.h
+++ b/src/include/binder/ddl/property_definition.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "binder/expression/expression.h"
 #include "common/types/types.h"
 #include "parser/expression/parsed_expression.h"
 

--- a/src/include/main/prepared_statement.h
+++ b/src/include/main/prepared_statement.h
@@ -43,12 +43,12 @@ public:
         return parameterMap;
     }
 
-    common::StatementType getStatementType();
+    common::StatementType getStatementType() const;
 
     KUZU_API ~PreparedStatement();
 
 private:
-    bool isProfile();
+    bool isProfile() const;
 
 private:
     bool success = true;

--- a/src/include/parser/parser.h
+++ b/src/include/parser/parser.h
@@ -15,8 +15,7 @@ namespace parser {
 class Parser {
 
 public:
-    static std::vector<std::shared_ptr<Statement>> parseQuery(std::string_view query,
-        main::ClientContext* context);
+    static std::vector<std::shared_ptr<Statement>> parseQuery(std::string_view query);
 };
 
 } // namespace parser

--- a/src/include/parser/statement.h
+++ b/src/include/parser/statement.h
@@ -17,7 +17,7 @@ public:
     void setToInternal() { internal = true; }
     bool isInternal() const { return internal; }
 
-    bool requireTx() const {
+    bool requireTransaction() const {
         switch (statementType) {
         case common::StatementType::TRANSACTION:
             return false;

--- a/src/include/parser/transformer.h
+++ b/src/include/parser/transformer.h
@@ -33,8 +33,7 @@ struct JoinHintNode;
 
 class Transformer {
 public:
-    explicit Transformer(CypherParser::Ku_StatementsContext& root, main::ClientContext* context)
-        : root{root}, context{context} {}
+    explicit Transformer(CypherParser::Ku_StatementsContext& root) : root{root} {}
 
     std::vector<std::shared_ptr<Statement>> transform();
 
@@ -239,7 +238,6 @@ private:
 
 private:
     CypherParser::Ku_StatementsContext& root;
-    main::ClientContext* context;
 };
 
 } // namespace parser

--- a/src/main/prepared_statement.cpp
+++ b/src/main/prepared_statement.cpp
@@ -25,11 +25,11 @@ bool PreparedStatement::isReadOnly() const {
     return readOnly;
 }
 
-bool PreparedStatement::isProfile() {
+bool PreparedStatement::isProfile() const {
     return logicalPlan->isProfile();
 }
 
-StatementType PreparedStatement::getStatementType() {
+StatementType PreparedStatement::getStatementType() const {
     return parsedStatement->getStatementType();
 }
 

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -65,7 +65,7 @@ void Optimizer::optimize(planner::LogicalPlan* plan, main::ClientContext* contex
             const auto& explain = plan->getLastOperatorRef().cast<planner::LogicalExplain>();
             if (explain.getExplainType() == common::ExplainType::LOGICAL_PLAN) {
                 auto cardinalityUpdater =
-                    CardinalityUpdater(cardinalityEstimator, context->getTx());
+                    CardinalityUpdater(cardinalityEstimator, context->getTransaction());
                 cardinalityUpdater.rewrite(plan);
             }
         }

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -8,7 +8,6 @@
 
 #include "common/exception/parser.h"
 #include "common/string_utils.h"
-#include "main/client_context.h"
 #include "parser/antlr_parser/kuzu_cypher_parser.h"
 #include "parser/antlr_parser/parser_error_listener.h"
 #include "parser/antlr_parser/parser_error_strategy.h"
@@ -19,8 +18,7 @@ using namespace antlr4;
 namespace kuzu {
 namespace parser {
 
-std::vector<std::shared_ptr<Statement>> Parser::parseQuery(std::string_view query,
-    main::ClientContext* context) {
+std::vector<std::shared_ptr<Statement>> Parser::parseQuery(std::string_view query) {
     auto queryStr = std::string(query);
     queryStr = common::StringUtils::ltrim(queryStr);
     queryStr = common::StringUtils::ltrimNewlines(queryStr);
@@ -47,7 +45,7 @@ std::vector<std::shared_ptr<Statement>> Parser::parseQuery(std::string_view quer
     kuzuCypherParser.addErrorListener(&parserErrorListener);
     kuzuCypherParser.setErrorHandler(std::make_shared<ParserErrorStrategy>());
 
-    Transformer transformer(*kuzuCypherParser.ku_Statements(), context);
+    Transformer transformer(*kuzuCypherParser.ku_Statements());
     return transformer.transform();
 }
 

--- a/src/parser/transform/transform_ddl.cpp
+++ b/src/parser/transform/transform_ddl.cpp
@@ -219,9 +219,7 @@ std::unique_ptr<Statement> Transformer::transformAddProperty(
     if (addPropertyCtx->kU_Default()) {
         defaultValue = transformExpression(*addPropertyCtx->kU_Default()->oC_Expression());
     } else {
-        auto type = LogicalType::convertFromString(dataType, context);
-        defaultValue =
-            std::make_unique<ParsedLiteralExpression>(Value::createNullValue(type), "NULL");
+        defaultValue = std::make_unique<ParsedLiteralExpression>(Value::createNullValue(), "NULL");
     }
     auto extraInfo = std::make_unique<ExtraAddPropertyInfo>(std::move(propertyName),
         std::move(dataType), std::move(defaultValue));
@@ -292,9 +290,8 @@ std::vector<ParsedPropertyDefinition> Transformer::transformPropertyDefinitions(
         if (definition->kU_Default()) {
             defaultExpr = transformExpression(*definition->kU_Default()->oC_Expression());
         } else {
-            auto type = LogicalType::convertFromString(columnDefinition.type, context);
             defaultExpr =
-                std::make_unique<ParsedLiteralExpression>(Value::createNullValue(type), "NULL");
+                std::make_unique<ParsedLiteralExpression>(Value::createNullValue(), "NULL");
         }
         definitions.push_back(
             ParsedPropertyDefinition(std::move(columnDefinition), std::move(defaultExpr)));

--- a/src/planner/join_order/cardinality_estimator.cpp
+++ b/src/planner/join_order/cardinality_estimator.cpp
@@ -173,7 +173,7 @@ static std::optional<cardinality_t> getTableStatsIfPossible(main::ClientContext*
         auto tableID = propertyExpr.getSingleTableID();
         if (nodeTableStats.contains(tableID)) {
             auto columnID = propertyExpr.getColumnID(
-                *context->getCatalog()->getTableCatalogEntry(context->getTx(), tableID));
+                *context->getCatalog()->getTableCatalogEntry(context->getTransaction(), tableID));
             if (columnID != INVALID_COLUMN_ID && columnID != ROW_IDX_COLUMN_ID) {
                 auto& stats = nodeTableStats.at(tableID);
                 return atLeastOne(stats.getNumDistinctValues(columnID));

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -93,7 +93,7 @@ void Planner::appendNonRecursiveExtend(const std::shared_ptr<NodeExpression>& bo
     extend->computeFactorizedSchema();
     // Update cost & cardinality. Note that extend does not change cardinality.
     const auto extensionRate =
-        cardinalityEstimator.getExtensionRate(*rel, *boundNode, clientContext->getTx());
+        cardinalityEstimator.getExtensionRate(*rel, *boundNode, clientContext->getTransaction());
     extend->setCardinality(
         cardinalityEstimator.estimateExtend(extensionRate, plan.getLastOperatorRef()));
     plan.setCost(CostModel::computeExtendCost(plan));
@@ -205,7 +205,7 @@ void Planner::appendRecursiveExtendAsGDS(const std::shared_ptr<NodeExpression>& 
     pathPropertyProbe->pathEdgeIDs = recursiveInfo->pathEdgeIDsExpr;
     pathPropertyProbe->computeFactorizedSchema();
     auto extensionRate =
-        cardinalityEstimator.getExtensionRate(*rel, *boundNode, clientContext->getTx());
+        cardinalityEstimator.getExtensionRate(*rel, *boundNode, clientContext->getTransaction());
     pathPropertyProbe->setCardinality(
         cardinalityEstimator.estimateExtend(extensionRate, plan.getLastOperatorRef()));
     probePlan.setLastOperator(pathPropertyProbe);
@@ -271,7 +271,7 @@ void Planner::appendRecursiveExtend(const std::shared_ptr<NodeExpression>& bound
         pathPropertyProbe->getSIPInfoUnsafe().position = SemiMaskPosition::PROHIBIT_PROBE_TO_BUILD;
     }
     auto extensionRate =
-        cardinalityEstimator.getExtensionRate(*rel, *boundNode, clientContext->getTx());
+        cardinalityEstimator.getExtensionRate(*rel, *boundNode, clientContext->getTransaction());
     pathPropertyProbe->setCardinality(
         cardinalityEstimator.estimateExtend(extensionRate, plan.getLastOperatorRef()));
     plan.setLastOperator(std::move(pathPropertyProbe));

--- a/src/planner/plan/plan_join_order.cpp
+++ b/src/planner/plan/plan_join_order.cpp
@@ -133,7 +133,7 @@ std::vector<std::unique_ptr<LogicalPlan>> Planner::enumerateQueryGraphCollection
 std::vector<std::unique_ptr<LogicalPlan>> Planner::enumerateQueryGraph(const QueryGraph& queryGraph,
     const QueryGraphPlanningInfo& info) {
     context.init(&queryGraph, info.predicates);
-    cardinalityEstimator.initNodeIDDom(clientContext->getTx(), queryGraph);
+    cardinalityEstimator.initNodeIDDom(clientContext->getTransaction(), queryGraph);
     if (info.hint != nullptr) {
         auto constructor = JoinTreeConstructor(queryGraph, propertyExprCollection, info.predicates);
         auto joinTree = constructor.construct(info.hint);

--- a/src/planner/plan/plan_port_db.cpp
+++ b/src/planner/plan/plan_port_db.cpp
@@ -28,10 +28,10 @@ std::unique_ptr<LogicalPlan> Planner::planExportDatabase(const BoundStatement& s
     auto fileTypeStr = FileTypeUtils::toString(fileType);
     StringUtils::toLower(fileTypeStr);
     auto copyToSuffix = "." + fileTypeStr;
-    auto functions = clientContext->getCatalog()->getFunctions(clientContext->getTx());
+    auto functions = clientContext->getCatalog()->getFunctions(clientContext->getTransaction());
     std::string name = common::stringFormat("COPY_{}", FileTypeUtils::toString(fileType));
-    auto func =
-        function::BuiltInFunctionsUtils::matchFunction(clientContext->getTx(), name, functions);
+    auto func = function::BuiltInFunctionsUtils::matchFunction(clientContext->getTransaction(),
+        name, functions);
     KU_ASSERT(func != nullptr);
     auto exportFunc = *func->constPtrCast<function::ExportFunction>();
     for (auto& exportTableData : *exportData) {

--- a/src/planner/plan/plan_read.cpp
+++ b/src/planner/plan/plan_read.cpp
@@ -174,8 +174,8 @@ void Planner::planGDSCall(const BoundReadingClause& readingClause,
     if (!properties.empty()) {
         auto& node = bindData->getNodeOutput()->constCast<NodeExpression>();
         auto scanPlan = LogicalPlan();
-        cardinalityEstimator.addNodeIDDomAndStats(clientContext->getTx(), *node.getInternalID(),
-            node.getTableIDs());
+        cardinalityEstimator.addNodeIDDomAndStats(clientContext->getTransaction(),
+            *node.getInternalID(), node.getTableIDs());
         appendScanNodeTable(node.getInternalID(), node.getTableIDs(), properties, scanPlan);
         expression_vector joinConditions;
         joinConditions.push_back(node.getInternalID());

--- a/src/processor/map/create_factorized_table_scan.cpp
+++ b/src/processor/map/create_factorized_table_scan.cpp
@@ -24,8 +24,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createFTableScan(const expression_
     }
     auto bindData =
         std::make_unique<FTableScanBindData>(table, std::move(colIndices), maxMorselSize);
-    auto function = function::BuiltInFunctionsUtils::matchFunction(clientContext->getTx(),
-        FTableScan::name, clientContext->getCatalog()->getFunctions(clientContext->getTx()));
+    auto function = function::BuiltInFunctionsUtils::matchFunction(clientContext->getTransaction(),
+        FTableScan::name,
+        clientContext->getCatalog()->getFunctions(clientContext->getTransaction()));
     auto info = TableFunctionCallInfo();
     info.function = *ku_dynamic_cast<TableFunction*>(function);
     info.bindData = std::move(bindData);

--- a/src/processor/map/map_delete.cpp
+++ b/src/processor/map/map_delete.cpp
@@ -18,7 +18,7 @@ NodeTableDeleteInfo PlanMapper::getNodeTableDeleteInfo(const TableCatalogEntry& 
     DataPos pkPos) const {
     auto storageManager = clientContext->getStorageManager();
     auto catalog = clientContext->getCatalog();
-    auto transaction = clientContext->getTx();
+    auto transaction = clientContext->getTransaction();
     auto tableID = entry.getTableID();
     auto table = storageManager->getTable(tableID)->ptrCast<NodeTable>();
     std::unordered_set<RelTable*> fwdRelTables;

--- a/src/processor/map/map_gds.cpp
+++ b/src/processor/map/map_gds.cpp
@@ -22,7 +22,7 @@ static std::unique_ptr<NodeOffsetMaskMap> getNodeOffsetMaskMap(main::ClientConte
     for (auto tableID : tableIDs) {
         auto nodeTable = storageManager->getTable(tableID)->ptrCast<NodeTable>();
         map->addMask(tableID, RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(tableID,
-                                  nodeTable->getNumTotalRows(context->getTx())));
+                                  nodeTable->getNumTotalRows(context->getTransaction())));
     }
     return map;
 }

--- a/src/processor/map/map_recursive_extend.cpp
+++ b/src/processor/map/map_recursive_extend.cpp
@@ -18,7 +18,7 @@ static std::shared_ptr<RecursiveJoinSharedState> createSharedState(const NodeExp
         auto tableID = entry->getTableID();
         auto table = context.getStorageManager()->getTable(tableID)->ptrCast<storage::NodeTable>();
         semiMasks.push_back(RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(tableID,
-            table->getNumTotalRows(context.getTx())));
+            table->getNumTotalRows(context.getTransaction())));
     }
     return std::make_shared<RecursiveJoinSharedState>(std::move(semiMasks));
 }
@@ -62,7 +62,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapRecursiveExtend(LogicalOperator
     } else {
         dataInfo.pathPos = DataPos::getInvalidPos();
     }
-    for (auto& entry : clientContext->getCatalog()->getTableEntries(clientContext->getTx())) {
+    for (auto& entry :
+        clientContext->getCatalog()->getTableEntries(clientContext->getTransaction())) {
         dataInfo.tableIDToName.insert({entry->getTableID(), entry->getName()});
     }
     // Info

--- a/src/processor/map/map_scan_node_table.cpp
+++ b/src/processor/map/map_scan_node_table.cpp
@@ -16,7 +16,7 @@ namespace processor {
 std::unique_ptr<PhysicalOperator> PlanMapper::mapScanNodeTable(LogicalOperator* logicalOperator) {
     auto catalog = clientContext->getCatalog();
     auto storageManager = clientContext->getStorageManager();
-    auto transaction = clientContext->getTx();
+    auto transaction = clientContext->getTransaction();
     auto& scan = logicalOperator->constCast<LogicalScanNodeTable>();
     const auto outSchema = scan.getSchema();
     auto nodeIDPos = getDataPos(*scan.getNodeID(), *outSchema);

--- a/src/processor/operator/ddl/alter.cpp
+++ b/src/processor/operator/ddl/alter.cpp
@@ -25,7 +25,7 @@ bool skipAlter(common::ConflictAction action, skip_alter_on_conflict skipAlterOn
 
 void Alter::executeDDLInternal(ExecutionContext* context) {
     auto catalog = context->clientContext->getCatalog();
-    auto transaction = context->clientContext->getTx();
+    auto transaction = context->clientContext->getTransaction();
     switch (info.alterType) {
     case common::AlterType::ADD_PROPERTY: {
         if (skipAlter(info.onConflict, [&]() {
@@ -58,10 +58,10 @@ void Alter::executeDDLInternal(ExecutionContext* context) {
         auto& addedProp = entry->getProperty(boundAddPropInfo.propertyDefinition.getName());
         storage::TableAddColumnState state{addedProp, *defaultValueEvaluator};
         storageManager->getTable(entry->getTableID())
-            ->addColumn(context->clientContext->getTx(), state);
+            ->addColumn(context->clientContext->getTransaction(), state);
     } else if (info.alterType == common::AlterType::DROP_PROPERTY) {
         const auto schema = context->clientContext->getCatalog()->getTableCatalogEntry(
-            context->clientContext->getTx(), info.tableName);
+            context->clientContext->getTransaction(), info.tableName);
         storageManager->getTable(schema->getTableID())->dropColumn();
     }
 }

--- a/src/processor/operator/ddl/create_sequence.cpp
+++ b/src/processor/operator/ddl/create_sequence.cpp
@@ -17,14 +17,15 @@ void CreateSequence::executeDDLInternal(ExecutionContext* context) {
     auto catalog = context->clientContext->getCatalog();
     switch (info.onConflict) {
     case common::ConflictAction::ON_CONFLICT_DO_NOTHING: {
-        if (catalog->containsSequence(context->clientContext->getTx(), info.sequenceName)) {
+        if (catalog->containsSequence(context->clientContext->getTransaction(),
+                info.sequenceName)) {
             return;
         }
     }
     default:
         break;
     }
-    catalog->createSequence(context->clientContext->getTx(), info);
+    catalog->createSequence(context->clientContext->getTransaction(), info);
 }
 
 std::string CreateSequence::getOutputMsg() {

--- a/src/processor/operator/ddl/create_table.cpp
+++ b/src/processor/operator/ddl/create_table.cpp
@@ -13,14 +13,14 @@ void CreateTable::executeDDLInternal(ExecutionContext* context) {
     auto catalog = context->clientContext->getCatalog();
     switch (info.onConflict) {
     case common::ConflictAction::ON_CONFLICT_DO_NOTHING: {
-        if (catalog->containsTable(context->clientContext->getTx(), info.tableName)) {
+        if (catalog->containsTable(context->clientContext->getTransaction(), info.tableName)) {
             return;
         }
     }
     default:
         break;
     }
-    auto newTableID = catalog->createTableSchema(context->clientContext->getTx(), info);
+    auto newTableID = catalog->createTableSchema(context->clientContext->getTransaction(), info);
     tableCreated = true;
     auto storageManager = context->clientContext->getStorageManager();
     storageManager->createTable(newTableID, catalog, context->clientContext);

--- a/src/processor/operator/ddl/create_type.cpp
+++ b/src/processor/operator/ddl/create_type.cpp
@@ -14,7 +14,7 @@ std::string CreateTypePrintInfo::toString() const {
 
 void CreateType::executeDDLInternal(ExecutionContext* context) {
     auto catalog = context->clientContext->getCatalog();
-    catalog->createType(context->clientContext->getTx(), name, type.copy());
+    catalog->createType(context->clientContext->getTransaction(), name, type.copy());
 }
 
 std::string CreateType::getOutputMsg() {

--- a/src/processor/operator/ddl/drop.cpp
+++ b/src/processor/operator/ddl/drop.cpp
@@ -13,11 +13,12 @@ bool isValidEntry(parser::DropInfo& dropInfo, main::ClientContext* context) {
     bool validEntry = false;
     switch (dropInfo.dropType) {
     case common::DropType::SEQUENCE: {
-        validEntry = context->getCatalog()->containsSequence(context->getTx(), dropInfo.name);
+        validEntry =
+            context->getCatalog()->containsSequence(context->getTransaction(), dropInfo.name);
     } break;
         // TODO(Ziyi): If the table has indexes, we should drop those indexes as well.
     case common::DropType::TABLE: {
-        validEntry = context->getCatalog()->containsTable(context->getTx(), dropInfo.name);
+        validEntry = context->getCatalog()->containsTable(context->getTransaction(), dropInfo.name);
     } break;
     default:
         KU_UNREACHABLE;
@@ -32,12 +33,12 @@ void Drop::executeDDLInternal(ExecutionContext* context) {
     }
     switch (dropInfo.dropType) {
     case common::DropType::SEQUENCE: {
-        context->clientContext->getCatalog()->dropSequence(context->clientContext->getTx(),
+        context->clientContext->getCatalog()->dropSequence(context->clientContext->getTransaction(),
             dropInfo.name);
     } break;
     case common::DropType::TABLE: {
-        context->clientContext->getCatalog()->dropTableEntry(context->clientContext->getTx(),
-            dropInfo.name);
+        context->clientContext->getCatalog()->dropTableEntry(
+            context->clientContext->getTransaction(), dropInfo.name);
     } break;
     default:
         KU_UNREACHABLE;

--- a/src/processor/operator/index_lookup.cpp
+++ b/src/processor/operator/index_lookup.cpp
@@ -124,7 +124,7 @@ bool IndexLookup::getNextTuplesInternal(ExecutionContext* context) {
     }
     for (auto& info : infos) {
         KU_ASSERT(info);
-        lookup(context->clientContext->getTx(), *info);
+        lookup(context->clientContext->getTransaction(), *info);
     }
     localState->errorHandler->flushStoredErrors();
     return true;

--- a/src/processor/operator/macro/create_macro.cpp
+++ b/src/processor/operator/macro/create_macro.cpp
@@ -15,7 +15,7 @@ bool CreateMacro::getNextTuplesInternal(kuzu::processor::ExecutionContext* conte
     if (hasExecuted) {
         return false;
     }
-    createMacroInfo->catalog->addScalarMacroFunction(context->clientContext->getTx(),
+    createMacroInfo->catalog->addScalarMacroFunction(context->clientContext->getTransaction(),
         createMacroInfo->macroName, createMacroInfo->macro->copy());
     hasExecuted = true;
     outputVector->setValue<std::string>(outputVector->state->getSelVector()[0],

--- a/src/processor/operator/partitioner.cpp
+++ b/src/processor/operator/partitioner.cpp
@@ -38,8 +38,8 @@ static partition_idx_t getNumPartitions(offset_t maxOffset) {
 
 void PartitionerSharedState::initialize(const PartitionerDataInfo& dataInfo,
     main::ClientContext* clientContext) {
-    maxNodeOffsets[0] = srcNodeTable->getNumTotalRows(clientContext->getTx());
-    maxNodeOffsets[1] = dstNodeTable->getNumTotalRows(clientContext->getTx());
+    maxNodeOffsets[0] = srcNodeTable->getNumTotalRows(clientContext->getTransaction());
+    maxNodeOffsets[1] = dstNodeTable->getNumTotalRows(clientContext->getTransaction());
     numPartitions[0] = getNumPartitions(maxNodeOffsets[0]);
     numPartitions[1] = getNumPartitions(maxNodeOffsets[1]);
     Partitioner::initializePartitioningStates(dataInfo, partitioningBuffers, numPartitions);

--- a/src/processor/operator/persistent/delete_executor.cpp
+++ b/src/processor/operator/persistent/delete_executor.cpp
@@ -73,10 +73,10 @@ void SingleLabelNodeDeleteExecutor::delete_(ExecutionContext* context) {
     KU_ASSERT(tableInfo.pkVector->state == info.nodeIDVector->state);
     auto deleteState =
         std::make_unique<NodeTableDeleteState>(*info.nodeIDVector, *tableInfo.pkVector);
-    if (!tableInfo.table->delete_(context->clientContext->getTx(), *deleteState)) {
+    if (!tableInfo.table->delete_(context->clientContext->getTransaction(), *deleteState)) {
         return;
     }
-    auto transaction = context->clientContext->getTx();
+    auto transaction = context->clientContext->getTransaction();
     switch (info.deleteType) {
     case DeleteNodeType::DELETE: {
         tableInfo.deleteFromRelTable(transaction, info.nodeIDVector);
@@ -107,10 +107,10 @@ void MultiLabelNodeDeleteExecutor::delete_(ExecutionContext* context) {
     auto& tableInfo = tableInfos.at(nodeID.tableID);
     auto deleteState =
         std::make_unique<NodeTableDeleteState>(*info.nodeIDVector, *tableInfo.pkVector);
-    if (!tableInfo.table->delete_(context->clientContext->getTx(), *deleteState)) {
+    if (!tableInfo.table->delete_(context->clientContext->getTransaction(), *deleteState)) {
         return;
     }
-    auto transaction = context->clientContext->getTx();
+    auto transaction = context->clientContext->getTransaction();
     switch (info.deleteType) {
     case DeleteNodeType::DELETE: {
         tableInfo.deleteFromRelTable(transaction, info.nodeIDVector);
@@ -136,7 +136,7 @@ void RelDeleteExecutor::init(ResultSet* resultSet, ExecutionContext*) {
 void SingleLabelRelDeleteExecutor::delete_(ExecutionContext* context) {
     auto deleteState = std::make_unique<RelTableDeleteState>(*info.srcNodeIDVector,
         *info.dstNodeIDVector, *info.relIDVector);
-    table->delete_(context->clientContext->getTx(), *deleteState);
+    table->delete_(context->clientContext->getTransaction(), *deleteState);
 }
 
 void MultiLabelRelDeleteExecutor::delete_(ExecutionContext* context) {
@@ -148,7 +148,7 @@ void MultiLabelRelDeleteExecutor::delete_(ExecutionContext* context) {
     auto table = tableIDToTableMap.at(relID.tableID);
     auto deleteState = std::make_unique<RelTableDeleteState>(*info.srcNodeIDVector,
         *info.dstNodeIDVector, *info.relIDVector);
-    table->delete_(context->clientContext->getTx(), *deleteState);
+    table->delete_(context->clientContext->getTransaction(), *deleteState);
 }
 
 } // namespace processor

--- a/src/processor/operator/persistent/insert.cpp
+++ b/src/processor/operator/persistent/insert.cpp
@@ -30,10 +30,10 @@ bool Insert::getNextTuplesInternal(ExecutionContext* context) {
         return false;
     }
     for (auto& executor : nodeExecutors) {
-        executor.insert(context->clientContext->getTx());
+        executor.insert(context->clientContext->getTransaction());
     }
     for (auto& executor : relExecutors) {
-        executor.insert(context->clientContext->getTx());
+        executor.insert(context->clientContext->getTransaction());
     }
     return true;
 }

--- a/src/processor/operator/persistent/merge.cpp
+++ b/src/processor/operator/persistent/merge.cpp
@@ -94,12 +94,12 @@ void Merge::executeOnNewPattern(PatternCreationInfo& patternCreationInfo,
     for (auto i = 0u; i < nodeInsertExecutors.size(); i++) {
         auto& executor = nodeInsertExecutors[i];
         executor.setNodeIDVectorToNonNull();
-        auto nodeID = executor.insert(context->clientContext->getTx());
+        auto nodeID = executor.insert(context->clientContext->getTransaction());
         patternCreationInfo.updateID(i, info.executorInfo, nodeID);
     }
     for (auto i = 0u; i < relInsertExecutors.size(); i++) {
         auto& executor = relInsertExecutors[i];
-        auto relID = executor.insert(context->clientContext->getTx());
+        auto relID = executor.insert(context->clientContext->getTransaction());
         patternCreationInfo.updateID(i + nodeInsertExecutors.size(), info.executorInfo, relID);
     }
     for (auto& executor : onCreateNodeSetExecutors) {

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -32,8 +32,8 @@ void NodeBatchInsertSharedState::initPKIndex(const ExecutionContext* context) {
     }
     auto* nodeTable = ku_dynamic_cast<NodeTable*>(table);
     nodeTable->getPKIndex()->bulkReserve(numRows);
-    globalIndexBuilder = IndexBuilder(
-        std::make_shared<IndexBuilderSharedState>(context->clientContext->getTx(), nodeTable));
+    globalIndexBuilder = IndexBuilder(std::make_shared<IndexBuilderSharedState>(
+        context->clientContext->getTransaction(), nodeTable));
 }
 
 void NodeBatchInsert::initGlobalStateInternal(ExecutionContext* context) {
@@ -93,12 +93,12 @@ void NodeBatchInsert::executeInternal(ExecutionContext* context) {
                 break;
             }
         }
-        copyToNodeGroup(context->clientContext->getTx(),
+        copyToNodeGroup(context->clientContext->getTransaction(),
             context->clientContext->getMemoryManager());
         nodeLocalState->columnState->setSelVector(originalSelVector);
     }
     if (nodeLocalState->chunkedGroup->getNumRows() > 0) {
-        appendIncompleteNodeGroup(context->clientContext->getTx(),
+        appendIncompleteNodeGroup(context->clientContext->getTransaction(),
             std::move(nodeLocalState->chunkedGroup), nodeLocalState->localIndexBuilder,
             context->clientContext->getMemoryManager());
     }
@@ -220,7 +220,7 @@ void NodeBatchInsert::finalize(ExecutionContext* context) {
     auto errorHandler = createErrorHandler(context);
     if (nodeSharedState->sharedNodeGroup) {
         while (nodeSharedState->sharedNodeGroup->getNumRows() > 0) {
-            writeAndResetNodeGroup(context->clientContext->getTx(),
+            writeAndResetNodeGroup(context->clientContext->getTransaction(),
                 nodeSharedState->sharedNodeGroup, nodeSharedState->globalIndexBuilder,
                 context->clientContext->getMemoryManager(), errorHandler);
         }

--- a/src/processor/operator/persistent/node_batch_insert_error_handler.cpp
+++ b/src/processor/operator/persistent/node_batch_insert_error_handler.cpp
@@ -25,7 +25,7 @@ void NodeBatchInsertErrorHandler::deleteCurrentErroneousRow() {
         *offsetVector,
         *keyVector,
     };
-    nodeTable->delete_(context->clientContext->getTx(), deleteState);
+    nodeTable->delete_(context->clientContext->getTransaction(), deleteState);
 }
 
 void NodeBatchInsertErrorHandler::flushStoredErrors() {

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -69,11 +69,11 @@ void RelBatchInsert::executeInternal(ExecutionContext* context) {
         // TODO(Guodong): We need to handle the concurrency between COPY and other insertions
         // into the same node group.
         auto& nodeGroup = relTable
-                              ->getOrCreateNodeGroup(context->clientContext->getTx(),
+                              ->getOrCreateNodeGroup(context->clientContext->getTransaction(),
                                   relLocalState->nodeGroupIdx, relInfo->direction)
                               ->cast<CSRNodeGroup>();
-        appendNodeGroup(context->clientContext->getTx(), nodeGroup, *relInfo, *relLocalState,
-            *sharedState, *partitionerSharedState);
+        appendNodeGroup(context->clientContext->getTransaction(), nodeGroup, *relInfo,
+            *relLocalState, *sharedState, *partitionerSharedState);
         updateProgress(context);
     }
 }

--- a/src/processor/operator/persistent/set_executor.cpp
+++ b/src/processor/operator/persistent/set_executor.cpp
@@ -55,7 +55,7 @@ void SingleLabelNodeSetExecutor::set(ExecutionContext* context) {
     auto updateState = std::make_unique<storage::NodeTableUpdateState>(tableInfo.columnID,
         *info.nodeIDVector, *info.columnDataVector);
     updateState->pkVector = info.pkVector;
-    tableInfo.table->update(context->clientContext->getTx(), *updateState);
+    tableInfo.table->update(context->clientContext->getTransaction(), *updateState);
     if (info.columnVectorPos.isValid()) {
         writeColumnUpdateResult(info.nodeIDVector, info.columnVector, info.columnDataVector);
     }
@@ -77,7 +77,7 @@ void MultiLabelNodeSetExecutor::set(ExecutionContext* context) {
     auto updateState = std::make_unique<storage::NodeTableUpdateState>(tableInfo.columnID,
         *info.nodeIDVector, *info.columnDataVector);
     updateState->pkVector = info.pkVector;
-    tableInfo.table->update(context->clientContext->getTx(), *updateState);
+    tableInfo.table->update(context->clientContext->getTransaction(), *updateState);
     if (info.columnVectorPos.isValid()) {
         writeColumnUpdateResult(info.nodeIDVector, info.columnVector, info.columnDataVector);
     }
@@ -112,7 +112,7 @@ void SingleLabelRelSetExecutor::set(ExecutionContext* context) {
     info.evaluator->evaluate();
     auto updateState = std::make_unique<storage::RelTableUpdateState>(tableInfo.columnID,
         *info.srcNodeIDVector, *info.dstNodeIDVector, *info.relIDVector, *info.columnDataVector);
-    tableInfo.table->update(context->clientContext->getTx(), *updateState);
+    tableInfo.table->update(context->clientContext->getTransaction(), *updateState);
     if (info.columnVectorPos.isValid()) {
         writeColumnUpdateResult(info.relIDVector, info.columnVector, info.columnDataVector);
     }
@@ -132,7 +132,7 @@ void MultiLabelRelSetExecutor::set(ExecutionContext* context) {
     auto& tableInfo = tableInfos.at(relID.tableID);
     auto updateState = std::make_unique<storage::RelTableUpdateState>(tableInfo.columnID,
         *info.srcNodeIDVector, *info.dstNodeIDVector, *info.relIDVector, *info.columnDataVector);
-    tableInfo.table->update(context->clientContext->getTx(), *updateState);
+    tableInfo.table->update(context->clientContext->getTransaction(), *updateState);
     if (info.columnVectorPos.isValid()) {
         writeColumnUpdateResult(info.relIDVector, info.columnVector, info.columnDataVector);
     }

--- a/src/processor/operator/scan/offset_scan_node_table.cpp
+++ b/src/processor/operator/scan/offset_scan_node_table.cpp
@@ -30,7 +30,7 @@ bool OffsetScanNodeTable::getNextTuplesInternal(ExecutionContext* context) {
         return false;
     }
     executed = true;
-    auto transaction = context->clientContext->getTx();
+    auto transaction = context->clientContext->getTransaction();
     auto nodeID = nodeIDVector->getValue<nodeID_t>(0);
     KU_ASSERT(tableIDToNodeInfo.contains(nodeID.tableID));
     auto& nodeInfo = tableIDToNodeInfo.at(nodeID.tableID);

--- a/src/processor/operator/scan/primary_key_scan_node_table.cpp
+++ b/src/processor/operator/scan/primary_key_scan_node_table.cpp
@@ -55,7 +55,7 @@ void PrimaryKeyScanNodeTable::initVectors(TableScanState& state, const ResultSet
 }
 
 bool PrimaryKeyScanNodeTable::getNextTuplesInternal(ExecutionContext* context) {
-    auto transaction = context->clientContext->getTx();
+    auto transaction = context->clientContext->getTransaction();
     auto tableIdx = sharedState->getTableIdx();
     if (tableIdx >= nodeInfos.size()) {
         return false;

--- a/src/processor/operator/scan/scan_multi_rel_tables.cpp
+++ b/src/processor/operator/scan/scan_multi_rel_tables.cpp
@@ -61,7 +61,7 @@ void ScanMultiRelTable::initLocalStateInternal(ResultSet* resultSet, ExecutionCo
             KU_ASSERT(outState == scanState.outState);
             scanState.nodeIDVector = boundNodeIDVector;
             if (const auto localRelTable =
-                    context->clientContext->getTx()->getLocalStorage()->getLocalTable(
+                    context->clientContext->getTransaction()->getLocalStorage()->getLocalTable(
                         relInfo.table->getTableID(), LocalStorage::NotExistAction::RETURN_NULL)) {
                 auto localTableColumnIDs = LocalRelTable::rewriteLocalColumnIDs(relInfo.direction,
                     relInfo.scanState->columnIDs);
@@ -88,7 +88,8 @@ void ScanMultiRelTable::initVectors(TableScanState& state, const ResultSet& resu
 
 bool ScanMultiRelTable::getNextTuplesInternal(ExecutionContext* context) {
     while (true) {
-        if (currentScanner != nullptr && currentScanner->scan(context->clientContext->getTx())) {
+        if (currentScanner != nullptr &&
+            currentScanner->scan(context->clientContext->getTransaction())) {
             metrics->numOutputTuple.increase(outState->getSelVector().getSelSize());
             return true;
         }

--- a/src/processor/operator/scan/scan_node_table.cpp
+++ b/src/processor/operator/scan/scan_node_table.cpp
@@ -103,13 +103,13 @@ void ScanNodeTable::initVectors(TableScanState& state, const ResultSet& resultSe
 void ScanNodeTable::initGlobalStateInternal(ExecutionContext* context) {
     KU_ASSERT(sharedStates.size() == nodeInfos.size());
     for (auto i = 0u; i < nodeInfos.size(); i++) {
-        sharedStates[i]->initialize(context->clientContext->getTx(), nodeInfos[i].table,
+        sharedStates[i]->initialize(context->clientContext->getTransaction(), nodeInfos[i].table,
             *progressSharedState);
     }
 }
 
 bool ScanNodeTable::getNextTuplesInternal(ExecutionContext* context) {
-    const auto transaction = context->clientContext->getTx();
+    const auto transaction = context->clientContext->getTransaction();
     while (currentTableIdx < nodeInfos.size()) {
         const auto& info = nodeInfos[currentTableIdx];
         auto& scanState = *info.localScanState;

--- a/src/processor/operator/scan/scan_rel_table.cpp
+++ b/src/processor/operator/scan/scan_rel_table.cpp
@@ -74,7 +74,7 @@ void ScanRelTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext
     relInfo.initScanState(context);
     initVectors(*relInfo.scanState, *resultSet);
     if (const auto localRelTable =
-            context->clientContext->getTx()->getLocalStorage()->getLocalTable(
+            context->clientContext->getTransaction()->getLocalStorage()->getLocalTable(
                 relInfo.table->getTableID(), LocalStorage::NotExistAction::RETURN_NULL)) {
         auto localTableColumnIDs =
             LocalRelTable::rewriteLocalColumnIDs(relInfo.direction, relInfo.scanState->columnIDs);
@@ -91,7 +91,7 @@ void ScanRelTable::initVectors(TableScanState& state, const ResultSet& resultSet
 }
 
 bool ScanRelTable::getNextTuplesInternal(ExecutionContext* context) {
-    const auto transaction = context->clientContext->getTx();
+    const auto transaction = context->clientContext->getTransaction();
     auto& scanState = *relInfo.scanState;
     while (true) {
         while (relInfo.table->scan(transaction, scanState)) {

--- a/src/processor/operator/simple/import_db.cpp
+++ b/src/processor/operator/simple/import_db.cpp
@@ -7,8 +7,6 @@ using namespace kuzu::catalog;
 namespace kuzu {
 namespace processor {
 
-using std::stringstream;
-
 void ImportDB::executeInternal(ExecutionContext* context) {
     if (query.empty()) { // Export empty database.
         return;
@@ -20,7 +18,7 @@ void ImportDB::executeInternal(ExecutionContext* context) {
     if (context->clientContext->getTransactionContext()->hasActiveTransaction()) {
         context->clientContext->getTransactionContext()->commit();
     }
-    context->clientContext->queryInternal(query, std::nullopt /* queryID */);
+    context->clientContext->queryNoLock(query);
 }
 
 std::string ImportDB::getOutputMsg() {

--- a/src/storage/local_storage/local_storage.cpp
+++ b/src/storage/local_storage/local_storage.cpp
@@ -43,13 +43,13 @@ void LocalStorage::commit() {
     for (auto& [tableID, localTable] : tables) {
         if (localTable->getTableType() == TableType::NODE) {
             const auto table = clientContext.getStorageManager()->getTable(tableID);
-            table->commit(clientContext.getTx(), localTable.get());
+            table->commit(clientContext.getTransaction(), localTable.get());
         }
     }
     for (auto& [tableID, localTable] : tables) {
         if (localTable->getTableType() == TableType::REL) {
             const auto table = clientContext.getStorageManager()->getTable(tableID);
-            table->commit(clientContext.getTx(), localTable.get());
+            table->commit(clientContext.getTransaction(), localTable.get());
         }
     }
 }

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -114,18 +114,18 @@ void StorageManager::createRelTableGroup(table_id_t, const RelGroupCatalogEntry*
 void StorageManager::createTable(table_id_t tableID, const Catalog* catalog,
     main::ClientContext* context) {
     std::lock_guard lck{mtx};
-    const auto tableEntry = catalog->getTableCatalogEntry(context->getTx(), tableID);
+    const auto tableEntry = catalog->getTableCatalogEntry(context->getTransaction(), tableID);
     switch (tableEntry->getTableType()) {
     case TableType::NODE: {
         createNodeTable(tableID, tableEntry->ptrCast<NodeTableCatalogEntry>(), context);
     } break;
     case TableType::REL: {
         createRelTable(tableID, tableEntry->ptrCast<RelTableCatalogEntry>(), catalog,
-            context->getTx());
+            context->getTransaction());
     } break;
     case TableType::REL_GROUP: {
         createRelTableGroup(tableID, tableEntry->ptrCast<RelGroupCatalogEntry>(), catalog,
-            context->getTx());
+            context->getTransaction());
     } break;
     default: {
         KU_UNREACHABLE;

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -94,7 +94,7 @@ void Transaction::pushCatalogEntry(CatalogSet& catalogSet, CatalogEntry& catalog
                 return;
             }
             wal->logCreateTableEntryRecord(
-                tableEntry.getBoundCreateTableInfo(clientContext->getTx()));
+                tableEntry.getBoundCreateTableInfo(clientContext->getTransaction()));
         } else {
             // Must be alter.
             KU_ASSERT(catalogEntry.getType() == newCatalogEntry->getType());
@@ -168,7 +168,7 @@ void Transaction::pushCatalogEntry(CatalogSet& catalogSet, CatalogEntry& catalog
 void Transaction::pushSequenceChange(SequenceCatalogEntry* sequenceEntry, int64_t kCount,
     const SequenceRollbackData& data) const {
     undoBuffer->createSequenceChange(*sequenceEntry, data);
-    if (clientContext->getTx()->shouldLogToWAL()) {
+    if (clientContext->getTransaction()->shouldLogToWAL()) {
         clientContext->getWAL()->logUpdateSequenceRecord(sequenceEntry->getOID(), kCount);
     }
 }

--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -30,8 +30,8 @@ public:
     bool reserve(uint64_t sizeToReserve) override {
         const bool inCheckpoint =
             ctx && !ctx->getTransactionManagerUnsafe()->hasActiveWriteTransactionNoLock();
-        const bool inCommit =
-            !inCheckpoint && ctx && ctx->getTx()->getCommitTS() != common::INVALID_TRANSACTION;
+        const bool inCommit = !inCheckpoint && ctx &&
+                              ctx->getTransaction()->getCommitTS() != common::INVALID_TRANSACTION;
         const bool inExecute = (!inCommit && !inCheckpoint);
         reserveCount = (reserveCount + 1) % failureFrequency;
         if ((canFailDuringCheckpoint || !inCheckpoint) && (canFailDuringExecute || !inExecute) &&
@@ -219,7 +219,6 @@ TEST_F(CopyTest, NodeInsertBMExceptionDuringCommitRecovery) {
             [](main::Connection* conn, int) {
                 const auto queryString = common::stringFormat(
                     "UNWIND RANGE(1,{}) AS i CREATE (a:account {ID:i})", numValues);
-
                 return conn->query(queryString);
             },
         .earlyExitOnFailureFunc = [](main::QueryResult*) { return false; },

--- a/test/storage/compress_chunk_test.cpp
+++ b/test/storage/compress_chunk_test.cpp
@@ -151,10 +151,10 @@ void CompressChunkTest::testCompressChunk(const std::vector<T>& bufferToCompress
     state.numValuesPerPage = state.metadata.compMeta.numValues(KUZU_PAGE_SIZE, dataType);
     if (chunkMetadata.compMeta.compression == CompressionType::ALP) {
         state.alpExceptionChunk = std::make_unique<InMemoryExceptionChunk<T>>(
-            clientContext->getTx(), state, dataFH, mm, &storageManager->getShadowFile());
+            clientContext->getTransaction(), state, dataFH, mm, &storageManager->getShadowFile());
     }
 
-    checkFunc(columnReader.get(), clientContext->getTx(), state, dataType);
+    checkFunc(columnReader.get(), clientContext->getTransaction(), state, dataType);
 }
 
 template<std::floating_point T>

--- a/test/storage/rel_scan_test.cpp
+++ b/test/storage/rel_scan_test.cpp
@@ -27,7 +27,7 @@ public:
         conn->query("BEGIN TRANSACTION");
         context = getClientContext(*conn);
         catalog = context->getCatalog();
-        auto transaction = context->getTx();
+        auto transaction = context->getTransaction();
         auto nodeTableIDs = catalog->getNodeTableIDs(transaction);
         auto relTableIDs = catalog->getRelTableIDs(transaction);
         entry = std::make_unique<kuzu::graph::GraphEntry>(
@@ -51,10 +51,10 @@ class RelScanTestAmazon : public RelScanTest {
 
 // Test correctness of scan fwd
 TEST_F(RelScanTest, ScanFwd) {
-    auto tableID = catalog->getTableID(context->getTx(), "person");
-    auto relTableID = catalog->getTableID(context->getTx(), "knows");
-    auto datePropertyIndex =
-        catalog->getTableCatalogEntry(context->getTx(), relTableID)->getPropertyIdx("date");
+    auto tableID = catalog->getTableID(context->getTransaction(), "person");
+    auto relTableID = catalog->getTableID(context->getTransaction(), "knows");
+    auto datePropertyIndex = catalog->getTableCatalogEntry(context->getTransaction(), relTableID)
+                                 ->getPropertyIdx("date");
     auto scanState = graph->prepareScan(relTableID, datePropertyIndex);
 
     std::unordered_map<offset_t, common::date_t> expectedDates = {
@@ -133,7 +133,7 @@ TEST_F(RelScanTest, ScanFwd) {
 }
 
 TEST_F(RelScanTest, ScanVertexProperties) {
-    auto tableID = catalog->getTableID(context->getTx(), "person");
+    auto tableID = catalog->getTableID(context->getTransaction(), "person");
     std::vector<std::string> properties = {"fname", "height"};
     auto scanState = graph->prepareVertexScan(tableID, properties);
 

--- a/test/test_files/transaction/ddl/sequence.test
+++ b/test/test_files/transaction/ddl/sequence.test
@@ -10,10 +10,10 @@
 ---- error
 Can not execute a write query inside a read-only transaction.
 -STATEMENT BEGIN TRANSACTION READ ONLY;
----- ok
--STATEMENT CREATE SEQUENCE after;
 ---- error
-Can not execute a write query inside a read-only transaction.
+Connection already has an active transaction. Cannot start a transaction within another one. For concurrent multiple transactions, please open other connections.
+-STATEMENT CREATE SEQUENCE after;
+---- ok
 -STATEMENT RETURN currval('before');
 ---- error
 Catalog exception: currval: sequence "before" is not yet defined. To define the sequence, call nextval first.


### PR DESCRIPTION
# Description

This PR fixes two problems related to the usage of transactions:
1. Parser relies on transaction to resolve data type for default null value, which should be done in the binder phase.
2. Parser and prepare unnecessarily starts and commits transactions, leading to multiple transactions in a single statement.

For the first problem, the PR moves resolving data type of default null from Parser to Binder, thus, Parser doesn't rely on transactions.
For the second problem, the PR unifies how transactions should auto begin and commit/rollback in `TransactionHelper::runFuncInTransaction()`, and avoids unnecessary begin/commits of transactions.