### PR TITLE
Implement show-extension functions

### DIFF
--- a/extension/fts/test/test_files/show_loaded_extensions.test
+++ b/extension/fts/test/test_files/show_loaded_extensions.test
@@ -1,0 +1,23 @@
+-DATASET CSV empty
+
+--
+
+-CASE show_loaded_extensions
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
+---- ok
+-STATEMENT CALL SHOW_LOADED_EXTENSIONS() RETURN *
+---- 1
+FTS|USER|${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/duckdb/build/libduckdb.kuzu_extension"
+---- ok
+-STATEMENT CALL SHOW_LOADED_EXTENSIONS() RETURN *
+---- 2
+FTS|USER|${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension
+DUCKDB|USER|${KUZU_ROOT_DIRECTORY}/extension/duckdb/build/libduckdb.kuzu_extension
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/httpfs/build/libhttpfs.kuzu_extension"
+---- ok
+-STATEMENT CALL SHOW_LOADED_EXTENSIONS() RETURN *
+---- 3
+FTS|USER|${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension
+DUCKDB|USER|${KUZU_ROOT_DIRECTORY}/extension/duckdb/build/libduckdb.kuzu_extension
+HTTPFS|USER|${KUZU_ROOT_DIRECTORY}/extension/httpfs/build/libhttpfs.kuzu_extension

--- a/src/extension/extension.cpp
+++ b/src/extension/extension.cpp
@@ -59,7 +59,18 @@ static ExtensionRepoInfo getExtensionRepoInfo(std::string& extensionURL) {
     auto hostURL = "http://" + hostName;
     auto hostPath = extensionURL.substr(hostNamePos);
     return {hostPath, hostURL, extensionURL};
-};
+}
+
+std::string ExtensionSourceUtils::toString(ExtensionSource source) {
+    switch (source) {
+    case ExtensionSource::OFFICIAL:
+        return "OFFICIAL";
+    case ExtensionSource::USER:
+        return "USER";
+    default:
+        KU_UNREACHABLE;
+    }
+}
 
 ExtensionRepoInfo ExtensionUtils::getExtensionLibRepoInfo(const std::string& extensionName) {
     auto extensionURL = common::stringFormat(EXTENSION_FILE_REPO, KUZU_EXTENSION_VERSION,

--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -37,22 +37,23 @@ namespace kuzu {
 namespace function {
 
 #define SCALAR_FUNCTION_BASE(_PARAM, _NAME)                                                        \
-    {_PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
 #define SCALAR_FUNCTION(_PARAM) SCALAR_FUNCTION_BASE(_PARAM, _PARAM::name)
 #define SCALAR_FUNCTION_ALIAS(_PARAM) SCALAR_FUNCTION_BASE(_PARAM::alias, _PARAM::name)
 #define REWRITE_FUNCTION(_PARAM)                                                                   \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY }
 #define AGGREGATE_FUNCTION(_PARAM)                                                                 \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY }
 #define EXPORT_FUNCTION(_PARAM)                                                                    \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY }
 #define TABLE_FUNCTION(_PARAM)                                                                     \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY }
 #define STANDALONE_TABLE_FUNCTION(_PARAM)                                                          \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY }
 #define ALGORITHM_FUNCTION(_PARAM)                                                                 \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY}
-#define FINAL_FUNCTION {nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY }
+#define FINAL_FUNCTION                                                                             \
+    { nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
 
 FunctionCollection* FunctionCollection::getFunctions() {
     static FunctionCollection functions[] = {

--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -37,23 +37,22 @@ namespace kuzu {
 namespace function {
 
 #define SCALAR_FUNCTION_BASE(_PARAM, _NAME)                                                        \
-    { _PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
 #define SCALAR_FUNCTION(_PARAM) SCALAR_FUNCTION_BASE(_PARAM, _PARAM::name)
 #define SCALAR_FUNCTION_ALIAS(_PARAM) SCALAR_FUNCTION_BASE(_PARAM::alias, _PARAM::name)
 #define REWRITE_FUNCTION(_PARAM)                                                                   \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY}
 #define AGGREGATE_FUNCTION(_PARAM)                                                                 \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY}
 #define EXPORT_FUNCTION(_PARAM)                                                                    \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY}
 #define TABLE_FUNCTION(_PARAM)                                                                     \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY}
 #define STANDALONE_TABLE_FUNCTION(_PARAM)                                                          \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY}
 #define ALGORITHM_FUNCTION(_PARAM)                                                                 \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY }
-#define FINAL_FUNCTION                                                                             \
-    { nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY}
+#define FINAL_FUNCTION {nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
 
 FunctionCollection* FunctionCollection::getFunctions() {
     static FunctionCollection functions[] = {
@@ -218,7 +217,8 @@ FunctionCollection* FunctionCollection::getFunctions() {
         TABLE_FUNCTION(StatsInfoFunction), TABLE_FUNCTION(StorageInfoFunction),
         TABLE_FUNCTION(ShowAttachedDatabasesFunction), TABLE_FUNCTION(ShowSequencesFunction),
         TABLE_FUNCTION(ShowFunctionsFunction), TABLE_FUNCTION(BMInfoFunction),
-        TABLE_FUNCTION(QueryHNSWIndexFunction),
+        TABLE_FUNCTION(QueryHNSWIndexFunction), TABLE_FUNCTION(ShowLoadedExtensionsFunction),
+        TABLE_FUNCTION(ShowOfficialExtensionsFunction),
 
         // Standalone Table functions
         STANDALONE_TABLE_FUNCTION(ClearWarningsFunction),

--- a/src/function/table/call/CMakeLists.txt
+++ b/src/function/table/call/CMakeLists.txt
@@ -16,7 +16,9 @@ add_library(kuzu_table_call
         storage_info.cpp
         table_info.cpp
         show_sequences.cpp
-        show_functions.cpp)
+        show_functions.cpp
+        show_loaded_extensions.cpp
+        show_official_extensions.cpp)
 
 set(ALL_OBJECT_FILES
         ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_table_call>

--- a/src/function/table/call/show_loaded_extensions.cpp
+++ b/src/function/table/call/show_loaded_extensions.cpp
@@ -1,0 +1,93 @@
+#include "binder/binder.h"
+#include "extension/extension.h"
+#include "extension/extension_manager.h"
+#include "function/table/simple_table_functions.h"
+
+using namespace kuzu::catalog;
+using namespace kuzu::common;
+using namespace kuzu::main;
+
+namespace kuzu {
+namespace function {
+
+struct LoadedExtensionInfo {
+    std::string name;
+    extension::ExtensionSource extensionSource;
+    std::string extensionPath;
+
+    LoadedExtensionInfo(std::string name, extension::ExtensionSource extensionSource,
+        std::string extensionPath)
+        : name{std::move(name)}, extensionSource{extensionSource},
+          extensionPath{std::move(extensionPath)} {}
+};
+
+struct ShowLoadedExtensionsBindData final : SimpleTableFuncBindData {
+    std::vector<LoadedExtensionInfo> loadedExtensionInfo;
+
+    ShowLoadedExtensionsBindData(std::vector<LoadedExtensionInfo> loadedExtensionInfo,
+        binder::expression_vector columns, offset_t maxOffset)
+        : SimpleTableFuncBindData{std::move(columns), maxOffset},
+          loadedExtensionInfo{std::move(loadedExtensionInfo)} {}
+
+    std::unique_ptr<TableFuncBindData> copy() const override {
+        return std::make_unique<ShowLoadedExtensionsBindData>(*this);
+    }
+};
+
+static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput& output) {
+    auto& dataChunk = output.dataChunk;
+    const auto sharedState = input.sharedState->ptrCast<SimpleTableFuncSharedState>();
+    const auto morsel = sharedState->getMorsel();
+    if (!morsel.hasMoreToOutput()) {
+        return 0;
+    }
+    auto& loadedExtensions =
+        input.bindData->constPtrCast<ShowLoadedExtensionsBindData>()->loadedExtensionInfo;
+    auto numTuplesToOutput = morsel.endOffset - morsel.startOffset;
+    for (auto i = 0u; i < numTuplesToOutput; i++) {
+        auto loadedExtension = loadedExtensions[morsel.startOffset + i];
+        dataChunk.getValueVectorMutable(0).setValue(i, loadedExtension.name);
+        dataChunk.getValueVectorMutable(1).setValue(i,
+            extension::ExtensionSourceUtils::toString(loadedExtension.extensionSource));
+        dataChunk.getValueVectorMutable(2).setValue(i, loadedExtension.extensionPath);
+    }
+    return numTuplesToOutput;
+}
+
+static binder::expression_vector bindColumns(binder::Binder& binder) {
+    std::vector<std::string> columnNames;
+    std::vector<LogicalType> columnTypes;
+    columnNames.emplace_back("extension name");
+    columnTypes.emplace_back(LogicalType::STRING());
+    columnNames.emplace_back("extension source");
+    columnTypes.emplace_back(LogicalType::STRING());
+    columnNames.emplace_back("extension path");
+    columnTypes.emplace_back(LogicalType::STRING());
+    return binder.createVariables(columnNames, columnTypes);
+}
+
+static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* context,
+    const TableFuncBindInput* input) {
+    auto loadedExtensions = context->getExtensionManager()->getLoadedExtensions();
+    std::vector<LoadedExtensionInfo> loadedExtensionInfo;
+    for (auto& loadedExtension : loadedExtensions) {
+        loadedExtensionInfo.emplace_back(loadedExtension.getExtensionName(),
+            loadedExtension.getSource(), loadedExtension.getFullPath());
+    }
+    return std::make_unique<ShowLoadedExtensionsBindData>(loadedExtensionInfo,
+        bindColumns(*input->binder), loadedExtensionInfo.size());
+}
+
+function_set ShowLoadedExtensionsFunction::getFunctionSet() {
+    function_set functionSet;
+    auto function = std::make_unique<TableFunction>(name, std::vector<common::LogicalTypeID>{});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initEmptyLocalState;
+    functionSet.push_back(std::move(function));
+    return functionSet;
+}
+
+} // namespace function
+} // namespace kuzu

--- a/src/function/table/call/show_official_extensions.cpp
+++ b/src/function/table/call/show_official_extensions.cpp
@@ -1,0 +1,64 @@
+#include "binder/binder.h"
+#include "extension/extension.h"
+#include "extension/extension_manager.h"
+#include "function/table/simple_table_functions.h"
+
+using namespace kuzu::catalog;
+using namespace kuzu::common;
+using namespace kuzu::main;
+
+namespace kuzu {
+namespace function {
+
+static std::unordered_map<std::string, std::string> OFFICIAL_EXTENSIONS = {
+    {"HTTPFS", "Adds support for reading and writing files over a HTTP(S)/S3 filesystem"},
+    {"DELTA", "Adds support for reading from delta tables"},
+    {"DUCKDB", "Adds support for reading from duckdb tables"},
+    {"FTS", "Adds support for full-text search indexes"},
+    {"ICEBERG", "Adds support for reading from iceberg tables"},
+    {"JSON", "Adds support for JSON operations"},
+    {"POSTGRES", "Adds support for reading from POSTGRES tables"},
+    {"SQLITE", "Adds support for reading from SQLITE tables"}};
+
+static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput& output) {
+    auto& dataChunk = output.dataChunk;
+    const auto sharedState = input.sharedState->ptrCast<SimpleTableFuncSharedState>();
+    const auto morsel = sharedState->getMorsel();
+    if (!morsel.hasMoreToOutput()) {
+        return 0;
+    }
+    auto numTuplesToOutput = OFFICIAL_EXTENSIONS.size();
+    auto vectorPosToWrite = 0u;
+    for (auto& [name, description] : OFFICIAL_EXTENSIONS) {
+        dataChunk.getValueVectorMutable(0).setValue(vectorPosToWrite, name);
+        dataChunk.getValueVectorMutable(1).setValue(vectorPosToWrite++, description);
+    }
+    return numTuplesToOutput;
+}
+
+static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* /*context*/,
+    const TableFuncBindInput* input) {
+    std::vector<std::string> columnNames;
+    std::vector<LogicalType> columnTypes;
+    columnNames.emplace_back("name");
+    columnTypes.emplace_back(LogicalType::STRING());
+    columnNames.emplace_back("description");
+    columnTypes.emplace_back(LogicalType::STRING());
+    auto columns = input->binder->createVariables(columnNames, columnTypes);
+    return std::make_unique<SimpleTableFuncBindData>(std::move(columns),
+        OFFICIAL_EXTENSIONS.size());
+}
+
+function_set ShowOfficialExtensionsFunction::getFunctionSet() {
+    function_set functionSet;
+    auto function = std::make_unique<TableFunction>(name, std::vector<common::LogicalTypeID>{});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initEmptyLocalState;
+    functionSet.push_back(std::move(function));
+    return functionSet;
+}
+
+} // namespace function
+} // namespace kuzu

--- a/src/function/table/call/show_official_extensions.cpp
+++ b/src/function/table/call/show_official_extensions.cpp
@@ -1,6 +1,5 @@
 #include "binder/binder.h"
 #include "extension/extension.h"
-#include "extension/extension_manager.h"
 #include "function/table/simple_table_functions.h"
 
 using namespace kuzu::catalog;
@@ -10,7 +9,7 @@ using namespace kuzu::main;
 namespace kuzu {
 namespace function {
 
-static std::unordered_map<std::string, std::string> OFFICIAL_EXTENSIONS = {
+inline static std::unordered_map<std::string, std::string> OFFICIAL_EXTENSIONS = {
     {"HTTPFS", "Adds support for reading and writing files over a HTTP(S)/S3 filesystem"},
     {"DELTA", "Adds support for reading from delta tables"},
     {"DUCKDB", "Adds support for reading from duckdb tables"},

--- a/src/function/table/call/show_official_extensions.cpp
+++ b/src/function/table/call/show_official_extensions.cpp
@@ -9,15 +9,16 @@ using namespace kuzu::main;
 namespace kuzu {
 namespace function {
 
-inline static std::unordered_map<std::string, std::string> OFFICIAL_EXTENSIONS = {
-    {"HTTPFS", "Adds support for reading and writing files over a HTTP(S)/S3 filesystem"},
-    {"DELTA", "Adds support for reading from delta tables"},
-    {"DUCKDB", "Adds support for reading from duckdb tables"},
-    {"FTS", "Adds support for full-text search indexes"},
-    {"ICEBERG", "Adds support for reading from iceberg tables"},
-    {"JSON", "Adds support for JSON operations"},
-    {"POSTGRES", "Adds support for reading from POSTGRES tables"},
-    {"SQLITE", "Adds support for reading from SQLITE tables"}};
+static std::unordered_map<std::string, std::string> getOfficialExtensions() {
+    return {{"HTTPFS", "Adds support for reading and writing files over a HTTP(S)/S3 filesystem"},
+        {"DELTA", "Adds support for reading from delta tables"},
+        {"DUCKDB", "Adds support for reading from duckdb tables"},
+        {"FTS", "Adds support for full-text search indexes"},
+        {"ICEBERG", "Adds support for reading from iceberg tables"},
+        {"JSON", "Adds support for JSON operations"},
+        {"POSTGRES", "Adds support for reading from POSTGRES tables"},
+        {"SQLITE", "Adds support for reading from SQLITE tables"}};
+}
 
 static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput& output) {
     auto& dataChunk = output.dataChunk;
@@ -26,9 +27,10 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput& output) 
     if (!morsel.hasMoreToOutput()) {
         return 0;
     }
-    auto numTuplesToOutput = OFFICIAL_EXTENSIONS.size();
+    auto officialExtensions = getOfficialExtensions();
+    auto numTuplesToOutput = officialExtensions.size();
     auto vectorPosToWrite = 0u;
-    for (auto& [name, description] : OFFICIAL_EXTENSIONS) {
+    for (auto& [name, description] : officialExtensions) {
         dataChunk.getValueVectorMutable(0).setValue(vectorPosToWrite, name);
         dataChunk.getValueVectorMutable(1).setValue(vectorPosToWrite++, description);
     }
@@ -45,7 +47,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* /*
     columnTypes.emplace_back(LogicalType::STRING());
     auto columns = input->binder->createVariables(columnNames, columnTypes);
     return std::make_unique<SimpleTableFuncBindData>(std::move(columns),
-        OFFICIAL_EXTENSIONS.size());
+        getOfficialExtensions().size());
 }
 
 function_set ShowOfficialExtensionsFunction::getFunctionSet() {

--- a/src/include/extension/extension.h
+++ b/src/include/extension/extension.h
@@ -59,6 +59,12 @@ struct ExtensionRepoInfo {
     std::string repoURL;
 };
 
+enum class ExtensionSource : uint8_t { OFFICIAL, USER };
+
+struct ExtensionSourceUtils {
+    static std::string toString(ExtensionSource source);
+};
+
 struct ExtensionUtils {
     static constexpr const char* EXTENSION_FILE_REPO = "http://extension.kuzudb.com/v{}/{}/{}/{}";
 

--- a/src/include/extension/extension_manager.h
+++ b/src/include/extension/extension_manager.h
@@ -24,6 +24,10 @@ public:
 
     std::vector<storage::StorageExtension*> getStorageExtensions();
 
+    KUZU_API const std::vector<LoadedExtension>& getLoadedExtensions() const {
+        return loadedExtensions;
+    }
+
 private:
     std::vector<LoadedExtension> loadedExtensions;
     std::unordered_map<std::string, main::ExtensionOption> extensionOptions;

--- a/src/include/extension/loaded_extension.h
+++ b/src/include/extension/loaded_extension.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstdint>
 #include <string>
 
 #include "extension.h"

--- a/src/include/extension/loaded_extension.h
+++ b/src/include/extension/loaded_extension.h
@@ -3,10 +3,10 @@
 #include <cstdint>
 #include <string>
 
+#include "extension.h"
+
 namespace kuzu {
 namespace extension {
-
-enum class ExtensionSource : uint8_t { OFFICIAL, USER };
 
 class LoadedExtension {
 
@@ -15,6 +15,10 @@ public:
         : extensionName{std::move(extensionName)}, fullPath{std::move(fullPath)}, source{source} {}
 
     std::string getExtensionName() const { return extensionName; }
+
+    std::string getFullPath() const { return fullPath; }
+
+    ExtensionSource getSource() const { return source; }
 
     std::string toCypher();
 

--- a/src/include/function/table/simple_table_functions.h
+++ b/src/include/function/table/simple_table_functions.h
@@ -152,5 +152,17 @@ struct DropProjectGraphFunction final : SimpleTableFunction {
     static function_set getFunctionSet();
 };
 
+struct ShowLoadedExtensionsFunction final : SimpleTableFunction {
+    static constexpr const char* name = "SHOW_LOADED_EXTENSIONS";
+
+    static function_set getFunctionSet();
+};
+
+struct ShowOfficialExtensionsFunction final : SimpleTableFunction {
+    static constexpr const char* name = "SHOW_OFFICIAL_EXTENSIONS";
+
+    static function_set getFunctionSet();
+};
+
 } // namespace function
 } // namespace kuzu

--- a/test/test_files/call/call.test
+++ b/test/test_files/call/call.test
@@ -275,3 +275,19 @@ Binder exception: a.fName has type PROPERTY but LITERAL,PARAMETER was expected.
 -STATEMENT CALL bm_info() RETURN mem_limit
 ---- 1
 67108864
+
+-LOG ShowLoadedExtension
+-STATEMENT CALL SHOW_LOADED_EXTENSIONS() RETURN *
+---- 0
+
+-LOG ShowOfficialExtensions
+-STATEMENT CALL SHOW_OFFICIAL_EXTENSIONS() RETURN *
+---- 8
+DELTA|Adds support for reading from delta tables
+DUCKDB|Adds support for reading from duckdb tables
+FTS|Adds support for full-text search indexes
+HTTPFS|Adds support for reading and writing files over a HTTP(S)/S3 filesystem
+ICEBERG|Adds support for reading from iceberg tables
+JSON|Adds support for JSON operations
+POSTGRES|Adds support for reading from POSTGRES tables
+SQLITE|Adds support for reading from SQLITE tables


### PR DESCRIPTION
This PR implements the following two utility functions:
1. `SHOW_OFFICIAL_EXTENSIONS` prints out all official extensions and their usages.
2. `SHOW_LOADED_EXTENSIONS` prints all loaded extensions and their name/path/source.

Closes #4693 