### PR TITLE
Refactor RJOutputWriter

### DIFF
--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -36,7 +36,7 @@ public:
             }
         }
     }
-    
+
     void incrementTargetMultiplicity(offset_t offset, uint64_t multiplicity) {
         getCurTargetMultiplicities()[offset].fetch_add(multiplicity);
     }
@@ -89,7 +89,7 @@ public:
 
     void initRJFromSource(nodeID_t source) override {
         multiplicities->pinTargetTable(source.tableID);
-        multiplicities->incrementTargetMultiplicity(source.offset,  1);
+        multiplicities->incrementTargetMultiplicity(source.offset, 1);
     }
 
     void beginFrontierComputeBetweenTables(table_id_t curFrontierTableID,

--- a/src/function/gds/output_writer.cpp
+++ b/src/function/gds/output_writer.cpp
@@ -387,7 +387,8 @@ DestinationsOutputWriter::DestinationsOutputWriter(main::ClientContext* context,
 void DestinationsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNodeID,
     GDSOutputCounter* counter) {
     auto length =
-        rjOutputs->ptrCast<SPDestinationOutputs>()->pathLengths->getMaskValueFromCurFrontier(dstNodeID.offset);
+        rjOutputs->ptrCast<SPDestinationOutputs>()->pathLengths->getMaskValueFromCurFrontier(
+            dstNodeID.offset);
     dstNodeIDVector->setValue<nodeID_t>(0, dstNodeID);
     setLength(lengthVector.get(), length);
     fTable.append(vectors);

--- a/src/function/gds/output_writer.cpp
+++ b/src/function/gds/output_writer.cpp
@@ -10,11 +10,6 @@ using namespace kuzu::processor;
 namespace kuzu {
 namespace function {
 
-void PathsOutputs::beginWritingOutputsForDstNodesInTable(common::table_id_t tableID) {
-    pathLengths->pinCurFrontierTableID(tableID);
-    bfsGraph->pinTableID(tableID);
-}
-
 std::unique_ptr<common::ValueVector> GDSOutputWriter::createVector(const LogicalType& type,
     storage::MemoryManager* mm) {
     auto vector = std::make_unique<ValueVector>(type.copy(), mm);
@@ -392,7 +387,7 @@ DestinationsOutputWriter::DestinationsOutputWriter(main::ClientContext* context,
 void DestinationsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNodeID,
     GDSOutputCounter* counter) {
     auto length =
-        rjOutputs->ptrCast<SPOutputs>()->pathLengths->getMaskValueFromCurFrontier(dstNodeID.offset);
+        rjOutputs->ptrCast<SPDestinationOutputs>()->pathLengths->getMaskValueFromCurFrontier(dstNodeID.offset);
     dstNodeIDVector->setValue<nodeID_t>(0, dstNodeID);
     setLength(lengthVector.get(), length);
     fTable.append(vectors);
@@ -403,7 +398,7 @@ void DestinationsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_
 }
 
 bool DestinationsOutputWriter::skipInternal(common::nodeID_t dstNodeID) const {
-    auto outputs = rjOutputs->ptrCast<SPOutputs>();
+    auto outputs = rjOutputs->ptrCast<SPDestinationOutputs>();
     return dstNodeID == outputs->sourceNodeID || outputs->pathLengths->getMaskValueFromCurFrontier(
                                                      dstNodeID.offset) == PathLengths::UNVISITED;
 }

--- a/src/function/gds/variable_length_path.cpp
+++ b/src/function/gds/variable_length_path.cpp
@@ -123,7 +123,7 @@ private:
         auto clientContext = context->clientContext;
         auto frontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
         auto bfsGraph = getBFSGraph(context);
-        auto output = std::make_unique<PathsOutputs>(sourceNodeID, frontier, std::move(bfsGraph));
+        auto output = std::make_unique<PathsOutputs>(sourceNodeID, std::move(bfsGraph));
         auto rjBindData = bindData->ptrCast<RJBindData>();
         auto writerInfo = rjBindData->getPathWriterInfo();
         writerInfo.pathNodeMask = sharedState->getPathNodeMaskMap();

--- a/src/include/function/gds/output_writer.h
+++ b/src/include/function/gds/output_writer.h
@@ -3,9 +3,9 @@
 #include "bfs_graph.h"
 #include "common/enums/path_semantic.h"
 #include "common/types/types.h"
+#include "gds_frontier.h"
 #include "processor/operator/gds_call_shared_state.h"
 #include "processor/result/factorized_table.h"
-#include "gds_frontier.h"
 
 namespace kuzu {
 namespace function {
@@ -37,7 +37,7 @@ struct SPDestinationOutputs : public RJOutputs {
     // Note: We do not fix the node table for pathLengths, because PathLengths is a
     // FrontierPair implementation and RJCompState will call beginFrontierComputeBetweenTables
     // on FrontierPair (and RJOutputs).
-    void beginFrontierComputeBetweenTables(common::table_id_t, common::table_id_t) override {};
+    void beginFrontierComputeBetweenTables(common::table_id_t, common::table_id_t) override{};
 
     void beginWritingOutputsForDstNodesInTable(common::table_id_t tableID) override {
         pathLengths->pinCurFrontierTableID(tableID);

--- a/src/include/function/gds/output_writer.h
+++ b/src/include/function/gds/output_writer.h
@@ -5,14 +5,14 @@
 #include "common/types/types.h"
 #include "processor/operator/gds_call_shared_state.h"
 #include "processor/result/factorized_table.h"
+#include "gds_frontier.h"
 
 namespace kuzu {
 namespace function {
 
-class PathLengths;
-
 struct RJOutputs {
-public:
+    common::nodeID_t sourceNodeID;
+
     explicit RJOutputs(common::nodeID_t sourceNodeID) : sourceNodeID{sourceNodeID} {}
     virtual ~RJOutputs() = default;
 
@@ -26,36 +26,38 @@ public:
     TARGET* ptrCast() {
         return common::ku_dynamic_cast<TARGET*>(this);
     }
-
-public:
-    common::nodeID_t sourceNodeID;
 };
 
-struct SPOutputs : public RJOutputs {
-public:
-    SPOutputs(common::nodeID_t sourceNodeID, std::shared_ptr<PathLengths> pathLengths)
+struct SPDestinationOutputs : public RJOutputs {
+    std::shared_ptr<PathLengths> pathLengths;
+
+    SPDestinationOutputs(common::nodeID_t sourceNodeID, std::shared_ptr<PathLengths> pathLengths)
         : RJOutputs{sourceNodeID}, pathLengths{std::move(pathLengths)} {}
 
-public:
-    std::shared_ptr<PathLengths> pathLengths;
+    // Note: We do not fix the node table for pathLengths, because PathLengths is a
+    // FrontierPair implementation and RJCompState will call beginFrontierComputeBetweenTables
+    // on FrontierPair (and RJOutputs).
+    void beginFrontierComputeBetweenTables(common::table_id_t, common::table_id_t) override {};
+
+    void beginWritingOutputsForDstNodesInTable(common::table_id_t tableID) override {
+        pathLengths->pinCurFrontierTableID(tableID);
+    }
 };
 
-struct PathsOutputs : public SPOutputs {
-    PathsOutputs(common::nodeID_t sourceNodeID, std::shared_ptr<PathLengths> pathLengths,
-        std::unique_ptr<BFSGraph> bfsGraph)
-        : SPOutputs(sourceNodeID, std::move(pathLengths)), bfsGraph{std::move(bfsGraph)} {}
+struct PathsOutputs : public RJOutputs {
+    std::unique_ptr<BFSGraph> bfsGraph;
+
+    PathsOutputs(common::nodeID_t sourceNodeID, std::unique_ptr<BFSGraph> bfsGraph)
+        : RJOutputs(sourceNodeID), bfsGraph{std::move(bfsGraph)} {}
 
     void beginFrontierComputeBetweenTables(common::table_id_t,
         common::table_id_t nextFrontierTableID) override {
-        // Note: We do not fix the node table for pathLengths, which is inherited from AllSPOutputs.
-        // See the comment in SingleSPOutputs::beginFrontierComputeBetweenTables() for details.
         bfsGraph->pinTableID(nextFrontierTableID);
     };
 
-    void beginWritingOutputsForDstNodesInTable(common::table_id_t tableID) override;
-
-public:
-    std::unique_ptr<BFSGraph> bfsGraph;
+    void beginWritingOutputsForDstNodesInTable(common::table_id_t tableID) override {
+        bfsGraph->pinTableID(tableID);
+    }
 };
 
 class GDSOutputWriter {


### PR DESCRIPTION
# Description

Remove unnecessary PathLength frontier in PathOutput. 

Remove SPOutput to SPDestinationOutput (because it's used only when outputting destinations).

Remove ad-hoc function in PathMultiplicities.

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).