### PR TITLE
Optimize page rank contention

### DIFF
--- a/src/function/gds/degrees.h
+++ b/src/function/gds/degrees.h
@@ -1,0 +1,83 @@
+#include "function/gds/gds_object_manager.h"
+#include "function/gds/gds_utils.h"
+#include "graph/graph.h"
+#include "function/gds/compute.h"
+#include "function/gds/gds_frontier.h"
+
+using namespace kuzu::common;
+using namespace kuzu::storage;
+
+namespace kuzu {
+namespace function {
+
+using degree_t = uint64_t;
+static constexpr degree_t INVALID_DEGREE = UINT64_MAX;
+
+class Degrees {
+public:
+    Degrees(const table_id_map_t<offset_t>& numNodesMap, MemoryManager* mm) {
+        init(numNodesMap, mm);
+    }
+
+    void pinTable(table_id_t tableID) { degreeValues = degreeValuesMap.getData(tableID); }
+
+    void addDegree(offset_t offset, uint64_t degree) {
+        degreeValues[offset].fetch_add(degree, std::memory_order_relaxed);
+    }
+
+    void decreaseDegreeByOne(offset_t offset) {
+        degreeValues[offset].fetch_sub(1, std::memory_order_relaxed);
+    }
+
+    degree_t getValue(offset_t offset) {
+        return degreeValues[offset].load(std::memory_order_relaxed);
+    }
+
+private:
+    void init(const table_id_map_t<offset_t>& numNodesMap, MemoryManager* mm) {
+        for (const auto& [tableID, numNodes] : numNodesMap) {
+            degreeValuesMap.allocate(tableID, numNodes, mm);
+            pinTable(tableID);
+            for (auto i = 0u; i < numNodes; ++i) {
+                degreeValues[i].store(0, std::memory_order_relaxed);
+            }
+        }
+    }
+
+private:
+    std::atomic<degree_t>* degreeValues = nullptr;
+    ObjectArraysMap<std::atomic<degree_t>> degreeValuesMap;
+};
+
+struct DegreeEdgeCompute : public EdgeCompute {
+    Degrees* degrees;
+
+    explicit DegreeEdgeCompute(Degrees* degrees) : degrees{degrees} {}
+
+    std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, graph::NbrScanState::Chunk& chunk,
+        bool) override {
+        degrees->addDegree(boundNodeID.offset, chunk.size());
+        return {};
+    }
+
+    std::unique_ptr<EdgeCompute> copy() override {
+        return std::make_unique<DegreeEdgeCompute>(degrees);
+    }
+};
+
+struct DegreesUtils {
+    static void computeDegree(processor::ExecutionContext* context, graph::Graph* graph, Degrees* degrees, ExtendDirection direction) {
+        auto currentFrontier = PathLengths::getFrontier(context, graph, PathLengths::UNVISITED);
+        auto nextFrontier = PathLengths::getFrontier(context, graph, 0);
+        auto frontierPair = std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier, nextFrontier);
+        frontierPair->setActiveNodesForNextIter();
+        frontierPair->getNextSparseFrontier().disable();
+        auto ec = std::make_unique<DegreeEdgeCompute>(degrees);
+        auto computeState = GDSComputeState(std::move(frontierPair), std::move(ec), nullptr);
+        GDSUtils::runFrontiersUntilConvergence(context, computeState, graph, direction,
+            1 /* maxIters */);
+    }
+};
+
+}
+}

--- a/src/function/gds/degrees.h
+++ b/src/function/gds/degrees.h
@@ -1,8 +1,8 @@
+#include "function/gds/compute.h"
+#include "function/gds/gds_frontier.h"
 #include "function/gds/gds_object_manager.h"
 #include "function/gds/gds_utils.h"
 #include "graph/graph.h"
-#include "function/gds/compute.h"
-#include "function/gds/gds_frontier.h"
 
 using namespace kuzu::common;
 using namespace kuzu::storage;
