### PR TITLE
Distinct optimizations

### DIFF
--- a/src/include/processor/result/base_hash_table.h
+++ b/src/include/processor/result/base_hash_table.h
@@ -46,6 +46,8 @@ protected:
     std::shared_ptr<common::DataChunkState> hashState;
     std::unique_ptr<common::ValueVector> hashVector;
     common::SelectionVector hashSelVec;
+    std::unique_ptr<common::ValueVector> tmpHashResultVector;
+    std::unique_ptr<common::ValueVector> tmpHashCombineResultVector;
 };
 
 } // namespace processor

--- a/src/processor/operator/aggregate/aggregate_hash_table.cpp
+++ b/src/processor/operator/aggregate/aggregate_hash_table.cpp
@@ -447,7 +447,7 @@ void AggregateHashTable::findHashSlots(const std::vector<ValueVector*>& flatKeyV
             matchFTEntries(flatKeyVectors, unFlatKeyVectors, numMayMatches, numNoMatches);
         increaseHashSlotIdxes(numNoMatches);
         numEntriesToFindHashSlots = numNoMatches;
-        memcpy(tmpValueIdxes.get(), noMatchIdxes.get(), DEFAULT_VECTOR_CAPACITY * sizeof(uint64_t));
+        memcpy(tmpValueIdxes.get(), noMatchIdxes.get(), numNoMatches * sizeof(uint64_t));
     }
 }
 

--- a/src/processor/result/base_hash_table.cpp
+++ b/src/processor/result/base_hash_table.cpp
@@ -30,10 +30,6 @@ void BaseHashTable::computeAndCombineVecHash(const std::vector<ValueVector*>& un
     uint32_t startVecIdx) {
     for (; startVecIdx < unFlatKeyVectors.size(); startVecIdx++) {
         auto keyVector = unFlatKeyVectors[startVecIdx];
-        auto tmpHashResultVector =
-            std::make_unique<ValueVector>(LogicalType::HASH(), &memoryManager);
-        auto tmpHashCombineResultVector =
-            std::make_unique<ValueVector>(LogicalType::HASH(), &memoryManager);
         tmpHashResultVector->state = keyVector->state;
         tmpHashCombineResultVector->state = keyVector->state;
         VectorHashFunction::computeHash(*keyVector, keyVector->state->getSelVector(),
@@ -43,7 +39,7 @@ void BaseHashTable::computeAndCombineVecHash(const std::vector<ValueVector*>& un
         VectorHashFunction::combineHash(*hashVector, hashVector->state->getSelVector(),
             *tmpHashResultVector, tmpHashResultVector->state->getSelVector(),
             *tmpHashCombineResultVector, tmpHashCombineResultVector->state->getSelVector());
-        hashVector = std::move(tmpHashCombineResultVector);
+        hashVector.swap(tmpHashCombineResultVector);
     }
 }
 
@@ -204,6 +200,8 @@ void BaseHashTable::initTmpHashVector() {
     hashState->setToFlat();
     hashVector = std::make_unique<ValueVector>(LogicalType::HASH(), &memoryManager);
     hashVector->state = hashState;
+    tmpHashResultVector = std::make_unique<ValueVector>(LogicalType::HASH(), &memoryManager);
+    tmpHashCombineResultVector = std::make_unique<ValueVector>(LogicalType::HASH(), &memoryManager);
 }
 
 } // namespace processor


### PR DESCRIPTION
Some of the distinct aggregate queries I've tried have had very poor performance due to them processing a single tuple at a time (which the AggregateHashTable is not really designed for). These two small changes mitigate a significant part of the cost of doing so, without having any adverse effects when processing larger batches of tuples.

- Re-use the temporary ValueVectors in `BaseHashTable::computeAndCombineVecHash`
- Don't copy the entire vector when updating `tmpValueIdxes` in `AggregateHashTable::findHashSlots` (this should be universally better. Even if there is some optimization that can be done by passing a constant to memcpy, any time the loop runs multiple times we'd be better off copying less than the full vector).