### PR TITLE
Fix FTS prepare test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,9 +195,9 @@ extension-json-test-build:
 
 extension-test: extension-test-build
 ifeq ($(OS),Windows_NT)
-	set "E2E_TEST_FILES_DIRECTORY=extension" && ctest -R "e2e_test" --test-dir build/relwithdebinfo/test --output-on-failure -j ${TEST_JOBS} --exclude-regex "${EXTENSION_TEST_EXCLUDE_FILTER}"
+	set "E2E_TEST_FILES_DIRECTORY=extension" && ctest --test-dir build/relwithdebinfo/test/runner --output-on-failure -j ${TEST_JOBS} --exclude-regex "${EXTENSION_TEST_EXCLUDE_FILTER}"
 else
-	E2E_TEST_FILES_DIRECTORY=extension ctest --test-dir build/relwithdebinfo/test --output-on-failure -j ${TEST_JOBS} --exclude-regex "${EXTENSION_TEST_EXCLUDE_FILTER}" -R e2e_test
+	E2E_TEST_FILES_DIRECTORY=extension ctest --test-dir build/relwithdebinfo/test/runner --output-on-failure -j ${TEST_JOBS} --exclude-regex "${EXTENSION_TEST_EXCLUDE_FILTER}"
 endif
 	aws s3 rm s3://kuzu-dataset-us/${RUN_ID}/ --recursive
 

