### PR TITLE
Add extension dir to tidy analyzer

### DIFF
--- a/.clang-tidy-analyzer
+++ b/.clang-tidy-analyzer
@@ -6,5 +6,5 @@ Checks:
   -clang-analyzer-cplusplus.NewDeleteLeaks,
 
 HeaderFilterRegex:
-  src/include|tools/benchmark/include|tools/nodejs_api/src_cpp/include|tools/python_api/src_cpp/include|tools/rust_api/include|tools/shell/include
+  src/include|tools/benchmark/include|tools/nodejs_api/src_cpp/include|tools/python_api/src_cpp/include|tools/rust_api/include|tools/shell/include|extension/[a-zA-Z0-9]*/src/include
 WarningsAsErrors: "*"


### PR DESCRIPTION
# Description

See title. Forgot to add extension directory to `.clang-tidy-analyzer` file when I added them to the `.clang-tidy` file in #4672 .