### PR TITLE
Add parsing time to compilation time and remove unnecessary clone of plan

### DIFF
--- a/src/include/parser/statement.h
+++ b/src/include/parser/statement.h
@@ -9,13 +9,15 @@ namespace parser {
 class Statement {
 public:
     explicit Statement(common::StatementType statementType)
-        : statementType{statementType}, internal{false} {}
+        : parsingTime{0}, statementType{statementType}, internal{false} {}
 
     virtual ~Statement() = default;
 
     common::StatementType getStatementType() const { return statementType; }
     void setToInternal() { internal = true; }
     bool isInternal() const { return internal; }
+    void setParsingTime(double time) { parsingTime = time; }
+    double getParsingTime() const { return parsingTime; }
 
     bool requireTransaction() const {
         switch (statementType) {
@@ -40,6 +42,7 @@ public:
     }
 
 private:
+    double parsingTime;
     common::StatementType statementType;
     // By setting the statement to internal, we still execute the statement, but will not return the
     // executio result as part of the query result returned to users.

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -113,8 +113,7 @@ std::unique_ptr<LogicalPlan> Planner::getBestPlan(const BoundStatement& statemen
     default:
         KU_UNREACHABLE;
     }
-    // Avoid sharing operator across plans.
-    return plan->deepCopy();
+    return plan;
 }
 
 std::vector<std::unique_ptr<LogicalPlan>> Planner::getAllPlans(const BoundStatement& statement) {


### PR DESCRIPTION
# Description

As stated in the title, this PR takes Parser into consideration when profiling the time spent on query compilation.

Also, removed the unnecessary clone of the best logical plan in `Planner::getBestPlan()`.