### PR TITLE
Refactor on disk graph interface

### DIFF
--- a/src/function/gds/gds_frontier.cpp
+++ b/src/function/gds/gds_frontier.cpp
@@ -9,13 +9,11 @@ namespace kuzu {
 namespace function {
 
 FrontierMorselDispatcher::FrontierMorselDispatcher(uint64_t maxThreads)
-    : tableID{INVALID_TABLE_ID}, maxOffset{INVALID_OFFSET}, maxThreads{maxThreads},
-      morselSize(UINT64_MAX) {
+    : maxOffset{INVALID_OFFSET}, maxThreads{maxThreads}, morselSize(UINT64_MAX) {
     nextOffset.store(INVALID_OFFSET);
 }
 
-void FrontierMorselDispatcher::init(common::table_id_t _tableID, common::offset_t _maxOffset) {
-    tableID = _tableID;
+void FrontierMorselDispatcher::init(common::offset_t _maxOffset) {
     maxOffset = _maxOffset;
     nextOffset.store(0u);
     // Frontier size calculation: The ideal scenario is to have k^2 many morsels where k
@@ -32,7 +30,7 @@ bool FrontierMorselDispatcher::getNextRangeMorsel(FrontierMorsel& frontierMorsel
         return false;
     }
     auto endOffset = beginOffset + morselSize > maxOffset ? maxOffset : beginOffset + morselSize;
-    frontierMorsel.init(tableID, beginOffset, endOffset);
+    frontierMorsel.init(beginOffset, endOffset);
     return true;
 }
 

--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -1,5 +1,5 @@
 #include "function/gds/gds_task.h"
-
+#include "catalog/catalog_entry/table_catalog_entry.h"
 #include "graph/graph.h"
 
 using namespace kuzu::common;
@@ -20,10 +20,10 @@ void FrontierTask::run() {
     FrontierMorsel morsel;
     auto numActiveNodes = 0u;
     auto graph = info.graph;
-    auto scanState = graph->prepareScan(info.relTableID, info.edgePropertyIdx);
+    auto scanState = graph->prepareRelScan(info.relEntry, info.propertyToScan);
     auto localEc = info.edgeCompute.copy();
     SparseFrontier localFrontier;
-    localFrontier.pinTableID(info.nbrTableID);
+    localFrontier.pinTableID(info.nbrEntry->getTableID());
     auto& curFrontier = sharedState->frontierPair.getCurDenseFrontier();
     switch (info.direction) {
     case ExtendDirection::FWD: {
@@ -32,7 +32,7 @@ void FrontierTask::run() {
                 if (!curFrontier.isActive(offset)) {
                     continue;
                 }
-                nodeID_t nodeID = {offset, morsel.getTableID()};
+                nodeID_t nodeID = {offset, info.boundEntry->getTableID()};
                 for (auto chunk : graph->scanFwd(nodeID, *scanState)) {
                     numActiveNodes += runEdgeCompute(nodeID, chunk, *localEc,
                         sharedState->frontierPair, true, localFrontier);
@@ -46,7 +46,7 @@ void FrontierTask::run() {
                 if (!curFrontier.isActive(offset)) {
                     continue;
                 }
-                nodeID_t nodeID = {offset, morsel.getTableID()};
+                nodeID_t nodeID = {offset, info.boundEntry->getTableID()};
                 for (auto chunk : graph->scanBwd(nodeID, *scanState)) {
                     numActiveNodes += runEdgeCompute(nodeID, chunk, *localEc,
                         sharedState->frontierPair, false, localFrontier);
@@ -66,10 +66,10 @@ void FrontierTask::run() {
 void FrontierTask::runSparse() {
     auto numActiveNodes = 0u;
     auto graph = info.graph;
-    auto scanState = graph->prepareScan(info.relTableID, info.edgePropertyIdx);
+    auto scanState = graph->prepareRelScan(info.relEntry, info.propertyToScan);
     auto localEc = info.edgeCompute.copy();
     SparseFrontier localFrontier;
-    localFrontier.pinTableID(info.nbrTableID);
+    localFrontier.pinTableID(info.nbrEntry->getTableID());
     auto& curFrontier = sharedState->frontierPair.getCurSparseFrontier();
     switch (info.direction) {
     case ExtendDirection::FWD: {
@@ -103,9 +103,8 @@ void VertexComputeTask::run() {
     FrontierMorsel morsel;
     auto graph = info.graph;
     auto localVc = info.vc.copy();
-    auto tableID = sharedState->morselDispatcher.getTableID();
     if (info.hasPropertiesToScan()) {
-        auto scanState = graph->prepareVertexScan(tableID, info.propertiesToScan);
+        auto scanState = graph->prepareVertexScan(info.tableEntry, info.propertiesToScan);
         while (sharedState->morselDispatcher.getNextRangeMorsel(morsel)) {
             for (auto chunk :
                 graph->scanVertices(morsel.getBeginOffset(), morsel.getEndOffset(), *scanState)) {
@@ -114,7 +113,8 @@ void VertexComputeTask::run() {
         }
     } else {
         while (sharedState->morselDispatcher.getNextRangeMorsel(morsel)) {
-            localVc->vertexCompute(morsel.getBeginOffset(), morsel.getEndOffset(), tableID);
+            localVc->vertexCompute(morsel.getBeginOffset(), morsel.getEndOffset(),
+                info.tableEntry->getTableID());
         }
     }
 }

--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -1,4 +1,5 @@
 #include "function/gds/gds_task.h"
+
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "graph/graph.h"
 

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -19,21 +19,17 @@ class FrontierMorsel {
 public:
     FrontierMorsel() = default;
 
-    common::table_id_t getTableID() const { return tableID; }
     common::offset_t getBeginOffset() const { return beginOffset; }
-    common::offset_t getEndOffset() const { return endOffsetExclusive; }
+    common::offset_t getEndOffset() const { return endOffset; }
 
-    void init(common::table_id_t _tableID, common::offset_t _beginOffset,
-        common::offset_t _endOffsetExclusive) {
-        tableID = _tableID;
-        beginOffset = _beginOffset;
-        endOffsetExclusive = _endOffsetExclusive;
+    void init(common::offset_t beginOffset_, common::offset_t endOffset_) {
+        beginOffset = beginOffset_;
+        endOffset = endOffset_;
     }
 
 private:
-    common::table_id_t tableID = common::INVALID_TABLE_ID;
     common::offset_t beginOffset = common::INVALID_OFFSET;
-    common::offset_t endOffsetExclusive = common::INVALID_OFFSET;
+    common::offset_t endOffset = common::INVALID_OFFSET;
 };
 
 class KUZU_API FrontierMorselDispatcher {
@@ -46,14 +42,11 @@ class KUZU_API FrontierMorselDispatcher {
 public:
     explicit FrontierMorselDispatcher(uint64_t maxThreads);
 
-    void init(common::table_id_t _tableID, common::offset_t _maxOffset);
+    void init(common::offset_t _maxOffset);
 
     bool getNextRangeMorsel(FrontierMorsel& frontierMorsel);
 
-    common::table_id_t getTableID() const { return tableID; }
-
 private:
-    common::table_id_t tableID;
     common::offset_t maxOffset;
     std::atomic<common::offset_t> nextOffset;
     uint64_t maxThreads;

--- a/src/include/function/gds/gds_task.h
+++ b/src/include/function/gds/gds_task.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "common/enums/extend_direction.h"
 #include "common/task_system/task.h"
 #include "function/gds/gds_frontier.h"
@@ -9,22 +11,24 @@ namespace kuzu {
 namespace function {
 
 struct FrontierTaskInfo {
-    common::table_id_t nbrTableID;
-    common::table_id_t relTableID;
+    catalog::TableCatalogEntry* boundEntry = nullptr;
+    catalog::TableCatalogEntry* nbrEntry = nullptr;
+    catalog::TableCatalogEntry* relEntry = nullptr;
     graph::Graph* graph;
     common::ExtendDirection direction;
     EdgeCompute& edgeCompute;
-    std::optional<common::idx_t> edgePropertyIdx;
+    std::string propertyToScan;
 
-    FrontierTaskInfo(common::table_id_t nbrTableID, common::table_id_t relTableID,
-        graph::Graph* graph, common::ExtendDirection direction, EdgeCompute& edgeCompute,
-        std::optional<common::idx_t> edgePropertyIdx)
-        : nbrTableID{nbrTableID}, relTableID{relTableID}, graph{graph}, direction{direction},
-          edgeCompute{edgeCompute}, edgePropertyIdx{edgePropertyIdx} {}
+    FrontierTaskInfo(catalog::TableCatalogEntry* boundEntry, catalog::TableCatalogEntry* nbrEntry,
+        catalog::TableCatalogEntry* relEntry, graph::Graph* graph,
+        common::ExtendDirection direction, EdgeCompute& edgeCompute,
+        std::string  propertyToScan)
+        : boundEntry{boundEntry}, nbrEntry{nbrEntry}, relEntry{relEntry}, graph{graph},
+          direction{direction}, edgeCompute{edgeCompute}, propertyToScan{std::move(propertyToScan)} {}
     FrontierTaskInfo(const FrontierTaskInfo& other)
-        : nbrTableID{other.nbrTableID}, relTableID{other.relTableID}, graph{other.graph},
-          direction{other.direction}, edgeCompute{other.edgeCompute},
-          edgePropertyIdx{other.edgePropertyIdx} {}
+        : boundEntry{other.boundEntry}, nbrEntry{other.nbrEntry}, relEntry{other.relEntry},
+          graph{other.graph}, direction{other.direction}, edgeCompute{other.edgeCompute},
+          propertyToScan{other.propertyToScan} {}
 };
 
 struct FrontierTaskSharedState {
@@ -41,10 +45,6 @@ public:
     FrontierTask(uint64_t maxNumThreads, const FrontierTaskInfo& info,
         std::shared_ptr<FrontierTaskSharedState> sharedState)
         : common::Task{maxNumThreads}, info{info}, sharedState{std::move(sharedState)} {}
-
-    void init(common::table_id_t tableID, common::offset_t numNodes) {
-        sharedState->morselDispatcher.init(tableID, numNodes);
-    }
 
     void run() override;
 
@@ -65,13 +65,16 @@ struct VertexComputeTaskSharedState {
 struct VertexComputeTaskInfo {
     VertexCompute& vc;
     graph::Graph* graph;
+    catalog::TableCatalogEntry* tableEntry;
     std::vector<std::string> propertiesToScan;
 
     VertexComputeTaskInfo(VertexCompute& vc, graph::Graph* graph,
-        std::vector<std::string> propertiesToScan)
-        : vc{vc}, graph{graph}, propertiesToScan{std::move(propertiesToScan)} {}
+        catalog::TableCatalogEntry* tableEntry, std::vector<std::string> propertiesToScan)
+        : vc{vc}, graph{graph}, tableEntry{tableEntry},
+          propertiesToScan{std::move(propertiesToScan)} {}
     VertexComputeTaskInfo(const VertexComputeTaskInfo& other)
-        : vc{other.vc}, graph{other.graph}, propertiesToScan{other.propertiesToScan} {}
+        : vc{other.vc}, graph{other.graph}, tableEntry{other.tableEntry},
+          propertiesToScan{other.propertiesToScan} {}
 
     bool hasPropertiesToScan() const { return !propertiesToScan.empty(); }
 };
@@ -82,9 +85,7 @@ public:
         std::shared_ptr<VertexComputeTaskSharedState> sharedState)
         : common::Task{maxNumThreads}, info{info}, sharedState{std::move(sharedState)} {};
 
-    void init(common::table_id_t tableID, common::offset_t numNodes) {
-        sharedState->morselDispatcher.init(tableID, numNodes);
-    }
+    VertexComputeTaskSharedState* getSharedState() const { return sharedState.get(); }
 
     void run() override;
 

--- a/src/include/function/gds/gds_task.h
+++ b/src/include/function/gds/gds_task.h
@@ -21,10 +21,10 @@ struct FrontierTaskInfo {
 
     FrontierTaskInfo(catalog::TableCatalogEntry* boundEntry, catalog::TableCatalogEntry* nbrEntry,
         catalog::TableCatalogEntry* relEntry, graph::Graph* graph,
-        common::ExtendDirection direction, EdgeCompute& edgeCompute,
-        std::string  propertyToScan)
+        common::ExtendDirection direction, EdgeCompute& edgeCompute, std::string propertyToScan)
         : boundEntry{boundEntry}, nbrEntry{nbrEntry}, relEntry{relEntry}, graph{graph},
-          direction{direction}, edgeCompute{edgeCompute}, propertyToScan{std::move(propertyToScan)} {}
+          direction{direction}, edgeCompute{edgeCompute},
+          propertyToScan{std::move(propertyToScan)} {}
     FrontierTaskInfo(const FrontierTaskInfo& other)
         : boundEntry{other.boundEntry}, nbrEntry{other.nbrEntry}, relEntry{other.relEntry},
           graph{other.graph}, direction{other.direction}, edgeCompute{other.edgeCompute},

--- a/src/include/function/gds/gds_utils.h
+++ b/src/include/function/gds/gds_utils.h
@@ -2,6 +2,7 @@
 
 #include <optional>
 
+#include "catalog/catalog_entry/table_catalog_entry.h"
 #include "common/enums/extend_direction.h"
 #include "common/types/types.h"
 
@@ -42,11 +43,11 @@ struct KUZU_API GDSComputeState {
 
 class KUZU_API GDSUtils {
 public:
-    static void scheduleFrontierTask(common::table_id_t boundTableID, common::table_id_t nbrTableID,
-        common::table_id_t relTableID, graph::Graph* graph, common::ExtendDirection extendDirection,
-        GDSComputeState& rjCompState, processor::ExecutionContext* context,
-        std::optional<uint64_t> numThreads = std::nullopt,
-        std::optional<common::idx_t> edgePropertyIdx = std::nullopt);
+    static void scheduleFrontierTask(catalog::TableCatalogEntry* fromEntry,
+        catalog::TableCatalogEntry* toEntry, catalog::TableCatalogEntry* relEntry,
+        graph::Graph* graph, common::ExtendDirection extendDirection, GDSComputeState& rjCompState,
+        processor::ExecutionContext* context, std::optional<uint64_t> numThreads = std::nullopt,
+        const std::string& propertyToScan = "");
     static void runFrontiersUntilConvergence(processor::ExecutionContext* context,
         GDSComputeState& rjCompState, graph::Graph* graph, common::ExtendDirection extendDirection,
         uint64_t maxIters);
@@ -58,7 +59,8 @@ public:
         VertexCompute& vc, std::vector<std::string> propertiesToScan);
     // Run vertex compute on specific table with property scan
     static void runVertexCompute(processor::ExecutionContext* context, graph::Graph* graph,
-        VertexCompute& vc, common::table_id_t tableID, std::vector<std::string> propertiesToScan);
+        VertexCompute& vc, catalog::TableCatalogEntry* entry,
+        std::vector<std::string> propertiesToScan);
     static void runVertexComputeSparse(SparseFrontier& sparseFrontier, graph::Graph* graph,
         VertexCompute& vc);
 };


### PR DESCRIPTION
# Description

This PR contains the following refactor

1. Remove unnecessary tableID in frontier morsel. Given we first pin to a specific table, frontier morsel should contain pure offset.
2. Pass TableCatalogEntry instead of tableID in many interfaces. Practically speaking they don't make a difference, using TableCatalogEntry will let us access catalog for fewer times. And code looks cleaner.
3. Pass edge property name instead of edge property idx. This is to align with vertex scan which takes vertex property names. Also using string based name is easier to interpret for new users.
4. Rename prepareScan to prepareRelScan because we also have a prepareVertexScan.
5. Remove `std::vector<std::pair<common::table_id_t, OnDiskGraphNbrScanState>> scanStates;` because we no longer need to scan multiple rel table in one `scanFwd/scanBwd`. The infrastructure force scan always happens on exactly one rel table. The design can be further simplified but I would do it in a followed up PR.

@benjaminwinger please review for changes 3, 4 & 5

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).