@@ -66,10 +66,12 @@ struct DegreeEdgeCompute : public EdgeCompute {
 };
 
 struct DegreesUtils {
-    static void computeDegree(processor::ExecutionContext* context, graph::Graph* graph, Degrees* degrees, ExtendDirection direction) {
+    static void computeDegree(processor::ExecutionContext* context, graph::Graph* graph,
+        Degrees* degrees, ExtendDirection direction) {
         auto currentFrontier = PathLengths::getFrontier(context, graph, PathLengths::UNVISITED);
         auto nextFrontier = PathLengths::getFrontier(context, graph, 0);
-        auto frontierPair = std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier, nextFrontier);
+        auto frontierPair =
+            std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier, nextFrontier);
         frontierPair->setActiveNodesForNextIter();
         frontierPair->getNextSparseFrontier().disable();
         auto ec = std::make_unique<DegreeEdgeCompute>(degrees);
@@ -79,5 +81,5 @@ struct DegreesUtils {
     }
 };
 
-}
-}
+} // namespace function
+} // namespace kuzu

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -31,14 +31,8 @@ std::shared_ptr<Expression> GDSAlgorithm::bindNodeOutput(Binder* binder,
 }
 
 std::shared_ptr<PathLengths> GDSAlgorithm::getPathLengthsFrontier(
-    processor::ExecutionContext* context, uint16_t val) {
-    auto tx = context->clientContext->getTransaction();
-    auto mm = context->clientContext->getMemoryManager();
-    auto graph = sharedState->graph.get();
-    auto pathLengths = std::make_shared<PathLengths>(graph->getNumNodesMap(tx), mm);
-    auto vc = std::make_unique<PathLengthsInitVertexCompute>(*pathLengths, val);
-    GDSUtils::runVertexCompute(context, graph, *vc);
-    return pathLengths;
+    processor::ExecutionContext* context, uint16_t initialVal) {
+    return PathLengths::getFrontier(context, sharedState->graph.get(), initialVal);
 }
 
 } // namespace function

--- a/src/function/gds/gds_frontier.cpp
+++ b/src/function/gds/gds_frontier.cpp
@@ -1,6 +1,7 @@
 #include "function/gds/gds_frontier.h"
-#include "processor/execution_context.h"
+
 #include "function/gds/gds_utils.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::common;
 
@@ -108,7 +109,8 @@ void PathLengths::pinNextFrontierTableID(common::table_id_t tableID) {
     nextFrontier.store(getMaskData(tableID), std::memory_order_relaxed);
 }
 
