### PR TITLE
Skip limit parameter

### DIFF
--- a/src/binder/expression/expression_util.cpp
+++ b/src/binder/expression/expression_util.cpp
@@ -6,6 +6,7 @@
 #include "binder/expression/node_rel_expression.h"
 #include "binder/expression/parameter_expression.h"
 #include "common/exception/binder.h"
+#include "common/type_utils.h"
 #include "common/types/value/nested.h"
 
 using namespace kuzu::common;
@@ -409,6 +410,8 @@ bool ExpressionUtil::canCastStatically(const Expression& expr, const LogicalType
         return compatible(expr.getDataType(), targetType);
     }
 }
+
+
 
 } // namespace binder
 } // namespace kuzu

--- a/src/binder/expression/expression_util.cpp
+++ b/src/binder/expression/expression_util.cpp
@@ -6,7 +6,6 @@
 #include "binder/expression/node_rel_expression.h"
 #include "binder/expression/parameter_expression.h"
 #include "common/exception/binder.h"
-#include "common/type_utils.h"
 #include "common/types/value/nested.h"
 
 using namespace kuzu::common;

--- a/src/binder/expression/expression_util.cpp
+++ b/src/binder/expression/expression_util.cpp
@@ -411,7 +411,5 @@ bool ExpressionUtil::canCastStatically(const Expression& expr, const LogicalType
     }
 }
 
-
-
 } // namespace binder
 } // namespace kuzu

--- a/src/binder/expression/expression_util.cpp
+++ b/src/binder/expression/expression_util.cpp
@@ -410,5 +410,11 @@ bool ExpressionUtil::canCastStatically(const Expression& expr, const LogicalType
     }
 }
 
+bool ExpressionUtil::canEvaluateAsLiteral(const kuzu::binder::Expression& expr) {
+    return (expr.expressionType == common::ExpressionType::LITERAL ||
+            (expr.expressionType == common::ExpressionType::PARAMETER &&
+                expr.getDataType().getLogicalTypeID() != common::LogicalTypeID::ANY));
+}
+
 } // namespace binder
 } // namespace kuzu

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -224,7 +224,7 @@ public:
 
     expression_vector bindOrderByExpressions(
         const std::vector<std::unique_ptr<parser::ParsedExpression>>& parsedExprs);
-    uint64_t bindSkipLimitExpression(const parser::ParsedExpression& expression);
+    std::shared_ptr<Expression> bindSkipLimitExpression(const parser::ParsedExpression& expression);
 
     /*** bind graph pattern ***/
     BoundGraphPattern bindGraphPattern(const std::vector<parser::PatternElement>& graphPattern);

--- a/src/include/binder/expression/expression_util.h
+++ b/src/include/binder/expression/expression_util.h
@@ -57,6 +57,8 @@ struct KUZU_API ExpressionUtil {
     // This mostly happen when a literal is an empty list. By default, we assign its data type to
     // INT64[] but it can be cast to any other list type at compile time.
     static bool canCastStatically(const Expression& expr, const common::LogicalType& targetType);
+
+    static bool canEvaluateAsLiteral(const Expression& expr);
 };
 
 } // namespace binder

--- a/src/include/binder/query/return_with_clause/bound_projection_body.h
+++ b/src/include/binder/query/return_with_clause/bound_projection_body.h
@@ -10,7 +10,7 @@ class BoundProjectionBody {
 
 public:
     explicit BoundProjectionBody(bool distinct)
-        : distinct{distinct}, skipNumber{INVALID_NUMBER}, limitNumber{INVALID_NUMBER} {}
+        : distinct{distinct}, skipNumber{nullptr}, limitNumber{nullptr} {}
     EXPLICIT_COPY_DEFAULT_MOVE(BoundProjectionBody);
 
     bool isDistinct() const { return distinct; }
@@ -39,13 +39,13 @@ public:
     const expression_vector& getOrderByExpressions() const { return orderByExpressions; }
     const std::vector<bool>& getSortingOrders() const { return isAscOrders; }
 
-    void setSkipNumber(uint64_t number) { skipNumber = number; }
-    bool hasSkip() const { return skipNumber != INVALID_NUMBER; }
-    uint64_t getSkipNumber() const { return skipNumber; }
+    void setSkipNumber(std::shared_ptr<Expression> number) { skipNumber = number; }
+    bool hasSkip() const { return skipNumber != nullptr; }
+    std::shared_ptr<Expression> getSkipNumber() const { return skipNumber; }
 
-    void setLimitNumber(uint64_t number) { limitNumber = number; }
-    bool hasLimit() const { return limitNumber != INVALID_NUMBER; }
-    uint64_t getLimitNumber() const { return limitNumber; }
+    void setLimitNumber(std::shared_ptr<Expression> number) { limitNumber = number; }
+    bool hasLimit() const { return limitNumber != nullptr; }
+    std::shared_ptr<Expression> getLimitNumber() const { return limitNumber; }
 
     bool hasSkipOrLimit() const { return hasSkip() || hasLimit(); }
 
@@ -64,8 +64,8 @@ private:
     expression_vector aggregateExpressions;
     expression_vector orderByExpressions;
     std::vector<bool> isAscOrders;
-    uint64_t skipNumber;
-    uint64_t limitNumber;
+    std::shared_ptr<Expression> skipNumber;
+    std::shared_ptr<Expression> limitNumber;
 };
 
 } // namespace binder