--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -14,6 +14,10 @@ function(set_apple_dynamic_lookup target_name)
     set_target_properties(${target_name} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
 endfunction()
 
+if (${BUILD_EXTENSION_TESTS})
+    enable_testing()
+endif ()
+
 if ("httpfs" IN_LIST BUILD_EXTENSIONS)
     add_subdirectory(httpfs)
 endif ()
@@ -56,8 +60,4 @@ endif ()
 
 if ("iceberg" IN_LIST BUILD_EXTENSIONS)
     add_subdirectory(iceberg)
-endif ()
-
-if (${BUILD_EXTENSION_TESTS})
-    enable_testing()
 endif ()

--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -38,7 +38,7 @@ struct QueryFTSBindData final : GDSBindData {
     QueryFTSBindData(graph::GraphEntry graphEntry, std::shared_ptr<Expression> docs,
         std::shared_ptr<Expression> query, const FTSIndexCatalogEntry& entry, QueryFTSConfig config)
         : GDSBindData{std::move(graphEntry), std::move(docs)}, query{std::move(query)},
-          entry{entry}, config{config},
+          config{config}, entry{entry},
           outputTableID{nodeOutput->constCast<NodeExpression>().getSingleEntry()->getTableID()} {}
     QueryFTSBindData(const QueryFTSBindData& other)
         : GDSBindData{other}, query{other.query}, entry{other.entry}, config{other.config},

--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -41,7 +41,7 @@ struct QueryFTSBindData final : GDSBindData {
           config{config}, entry{entry},
           outputTableID{nodeOutput->constCast<NodeExpression>().getSingleEntry()->getTableID()} {}
     QueryFTSBindData(const QueryFTSBindData& other)
-        : GDSBindData{other}, query{other.query}, entry{other.entry}, config{other.config},
+        : GDSBindData{other}, query{other.query}, config{other.config}, entry{other.entry},
           outputTableID{other.outputTableID} {}
 
     bool hasNodeInput() const override { return false; }

--- a/extension/fts/test/prepare_test.cpp
+++ b/extension/fts/test/prepare_test.cpp
@@ -18,7 +18,7 @@ TEST_F(ApiTest, PrepareFTSTest) {
     auto preparedResult = TestHelper::convertResultToString(
         *conn->execute(prepared.get(), std::make_pair(std::string("q"), std::string("alice"))));
     auto nonPreparedResult = TestHelper::convertResultToString(*conn->query(
-        "CALL QUERY_FTS_INDEX('person', 'personIdx', 'alicdd') RETURN _node.ID, score;"));
+        "CALL QUERY_FTS_INDEX('person', 'personIdx', 'alice') RETURN _node.ID, score;"));
     sortAndCheckTestResults(preparedResult, nonPreparedResult);
 }
 

--- a/extension/fts/test/prepare_test.cpp
+++ b/extension/fts/test/prepare_test.cpp
@@ -7,10 +7,10 @@ namespace testing {
 
 TEST_F(ApiTest, PrepareFTSTest) {
     createDBAndConn();
-    ASSERT_TRUE(conn
-            ->query(common::stringFormat("LOAD EXTENSION '{}'",
-                TestHelper::appendKuzuRootPath("extension/fts/build/libfts.kuzu_extension")))
-            ->isSuccess());
+    ASSERT_TRUE(conn->query(common::stringFormat("LOAD EXTENSION '{}'",
+                                TestHelper::appendKuzuRootPath(
+                                    "extension/fts/build/libfts.kuzu_extension")))
+                    ->isSuccess());
     ASSERT_TRUE(
         conn->query("CALL CREATE_FTS_INDEX('person', 'personIdx', ['fName'])")->isSuccess());
     auto prepared =

--- a/extension/fts/test/prepare_test.cpp
+++ b/extension/fts/test/prepare_test.cpp
@@ -7,18 +7,18 @@ namespace testing {
 
 TEST_F(ApiTest, PrepareFTSTest) {
     createDBAndConn();
-    ASSERT_TRUE(conn->query(common::stringFormat("LOAD EXTENSION '{}'",
-                                TestHelper::appendKuzuRootPath(
-                                    "extension/fts/build/libfts.kuzu_extension")))
-                    ->isSuccess());
+    ASSERT_TRUE(conn
+            ->query(common::stringFormat("LOAD EXTENSION '{}'",
+                TestHelper::appendKuzuRootPath("extension/fts/build/libfts.kuzu_extension")))
+            ->isSuccess());
     ASSERT_TRUE(
         conn->query("CALL CREATE_FTS_INDEX('person', 'personIdx', ['fName'])")->isSuccess());
     auto prepared =
-        conn->prepare("CALL QUERY_FTS_INDEX('person', 'personIdx', $q) RETURN node.ID, score;");
+        conn->prepare("CALL QUERY_FTS_INDEX('person', 'personIdx', $q) RETURN _node.ID, score;");
     auto preparedResult = TestHelper::convertResultToString(
         *conn->execute(prepared.get(), std::make_pair(std::string("q"), std::string("alice"))));
     auto nonPreparedResult = TestHelper::convertResultToString(*conn->query(
-        "CALL QUERY_FTS_INDEX('person', 'personIdx', 'alice') RETURN node.ID, score;"));
+        "CALL QUERY_FTS_INDEX('person', 'personIdx', 'alicdd') RETURN _node.ID, score;"));
     sortAndCheckTestResults(preparedResult, nonPreparedResult);
 }
 

--- a/extension/fts/test/prepare_test.cpp
+++ b/extension/fts/test/prepare_test.cpp
@@ -7,10 +7,10 @@ namespace testing {
 
 TEST_F(ApiTest, PrepareFTSTest) {
     createDBAndConn();
-    ASSERT_TRUE(conn->query(common::stringFormat("LOAD EXTENSION '{}'",
-                                TestHelper::appendKuzuRootPath(
-                                    "extension/fts/build/libfts.kuzu_extension")))
-                    ->isSuccess());
+    ASSERT_TRUE(conn
+            ->query(common::stringFormat("LOAD EXTENSION '{}'",
+                TestHelper::appendKuzuRootPath("extension/fts/build/libfts.kuzu_extension")))
+            ->isSuccess());
     ASSERT_TRUE(
         conn->query("CALL CREATE_FTS_INDEX('person', 'personIdx', ['fName'])")->isSuccess());
     auto prepared =
@@ -20,6 +20,30 @@ TEST_F(ApiTest, PrepareFTSTest) {
     auto nonPreparedResult = TestHelper::convertResultToString(*conn->query(
         "CALL QUERY_FTS_INDEX('person', 'personIdx', 'alice') RETURN _node.ID, score;"));
     sortAndCheckTestResults(preparedResult, nonPreparedResult);
+
+    // The query parameter has to be a literal/parameter expression.
+    prepared = conn->prepare("MATCH (d:person) CALL QUERY_FTS_INDEX('person', 'personIdx', "
+                             "d.fName) RETURN _node.ID, score;");
+    auto result = conn->execute(prepared.get());
+    ASSERT_FALSE(result->isSuccess());
+    ASSERT_EQ(result->getErrorMessage(),
+        "Runtime exception: The query must be a parameter/literal expression.");
+
+    // User must have to give a value when executing the QUERY_FTS_INDEX.
+    prepared =
+        conn->prepare("CALL QUERY_FTS_INDEX('person', 'personIdx', $1) RETURN _node.ID, score;");
+    result = conn->execute(prepared.get());
+    ASSERT_FALSE(result->isSuccess());
+    ASSERT_EQ(result->getErrorMessage(),
+        "Runtime exception: The query is a parameter expression. Please assign it a value.");
+
+    // Table name can't be a parameter expression.
+    prepared =
+        conn->prepare("CALL QUERY_FTS_INDEX($3, 'personIdx', 'alice') RETURN _node.ID, score;");
+    result = conn->execute(prepared.get(), std::make_pair(std::string("3"), std::string("person")));
+    ASSERT_FALSE(result->isSuccess());
+    ASSERT_EQ(result->getErrorMessage(),
+        "Binder exception: The table and index name must be literal expressions.");
 }
 
 } // namespace testing

--- a/src/binder/expression/expression_util.cpp
+++ b/src/binder/expression/expression_util.cpp
@@ -416,5 +416,21 @@ bool ExpressionUtil::canEvaluateAsLiteral(const kuzu::binder::Expression& expr) 
                 expr.getDataType().getLogicalTypeID() != common::LogicalTypeID::ANY));
 }
 
