### PR TITLE
Fix Java docstring

### DIFF
--- a/tools/java_api/src/main/java/com/kuzudb/InternalID.java
+++ b/tools/java_api/src/main/java/com/kuzudb/InternalID.java
@@ -53,7 +53,6 @@ public class InternalID {
 
     /**
      * Returns a string representation of this InternalID.
-     * The format is "InternalID{tableId=<tableId>, offset=<offset>}".
      *
      * @return A string representation of this InternalID.
      */


### PR DESCRIPTION
# Description

The format string in the docstring seems to cause docs generation and deployment failure. In this PR I remove it.