--- a/src/include/planner/operator/logical_limit.h
+++ b/src/include/planner/operator/logical_limit.h
@@ -8,8 +8,8 @@ class LogicalLimit final : public LogicalOperator {
 public:
     LogicalLimit(std::shared_ptr<binder::Expression> skipNum,
         std::shared_ptr<binder::Expression> limitNum, std::shared_ptr<LogicalOperator> child)
-        : LogicalOperator{LogicalOperatorType::LIMIT, std::move(child)}, skipNum{skipNum},
-          limitNum{limitNum} {}
+        : LogicalOperator{LogicalOperatorType::LIMIT, std::move(child)},
+          skipNum{std::move(skipNum)}, limitNum{std::move(limitNum)} {}
 
     f_group_pos_set getGroupsPosToFlatten();
 

--- a/src/include/planner/operator/logical_limit.h
+++ b/src/include/planner/operator/logical_limit.h
@@ -4,38 +4,42 @@
 
 namespace kuzu {
 namespace planner {
-
 class LogicalLimit final : public LogicalOperator {
 public:
-    LogicalLimit(uint64_t skipNum, uint64_t limitNum, std::shared_ptr<LogicalOperator> child)
-        : LogicalOperator{LogicalOperatorType::LIMIT, std::move(child), limitNum}, skipNum{skipNum},
+    LogicalLimit(std::shared_ptr<binder::Expression> skipNum,
+        std::shared_ptr<binder::Expression> limitNum, std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{LogicalOperatorType::LIMIT, std::move(child)}, skipNum{skipNum},
           limitNum{limitNum} {}
 
     f_group_pos_set getGroupsPosToFlatten();
 
-    inline void computeFactorizedSchema() override { copyChildSchema(0); }
-    inline void computeFlatSchema() override { copyChildSchema(0); }
+    void computeFactorizedSchema() override { copyChildSchema(0); }
+    void computeFlatSchema() override { copyChildSchema(0); }
 
     std::string getExpressionsForPrinting() const override;
 
-    inline bool hasSkipNum() const { return skipNum != UINT64_MAX; }
-    inline uint64_t getSkipNum() const { return skipNum; }
-    inline bool hasLimitNum() const { return limitNum != UINT64_MAX; }
-    inline uint64_t getLimitNum() const { return limitNum; }
+    bool hasSkipNum() const { return skipNum != nullptr; }
+    bool canEvaluateSkipNum() const;
+    std::shared_ptr<binder::Expression> getSkipNum() const { return skipNum; }
+    uint64_t evaluateSkipNum() const;
+    bool hasLimitNum() const { return limitNum != nullptr; }
+    bool canEvaluateLimitNum() const;
+    std::shared_ptr<binder::Expression> getLimitNum() const { return limitNum; }
+    uint64_t evaluateLimitNum() const;
 
     f_group_pos getGroupPosToSelect() const;
 
-    inline std::unordered_set<f_group_pos> getGroupsPosToLimit() const {
+    std::unordered_set<f_group_pos> getGroupsPosToLimit() const {
         return schema->getGroupsPosInScope();
     }
 
-    inline std::unique_ptr<LogicalOperator> copy() override {
+    std::unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalLimit>(skipNum, limitNum, children[0]->copy());
     }
 
 private:
-    uint64_t skipNum;
-    uint64_t limitNum;
+    std::shared_ptr<binder::Expression> skipNum;
+    std::shared_ptr<binder::Expression> limitNum;
 };
 
 } // namespace planner

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -227,7 +227,8 @@ public:
     void appendOrderBy(const binder::expression_vector& expressions,
         const std::vector<bool>& isAscOrders, LogicalPlan& plan);
     void appendMultiplicityReducer(LogicalPlan& plan);
-    void appendLimit(uint64_t skipNum, uint64_t limitNum, LogicalPlan& plan);
+    void appendLimit(std::shared_ptr<binder::Expression> skipNum,
+        std::shared_ptr<binder::Expression> limitNum, LogicalPlan& plan);
 
     // Append scan operators
     void appendExpressionsScan(const binder::expression_vector& expressions, LogicalPlan& plan);

--- a/src/optimizer/cardinality_updater.cpp
+++ b/src/optimizer/cardinality_updater.cpp
@@ -122,7 +122,9 @@ void CardinalityUpdater::visitFilter(planner::LogicalOperator* op) {
 
 void CardinalityUpdater::visitLimit(planner::LogicalOperator* op) {
     auto& limit = op->cast<planner::LogicalLimit&>();
-    limit.setCardinality(limit.getLimitNum());
+    if (limit.canEvaluateLimitNum()) {
+        limit.setCardinality(limit.evaluateLimitNum());
+    }
 }
 
 void CardinalityUpdater::visitAggregate(planner::LogicalOperator* op) {

--- a/src/optimizer/limit_push_down_optimizer.cpp
+++ b/src/optimizer/limit_push_down_optimizer.cpp
@@ -21,11 +21,11 @@ void LimitPushDownOptimizer::visitOperator(planner::LogicalOperator* op) {
     switch (op->getOperatorType()) {
     case LogicalOperatorType::LIMIT: {
         auto& limit = op->constCast<LogicalLimit>();
-        if (limit.hasSkipNum()) {
-            skipNumber = limit.getSkipNum();
+        if (limit.hasSkipNum() && limit.canEvaluateSkipNum()) {
+            skipNumber = limit.evaluateSkipNum();
         }
-        if (limit.hasLimitNum()) {
-            limitNumber = limit.getLimitNum();
+        if (limit.hasLimitNum() && limit.canEvaluateLimitNum()) {
+            limitNumber = limit.evaluateLimitNum();
         }
         visitOperator(limit.getChild(0).get());
         return;

--- a/src/optimizer/top_k_optimizer.cpp
+++ b/src/optimizer/top_k_optimizer.cpp
@@ -49,9 +49,11 @@ std::shared_ptr<LogicalOperator> TopKOptimizer::visitLimitReplace(
     } else {
         return op;
     }
-    orderBy->setLimitNum(limit->getLimitNum());
-    auto skipNum = limit->hasSkipNum() ? limit->getSkipNum() : 0;
-    orderBy->setSkipNum(skipNum);
+    if (limit->canEvaluateLimitNum() || limit->canEvaluateSkipNum()) {
+        orderBy->setLimitNum(limit->evaluateLimitNum());
+        auto skipNum = limit->hasSkipNum() ? limit->evaluateSkipNum() : 0;
+        orderBy->setSkipNum(skipNum);
+    }
     return projectionOrOrderBy;
 }
 

--- a/src/planner/operator/logical_limit.cpp
+++ b/src/planner/operator/logical_limit.cpp
@@ -1,20 +1,77 @@
 #include "planner/operator/logical_limit.h"
 
+#include "binder/expression/expression_util.h"
+#include "binder/expression/literal_expression.h"
+#include "binder/expression/parameter_expression.h"
+#include "common/exception/runtime.h"
+#include "common/type_utils.h"
 #include "planner/operator/factorization/flatten_resolver.h"
 
 namespace kuzu {
 namespace planner {
 
+static uint64_t getLiteralNumber(std::shared_ptr<kuzu::binder::Expression> expr) {
+    uint64_t number = common::INVALID_LIMIT;
+    if (expr == nullptr) {
+        return number;
+    }
+    auto value = common::Value::createDefaultValue(expr->dataType);
+    switch (expr->expressionType) {
+    case common::ExpressionType::LITERAL: {
+        value = expr->constCast<binder::LiteralExpression>().getValue();
+    } break;
+    case common::ExpressionType::PARAMETER: {
+        value = expr->constCast<binder::ParameterExpression>().getValue();
+    } break;
+    default:
+        KU_UNREACHABLE;
+    }
+    auto errorMsg = "The number of rows to skip/limit must be a non-negative integer.";
+    common::TypeUtils::visit(
+        value.getDataType(),
+        [&]<common::IntegerTypes T>(T) {
+            if (value.getValue<T>() < 0) {
+                throw common::RuntimeException{errorMsg};
+            }
+            number = (uint64_t)value.getValue<T>();
+        },
+        [&](auto) { throw common::RuntimeException{errorMsg}; });
+    return number;
+}
+
+static bool canEvaluate(std::shared_ptr<binder::Expression> expr) {
+    KU_ASSERT(expr != nullptr);
+    return (expr->expressionType == common::ExpressionType::LITERAL ||
+            (expr->expressionType == common::ExpressionType::PARAMETER &&
+                expr->getDataType().getLogicalTypeID() != common::LogicalTypeID::ANY));
+}
+
+bool LogicalLimit::canEvaluateSkipNum() const {
+    return canEvaluate(skipNum);
+}
+
+uint64_t LogicalLimit::evaluateSkipNum() const {
+    return getLiteralNumber(skipNum);
+}
+
+bool LogicalLimit::canEvaluateLimitNum() const {
+    return canEvaluate(limitNum);
+}
+
+uint64_t LogicalLimit::evaluateLimitNum() const {
+    return getLiteralNumber(limitNum);
+}
+
 std::string LogicalLimit::getExpressionsForPrinting() const {
     std::string result;
     if (hasSkipNum()) {
-        result += "SKIP " + std::to_string(skipNum);
+        result += "SKIP "; //+ std::to_string(skipNum);
     }
     if (hasLimitNum()) {
         if (!result.empty()) {
             result += ",";
         }
-        result += "LIMIT " + std::to_string(limitNum);
+        result += "LIMIT "; //+ std::to_string(limitNum);
     }
     return result;
 }

--- a/src/planner/operator/logical_limit.cpp
+++ b/src/planner/operator/logical_limit.cpp
@@ -1,5 +1,6 @@
 #include "planner/operator/logical_limit.h"
 
+#include "binder/expression/expression_util.h"
 #include "binder/expression/literal_expression.h"
 #include "binder/expression/parameter_expression.h"
 #include "common/exception/runtime.h"
@@ -38,15 +39,8 @@ static uint64_t getLiteralNumber(std::shared_ptr<kuzu::binder::Expression> expr)
     return number;
 }
 
-static bool canEvaluate(std::shared_ptr<binder::Expression> expr) {
-    KU_ASSERT(expr != nullptr);
-    return (expr->expressionType == common::ExpressionType::LITERAL ||
-            (expr->expressionType == common::ExpressionType::PARAMETER &&
-                expr->getDataType().getLogicalTypeID() != common::LogicalTypeID::ANY));
-}
-
 bool LogicalLimit::canEvaluateSkipNum() const {
-    return canEvaluate(skipNum);
+    return binder::ExpressionUtil::canEvaluateAsLiteral(*skipNum);
 }
 
 uint64_t LogicalLimit::evaluateSkipNum() const {
@@ -54,7 +48,7 @@ uint64_t LogicalLimit::evaluateSkipNum() const {
 }
 
 bool LogicalLimit::canEvaluateLimitNum() const {
-    return canEvaluate(limitNum);
+    return binder::ExpressionUtil::canEvaluateAsLiteral(*limitNum);
 }
 
 uint64_t LogicalLimit::evaluateLimitNum() const {

--- a/src/planner/operator/logical_limit.cpp
+++ b/src/planner/operator/logical_limit.cpp
@@ -1,6 +1,5 @@
 #include "planner/operator/logical_limit.h"
 
-#include "binder/expression/expression_util.h"
 #include "binder/expression/literal_expression.h"
 #include "binder/expression/parameter_expression.h"
 #include "common/exception/runtime.h"

--- a/src/planner/operator/logical_limit.cpp
+++ b/src/planner/operator/logical_limit.cpp
@@ -65,13 +65,19 @@ uint64_t LogicalLimit::evaluateLimitNum() const {
 std::string LogicalLimit::getExpressionsForPrinting() const {
     std::string result;
     if (hasSkipNum()) {
-        result += "SKIP "; //+ std::to_string(skipNum);
+        result += "SKIP ";
+        if (canEvaluateSkipNum()) {
+            result += std::to_string(evaluateSkipNum());
+        }
     }
     if (hasLimitNum()) {
         if (!result.empty()) {
             result += ",";
         }
-        result += "LIMIT "; //+ std::to_string(limitNum);
+        result += "LIMIT ";
+        if (canEvaluateLimitNum()) {
+            result += std::to_string(evaluateLimitNum());
+        }
     }
     return result;
 }

--- a/src/planner/plan/append_limit.cpp
+++ b/src/planner/plan/append_limit.cpp
@@ -1,4 +1,3 @@
-#include "binder/expression/expression_util.h"
 #include "planner/operator/logical_limit.h"
 #include "planner/planner.h"
 

--- a/src/planner/plan/append_limit.cpp
+++ b/src/planner/plan/append_limit.cpp
@@ -1,10 +1,12 @@
+#include "binder/expression/expression_util.h"
 #include "planner/operator/logical_limit.h"
 #include "planner/planner.h"
 
 namespace kuzu {
 namespace planner {
 
-void Planner::appendLimit(uint64_t skipNum, uint64_t limitNum, LogicalPlan& plan) {
+void Planner::appendLimit(std::shared_ptr<binder::Expression> skipNum,
+    std::shared_ptr<binder::Expression> limitNum, LogicalPlan& plan) {
     auto limit = make_shared<LogicalLimit>(skipNum, limitNum, plan.getLastOperator());
     appendFlattens(limit->getGroupsPosToFlatten(), plan);
     limit->setChild(0, plan.getLastOperator());

--- a/src/processor/map/map_limit.cpp
+++ b/src/processor/map/map_limit.cpp
@@ -1,3 +1,4 @@
+#include "common/exception/runtime.h"
 #include "planner/operator/logical_limit.h"
 #include "processor/operator/limit.h"
 #include "processor/operator/skip.h"
@@ -15,16 +16,26 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapLimit(LogicalOperator* logicalO
     auto groupsPotToLimit = logicalLimit.getGroupsPosToLimit();
     std::unique_ptr<PhysicalOperator> lastOperator = std::move(prevOperator);
     if (logicalLimit.hasSkipNum()) {
-        auto printInfo = std::make_unique<SkipPrintInfo>(logicalLimit.getSkipNum());
-        lastOperator = make_unique<Skip>(logicalLimit.getSkipNum(),
-            std::make_shared<std::atomic_uint64_t>(0), dataChunkToSelectPos, groupsPotToLimit,
-            std::move(lastOperator), getOperatorID(), printInfo->copy());
+        if (!logicalLimit.canEvaluateSkipNum()) {
+            throw common::RuntimeException{
+                "The number of rows to skip is a parameter. Please give a valid skip number."};
+        }
+        auto skipNum = logicalLimit.evaluateSkipNum();
+        auto printInfo = std::make_unique<SkipPrintInfo>(skipNum);
+        lastOperator = make_unique<Skip>(skipNum, std::make_shared<std::atomic_uint64_t>(0),
+            dataChunkToSelectPos, groupsPotToLimit, std::move(lastOperator), getOperatorID(),
+            printInfo->copy());
     }
     if (logicalLimit.hasLimitNum()) {
-        auto printInfo = std::make_unique<LimitPrintInfo>(logicalLimit.getLimitNum());
-        lastOperator = make_unique<Limit>(logicalLimit.getLimitNum(),
-            std::make_shared<std::atomic_uint64_t>(0), dataChunkToSelectPos, groupsPotToLimit,
-            std::move(lastOperator), getOperatorID(), printInfo->copy());
+        if (!logicalLimit.canEvaluateLimitNum()) {
+            throw common::RuntimeException{
+                "The number of rows to limit is a parameter. Please give a valid limit number."};
+        }
+        auto limitNum = logicalLimit.evaluateLimitNum();
+        auto printInfo = std::make_unique<LimitPrintInfo>(limitNum);
+        lastOperator = make_unique<Limit>(limitNum, std::make_shared<std::atomic_uint64_t>(0),
+            dataChunkToSelectPos, groupsPotToLimit, std::move(lastOperator), getOperatorID(),
+            printInfo->copy());
     }
     return lastOperator;
 }

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -149,7 +149,7 @@ void HashIndex<T>::splitSlots(const Transaction* transaction, HashIndexHeader& h
         Slot<T>* originalSlot = &*originalSlotIterator.seek(header.nextSplitSlotId);
         do {
             for (entry_pos_t originalEntryPos = 0; originalEntryPos < getSlotCapacity<T>();
-                originalEntryPos++) {
+                 originalEntryPos++) {
                 if (!originalSlot->header.isEntryValid(originalEntryPos)) {
                     continue; // Skip invalid entries.
                 }
@@ -296,9 +296,10 @@ void HashIndex<T>::mergeBulkInserts(const Transaction* transaction,
     // may not be consecutive, but we reduce the memory overhead for storing the information about
     // the sorted data and still just process each page once.
     for (uint64_t localSlotId = 0; localSlotId < insertLocalStorage.numPrimarySlots();
-        localSlotId += NUM_SLOTS_PER_PAGE) {
+         localSlotId += NUM_SLOTS_PER_PAGE) {
         for (size_t i = 0;
-            i < NUM_SLOTS_PER_PAGE && localSlotId + i < insertLocalStorage.numPrimarySlots(); i++) {
+             i < NUM_SLOTS_PER_PAGE && localSlotId + i < insertLocalStorage.numPrimarySlots();
+             i++) {
             auto localSlot =
                 typename InMemHashIndex<T>::SlotIterator(localSlotId + i, &insertLocalStorage);
             partitionedEntries[i].clear();
@@ -442,7 +443,7 @@ PrimaryKeyIndex::PrimaryKeyIndex(const DBFileIDAndName& dbFileIDAndName, bool re
             fileHandle->optimisticReadPage(headerPageIdx, [&](auto* frame) {
                 const auto onDiskHeaders = reinterpret_cast<HashIndexHeaderOnDisk*>(frame);
                 for (size_t i = 0; i < INDEX_HEADERS_PER_PAGE && headerIdx < NUM_HASH_INDEXES;
-                    i++) {
+                     i++) {
                     hashIndexHeadersForReadTrx.emplace_back(onDiskHeaders[i]);
                     headerIdx++;
                 }
@@ -566,7 +567,7 @@ void PrimaryKeyIndex::writeHeaders() {
             [&](auto* frame) {
                 auto onDiskFrame = reinterpret_cast<HashIndexHeaderOnDisk*>(frame);
                 for (size_t i = 0; i < INDEX_HEADERS_PER_PAGE && headerIdx < NUM_HASH_INDEXES;
-                    i++) {
+                     i++) {
                     hashIndexHeadersForWriteTrx[headerIdx++].write(onDiskFrame[i]);
                 }
             });

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -149,7 +149,7 @@ void HashIndex<T>::splitSlots(const Transaction* transaction, HashIndexHeader& h
         Slot<T>* originalSlot = &*originalSlotIterator.seek(header.nextSplitSlotId);
         do {
             for (entry_pos_t originalEntryPos = 0; originalEntryPos < getSlotCapacity<T>();
-                 originalEntryPos++) {
+                originalEntryPos++) {
                 if (!originalSlot->header.isEntryValid(originalEntryPos)) {
                     continue; // Skip invalid entries.
                 }
@@ -296,10 +296,9 @@ void HashIndex<T>::mergeBulkInserts(const Transaction* transaction,
     // may not be consecutive, but we reduce the memory overhead for storing the information about
     // the sorted data and still just process each page once.
     for (uint64_t localSlotId = 0; localSlotId < insertLocalStorage.numPrimarySlots();
-         localSlotId += NUM_SLOTS_PER_PAGE) {
+        localSlotId += NUM_SLOTS_PER_PAGE) {
         for (size_t i = 0;
-             i < NUM_SLOTS_PER_PAGE && localSlotId + i < insertLocalStorage.numPrimarySlots();
-             i++) {
+            i < NUM_SLOTS_PER_PAGE && localSlotId + i < insertLocalStorage.numPrimarySlots(); i++) {
             auto localSlot =
                 typename InMemHashIndex<T>::SlotIterator(localSlotId + i, &insertLocalStorage);
             partitionedEntries[i].clear();
@@ -443,7 +442,7 @@ PrimaryKeyIndex::PrimaryKeyIndex(const DBFileIDAndName& dbFileIDAndName, bool re
             fileHandle->optimisticReadPage(headerPageIdx, [&](auto* frame) {
                 const auto onDiskHeaders = reinterpret_cast<HashIndexHeaderOnDisk*>(frame);
                 for (size_t i = 0; i < INDEX_HEADERS_PER_PAGE && headerIdx < NUM_HASH_INDEXES;
-                     i++) {
+                    i++) {
                     hashIndexHeadersForReadTrx.emplace_back(onDiskHeaders[i]);
                     headerIdx++;
                 }
@@ -567,7 +566,7 @@ void PrimaryKeyIndex::writeHeaders() {
             [&](auto* frame) {
                 auto onDiskFrame = reinterpret_cast<HashIndexHeaderOnDisk*>(frame);
                 for (size_t i = 0; i < INDEX_HEADERS_PER_PAGE && headerIdx < NUM_HASH_INDEXES;
-                     i++) {
+                    i++) {
                     hashIndexHeadersForWriteTrx[headerIdx++].write(onDiskFrame[i]);
                 }
             });

--- a/test/test_files/exceptions/binder/binder_error.test
+++ b/test/test_files/exceptions/binder/binder_error.test
@@ -369,12 +369,12 @@ Binder exception: Table person1 does not exist.
 -LOG InvalidLimitNumberType
 -STATEMENT MATCH (a:person) RETURN a.age LIMIT "abc"
 ---- error
-Binder exception: The number of rows to skip/limit must be a non-negative integer.
+Runtime exception: The number of rows to skip/limit must be a non-negative integer.
 
 -LOG NegativeLimitNumber
 -STATEMENT MATCH (a:person) RETURN a.age LIMIT -1
 ---- error
-Binder exception: The number of rows to skip/limit must be a non-negative integer.
+Runtime exception: The number of rows to skip/limit must be a non-negative integer.
 
 -LOG DuplicateVariableName
 -STATEMENT MATCH (a:person) UNWIND [1,2] AS a RETURN COUNT(*)

--- a/test/test_files/projection/skip_limit.test
+++ b/test/test_files/projection/skip_limit.test
@@ -112,3 +112,26 @@ Bob
 ---- 2
 [2.100000,4.400000]
 [3.800000,2.500000]
+
+-LOG LimitWithConstantExpr
+-STATEMENT MATCH (a:person) RETURN a.ID LIMIT 2 + 3
+---- 5
+0
+2
+3
+5
+7
+
+-LOG SkipWithConstantExpr
+-STATEMENT MATCH (a:person) RETURN a.ID SKIP 1 + 2
+---- 5
+5
+7
+8
+9
+10
+
+-LOG SkipLimitWithConstantExpr
+-STATEMENT MATCH (a:person) RETURN a.ID SKIP 1 + 2 LIMIT 0 + 1
+---- 5
+5

--- a/test/test_files/projection/skip_limit.test
+++ b/test/test_files/projection/skip_limit.test
@@ -133,5 +133,5 @@ Bob
 
 -LOG SkipLimitWithConstantExpr
 -STATEMENT MATCH (a:person) RETURN a.ID SKIP 1 + 2 LIMIT 0 + 1
----- 5
+---- 1
 5

--- a/test/test_files/tck/return_skip_limit/return_skip_limit1.test
+++ b/test/test_files/tck/return_skip_limit/return_skip_limit1.test
@@ -73,7 +73,7 @@ True
 ---- ok
 -STATEMENT MATCH (n) RETURN n SKIP n.count;
 ---- error
-Binder exception: The number of rows to skip/limit must be a non-negative integer.
+Binder exception: The number of rows to skip/limit must be a parameter/literal expression.
 
 # Negative parameter for SKIP should fail
 -CASE Scenario6
@@ -100,7 +100,7 @@ Binder exception: The number of rows to skip/limit must be a non-negative intege
            RETURN p.name AS name
            SKIP -1;
 ---- error
-Binder exception: The number of rows to skip/limit must be a non-negative integer.
+Runtime exception: The number of rows to skip/limit must be a non-negative integer.
 
 # Floating point parameter for SKIP should fail
 -CASE Scenario8
@@ -114,7 +114,7 @@ Binder exception: The number of rows to skip/limit must be a non-negative intege
            RETURN p.name AS name
            SKIP $_limit;
 ---- error
-Binder exception: The number of rows to skip/limit must be a non-negative integer.
+Binder exception: The number of rows to skip/limit must be a parameter/literal expression.
 
 # Floating point SKIP should fail
 -CASE Scenario9
@@ -127,7 +127,7 @@ Binder exception: The number of rows to skip/limit must be a non-negative intege
            RETURN p.name AS name
            SKIP 1.5;
 ---- error
-Binder exception: The number of rows to skip/limit must be a non-negative integer.
+Runtime exception: The number of rows to skip/limit must be a non-negative integer.
 
 # Floating point SKIP should fail
 -CASE Scenario10
@@ -137,7 +137,7 @@ Binder exception: The number of rows to skip/limit must be a non-negative intege
            RETURN n
            SKIP n.count;
 ---- error
-Binder exception: The number of rows to skip/limit must be a non-negative integer.
+Binder exception: The number of rows to skip/limit must be a parameter/literal expression.
 
 # Fail when using negative value in SKIP
 -CASE Scenario11
@@ -147,4 +147,4 @@ Binder exception: The number of rows to skip/limit must be a non-negative intege
            RETURN n
            SKIP -1;
 ---- error
-Binder exception: The number of rows to skip/limit must be a non-negative integer.
+Runtime exception: The number of rows to skip/limit must be a non-negative integer.

--- a/test/test_files/tck/return_skip_limit/return_skip_limit2.test
+++ b/test/test_files/tck/return_skip_limit/return_skip_limit2.test
@@ -128,7 +128,7 @@ Craig
 ---- ok
 -STATEMENT MATCH (n) RETURN n LIMIT n.count;
 ---- error
-Binder exception: The number of rows to skip/limit must be a non-negative integer.
+Binder exception: The number of rows to skip/limit must be a parameter/literal expression.
 
 # Negative parameter for LIMIT should fail
 -CASE Scenario10
@@ -142,7 +142,7 @@ Binder exception: The number of rows to skip/limit must be a non-negative intege
            RETURN p.name AS name
            LIMIT $_limit;
 ---- error
-Binder exception: The number of rows to skip/limit must be a non-negative integer.
+Runtime exception: The number of rows to skip/limit must be a non-negative integer.
 
 # Negative parameter for LIMIT with ORDER BY should fail
 -CASE Scenario11
@@ -156,7 +156,7 @@ Binder exception: The number of rows to skip/limit must be a non-negative intege
            RETURN p.name AS name
            ORDER BY name LIMIT $_limit;
 ---- error
-Binder exception: The number of rows to skip/limit must be a non-negative integer.
+Runtime exception: The number of rows to skip/limit must be a non-negative integer.
 
 # Fail when using negative value in LIMIT 1
 -CASE Scenario12
@@ -166,7 +166,7 @@ Binder exception: The number of rows to skip/limit must be a non-negative intege
            RETURN n
              LIMIT -1;
 ---- error
-Binder exception: The number of rows to skip/limit must be a non-negative integer.
+Runtime exception: The number of rows to skip/limit must be a non-negative integer.
 
 # Fail when using negative value in LIMIT 2
 -CASE Scenario13
@@ -179,7 +179,7 @@ Binder exception: The number of rows to skip/limit must be a non-negative intege
            RETURN p.name AS name
            LIMIT -1;
 ---- error
-Binder exception: The number of rows to skip/limit must be a non-negative integer.
+Runtime exception: The number of rows to skip/limit must be a non-negative integer.
 
 # Floating point parameter for LIMIT should fail
 -CASE Scenario14
@@ -193,7 +193,7 @@ Binder exception: The number of rows to skip/limit must be a non-negative intege
            RETURN p.name AS name
            LIMIT $_limit;
 ---- error
-Binder exception: The number of rows to skip/limit must be a non-negative integer.
+Runtime exception: The number of rows to skip/limit must be a non-negative integer.
 
 # Floating point parameter for LIMIT with ORDER BY should fail
 -CASE Scenario15
@@ -207,7 +207,7 @@ Binder exception: The number of rows to skip/limit must be a non-negative intege
            RETURN p.name AS name
            ORDER BY name LIMIT $_limit;
 ---- error
-Binder exception: The number of rows to skip/limit must be a non-negative integer.
+Runtime exception: The number of rows to skip/limit must be a non-negative integer.
 
 # Fail when using floating point in LIMIT 1
 -CASE Scenario16
@@ -217,7 +217,7 @@ Binder exception: The number of rows to skip/limit must be a non-negative intege
            RETURN n
              LIMIT 1.7;
 ---- error
-Binder exception: The number of rows to skip/limit must be a non-negative integer.
+Runtime exception: The number of rows to skip/limit must be a non-negative integer.
 
 # Fail when using floating point in LIMIT 2
 -CASE Scenario17
@@ -230,4 +230,4 @@ Binder exception: The number of rows to skip/limit must be a non-negative intege
            RETURN p.name AS name
            LIMIT 1.5;
 ---- error
-Binder exception: The number of rows to skip/limit must be a non-negative integer.
+Runtime exception: The number of rows to skip/limit must be a non-negative integer.

--- a/tools/java_api/src/test/java/com/kuzudb/ConnectionTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/ConnectionTest.java
@@ -277,6 +277,27 @@ public class ConnectionTest extends TestBase {
     }
 
     @Test
+    void ConnPrepareLimit() throws ObjectRefDestroyedException {
+        String query = "MATCH (a:person) RETURN a.ID LIMIT $lt";
+        Map<String, Value> m = new HashMap<String, Value>();
+        m.put("lt", new Value((int) 2));
+        PreparedStatement statement = conn.prepare(query);
+        assertNotNull(statement);
+        QueryResult result = conn.execute(statement, m);
+        assertTrue(result.isSuccess());
+        assertTrue(result.hasNext());
+        assertTrue(result.getErrorMessage().equals(""));
+        assertEquals(result.getNumTuples(), 2);
+        assertEquals(result.getNumColumns(), 1);
+        FlatTuple tuple = result.getNext();
+        assertEquals(((long) tuple.getValue(0).getValue()), 0);
+        tuple = result.getNext();
+        assertEquals(((long) tuple.getValue(0).getValue()), 2);
+        statement.close();
+        result.close();
+    }
+
+    @Test
     void ConnQueryTimeout() throws ObjectRefDestroyedException {
         conn.setQueryTimeout(1);
         try (QueryResult result = conn.query("UNWIND RANGE(1,100000) AS x UNWIND RANGE(1, 100000) AS y RETURN COUNT(x + y);")) {

--- a/tools/python_api/test/test_prepared_statement.py
+++ b/tools/python_api/test/test_prepared_statement.py
@@ -119,3 +119,10 @@ def test_error(conn_db_readonly: ConnDB) -> None:
     prepared_statement = conn_db_readonly[0].prepare("SELECT * FROM person")
     assert not prepared_statement.is_success()
     assert prepared_statement.get_error_message().startswith("Parser exception: extraneous input 'SELECT'")
+
+def test_prepare_limit(conn_db_readonly: ConnDB) -> None:
+    prepared_statement = conn_db_readonly[0].prepare("MATCH (p:person) return p.ID limit $lt")
+    result = conn_db_readonly[0].execute(prepared_statement, {'lt': 3})
+    assert result.get_next() == [0]
+    assert result.get_next() == [2]
+    assert result.get_next() == [3]


### PR DESCRIPTION
closes #4704
This PR allows user to write parameter expression as limit/skip number.
Instead of binding the limit/skip number at runtime, we are going to evaluate and bind at run time.
example:
```
auto prepared = conn->prepare("MATCH (p:person) RETURN p.ID skip $sp");
auto result = conn->execute(prepared.get(), std::make_pair(std::string{"sp"}, 2));
```