+common::Value ExpressionUtil::evaluateAsLiteralValue(const kuzu::binder::Expression& expr) {
+    KU_ASSERT(canEvaluateAsLiteral(expr));
+    auto value = Value::createDefaultValue(expr.dataType);
+    switch (expr.expressionType) {
+    case ExpressionType::LITERAL: {
+        value = expr.constCast<binder::LiteralExpression>().getValue();
+    } break;
+    case ExpressionType::PARAMETER: {
+        value = expr.constCast<binder::ParameterExpression>().getValue();
+    } break;
+    default:
+        KU_UNREACHABLE;
+    }
+    return value;
+}
+
 } // namespace binder
 } // namespace kuzu

--- a/src/include/binder/expression/expression_util.h
+++ b/src/include/binder/expression/expression_util.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common/types/value/value.h"
 #include "expression.h"
 
 namespace kuzu {
@@ -59,6 +60,8 @@ struct KUZU_API ExpressionUtil {
     static bool canCastStatically(const Expression& expr, const common::LogicalType& targetType);
 
     static bool canEvaluateAsLiteral(const Expression& expr);
+
+    static common::Value evaluateAsLiteralValue(const Expression& expr);
 };
 
 } // namespace binder

--- a/src/planner/operator/logical_limit.cpp
+++ b/src/planner/operator/logical_limit.cpp
@@ -1,8 +1,6 @@
 #include "planner/operator/logical_limit.h"
 
 #include "binder/expression/expression_util.h"
-#include "binder/expression/literal_expression.h"
-#include "binder/expression/parameter_expression.h"
 #include "common/exception/runtime.h"
 #include "common/type_utils.h"
 #include "planner/operator/factorization/flatten_resolver.h"
@@ -15,17 +13,7 @@ static uint64_t getLiteralNumber(std::shared_ptr<kuzu::binder::Expression> expr)
     if (expr == nullptr) {
         return number;
     }
-    auto value = common::Value::createDefaultValue(expr->dataType);
-    switch (expr->expressionType) {
-    case common::ExpressionType::LITERAL: {
-        value = expr->constCast<binder::LiteralExpression>().getValue();
-    } break;
-    case common::ExpressionType::PARAMETER: {
-        value = expr->constCast<binder::ParameterExpression>().getValue();
-    } break;
-    default:
-        KU_UNREACHABLE;
-    }
+    auto value = binder::ExpressionUtil::evaluateAsLiteralValue(*expr);
     auto errorMsg = "The number of rows to skip/limit must be a non-negative integer.";
     common::TypeUtils::visit(
         value.getDataType(),


### PR DESCRIPTION
Fix FTS prepare test which is disabled by accident before.
This PR allows `queryFTSIndex` function to take the parameterized query.
For example:
```
conn->prepare("CALL QUERY_FTS_INDEX('person', 'personIdx', $q) RETURN _node.ID, score;");
```
Users can specify the query parameter at runtime.
