### PR TITLE
Vector index prepare execute

### DIFF
--- a/src/common/expression_type.cpp
+++ b/src/common/expression_type.cpp
@@ -105,7 +105,6 @@ std::string ExpressionTypeUtil::toString(ExpressionType type) {
     default:
         KU_UNREACHABLE;
     }
-    return "";
 }
 
 std::string ExpressionTypeUtil::toParsableString(ExpressionType type) {

--- a/src/function/table/call/hnsw/query_hnsw_index.cpp
+++ b/src/function/table/call/hnsw/query_hnsw_index.cpp
@@ -1,5 +1,6 @@
 #include "binder/binder.h"
 #include "binder/expression/literal_expression.h"
+#include "binder/expression/parameter_expression.h"
 #include "catalog/catalog_entry/hnsw_index_catalog_entry.h"
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "common/types/value/nested.h"
@@ -35,7 +36,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     const TableFuncBindInput* input) {
     const auto indexName = input->getLiteralVal<std::string>(0);
     const auto tableName = input->getLiteralVal<std::string>(1);
-    const auto& queryVal = input->params[2]->constCast<binder::LiteralExpression>().getValue();
+    auto inputQueryExpression = input->params[2];
     const auto k = input->getLiteralVal<int64_t>(3);
 
     auto nodeTableEntry = storage::IndexUtils::bindTable(*context, tableName, indexName,
@@ -43,29 +44,102 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     const auto indexEntry = common::ku_dynamic_cast<catalog::HNSWIndexCatalogEntry*>(
         context->getCatalog()->getIndex(context->getTransaction(), nodeTableEntry->getTableID(),
             indexName));
-    auto& indexColumnType = nodeTableEntry->getProperty(indexEntry->getIndexColumnName()).getType();
-    KU_ASSERT(indexColumnType.getLogicalTypeID() == common::LogicalTypeID::ARRAY);
-    const auto dimension =
-        indexColumnType.getExtraTypeInfo()->constPtrCast<common::ArrayTypeInfo>()->getNumElements();
-    storage::HNSWIndexUtils::validateQueryVector(queryVal.getDataType(), dimension);
-
-    std::vector<float> queryVector;
-    KU_ASSERT(queryVal.getChildrenSize() > 0);
-    queryVector.resize(queryVal.getChildrenSize());
-    for (auto i = 0u; i < queryVector.size(); i++) {
-        queryVector[i] = common::NestedVal::getChildVal(&queryVal, i)->getValue<float>();
-    }
+    KU_ASSERT(nodeTableEntry->getProperty(indexEntry->getIndexColumnName())
+                  .getType()
+                  .getLogicalTypeID() == common::LogicalTypeID::ARRAY);
 
     auto outputNode = input->binder->createQueryNode("nn", {nodeTableEntry});
     input->binder->addToScope(outputNode->toString(), outputNode);
     binder::expression_vector columns;
     columns.push_back(outputNode->getInternalID());
     columns.push_back(input->binder->createVariable("_distance", common::LogicalType::DOUBLE()));
-    auto boundInput = BoundQueryHNSWIndexInput{nodeTableEntry, indexEntry, std::move(queryVector),
-        static_cast<uint64_t>(k)};
+    auto boundInput = BoundQueryHNSWIndexInput{nodeTableEntry, indexEntry,
+        std::move(inputQueryExpression), static_cast<uint64_t>(k)};
     auto config = storage::QueryHNSWConfig{input->optionalParams};
     return std::make_unique<QueryHNSWIndexBindData>(context, std::move(columns), boundInput, config,
         outputNode);
+}
+
+static common::PhysicalTypeID getChildQueryValType(const common::Value& value) {
+    auto childValType = common::PhysicalTypeID::ANY;
+    switch (value.getDataType().getPhysicalType()) {
+    case common::PhysicalTypeID::ARRAY: {
+        childValType = value.getDataType()
+                           .getExtraTypeInfo()
+                           ->constPtrCast<common::ArrayTypeInfo>()
+                           ->getChildType()
+                           .getPhysicalType();
+    } break;
+    case common::PhysicalTypeID::LIST: {
+        childValType = value.getDataType()
+                           .getExtraTypeInfo()
+                           ->constPtrCast<common::ListTypeInfo>()
+                           ->getChildType()
+                           .getPhysicalType();
+    } break;
+    default: {
+        throw common::RuntimeException(
+            common::stringFormat("Unsupported data type {} as a query vector in {}",
+                value.getDataType().toString(), QueryHNSWIndexFunction::name));
+    }
+    }
+    return childValType;
+}
+
+template<typename T>
+static void convertQueryVector(const common::Value& value, std::vector<float>& queryVector) {
+    auto numElements = value.getChildrenSize();
+    queryVector.resize(numElements);
+    for (auto i = 0u; i < queryVector.size(); i++) {
+        queryVector[i] = common::NestedVal::getChildVal(&value, i)->getValue<T>();
+    }
+}
+
+static common::Value getQueryValue(const binder::Expression& queryExpression) {
+    auto value = common::Value::createDefaultValue(queryExpression.dataType);
+    switch (queryExpression.expressionType) {
+    case common::ExpressionType::LITERAL: {
+        value = queryExpression.constCast<binder::LiteralExpression>().getValue();
+    } break;
+    case common::ExpressionType::PARAMETER: {
+        value = queryExpression.constCast<binder::ParameterExpression>().getValue();
+    } break;
+    default: {
+        throw common::RuntimeException(common::stringFormat("Unsupported expression type {} in {}",
+            common::ExpressionTypeUtil::toString(queryExpression.expressionType),
+            QueryHNSWIndexFunction::name));
+    }
+    }
+    return value;
+}
+
+static std::vector<float> getQueryVector(const binder::Expression& queryExpression,
+    uint64_t dimension) {
+    auto value = getQueryValue(queryExpression);
+    common::PhysicalTypeID childValType = getChildQueryValType(value);
+    std::vector<float> queryVector;
+    if (value.getChildrenSize() != dimension) {
+        throw common::RuntimeException("Query vector dimension does not match index dimension.");
+    }
+    switch (childValType) {
+    case common::PhysicalTypeID::FLOAT: {
+        convertQueryVector<float>(value, queryVector);
+    } break;
+    case common::PhysicalTypeID::DOUBLE: {
+        convertQueryVector<double>(value, queryVector);
+    } break;
+    default: {
+        throw common::RuntimeException(
+            common::stringFormat("Unsupported data type {} as a query vector in {}",
+                value.getDataType().toString(), QueryHNSWIndexFunction::name));
+    }
+    }
+    return queryVector;
+}
+
+static const common::LogicalType& getIndexColumnType(const BoundQueryHNSWIndexInput& boundInput) {
+    return boundInput.nodeTableEntry->getProperty(boundInput.indexEntry->getIndexColumnName())
+        .getType();
 }
 
 static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput& output) {
@@ -81,9 +155,13 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput& 
             bindData->boundInput.indexEntry->getConfig().copy());
         index->setDefaultUpperEntryPoint(bindData->boundInput.indexEntry->getUpperEntryPoint());
         index->setDefaultLowerEntryPoint(bindData->boundInput.indexEntry->getLowerEntryPoint());
