### PR TITLE
Fix macos extension test

### DIFF
--- a/src/function/table/simple_table_functions.cpp
+++ b/src/function/table/simple_table_functions.cpp
@@ -5,6 +5,8 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace function {
 
+SimpleTableFuncSharedState::~SimpleTableFuncSharedState() = default;
+
 SimpleTableFuncMorsel SimpleTableFuncSharedState::getMorsel() {
     std::lock_guard lck{mtx};
     KU_ASSERT(curOffset <= maxOffset);

--- a/src/include/function/table/simple_table_functions.h
+++ b/src/include/function/table/simple_table_functions.h
@@ -26,6 +26,8 @@ struct KUZU_API SimpleTableFuncSharedState final : TableFuncSharedState {
     common::offset_t curOffset;
     std::mutex mtx;
 
+    ~SimpleTableFuncSharedState() override;
+
     explicit SimpleTableFuncSharedState(common::offset_t maxOffset)
         : maxOffset{maxOffset}, curOffset{0} {}
 


### PR DESCRIPTION
# Description

Add non-inlined virtual destructor to `SimpleTableFuncSharedState` to ensure that `dynamic_cast` to this class works when called from extensions.

See https://github.com/android/ndk/issues/533#issuecomment-335977747 for more details.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).