### PR TITLE
Index entry serialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(Kuzu VERSION 0.7.1.1 LANGUAGES CXX C)
+project(Kuzu VERSION 0.7.1.2 LANGUAGES CXX C)
 
 option(SINGLE_THREADED "Single-threaded mode" FALSE)
 if(SINGLE_THREADED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(Kuzu VERSION 0.7.1.2 LANGUAGES CXX C)
+project(Kuzu VERSION 0.7.1.3 LANGUAGES CXX C)
 
 option(SINGLE_THREADED "Single-threaded mode" FALSE)
 if(SINGLE_THREADED)

--- a/extension/fts/src/catalog/fts_index_catalog_entry.cpp
+++ b/extension/fts/src/catalog/fts_index_catalog_entry.cpp
@@ -1,5 +1,7 @@
 #include "catalog/fts_index_catalog_entry.h"
 
+#include "common/serializer/buffered_reader.h"
+
 namespace kuzu {
 namespace fts_extension {
 
@@ -9,6 +11,28 @@ std::unique_ptr<catalog::IndexCatalogEntry> FTSIndexCatalogEntry::copy() const {
     other->avgDocLen = avgDocLen;
     other->copyFrom(*this);
     return other;
+}
+
+void FTSIndexCatalogEntry::serializeAuxInfo(common::Serializer& serializer) const {
+    auto len = sizeof(numDocs) + sizeof(avgDocLen) + config.getNumBytesForSerialization();
+    serializer.serializeValue(len);
+    serializer.serializeValue(numDocs);
+    serializer.serializeValue(avgDocLen);
+    config.serialize(serializer);
+}
+
+std::unique_ptr<FTSIndexCatalogEntry> FTSIndexCatalogEntry::deserializeAuxInfo(
+    catalog::IndexCatalogEntry* indexCatalogEntry) {
+    auto reader = std::make_unique<common::BufferReader>(indexCatalogEntry->getAuxBuffer(),
+        indexCatalogEntry->getAuxBufferSize());
+    common::Deserializer deserializer{std::move(reader)};
+    common::idx_t numDocs = 0;
+    deserializer.deserializeValue(numDocs);
+    double avgDocLen = 0;
+    deserializer.deserializeValue(avgDocLen);
+    auto config = FTSConfig::deserialize(deserializer);
+    return std::make_unique<FTSIndexCatalogEntry>(indexCatalogEntry->getTableID(),
+        indexCatalogEntry->getIndexName(), numDocs, avgDocLen, config);
 }
 
 } // namespace fts_extension

--- a/extension/fts/src/fts_extension.cpp
+++ b/extension/fts/src/fts_extension.cpp
@@ -5,7 +5,7 @@
 #include "catalog/fts_index_catalog_entry.h"
 #include "function/create_fts_index.h"
 #include "function/drop_fts_index.h"
-#include "function/query_fts.h"
+#include "function/query_fts_index.h"
 #include "function/stem.h"
 #include "main/client_context.h"
 #include "main/database.h"
@@ -16,7 +16,7 @@ namespace fts_extension {
 void FTSExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
     ADD_SCALAR_FUNC(StemFunction);
-    ADD_GDS_FUNC(QFTSFunction);
+    ADD_GDS_FUNC(QueryFTSFunction);
     db.addStandaloneCallFunction(CreateFTSFunction::name, CreateFTSFunction::getFunctionSet());
     db.addStandaloneCallFunction(DropFTSFunction::name, DropFTSFunction::getFunctionSet());
 

--- a/extension/fts/src/function/CMakeLists.txt
+++ b/extension/fts/src/function/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(kuzu_fts_function
         create_fts_index.cpp
         fts_config.cpp
         drop_fts_index.cpp
-        query_fts.cpp
+        query_fts_index.cpp
         fts_utils.cpp)
 
 set(FTS_OBJECT_FILES

--- a/extension/fts/src/function/fts_config.cpp
+++ b/extension/fts/src/function/fts_config.cpp
@@ -1,6 +1,7 @@
 #include "function/fts_config.h"
 
 #include "common/exception/binder.h"
+#include "common/serializer/deserializer.h"
 #include "common/serializer/serializer.h"
 #include "common/string_utils.h"
 #include "function/stem.h"
@@ -29,12 +30,9 @@ void FTSConfig::serialize(common::Serializer& serializer) const {
     serializer.serializeValue(stemmer);
 }
 
-FTSConfig FTSConfig::deserialize(uint8_t* buffer) {
+FTSConfig FTSConfig::deserialize(common::Deserializer& deserializer) {
     auto config = FTSConfig{};
-    uint64_t len = 0;
-    memcpy(&len, buffer, sizeof(len));
-    buffer += sizeof(len);
-    memcpy(config.stemmer.data(), buffer, len);
+    deserializer.deserializeValue(config.stemmer);
     return config;
 }
 

--- a/extension/fts/src/function/fts_config.cpp
+++ b/extension/fts/src/function/fts_config.cpp
@@ -1,6 +1,7 @@
 #include "function/fts_config.h"
 
 #include "common/exception/binder.h"
+#include "common/serializer/serializer.h"
 #include "common/string_utils.h"
 #include "function/stem.h"
 
@@ -22,6 +23,24 @@ FTSConfig::FTSConfig(const function::optional_params_t& optionalParams) {
             throw common::BinderException{"Unrecognized optional parameter: " + name};
         }
     }
+}
+
+void FTSConfig::serialize(common::Serializer& serializer) const {
+    serializer.serializeValue(stemmer);
+}
+
+FTSConfig FTSConfig::deserialize(uint8_t* buffer) {
+    auto config = FTSConfig{};
+    uint64_t len = 0;
+    memcpy(&len, buffer, sizeof(len));
+    buffer += sizeof(len);
+    memcpy(config.stemmer.data(), buffer, len);
+    return config;
+}
+
+// We store the length + the string itself. So the total size is sizeof(length) + string length.
+uint64_t FTSConfig::getNumBytesForSerialization() const {
+    return sizeof(stemmer.size()) + stemmer.size();
 }
 
 void K::validate(double value) {

--- a/extension/fts/src/include/catalog/fts_index_catalog_entry.h
+++ b/extension/fts/src/include/catalog/fts_index_catalog_entry.h
@@ -14,7 +14,7 @@ public:
     FTSIndexCatalogEntry() = default;
     FTSIndexCatalogEntry(common::table_id_t tableID, std::string indexName, common::idx_t numDocs,
         double avgDocLen, FTSConfig config)
-        : catalog::IndexCatalogEntry{tableID, std::move(indexName)}, numDocs{numDocs},
+        : catalog::IndexCatalogEntry{TYPE_NAME, tableID, std::move(indexName)}, numDocs{numDocs},
           avgDocLen{avgDocLen}, config{std::move(config)} {}
 
     //===--------------------------------------------------------------------===//
@@ -28,6 +28,30 @@ public:
     // serialization & deserialization
     //===--------------------------------------------------------------------===//
     std::unique_ptr<catalog::IndexCatalogEntry> copy() const override;
+
+    void serializeAuxInfo(common::Serializer& serializer) const override {
+        auto len = sizeof(numDocs) + sizeof(avgDocLen) + config.getNumBytesForSerialization();
+        serializer.serializeValue(len);
+        serializer.serializeValue(numDocs);
+        serializer.serializeValue(avgDocLen);
+        config.serialize(serializer);
+    }
+
+    static std::unique_ptr<FTSIndexCatalogEntry> deserializeAuxInfo(
+        catalog::IndexCatalogEntry* indexCatalogEntry, uint8_t* buffer) {
+        common::idx_t numDocs = 0;
+        memcpy(&numDocs, buffer, sizeof(numDocs));
+        buffer += sizeof(numDocs);
+        double avgDocLen = 0;
+        memcpy(&avgDocLen, buffer, sizeof(avgDocLen));
+        buffer += sizeof(avgDocLen);
+        auto config = FTSConfig::deserialize(buffer);
+        return std::make_unique<FTSIndexCatalogEntry>(indexCatalogEntry->getTableID(),
+            indexCatalogEntry->getIndexName(), numDocs, avgDocLen, config);
+    }
+
+public:
+    static constexpr char TYPE_NAME[] = "FTS";
 
 private:
     common::idx_t numDocs = 0;

--- a/extension/fts/src/include/catalog/fts_index_catalog_entry.h
+++ b/extension/fts/src/include/catalog/fts_index_catalog_entry.h
@@ -29,26 +29,10 @@ public:
     //===--------------------------------------------------------------------===//
     std::unique_ptr<catalog::IndexCatalogEntry> copy() const override;
 
-    void serializeAuxInfo(common::Serializer& serializer) const override {
-        auto len = sizeof(numDocs) + sizeof(avgDocLen) + config.getNumBytesForSerialization();
-        serializer.serializeValue(len);
-        serializer.serializeValue(numDocs);
-        serializer.serializeValue(avgDocLen);
-        config.serialize(serializer);
-    }
+    void serializeAuxInfo(common::Serializer& serializer) const override;
 
     static std::unique_ptr<FTSIndexCatalogEntry> deserializeAuxInfo(
-        catalog::IndexCatalogEntry* indexCatalogEntry, uint8_t* buffer) {
-        common::idx_t numDocs = 0;
-        memcpy(&numDocs, buffer, sizeof(numDocs));
-        buffer += sizeof(numDocs);
-        double avgDocLen = 0;
-        memcpy(&avgDocLen, buffer, sizeof(avgDocLen));
-        buffer += sizeof(avgDocLen);
-        auto config = FTSConfig::deserialize(buffer);
-        return std::make_unique<FTSIndexCatalogEntry>(indexCatalogEntry->getTableID(),
-            indexCatalogEntry->getIndexName(), numDocs, avgDocLen, config);
-    }
+        catalog::IndexCatalogEntry* indexCatalogEntry);
 
 public:
     static constexpr char TYPE_NAME[] = "FTS";

--- a/extension/fts/src/include/function/fts_config.h
+++ b/extension/fts/src/include/function/fts_config.h
@@ -21,6 +21,12 @@ struct FTSConfig {
 
     FTSConfig() = default;
     explicit FTSConfig(const function::optional_params_t& optionalParams);
+
+    void serialize(common::Serializer& serializer) const;
+
+    static FTSConfig deserialize(uint8_t* buffer);
+
+    uint64_t getNumBytesForSerialization() const;
 };
 
 struct K {

--- a/extension/fts/src/include/function/fts_config.h
+++ b/extension/fts/src/include/function/fts_config.h
@@ -24,7 +24,7 @@ struct FTSConfig {
 
     void serialize(common::Serializer& serializer) const;
 
-    static FTSConfig deserialize(uint8_t* buffer);
+    static FTSConfig deserialize(common::Deserializer& deserializer);
 
     uint64_t getNumBytesForSerialization() const;
 };

--- a/extension/fts/src/include/function/query_fts_index.h
+++ b/extension/fts/src/include/function/query_fts_index.h
@@ -7,7 +7,7 @@
 namespace kuzu {
 namespace fts_extension {
 
-class QFTSAlgorithm : public function::GDSAlgorithm {
+class QueryFTSAlgorithm : public function::GDSAlgorithm {
 public:
     static constexpr char SCORE_PROP_NAME[] = "score";
     static constexpr char TERM_FREQUENCY_PROP_NAME[] = "tf";
@@ -15,8 +15,8 @@ public:
     static constexpr char DOC_ID_PROP_NAME[] = "docID";
 
 public:
-    QFTSAlgorithm() = default;
-    QFTSAlgorithm(const QFTSAlgorithm& other) : GDSAlgorithm{other} {}
+    QueryFTSAlgorithm() = default;
+    QueryFTSAlgorithm(const QueryFTSAlgorithm& other) : GDSAlgorithm{other} {}
 
     /*
      * Inputs include the following:
@@ -34,7 +34,7 @@ public:
     void exec(processor::ExecutionContext* executionContext) override;
 
     std::unique_ptr<GDSAlgorithm> copy() const override {
-        return std::make_unique<QFTSAlgorithm>(*this);
+        return std::make_unique<QueryFTSAlgorithm>(*this);
     }
 
     binder::expression_vector getResultColumns(binder::Binder* binder) const override;
@@ -42,7 +42,7 @@ public:
     void bind(const function::GDSBindInput& input, main::ClientContext&) override;
 };
 
-struct QFTSFunction {
+struct QueryFTSFunction {
     static constexpr const char* name = "QUERY_FTS_INDEX";
 
     static function::function_set getFunctionSet();

--- a/extension/fts/test/test_files/fts_small.test
+++ b/extension/fts/test/test_files/fts_small.test
@@ -163,3 +163,23 @@ Binder exception: BM25 model requires the Term Frequency Saturation(k) value to 
 -STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'alice waterloo', conjunctive := true) RETURN _node.ID, score
 ---- 1
 0|0.465323
+
+-CASE fts_serialization
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
+---- ok
+-STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx', ['content', 'author', 'name'])
+---- ok
+-STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'Alice') RETURN _node.ID, score
+---- 2
+0|0.271133
+3|0.209476
+-RELOADDB
+-STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'Alice') RETURN _node.ID, score
+---- error
+Catalog exception: QUERY_FTS_INDEX function does not exist.
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
+---- ok
+-STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'Alice') RETURN _node.ID, score
+---- 2
+0|0.271133
+3|0.209476

--- a/extension/fts/test/test_files/fts_small.test
+++ b/extension/fts/test/test_files/fts_small.test
@@ -165,6 +165,7 @@ Binder exception: BM25 model requires the Term Frequency Saturation(k) value to 
 0|0.465323
 
 -CASE fts_serialization
+-SKIP_IN_MEM
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
 ---- ok
 -STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx', ['content', 'author', 'name'])

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -331,6 +331,10 @@ IndexCatalogEntry* Catalog::getIndex(const Transaction* transaction, common::tab
         ->ptrCast<IndexCatalogEntry>();
 }
 
+CatalogSet* Catalog::getIndexes() const {
+    return indexes.get();
+}
+
 bool Catalog::containsIndex(const transaction::Transaction* transaction, common::table_id_t tableID,
     std::string indexName) const {
     return indexes->containsEntry(transaction, common::stringFormat("{}_{}", tableID, indexName));
@@ -473,6 +477,7 @@ void Catalog::saveToFile(const std::string& directory, VirtualFileSystem* fs,
     sequences->serialize(serializer);
     functions->serialize(serializer);
     types->serialize(serializer);
+    indexes->serialize(serializer);
 }
 
 void Catalog::readFromFile(const std::string& directory, VirtualFileSystem* fs,
@@ -489,7 +494,7 @@ void Catalog::readFromFile(const std::string& directory, VirtualFileSystem* fs,
     sequences = CatalogSet::deserialize(deserializer);
     functions = CatalogSet::deserialize(deserializer);
     types = CatalogSet::deserialize(deserializer);
-    indexes = std::make_unique<CatalogSet>();
+    indexes = CatalogSet::deserialize(deserializer);
 }
 
 void Catalog::registerBuiltInFunctions() {

--- a/src/catalog/catalog_entry/CMakeLists.txt
+++ b/src/catalog/catalog_entry/CMakeLists.txt
@@ -9,7 +9,8 @@ add_library(kuzu_catalog_entry
         rel_group_catalog_entry.cpp
         scalar_macro_catalog_entry.cpp
         type_catalog_entry.cpp
-        sequence_catalog_entry.cpp)
+        sequence_catalog_entry.cpp
+        index_catalog_entry.cpp)
 
 set(ALL_OBJECT_FILES
         ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_catalog_entry>

--- a/src/catalog/catalog_entry/catalog_entry.cpp
+++ b/src/catalog/catalog_entry/catalog_entry.cpp
@@ -1,5 +1,6 @@
 #include "catalog/catalog_entry/catalog_entry.h"
 
+#include "catalog/catalog_entry/index_catalog_entry.h"
 #include "catalog/catalog_entry/scalar_macro_catalog_entry.h"
 #include "catalog/catalog_entry/sequence_catalog_entry.h"
 #include "catalog/catalog_entry/table_catalog_entry.h"
@@ -50,6 +51,9 @@ std::unique_ptr<CatalogEntry> CatalogEntry::deserialize(common::Deserializer& de
     } break;
     case CatalogEntryType::TYPE_ENTRY: {
         entry = TypeCatalogEntry::deserialize(deserializer);
+    } break;
+    case CatalogEntryType::INDEX_ENTRY: {
+        entry = IndexCatalogEntry::deserialize(deserializer);
     } break;
     default:
         KU_UNREACHABLE;

--- a/src/catalog/catalog_entry/index_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/index_catalog_entry.cpp
@@ -1,0 +1,39 @@
+#include "catalog/catalog_entry/index_catalog_entry.h"
+
+namespace kuzu {
+namespace catalog {
+
+void IndexCatalogEntry::serialize(common::Serializer& serializer) const {
+    CatalogEntry::serialize(serializer);
+    serializer.write(type);
+    serializer.write(tableID);
+    serializer.write(indexName);
+    serializeAuxInfo(serializer);
+}
+
+std::unique_ptr<IndexCatalogEntry> IndexCatalogEntry::deserialize(
+    common::Deserializer& deserializer) {
+    std::string type;
+    common::table_id_t tableID = common::INVALID_TABLE_ID;
+    std::string indexName;
+    deserializer.deserializeValue(type);
+    deserializer.deserializeValue(tableID);
+    deserializer.deserializeValue(indexName);
+    auto indexEntry = std::make_unique<IndexCatalogEntry>(type, tableID, std::move(indexName));
+    uint64_t auxBufferSize = 0;
+    deserializer.deserializeValue(auxBufferSize);
+    indexEntry->auxBuffer = std::make_unique<uint8_t[]>(auxBufferSize);
+    indexEntry->auxBufferSize = auxBufferSize;
+    deserializer.read(indexEntry->auxBuffer.get(), auxBufferSize);
+    return indexEntry;
+}
+
+void IndexCatalogEntry::copyFrom(const CatalogEntry& other) {
+    CatalogEntry::copyFrom(other);
+    auto& otherTable = other.constCast<IndexCatalogEntry>();
+    tableID = otherTable.tableID;
+    indexName = otherTable.indexName;
+}
+
+} // namespace catalog
+} // namespace kuzu

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -124,6 +124,7 @@ public:
         std::unique_ptr<IndexCatalogEntry> indexCatalogEntry);
     IndexCatalogEntry* getIndex(const transaction::Transaction*, common::table_id_t tableID,
         std::string indexName) const;
+    CatalogSet* getIndexes() const;
     bool containsIndex(const transaction::Transaction* transaction, common::table_id_t tableID,
         std::string indexName) const;
     void dropAllIndexes(transaction::Transaction* transaction, common::table_id_t tableID);

--- a/src/include/catalog/catalog_entry/index_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/index_catalog_entry.h
@@ -31,7 +31,13 @@ public:
     //===--------------------------------------------------------------------===//
     // serialization & deserialization
     //===--------------------------------------------------------------------===//
+    // When serializing index entries to disk, we first write the fields of the base class,
+    // followed by the size (in bytes) of the auxiliary data and its content.
     void serialize(common::Serializer& serializer) const override;
+    // During deserialization of index entries from disk, we first read the base class
+    // (IndexCatalogEntry). The auxiliary data is stored in auxBuffer, with its size in
+    // auxBufferSize. Once the extension is loaded, the corresponding indexes are reconstructed
+    // using the auxBuffer.
     static std::unique_ptr<IndexCatalogEntry> deserialize(common::Deserializer& deserializer);
 
     virtual void serializeAuxInfo(common::Serializer& /*serializer*/) const { KU_UNREACHABLE; }

--- a/src/include/catalog/catalog_entry/index_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/index_catalog_entry.h
@@ -26,30 +26,13 @@ public:
 
     uint8_t* getAuxBuffer() const { return auxBuffer.get(); }
 
+    uint64_t getAuxBufferSize() const { return auxBufferSize; }
+
     //===--------------------------------------------------------------------===//
     // serialization & deserialization
     //===--------------------------------------------------------------------===//
-    void serialize(common::Serializer& serializer) const override {
-        CatalogEntry::serialize(serializer);
-        serializer.write(type);
-        serializer.write(tableID);
-        serializer.write(indexName);
-        serializeAuxInfo(serializer);
-    }
-    static std::unique_ptr<IndexCatalogEntry> deserialize(common::Deserializer& deserializer) {
-        std::string type;
-        common::table_id_t tableID = common::INVALID_TABLE_ID;
-        std::string indexName;
-        deserializer.deserializeValue(type);
-        deserializer.deserializeValue(tableID);
-        deserializer.deserializeValue(indexName);
-        auto indexEntry = std::make_unique<IndexCatalogEntry>(type, tableID, std::move(indexName));
-        uint64_t auxBufferSize = 0;
-        deserializer.deserializeValue(auxBufferSize);
-        indexEntry->auxBuffer = std::make_unique<uint8_t[]>(auxBufferSize);
-        deserializer.read(indexEntry->auxBuffer.get(), auxBufferSize);
-        return indexEntry;
-    }
+    void serialize(common::Serializer& serializer) const override;
+    static std::unique_ptr<IndexCatalogEntry> deserialize(common::Deserializer& deserializer);
 
     virtual void serializeAuxInfo(common::Serializer& /*serializer*/) const { KU_UNREACHABLE; }
 
@@ -58,18 +41,14 @@ public:
         return std::make_unique<IndexCatalogEntry>(type, tableID, indexName);
     }
 
-    void copyFrom(const CatalogEntry& other) override {
-        CatalogEntry::copyFrom(other);
-        auto& otherTable = other.constCast<IndexCatalogEntry>();
-        tableID = otherTable.tableID;
-        indexName = otherTable.indexName;
-    }
+    void copyFrom(const CatalogEntry& other) override;
 
 protected:
     std::string type;
     common::table_id_t tableID = common::INVALID_TABLE_ID;
     std::string indexName;
     std::unique_ptr<uint8_t[]> auxBuffer;
+    uint64_t auxBufferSize = 0;
 };
 
 } // namespace catalog

--- a/src/include/catalog/catalog_set.h
+++ b/src/include/catalog/catalog_set.h
@@ -28,7 +28,7 @@ class KUZU_API CatalogSet {
 public:
     bool containsEntry(const transaction::Transaction* transaction, const std::string& name);
     CatalogEntry* getEntry(const transaction::Transaction* transaction, const std::string& name);
-    KUZU_API common::oid_t createEntry(transaction::Transaction* transaction,
+    common::oid_t createEntry(transaction::Transaction* transaction,
         std::unique_ptr<CatalogEntry> entry);
     void dropEntry(transaction::Transaction* transaction, const std::string& name,
         common::oid_t oid);

--- a/src/include/catalog/catalog_set.h
+++ b/src/include/catalog/catalog_set.h
@@ -22,7 +22,7 @@ class Transaction;
 using CatalogEntrySet = common::case_insensitive_map_t<catalog::CatalogEntry*>;
 
 namespace catalog {
-class CatalogSet {
+class KUZU_API CatalogSet {
     friend class storage::UndoBuffer;
 
 public:

--- a/src/include/common/serializer/buffered_reader.h
+++ b/src/include/common/serializer/buffered_reader.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstring>
+
 #include "common/serializer/reader.h"
 
 namespace kuzu {

--- a/src/include/common/serializer/buffered_reader.h
+++ b/src/include/common/serializer/buffered_reader.h
@@ -15,7 +15,7 @@ struct BufferReader : Reader {
         readSize += size;
     }
 
-    bool finished() final { return (readSize >= dataSize); }
+    bool finished() final { return readSize >= dataSize; }
 
     uint8_t* data;
     size_t dataSize;

--- a/src/include/common/serializer/buffered_reader.h
+++ b/src/include/common/serializer/buffered_reader.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "common/serializer/reader.h"
+
+namespace kuzu {
+namespace common {
+
+struct BufferReader : Reader {
+    BufferReader(uint8_t* data, size_t dataSize) : data(data), dataSize(dataSize), readSize(0) {}
+
+    void read(uint8_t* outputData, uint64_t size) final {
+        memcpy(outputData, data + readSize, size);
+        readSize += size;
+    }
+
+    bool finished() final { return (readSize >= dataSize); }
+
+    uint8_t* data;
+    size_t dataSize;
+    size_t readSize;
+};
+
+} // namespace common
+} // namespace kuzu

--- a/src/include/common/serializer/deserializer.h
+++ b/src/include/common/serializer/deserializer.h
@@ -14,7 +14,7 @@
 namespace kuzu {
 namespace common {
 
-class Deserializer {
+class KUZU_API Deserializer {
 public:
     explicit Deserializer(std::unique_ptr<Reader> reader) : reader(std::move(reader)) {}
 

--- a/src/include/common/serializer/serializer.h
+++ b/src/include/common/serializer/serializer.h
@@ -13,7 +13,7 @@
 namespace kuzu {
 namespace common {
 
-class Serializer {
+class KUZU_API Serializer {
 public:
     explicit Serializer(std::shared_ptr<Writer> writer) : writer(std::move(writer)) {}
 

--- a/src/include/parser/visitor/statement_read_write_analyzer.h
+++ b/src/include/parser/visitor/statement_read_write_analyzer.h
@@ -21,6 +21,7 @@ private:
     void visitStandaloneCall(const Statement& /*statement*/) override { readOnly = true; }
     void visitStandaloneCallFunction(const Statement& /*statement*/) override { readOnly = false; }
     void visitCreateMacro(const Statement& /*statement*/) override { readOnly = false; }
+    void visitExtension(const Statement& /*statement*/) override { readOnly = false; }
 
     void visitReadingClause(const ReadingClause* readingClause) override;
     void visitWithClause(const WithClause* withClause) override;

--- a/test/storage/compression_test.cpp
+++ b/test/storage/compression_test.cpp
@@ -4,6 +4,7 @@
 #include "common/constants.h"
 #include "common/exception/not_implemented.h"
 #include "common/exception/storage.h"
+#include "common/serializer/buffered_reader.h"
 #include "common/serializer/buffered_serializer.h"
 #include "common/serializer/deserializer.h"
 #include "common/serializer/reader.h"
@@ -60,21 +61,6 @@ bool operator==(const CompressionMetadata& a, const CompressionMetadata& b) {
     }
     return true;
 }
-
-struct BufferReader : Reader {
-    BufferReader(uint8_t* data, size_t dataSize) : data(data), dataSize(dataSize), readSize(0) {}
-
-    void read(uint8_t* outputData, uint64_t size) final {
-        memcpy(outputData, data + readSize, size);
-        readSize += size;
-    }
-
-    bool finished() final { return (readSize >= dataSize); }
-
-    uint8_t* data;
-    size_t dataSize;
-    size_t readSize;
-};
 
 void testSerializeThenDeserialize(const CompressionMetadata& orig) {
     // test serializing/deserializing twice

--- a/tools/python_api/test/test_extension.py
+++ b/tools/python_api/test/test_extension.py
@@ -27,7 +27,7 @@ def extension_extension_dir_prefix() -> str:
     return extension_extension_dir_prefix
 
 
-def test_extension_install_httpfs(conn_db_readonly: ConnDB, tmpdir: str, extension_extension_dir_prefix: str) -> None:
+def test_extension_install_httpfs(conn_db_readwrite: ConnDB, tmpdir: str, extension_extension_dir_prefix: str) -> None:
     current_dir = Path(__file__).resolve().parent
     cmake_list_file = Path(current_dir).parent.parent.parent / "CMakeLists.txt"
     extension_version = None
@@ -56,7 +56,7 @@ def test_extension_install_httpfs(conn_db_readonly: ConnDB, tmpdir: str, extensi
     temp_path = Path(tmpdir) / "libhttpfs.kuzu_extension"
     urllib.request.urlretrieve(download_url, temp_path)
 
-    conn, _ = conn_db_readonly
+    conn, _ = conn_db_readwrite
     conn.execute("INSTALL httpfs")
 
     assert Path.exists(extension_path)


### PR DESCRIPTION
This PR supports serializing index catalog entries to disk.
General idea:
Serialization:
We serialize the full index entries to disk.
Deserialization:
We only deserialize the base class and save the auxiliary information in an array.
When the extension is loaded, it is going to deserialize the auxiliary information stored in the array and recreate the index.