+
+        auto dimension =
+            common::ArrayType::getNumElements(getIndexColumnType(bindData->boundInput));
+        auto queryVector = getQueryVector(*bindData->boundInput.queryExpression, dimension);
         localState->result = index->search(input.context->clientContext->getTransaction(),
-            bindData->boundInput.queryVector, bindData->boundInput.k, bindData->config,
-            localState->visited, *localState->embeddingScanState.scanState);
+            queryVector, bindData->boundInput.k, bindData->config, localState->visited,
+            *localState->embeddingScanState.scanState);
     }
     KU_ASSERT(localState->result.has_value());
     if (localState->numRowsOutput >= localState->result->size()) {

--- a/src/include/function/table/hnsw/hnsw_index_functions.h
+++ b/src/include/function/table/hnsw/hnsw_index_functions.h
@@ -53,7 +53,7 @@ struct CreateHNSWLocalState final : TableFuncLocalState {
 struct BoundQueryHNSWIndexInput {
     catalog::NodeTableCatalogEntry* nodeTableEntry;
     catalog::HNSWIndexCatalogEntry* indexEntry;
-    std::vector<float> queryVector;
+    std::shared_ptr<binder::Expression> queryExpression;
     uint64_t k;
 };
 

--- a/src/include/storage/index/hnsw_index_utils.h
+++ b/src/include/storage/index/hnsw_index_utils.h
@@ -15,8 +15,6 @@ struct HNSWIndexUtils {
     static void validateColumnType(const catalog::TableCatalogEntry& tableEntry,
         const std::string& columnName);
 
-    static void validateQueryVector(const common::LogicalType& type, uint64_t dimension);
-
     static std::string getUpperGraphTableName(const std::string& indexName) {
         return "_" + indexName + "_UPPER";
     }

--- a/src/storage/index/hnsw_index_utils.cpp
+++ b/src/storage/index/hnsw_index_utils.cpp
@@ -38,14 +38,6 @@ void HNSWIndexUtils::validateColumnType(const catalog::TableCatalogEntry& tableE
     validateColumnType(type);
 }
 
-void HNSWIndexUtils::validateQueryVector(const common::LogicalType& type, uint64_t dimension) {
-    validateColumnType(type);
-    if (type.getExtraTypeInfo()->constPtrCast<common::ArrayTypeInfo>()->getNumElements() !=
-        dimension) {
-        throw common::BinderException("Query vector dimension does not match index dimension.");
-    }
-}
-
 double HNSWIndexUtils::computeDistance(DistFuncType funcType, const float* left, const float* right,
     uint32_t dimension) {
     double distance = 0.0;

--- a/test/test_files/function/hnsw/error.test
+++ b/test/test_files/function/hnsw/error.test
@@ -16,7 +16,7 @@ Binder exception: HNSW_INDEX only supports FLOAT ARRAY columns.
 ---- ok
 -STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.0459,0.0439,0.0251], 'FLOAT[3]'), 10) RETURN *;
 ---- error
-Binder exception: Query vector dimension does not match index dimension.
+Runtime exception: Query vector dimension does not match index dimension.
 -STATEMENT CALL DROP_HNSW_INDEX('e_hnsw_index2', 'embeddings');
 ---- error
 Binder exception: Table embeddings doesn't have an index with name e_hnsw_index2.

--- a/tools/python_api/test/test_vector_index.py
+++ b/tools/python_api/test/test_vector_index.py
@@ -16,7 +16,7 @@ def test_vector_index(conn_db_readwrite: ConnDB) -> None:
     conn.execute(query)
     vec = [0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557]
     res = conn.execute("""
-                CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', $q, 3) RETURN nn.id AS id;
+                CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', $q, 3) RETURN nn.id AS id ORDER BY id;
                 """, {'q': vec}).get_as_arrow()
     assert len(res) == 3
-    assert res["id"].to_pylist() == [333, 444, 133]
+    assert res["id"].to_pylist() == [133, 333, 444]

--- a/tools/python_api/test/test_vector_index.py
+++ b/tools/python_api/test/test_vector_index.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from test_helper import KUZU_ROOT
+from type_aliases import ConnDB
+
+
+def test_vector_index(conn_db_readwrite: ConnDB) -> None:
+    conn, _ = conn_db_readwrite
+    query = "CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));"
+    conn.execute(query)
+    query = f"""
+    COPY embeddings FROM '{KUZU_ROOT}/dataset/embeddings/embeddings-8-1k.csv' (deLim=',');
+    """
+    conn.execute(query)
+    query = "CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec', distFunc := 'l2');"
+    conn.execute(query)
+    vec = [0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557]
+    res = conn.execute("""
+                CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', $q, 3) RETURN nn.id AS id;
+                """, {'q': vec}).get_as_arrow()
+    assert len(res) == 3
+    assert res["id"].to_pylist() == [333, 444, 133]


### PR DESCRIPTION
# Description

This is on top of #4578.

Add support for passing in a parameter expression (e.g., python list) as the query vector, so the input query vector doesn't have to be a float array casted from string. Potentially this can reduce parsing overheads of large query vectors.