### PR TITLE
Move morsel dispatcher out of frontier pair

### DIFF
--- a/extension/fts/src/function/query_fts.cpp
+++ b/extension/fts/src/function/query_fts.cpp
@@ -148,7 +148,7 @@ void runFrontiersOnce(processor::ExecutionContext* executionContext, QFTSState& 
     auto& appearsInTableInfo = relTableIDInfos[0];
     frontierPair->beginFrontierComputeBetweenTables(appearsInTableInfo.fromNodeTableID,
         appearsInTableInfo.toNodeTableID);
-    GDSUtils::scheduleFrontierTask(appearsInTableInfo.toNodeTableID, appearsInTableInfo.relTableID,
+    GDSUtils::scheduleFrontierTask(appearsInTableInfo.fromNodeTableID, appearsInTableInfo.toNodeTableID, appearsInTableInfo.relTableID,
         graph, ExtendDirection::FWD, qFtsState, executionContext, 1 /* numThreads */,
         tfPropertyIdx);
 }
@@ -310,7 +310,7 @@ void QFTSAlgorithm::exec(processor::ExecutionContext* executionContext) {
     auto currentFrontier = getPathLengthsFrontier(executionContext, PathLengths::UNVISITED);
     auto nextFrontier = getPathLengthsFrontier(executionContext, PathLengths::UNVISITED);
     auto frontierPair = std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier,
-        nextFrontier, 1 /* numThreads */);
+        nextFrontier);
     auto edgeCompute = std::make_unique<QFTSEdgeCompute>(frontierPair.get(), &output->scores,
         &termsComputeSharedState.dfs);
 

--- a/extension/fts/src/function/query_fts.cpp
+++ b/extension/fts/src/function/query_fts.cpp
@@ -148,9 +148,9 @@ void runFrontiersOnce(processor::ExecutionContext* executionContext, QFTSState& 
     auto& appearsInTableInfo = relTableIDInfos[0];
     frontierPair->beginFrontierComputeBetweenTables(appearsInTableInfo.fromNodeTableID,
         appearsInTableInfo.toNodeTableID);
-    GDSUtils::scheduleFrontierTask(appearsInTableInfo.fromNodeTableID, appearsInTableInfo.toNodeTableID, appearsInTableInfo.relTableID,
-        graph, ExtendDirection::FWD, qFtsState, executionContext, 1 /* numThreads */,
-        tfPropertyIdx);
+    GDSUtils::scheduleFrontierTask(appearsInTableInfo.fromNodeTableID,
+        appearsInTableInfo.toNodeTableID, appearsInTableInfo.relTableID, graph,
+        ExtendDirection::FWD, qFtsState, executionContext, 1 /* numThreads */, tfPropertyIdx);
 }
 
 class QFTSOutputWriter {
@@ -309,8 +309,8 @@ void QFTSAlgorithm::exec(processor::ExecutionContext* executionContext) {
     // vertex compute.
     auto currentFrontier = getPathLengthsFrontier(executionContext, PathLengths::UNVISITED);
     auto nextFrontier = getPathLengthsFrontier(executionContext, PathLengths::UNVISITED);
-    auto frontierPair = std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier,
-        nextFrontier);
+    auto frontierPair =
+        std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier, nextFrontier);
     auto edgeCompute = std::make_unique<QFTSEdgeCompute>(frontierPair.get(), &output->scores,
         &termsComputeSharedState.dfs);
 

--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -253,8 +253,7 @@ private:
             std::make_unique<AllSPDestinationsOutputs>(sourceNodeID, frontier, multiplicities);
         auto outputWriter = std::make_unique<AllSPDestinationsOutputWriter>(clientContext,
             output.get(), sharedState->getOutputNodeMaskMap());