-std::shared_ptr<PathLengths> PathLengths::getFrontier(processor::ExecutionContext* context, graph::Graph* graph, uint16_t initialValue) {
+std::shared_ptr<PathLengths> PathLengths::getFrontier(processor::ExecutionContext* context,
+    graph::Graph* graph, uint16_t initialValue) {
     auto tx = context->clientContext->getTransaction();
     auto mm = context->clientContext->getMemoryManager();
     auto pathLengths = std::make_shared<PathLengths>(graph->getNumNodesMap(tx), mm);

--- a/src/function/gds/k_core_decomposition.cpp
+++ b/src/function/gds/k_core_decomposition.cpp
@@ -1,6 +1,7 @@
 #include "binder/binder.h"
 #include "binder/expression/expression_util.h"
 #include "common/types/types.h"
+#include "degrees.h"
 #include "function/gds/gds_frontier.h"
 #include "function/gds/gds_function_collection.h"
 #include "function/gds/gds_object_manager.h"
@@ -10,7 +11,6 @@
 #include "graph/graph.h"
 #include "processor/execution_context.h"
 #include "processor/result/factorized_table.h"
-#include "degrees.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -250,8 +250,8 @@ public:
             &degrees, &coreValues);
         // Compute Core values
         auto removeVertexEdgeCompute = std::make_unique<RemoveVertexEdgeCompute>(&degrees);
-        auto computeState = GDSComputeState(std::move(frontierPair), std::move(removeVertexEdgeCompute),
-            sharedState->getOutputNodeMaskMap());
+        auto computeState = GDSComputeState(std::move(frontierPair),
+            std::move(removeVertexEdgeCompute), sharedState->getOutputNodeMaskMap());
         auto coreValue = 0u;
         auto numNodes = graph->getNumNodes(clientContext->getTransaction());
         auto numNodesComputed = 0u;

--- a/src/function/gds/k_core_decomposition.cpp
+++ b/src/function/gds/k_core_decomposition.cpp
@@ -10,6 +10,7 @@
 #include "graph/graph.h"
 #include "processor/execution_context.h"
 #include "processor/result/factorized_table.h"
+#include "degrees.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -19,45 +20,6 @@ using namespace kuzu::graph;
 
 namespace kuzu {
 namespace function {
-
-using degree_t = uint64_t;
-static constexpr degree_t INVALID_DEGREE = UINT64_MAX;
-
-class Degrees {
-public:
-    Degrees(const table_id_map_t<offset_t>& numNodesMap, MemoryManager* mm) {
-        init(numNodesMap, mm);
-    }
-
-    void pinTable(table_id_t tableID) { degreeValues = degreeValuesMap.getData(tableID); }
-
-    void addDegree(offset_t offset, uint64_t degree) {
-        degreeValues[offset].fetch_add(degree, std::memory_order_relaxed);
-    }
-
-    void decreaseDegreeByOne(offset_t offset) {
-        degreeValues[offset].fetch_sub(1, std::memory_order_relaxed);
-    }
-
-    degree_t getValue(offset_t offset) {
-        return degreeValues[offset].load(std::memory_order_relaxed);
-    }
-
-private:
-    void init(const table_id_map_t<offset_t>& numNodesMap, MemoryManager* mm) {
-        for (const auto& [tableID, numNodes] : numNodesMap) {
-            degreeValuesMap.allocate(tableID, numNodes, mm);
-            pinTable(tableID);
-            for (auto i = 0u; i < numNodes; ++i) {
-                degreeValues[i].store(0, std::memory_order_relaxed);
-            }
-        }
-    }
-
-private:
-    std::atomic<degree_t>* degreeValues = nullptr;
-    ObjectArraysMap<std::atomic<degree_t>> degreeValuesMap;
-};
 
 class CoreValues {
 public:
@@ -126,22 +88,6 @@ public:
 private:
     Degrees* degrees;
     CoreValues* coreValues;
-};
-
-struct DegreeEdgeCompute : public EdgeCompute {
-    Degrees* degrees;
-
-    explicit DegreeEdgeCompute(Degrees* degrees) : degrees{degrees} {}
-
-    std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, graph::NbrScanState::Chunk& chunk,
-        bool) override {
-        degrees->addDegree(boundNodeID.offset, chunk.size());
-        return {};
-    }
-
-    std::unique_ptr<EdgeCompute> copy() override {
-        return std::make_unique<DegreeEdgeCompute>(degrees);
-    }
 };
 
 struct RemoveVertexEdgeCompute : public EdgeCompute {
@@ -231,6 +177,7 @@ public:
           coreValue{coreValue}, numActiveNodes{numActiveNodes} {}
 
     bool beginOnTable(table_id_t tableID) override {
+        frontierPair->pinNextFrontier(tableID);
         degrees->pinTable(tableID);
         coreValues->pinTable(tableID);
         return true;
@@ -295,24 +242,16 @@ public:
         auto graph = sharedState->graph.get();
         auto numNodesMap = graph->getNumNodesMap(clientContext->getTransaction());
         auto degrees = Degrees(numNodesMap, mm);
+        DegreesUtils::computeDegree(context, graph, &degrees, ExtendDirection::BOTH);
         auto coreValues = CoreValues(numNodesMap, mm);
         auto currentFrontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
-        auto nextFrontier = getPathLengthsFrontier(context, 0);
+        auto nextFrontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
         auto frontierPair = std::make_unique<KCoreFrontierPair>(currentFrontier, nextFrontier,
             &degrees, &coreValues);
-        // Initialize starting nodes (all nodes) in the next frontier.
-        // When beginNewIteration, next frontier will become current frontier
-        frontierPair->setActiveNodesForNextIter();
-        frontierPair->getNextSparseFrontier().disable();
-        // Compute Degree
-        auto degreeEdgeCompute = std::make_unique<DegreeEdgeCompute>(&degrees);
-        auto computeState = GDSComputeState(std::move(frontierPair), std::move(degreeEdgeCompute),
-            sharedState->getOutputNodeMaskMap());
-        GDSUtils::runFrontiersUntilConvergence(context, computeState, graph, ExtendDirection::BOTH,
-            1 /* maxIters */);
         // Compute Core values
         auto removeVertexEdgeCompute = std::make_unique<RemoveVertexEdgeCompute>(&degrees);
-        computeState.edgeCompute = std::move(removeVertexEdgeCompute);
+        auto computeState = GDSComputeState(std::move(frontierPair), std::move(removeVertexEdgeCompute),
+            sharedState->getOutputNodeMaskMap());
         auto coreValue = 0u;
         auto numNodes = graph->getNumNodes(clientContext->getTransaction());
         auto numNodesComputed = 0u;

--- a/src/function/gds/page_rank.cpp
+++ b/src/function/gds/page_rank.cpp
@@ -10,6 +10,7 @@
 #include "main/client_context.h"
 #include "processor/execution_context.h"
 #include "processor/result/factorized_table.h"
+#include "degrees.h"
 
 using namespace kuzu::processor;
 using namespace kuzu::common;
@@ -62,7 +63,9 @@ public:
 
     double getValue(offset_t offset) { return values[offset].load(std::memory_order_relaxed); }
 
-    void addValueCAS(offset_t offset, double val) { addCAS(values[offset], val); }
+    void addValueCAS(offset_t offset, double val) {
+        addCAS(values[offset], val);
+    }
 
     void setValue(offset_t offset, double val) {
         values[offset].store(val, std::memory_order_relaxed);
@@ -76,23 +79,26 @@ private:
 // Sum the weight (current rank / degree) for each incoming edge.
 class PNextUpdateEdgeCompute : public EdgeCompute {
 public:
-    PNextUpdateEdgeCompute(PValues* pCurrent, PValues* pNext) : pCurrent{pCurrent}, pNext{pNext} {}
+    PNextUpdateEdgeCompute(Degrees* degrees, PValues* pCurrent, PValues* pNext) : degrees{degrees}, pCurrent{pCurrent}, pNext{pNext} {}
 
     std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, graph::NbrScanState::Chunk& chunk,
         bool) override {
         if (chunk.size() > 0) {
-            auto valToAdd = pCurrent->getValue(boundNodeID.offset) / chunk.size();
-            chunk.forEach(
-                [&](auto nbrNodeID, auto) { pNext->addValueCAS(nbrNodeID.offset, valToAdd); });
+            double valToAdd = 0;
+            chunk.forEach([&](auto nbrNodeID, auto) {
+                valToAdd += pCurrent->getValue(nbrNodeID.offset) / degrees->getValue(nbrNodeID.offset);
+            });
+            pNext->addValueCAS(boundNodeID.offset, valToAdd);
         }
         return {boundNodeID};
     }
 
     std::unique_ptr<EdgeCompute> copy() override {
-        return std::make_unique<PNextUpdateEdgeCompute>(pCurrent, pNext);
+        return std::make_unique<PNextUpdateEdgeCompute>(degrees, pCurrent, pNext);
     }
 
 private:
+    Degrees* degrees;
     PValues* pCurrent;
     PValues* pNext;
 };
@@ -157,29 +163,6 @@ private:
     PValues* pCurrent;
     PValues* pNext;
 };
-
-// class PResetVertexCompute : public VertexCompute {
-// public:
-//     explicit PResetVertexCompute(P* pCurrent) : pCurrent{pCurrent} {}
-//
-//     bool beginOnTable(common::table_id_t tableID) override {
-//         pCurrent->pin(tableID);
-//         return true;
-//     }
-//
-//     void vertexCompute(offset_t startOffset, offset_t endOffset, table_id_t) override {
-//         for (auto i = startOffset; i < endOffset; ++i) {
-//             pCurrent->setValue(i, 0);
-//         }
-//     }
-//
-//     std::unique_ptr<VertexCompute> copy() override {
-//         return std::make_unique<PResetVertexCompute>(pCurrent);
-//     }
-//
-// private:
-//     P* pCurrent;
-// };
 
 class PageRankOutputWriter : public GDSOutputWriter {
 public:
@@ -284,18 +267,20 @@ public:
         auto currentIter = 1u;
         auto currentFrontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
         auto nextFrontier = getPathLengthsFrontier(context, 0);
+        auto degrees = Degrees(numNodesMap, clientContext->getMemoryManager());
+        DegreesUtils::computeDegree(context, graph, &degrees, ExtendDirection::FWD);
         auto frontierPair =
             std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier, nextFrontier);
         frontierPair->setActiveNodesForNextIter();
         frontierPair->getNextSparseFrontier().disable();
+        auto computeState = GDSComputeState(std::move(frontierPair), nullptr,
+            sharedState->getOutputNodeMaskMap());
         auto pNextUpdateConstant = (1 - pageRankBindData->dampingFactor) * ((double)1 / numNodes);
-        auto computeState =
-            GDSComputeState(std::move(frontierPair), nullptr, sharedState->getOutputNodeMaskMap());
         while (currentIter < pageRankBindData->maxIteration) {
-            auto ec = std::make_unique<PNextUpdateEdgeCompute>(pCurrent, pNext);
+            auto ec = std::make_unique<PNextUpdateEdgeCompute>(&degrees, pCurrent, pNext);
             computeState.edgeCompute = std::move(ec);
             GDSUtils::runFrontiersUntilConvergence(context, computeState, graph,
-                ExtendDirection::FWD, computeState.frontierPair->getCurrentIter() + 1);
+                ExtendDirection::BWD, computeState.frontierPair->getCurrentIter() + 1);
             auto pNextUpdateVC = PNextUpdateVertexCompute(pageRankBindData->dampingFactor,
                 pNextUpdateConstant, pNext);
             GDSUtils::runVertexCompute(context, graph, pNextUpdateVC);

--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -160,7 +160,7 @@ OnDiskGraph::OnDiskGraph(ClientContext* context, const GraphEntry& entry)
     }
 }
 
-std::vector<table_id_t> OnDiskGraph::getNodeTableIDs() {
+std::vector<table_id_t> OnDiskGraph::getNodeTableIDs() const {
     std::vector<table_id_t> result;
     for (auto& entry : graphEntry.nodeEntries) {
         result.push_back(entry->getTableID());
@@ -168,7 +168,7 @@ std::vector<table_id_t> OnDiskGraph::getNodeTableIDs() {
     return result;
 }
 
-std::vector<table_id_t> OnDiskGraph::getRelTableIDs() {
+std::vector<table_id_t> OnDiskGraph::getRelTableIDs() const {
     std::vector<table_id_t> result;
     for (auto& entry : graphEntry.relEntries) {
         result.push_back(entry->getTableID());
@@ -176,7 +176,7 @@ std::vector<table_id_t> OnDiskGraph::getRelTableIDs() {
     return result;
 }
 
-table_id_map_t<offset_t> OnDiskGraph::getNumNodesMap(transaction::Transaction* transaction) {
+table_id_map_t<offset_t> OnDiskGraph::getNumNodesMap(transaction::Transaction* transaction) const {
     table_id_map_t<offset_t> retVal;
     for (auto tableID : getNodeTableIDs()) {
         retVal[tableID] = getNumNodes(transaction, tableID);
@@ -184,7 +184,7 @@ table_id_map_t<offset_t> OnDiskGraph::getNumNodesMap(transaction::Transaction* t
     return retVal;
 }
 
-offset_t OnDiskGraph::getNumNodes(transaction::Transaction* transaction) {
+offset_t OnDiskGraph::getNumNodes(transaction::Transaction* transaction) const {
     offset_t numNodes = 0u;
     for (auto id : getNodeTableIDs()) {
         numNodes += getNumNodes(transaction, id);
@@ -192,7 +192,7 @@ offset_t OnDiskGraph::getNumNodes(transaction::Transaction* transaction) {
     return numNodes;
 }
 
-offset_t OnDiskGraph::getNumNodes(transaction::Transaction* transaction, table_id_t id) {
+offset_t OnDiskGraph::getNumNodes(transaction::Transaction* transaction, table_id_t id) const {
     KU_ASSERT(nodeIDToNodeTable.contains(id));
     return nodeIDToNodeTable.at(id)->getNumTotalRows(transaction);
 }

--- a/src/include/function/gds/gds.h
+++ b/src/include/function/gds/gds.h
@@ -118,7 +118,7 @@ protected:
         const std::vector<catalog::TableCatalogEntry*>& nodeEntries);
 
     std::shared_ptr<PathLengths> getPathLengthsFrontier(processor::ExecutionContext* context,
-        uint16_t val);
+        uint16_t initialVal);
 
 protected:
     std::unique_ptr<GDSBindData> bindData;

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -8,6 +8,11 @@
 #include <span>
 
 namespace kuzu {
+
+namespace processor {
+struct ExecutionContext;
+}
+
 namespace function {
 
 class FrontierMorsel {
@@ -188,6 +193,8 @@ public:
     void pinTableID(common::table_id_t tableID) override { pinCurFrontierTableID(tableID); }
     void pinCurFrontierTableID(common::table_id_t tableID);
     void pinNextFrontierTableID(common::table_id_t tableID);
+
+    static std::shared_ptr<PathLengths> getFrontier(processor::ExecutionContext* context, graph::Graph* graph,uint16_t initialValue);
 
 private:
     uint16_t getCurIter() { return curIter.load(std::memory_order_relaxed); }

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -194,7 +194,8 @@ public:
     void pinCurFrontierTableID(common::table_id_t tableID);
     void pinNextFrontierTableID(common::table_id_t tableID);
 
-    static std::shared_ptr<PathLengths> getFrontier(processor::ExecutionContext* context, graph::Graph* graph,uint16_t initialValue);
+    static std::shared_ptr<PathLengths> getFrontier(processor::ExecutionContext* context,
+        graph::Graph* graph, uint16_t initialValue);
 
 private:
     uint16_t getCurIter() { return curIter.load(std::memory_order_relaxed); }

--- a/src/include/graph/graph.h
+++ b/src/include/graph/graph.h
@@ -184,18 +184,18 @@ public:
     virtual ~Graph() = default;
 
     // Get id for all node tables.
-    virtual std::vector<common::table_id_t> getNodeTableIDs() = 0;
+    virtual std::vector<common::table_id_t> getNodeTableIDs() const = 0;
     // Get id for all relationship tables.
-    virtual std::vector<common::table_id_t> getRelTableIDs() = 0;
+    virtual std::vector<common::table_id_t> getRelTableIDs() const = 0;
 
     virtual common::table_id_map_t<common::offset_t> getNumNodesMap(
-        transaction::Transaction* transaction) = 0;
+        transaction::Transaction* transaction) const = 0;
 
     // Get num rows for all node tables.
-    virtual common::offset_t getNumNodes(transaction::Transaction* transcation) = 0;
+    virtual common::offset_t getNumNodes(transaction::Transaction* transaction) const = 0;
     // Get num rows for given node table.
-    virtual common::offset_t getNumNodes(transaction::Transaction* transcation,
-        common::table_id_t id) = 0;
+    virtual common::offset_t getNumNodes(transaction::Transaction* transaction,
+        common::table_id_t id) const = 0;
 
     // Get all possible "forward" (fromNodeTableID, relTableID, toNodeTableID) combinations.
     virtual std::vector<RelTableIDInfo> getRelTableIDInfos() = 0;

--- a/src/include/graph/on_disk_graph.h
+++ b/src/include/graph/on_disk_graph.h
@@ -152,15 +152,15 @@ class KUZU_API OnDiskGraph final : public Graph {
 public:
     OnDiskGraph(main::ClientContext* context, const GraphEntry& entry);
 
-    std::vector<common::table_id_t> getNodeTableIDs() override;
-    std::vector<common::table_id_t> getRelTableIDs() override;
+    std::vector<common::table_id_t> getNodeTableIDs() const override;
+    std::vector<common::table_id_t> getRelTableIDs() const override;
 
     common::table_id_map_t<common::offset_t> getNumNodesMap(
-        transaction::Transaction* transaction) override;
+        transaction::Transaction* transaction) const override;
 
-    common::offset_t getNumNodes(transaction::Transaction* transcation) override;
+    common::offset_t getNumNodes(transaction::Transaction* transaction) const override;
     common::offset_t getNumNodes(transaction::Transaction* transaction,
-        common::table_id_t id) override;
+        common::table_id_t id) const override;
 
     std::vector<RelTableIDInfo> getRelTableIDInfos() override;
 


### PR DESCRIPTION
# Description

Improve page rank contention by using backward adjacency list when propagating ranks.

On the same LDBC100 person know person, performance becomes

1 thread - 5.2s
2 thread  - 2.6s
4 thread - 2.3s

The previous benchmark number was

5s, 2.7s, 4s

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).