-        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,
-            clientContext->getMaxNumThreadForExec());
+        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths);
         auto edgeCompute = std::make_unique<AllSPDestinationsEdgeCompute>(frontierPair.get(),
             output->multiplicities.get());
         return RJCompState(std::move(frontierPair), std::move(edgeCompute),
@@ -290,8 +289,7 @@ private:
         writerInfo.pathNodeMask = sharedState->getPathNodeMaskMap();
         auto outputWriter = std::make_unique<SPPathsOutputWriter>(clientContext, output.get(),
             sharedState->getOutputNodeMaskMap(), writerInfo);
-        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,
-            clientContext->getMaxNumThreadForExec());
+        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths);
         auto edgeCompute =
             std::make_unique<AllSPPathsEdgeCompute>(frontierPair.get(), output->bfsGraph.get());
         return RJCompState(std::move(frontierPair), std::move(edgeCompute),

--- a/src/function/gds/gds_frontier.cpp
+++ b/src/function/gds/gds_frontier.cpp
@@ -120,9 +120,8 @@ void PathLengthsInitVertexCompute::vertexCompute(common::offset_t startOffset,
 }
 
 FrontierPair::FrontierPair(std::shared_ptr<GDSFrontier> curFrontier,
-    std::shared_ptr<GDSFrontier> nextFrontier, uint64_t numThreads)
-    : curDenseFrontier{std::move(curFrontier)}, nextDenseFrontier{std::move(nextFrontier)},
-      morselDispatcher{numThreads} {
+    std::shared_ptr<GDSFrontier> nextFrontier)
+    : curDenseFrontier{std::move(curFrontier)}, nextDenseFrontier{std::move(nextFrontier)} {
     curSparseFrontier = std::make_shared<SparseFrontier>();
     nextSparseFrontier = std::make_shared<SparseFrontier>();
     vertexComputeCandidates = std::make_shared<SparseFrontier>();
@@ -144,7 +143,6 @@ void FrontierPair::beginFrontierComputeBetweenTables(common::table_id_t curTable
     common::table_id_t nextTableID) {
     pinCurrFrontier(curTableID);
     pinNextFrontier(nextTableID);
-    morselDispatcher.init(curTableID, curDenseFrontier->getNumNodes(curTableID));
 }
 
 bool FrontierPair::continueNextIter(uint16_t maxIter) {

--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -27,7 +27,7 @@ void FrontierTask::run() {
     auto& curFrontier = sharedState->frontierPair.getCurDenseFrontier();
     switch (info.direction) {
     case ExtendDirection::FWD: {
-        while (sharedState->frontierPair.getNextRangeMorsel(morsel)) {
+        while (sharedState->morselDispatcher.getNextRangeMorsel(morsel)) {
             for (auto offset = morsel.getBeginOffset(); offset < morsel.getEndOffset(); ++offset) {
                 if (!curFrontier.isActive(offset)) {
                     continue;
@@ -41,7 +41,7 @@ void FrontierTask::run() {
         }
     } break;
     case ExtendDirection::BWD: {
-        while (sharedState->frontierPair.getNextRangeMorsel(morsel)) {
+        while (sharedState->morselDispatcher.getNextRangeMorsel(morsel)) {
             for (auto offset = morsel.getBeginOffset(); offset < morsel.getEndOffset(); ++offset) {
                 if (!curFrontier.isActive(offset)) {
                     continue;
@@ -101,7 +101,7 @@ void FrontierTask::runSparse() {
 
 void VertexComputeTask::run() {
     FrontierMorsel morsel;
-    auto graph = sharedState->graph;
+    auto graph = info.graph;
     auto localVc = info.vc.copy();
     auto tableID = sharedState->morselDispatcher.getTableID();
     if (info.hasPropertiesToScan()) {

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -39,7 +39,8 @@ void GDSUtils::scheduleFrontierTask(table_id_t boundTableID, table_id_t nbrTable
     auto info = FrontierTaskInfo(nbrTableID, relTableID, graph, extendDirection,
         *gdsComputeState.edgeCompute, edgePropertyIdx);
     auto maxThreads = numThreads ? numThreads.value() : getNumThreads(*context);
-    auto sharedState = std::make_shared<FrontierTaskSharedState>(maxThreads, *gdsComputeState.frontierPair);
+    auto sharedState =
+        std::make_shared<FrontierTaskSharedState>(maxThreads, *gdsComputeState.frontierPair);
     auto task = std::make_shared<FrontierTask>(maxThreads, info, sharedState);
 
     if (gdsComputeState.frontierPair->isCurFrontierSparse()) {
@@ -76,24 +77,24 @@ void GDSUtils::runFrontiersUntilConvergence(processor::ExecutionContext* context
             case ExtendDirection::FWD: {
                 compState.beginFrontierComputeBetweenTables(info.fromNodeTableID,
                     info.toNodeTableID);
-                scheduleFrontierTask(info.fromNodeTableID, info.toNodeTableID, info.relTableID, graph,
-                    ExtendDirection::FWD, compState, context);
+                scheduleFrontierTask(info.fromNodeTableID, info.toNodeTableID, info.relTableID,
+                    graph, ExtendDirection::FWD, compState, context);
             } break;
             case ExtendDirection::BWD: {
                 compState.beginFrontierComputeBetweenTables(info.toNodeTableID,
                     info.fromNodeTableID);
-                scheduleFrontierTask(info.toNodeTableID, info.fromNodeTableID, info.relTableID, graph,
-                    ExtendDirection::BWD, compState, context);
+                scheduleFrontierTask(info.toNodeTableID, info.fromNodeTableID, info.relTableID,
+                    graph, ExtendDirection::BWD, compState, context);
             } break;
             case ExtendDirection::BOTH: {
                 compState.beginFrontierComputeBetweenTables(info.fromNodeTableID,
                     info.toNodeTableID);
-                scheduleFrontierTask(info.fromNodeTableID, info.toNodeTableID, info.relTableID, graph,
-                    ExtendDirection::FWD, compState, context);
+                scheduleFrontierTask(info.fromNodeTableID, info.toNodeTableID, info.relTableID,
+                    graph, ExtendDirection::FWD, compState, context);
                 compState.beginFrontierComputeBetweenTables(info.toNodeTableID,
                     info.fromNodeTableID);
-                scheduleFrontierTask(info.toNodeTableID, info.fromNodeTableID, info.relTableID, graph,
-                    ExtendDirection::BWD, compState, context);
+                scheduleFrontierTask(info.toNodeTableID, info.fromNodeTableID, info.relTableID,
+                    graph, ExtendDirection::BWD, compState, context);
             } break;
             default:
                 KU_UNREACHABLE;

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -31,15 +31,15 @@ static uint64_t getNumThreads(processor::ExecutionContext& context) {
         .getValue<uint64_t>();
 }
 
-void GDSUtils::scheduleFrontierTask(table_id_t nbrTableID, table_id_t relTableID,
-    graph::Graph* graph, ExtendDirection extendDirection, GDSComputeState& gdsComputeState,
-    processor::ExecutionContext* context, std::optional<uint64_t> numThreads,
-    std::optional<common::idx_t> edgePropertyIdx) {
+void GDSUtils::scheduleFrontierTask(table_id_t boundTableID, table_id_t nbrTableID,
+    table_id_t relTableID, graph::Graph* graph, ExtendDirection extendDirection,
+    GDSComputeState& gdsComputeState, processor::ExecutionContext* context,
+    std::optional<uint64_t> numThreads, std::optional<common::idx_t> edgePropertyIdx) {
     auto clientContext = context->clientContext;
     auto info = FrontierTaskInfo(nbrTableID, relTableID, graph, extendDirection,
         *gdsComputeState.edgeCompute, edgePropertyIdx);
-    auto sharedState = std::make_shared<FrontierTaskSharedState>(*gdsComputeState.frontierPair);
-    uint64_t maxThreads = numThreads ? numThreads.value() : getNumThreads(*context);
+    auto maxThreads = numThreads ? numThreads.value() : getNumThreads(*context);
+    auto sharedState = std::make_shared<FrontierTaskSharedState>(maxThreads, *gdsComputeState.frontierPair);
     auto task = std::make_shared<FrontierTask>(maxThreads, info, sharedState);
 
     if (gdsComputeState.frontierPair->isCurFrontierSparse()) {
@@ -55,6 +55,7 @@ void GDSUtils::scheduleFrontierTask(table_id_t nbrTableID, table_id_t relTableID
     // more generally decrease the number of worker threads by 1. Therefore, we instruct
     // scheduleTaskAndWaitOrError to start a new thread by passing true as the last
     // argument.
+    task->init(boundTableID, graph->getNumNodes(clientContext->getTransaction(), boundTableID));
     clientContext->getTaskScheduler()->scheduleTaskAndWaitOrError(task, context,
         true /* launchNewWorkerThread */);
 }
@@ -75,23 +76,23 @@ void GDSUtils::runFrontiersUntilConvergence(processor::ExecutionContext* context
             case ExtendDirection::FWD: {
                 compState.beginFrontierComputeBetweenTables(info.fromNodeTableID,
                     info.toNodeTableID);
-                scheduleFrontierTask(info.toNodeTableID, info.relTableID, graph,
+                scheduleFrontierTask(info.fromNodeTableID, info.toNodeTableID, info.relTableID, graph,
                     ExtendDirection::FWD, compState, context);
             } break;
             case ExtendDirection::BWD: {
                 compState.beginFrontierComputeBetweenTables(info.toNodeTableID,
                     info.fromNodeTableID);
-                scheduleFrontierTask(info.fromNodeTableID, info.relTableID, graph,
+                scheduleFrontierTask(info.toNodeTableID, info.fromNodeTableID, info.relTableID, graph,
                     ExtendDirection::BWD, compState, context);
             } break;
             case ExtendDirection::BOTH: {
                 compState.beginFrontierComputeBetweenTables(info.fromNodeTableID,
                     info.toNodeTableID);
-                scheduleFrontierTask(info.toNodeTableID, info.relTableID, graph,
+                scheduleFrontierTask(info.fromNodeTableID, info.toNodeTableID, info.relTableID, graph,
                     ExtendDirection::FWD, compState, context);
                 compState.beginFrontierComputeBetweenTables(info.toNodeTableID,
                     info.fromNodeTableID);
-                scheduleFrontierTask(info.fromNodeTableID, info.relTableID, graph,
+                scheduleFrontierTask(info.toNodeTableID, info.fromNodeTableID, info.relTableID, graph,
                     ExtendDirection::BWD, compState, context);
             } break;
             default:
@@ -112,8 +113,8 @@ static void runVertexComputeInternal(common::table_id_t tableID, graph::Graph* g
 void GDSUtils::runVertexCompute(processor::ExecutionContext* context, graph::Graph* graph,
     VertexCompute& vc, std::vector<std::string> propertiesToScan) {
     auto maxThreads = getNumThreads(*context);
-    auto info = VertexComputeTaskInfo(vc, propertiesToScan);
-    auto sharedState = std::make_shared<VertexComputeTaskSharedState>(maxThreads, graph);
+    auto info = VertexComputeTaskInfo(vc, graph, propertiesToScan);
+    auto sharedState = std::make_shared<VertexComputeTaskSharedState>(maxThreads);
     for (auto& tableID : graph->getNodeTableIDs()) {
         if (!vc.beginOnTable(tableID)) {
             continue;
@@ -130,8 +131,8 @@ void GDSUtils::runVertexCompute(ExecutionContext* context, Graph* graph, VertexC
 void GDSUtils::runVertexCompute(ExecutionContext* context, Graph* graph, VertexCompute& vc,
     table_id_t tableID, std::vector<std::string> propertiesToScan) {
     auto maxThreads = getNumThreads(*context);
-    auto info = VertexComputeTaskInfo(vc, propertiesToScan);
-    auto sharedState = std::make_shared<VertexComputeTaskSharedState>(maxThreads, graph);
+    auto info = VertexComputeTaskInfo(vc, graph, propertiesToScan);
+    auto sharedState = std::make_shared<VertexComputeTaskSharedState>(maxThreads);
     if (!vc.beginOnTable(tableID)) {
         return;
     }

--- a/src/function/gds/single_shortest_paths.cpp
+++ b/src/function/gds/single_shortest_paths.cpp
@@ -109,8 +109,7 @@ private:
         auto output = std::make_unique<SingleSPDestinationsOutputs>(sourceNodeID, frontier);
         auto outputWriter = std::make_unique<DestinationsOutputWriter>(clientContext, output.get(),
             sharedState->getOutputNodeMaskMap());
-        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,
-            clientContext->getMaxNumThreadForExec());
+        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths);
         auto edgeCompute = std::make_unique<SingleSPDestinationsEdgeCompute>(frontierPair.get());
         return RJCompState(std::move(frontierPair), std::move(edgeCompute),
             sharedState->getOutputNodeMaskMap(), std::move(output), std::move(outputWriter));
@@ -145,8 +144,7 @@ private:
         writerInfo.pathNodeMask = sharedState->getPathNodeMaskMap();
         auto outputWriter = std::make_unique<SPPathsOutputWriter>(clientContext, output.get(),
             sharedState->getOutputNodeMaskMap(), writerInfo);
-        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,
-            clientContext->getMaxNumThreadForExec());
+        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths);
         auto edgeCompute =
             std::make_unique<SingleSPPathsEdgeCompute>(frontierPair.get(), output->bfsGraph.get());
         return RJCompState(std::move(frontierPair), std::move(edgeCompute),

--- a/src/function/gds/variable_length_path.cpp
+++ b/src/function/gds/variable_length_path.cpp
@@ -140,7 +140,7 @@ private:
         auto currentFrontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
         auto nextFrontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
         auto frontierPair = std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier,
-            nextFrontier, clientContext->getMaxNumThreadForExec());
+            nextFrontier);
         auto edgeCompute =
             std::make_unique<VarLenJoinsEdgeCompute>(frontierPair.get(), output->bfsGraph.get());
         return RJCompState(std::move(frontierPair), std::move(edgeCompute),

--- a/src/function/gds/variable_length_path.cpp
+++ b/src/function/gds/variable_length_path.cpp
@@ -139,8 +139,8 @@ private:
             sharedState->getOutputNodeMaskMap(), writerInfo);
         auto currentFrontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
         auto nextFrontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
-        auto frontierPair = std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier,
-            nextFrontier);
+        auto frontierPair =
+            std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier, nextFrontier);
         auto edgeCompute =
             std::make_unique<VarLenJoinsEdgeCompute>(frontierPair.get(), output->bfsGraph.get());
         return RJCompState(std::move(frontierPair), std::move(edgeCompute),

--- a/src/function/gds/weakly_connected_components.cpp
+++ b/src/function/gds/weakly_connected_components.cpp
@@ -23,8 +23,8 @@ namespace function {
 class WCCFrontierPair : public FrontierPair {
 public:
     WCCFrontierPair(std::shared_ptr<GDSFrontier> curFrontier,
-        std::shared_ptr<GDSFrontier> nextFrontier,
-        table_id_map_t<offset_t> numNodesMap, storage::MemoryManager* mm)
+        std::shared_ptr<GDSFrontier> nextFrontier, table_id_map_t<offset_t> numNodesMap,
+        storage::MemoryManager* mm)
         : FrontierPair(curFrontier, nextFrontier) {
         for (const auto& [tableID, numNodes] : numNodesMap) {
             vertexValueMap.allocate(tableID, numNodes, mm);

--- a/src/function/gds/weakly_connected_components.cpp
+++ b/src/function/gds/weakly_connected_components.cpp
@@ -23,9 +23,9 @@ namespace function {
 class WCCFrontierPair : public FrontierPair {
 public:
     WCCFrontierPair(std::shared_ptr<GDSFrontier> curFrontier,
-        std::shared_ptr<GDSFrontier> nextFrontier, uint64_t maxThreads,
+        std::shared_ptr<GDSFrontier> nextFrontier,
         table_id_map_t<offset_t> numNodesMap, storage::MemoryManager* mm)
-        : FrontierPair(curFrontier, nextFrontier, maxThreads) {
+        : FrontierPair(curFrontier, nextFrontier) {
         for (const auto& [tableID, numNodes] : numNodesMap) {
             vertexValueMap.allocate(tableID, numNodes, mm);
             auto data = vertexValueMap.getData(tableID);
@@ -209,11 +209,10 @@ public:
         auto clientContext = context->clientContext;
         auto graph = sharedState->graph.get();
         auto numNodesMap = graph->getNumNodesMap(clientContext->getTransaction());
-        auto numThreads = clientContext->getMaxNumThreadForExec();
         auto currentFrontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
         auto nextFrontier = getPathLengthsFrontier(context, 0);
         auto frontierPair = std::make_unique<WCCFrontierPair>(currentFrontier, nextFrontier,
-            numThreads, numNodesMap, clientContext->getMemoryManager());
+            numNodesMap, clientContext->getMemoryManager());
         // Initialize starting nodes in the next frontier.
         // When beginNewIteration, next frontier will become current frontier
         frontierPair->setActiveNodesForNextIter();

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -249,13 +249,9 @@ private:
 class KUZU_API FrontierPair {
 public:
     FrontierPair(std::shared_ptr<GDSFrontier> curFrontier,
-        std::shared_ptr<GDSFrontier> nextFrontier, uint64_t maxThreads);
+        std::shared_ptr<GDSFrontier> nextFrontier);
 
     virtual ~FrontierPair() = default;
-
-    bool getNextRangeMorsel(FrontierMorsel& morsel) {
-        return morselDispatcher.getNextRangeMorsel(morsel);
-    }
 
     void setActiveNodesForNextIter() { hasActiveNodesForNextIter_.store(true); }
 
@@ -311,14 +307,12 @@ protected:
     std::shared_ptr<SparseFrontier> curSparseFrontier;
     std::shared_ptr<SparseFrontier> nextSparseFrontier;
     std::shared_ptr<SparseFrontier> vertexComputeCandidates;
-
-    FrontierMorselDispatcher morselDispatcher;
 };
 
 class SinglePathLengthsFrontierPair : public FrontierPair {
 public:
-    SinglePathLengthsFrontierPair(std::shared_ptr<PathLengths> pathLengths, uint64_t numThreads)
-        : FrontierPair(pathLengths /* curFrontier */, pathLengths /* nextFrontier */, numThreads),
+    SinglePathLengthsFrontierPair(std::shared_ptr<PathLengths> pathLengths)
+        : FrontierPair(pathLengths /* curFrontier */, pathLengths /* nextFrontier */),
           pathLengths{pathLengths} {}
 
     PathLengths* getPathLengths() const { return pathLengths.get(); }
@@ -343,8 +337,8 @@ private:
 class KUZU_API DoublePathLengthsFrontierPair : public FrontierPair {
 public:
     DoublePathLengthsFrontierPair(std::shared_ptr<PathLengths> curFrontier,
-        std::shared_ptr<PathLengths> nextFrontier, uint64_t numThreads)
-        : FrontierPair{curFrontier, nextFrontier, numThreads} {}
+        std::shared_ptr<PathLengths> nextFrontier)
+        : FrontierPair{curFrontier, nextFrontier} {}
 
     void initRJFromSource(common::nodeID_t source) override;
 

--- a/src/include/function/gds/gds_task.h
+++ b/src/include/function/gds/gds_task.h
@@ -28,9 +28,11 @@ struct FrontierTaskInfo {
 };
 
 struct FrontierTaskSharedState {
+    FrontierMorselDispatcher morselDispatcher;
     FrontierPair& frontierPair;
 
-    explicit FrontierTaskSharedState(FrontierPair& frontierPair) : frontierPair{frontierPair} {}
+    FrontierTaskSharedState(uint64_t maxNumThreads, FrontierPair& frontierPair)
+        : morselDispatcher{maxNumThreads}, frontierPair{frontierPair} {}
     DELETE_COPY_AND_MOVE(FrontierTaskSharedState);
 };
 
@@ -39,6 +41,10 @@ public:
     FrontierTask(uint64_t maxNumThreads, const FrontierTaskInfo& info,
         std::shared_ptr<FrontierTaskSharedState> sharedState)
         : common::Task{maxNumThreads}, info{info}, sharedState{std::move(sharedState)} {}
+
+    void init(common::table_id_t tableID, common::offset_t numNodes) {
+        sharedState->morselDispatcher.init(tableID, numNodes);
+    }
 
     void run() override;
 
@@ -51,20 +57,20 @@ private:
 
 struct VertexComputeTaskSharedState {
     FrontierMorselDispatcher morselDispatcher;
-    graph::Graph* graph;
 
-    VertexComputeTaskSharedState(uint64_t maxNumThreads, graph::Graph* graph)
-        : morselDispatcher{maxNumThreads}, graph{graph} {}
+    explicit VertexComputeTaskSharedState(uint64_t maxNumThreads)
+        : morselDispatcher{maxNumThreads} {}
 };
 
 struct VertexComputeTaskInfo {
     VertexCompute& vc;
+    graph::Graph* graph;
     std::vector<std::string> propertiesToScan;
 
-    explicit VertexComputeTaskInfo(VertexCompute& vc, std::vector<std::string> propertiesToScan)
-        : vc{vc}, propertiesToScan{std::move(propertiesToScan)} {}
+    VertexComputeTaskInfo(VertexCompute& vc, graph::Graph* graph, std::vector<std::string> propertiesToScan)
+        : vc{vc}, graph{graph}, propertiesToScan{std::move(propertiesToScan)} {}
     VertexComputeTaskInfo(const VertexComputeTaskInfo& other)
-        : vc{other.vc}, propertiesToScan{other.propertiesToScan} {}
+        : vc{other.vc}, graph{other.graph}, propertiesToScan{other.propertiesToScan} {}
 
     bool hasPropertiesToScan() const { return !propertiesToScan.empty(); }
 };

--- a/src/include/function/gds/gds_task.h
+++ b/src/include/function/gds/gds_task.h
@@ -67,7 +67,8 @@ struct VertexComputeTaskInfo {
     graph::Graph* graph;
     std::vector<std::string> propertiesToScan;
 
-    VertexComputeTaskInfo(VertexCompute& vc, graph::Graph* graph, std::vector<std::string> propertiesToScan)
+    VertexComputeTaskInfo(VertexCompute& vc, graph::Graph* graph,
+        std::vector<std::string> propertiesToScan)
         : vc{vc}, graph{graph}, propertiesToScan{std::move(propertiesToScan)} {}
     VertexComputeTaskInfo(const VertexComputeTaskInfo& other)
         : vc{other.vc}, graph{other.graph}, propertiesToScan{other.propertiesToScan} {}

--- a/src/include/function/gds/gds_utils.h
+++ b/src/include/function/gds/gds_utils.h
@@ -43,8 +43,9 @@ struct KUZU_API GDSComputeState {
 class KUZU_API GDSUtils {
 public:
     static void scheduleFrontierTask(common::table_id_t boundTableID, common::table_id_t nbrTableID,
-        common::table_id_t relTableID, graph::Graph* graph, common::ExtendDirection extendDirection, GDSComputeState& rjCompState,
-        processor::ExecutionContext* context, std::optional<uint64_t> numThreads = std::nullopt,
+        common::table_id_t relTableID, graph::Graph* graph, common::ExtendDirection extendDirection,
+        GDSComputeState& rjCompState, processor::ExecutionContext* context,
+        std::optional<uint64_t> numThreads = std::nullopt,
         std::optional<common::idx_t> edgePropertyIdx = std::nullopt);
     static void runFrontiersUntilConvergence(processor::ExecutionContext* context,
         GDSComputeState& rjCompState, graph::Graph* graph, common::ExtendDirection extendDirection,

--- a/src/include/function/gds/gds_utils.h
+++ b/src/include/function/gds/gds_utils.h
@@ -42,8 +42,8 @@ struct KUZU_API GDSComputeState {
 
 class KUZU_API GDSUtils {
 public:
-    static void scheduleFrontierTask(common::table_id_t nbrTableID, common::table_id_t relTableID,
-        graph::Graph* graph, common::ExtendDirection extendDirection, GDSComputeState& rjCompState,
+    static void scheduleFrontierTask(common::table_id_t boundTableID, common::table_id_t nbrTableID,
+        common::table_id_t relTableID, graph::Graph* graph, common::ExtendDirection extendDirection, GDSComputeState& rjCompState,
         processor::ExecutionContext* context, std::optional<uint64_t> numThreads = std::nullopt,
         std::optional<common::idx_t> edgePropertyIdx = std::nullopt);
     static void runFrontiersUntilConvergence(processor::ExecutionContext* context,


### PR DESCRIPTION
# Description

This PR moves morsel dispatcher out of frontier pair and into FrontierTask so that the design is consistent for Vertex/Edge Compute.

Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).