### PR TITLE
Improve catalog function interface

### DIFF
--- a/extension/fts/test/test_files/fts_small.test
+++ b/extension/fts/test/test_files/fts_small.test
@@ -188,7 +188,7 @@ Binder exception: BM25 model requires the Term Frequency Saturation(k) value to 
 -RELOADDB
 -STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'Alice') RETURN _node.ID, score
 ---- error
-Catalog exception: QUERY_FTS_INDEX function does not exist.
+Catalog exception: function QUERY_FTS_INDEX does not exist.
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
 ---- ok
 -STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'Alice') RETURN _node.ID, score

--- a/src/binder/bind/bind_standalone_call_function.cpp
+++ b/src/binder/bind/bind_standalone_call_function.cpp
@@ -2,7 +2,6 @@
 #include "binder/bound_standalone_call_function.h"
 #include "catalog/catalog.h"
 #include "common/exception/binder.h"
-#include "function/built_in_function_utils.h"
 #include "parser/expression/parsed_function_expression.h"
 #include "parser/standalone_call_function.h"
 
@@ -17,9 +16,7 @@ std::unique_ptr<BoundStatement> Binder::bindStandaloneCallFunction(
     auto& funcExpr =
         callStatement.getFunctionExpression()->constCast<parser::ParsedFunctionExpression>();
     auto funcName = funcExpr.getFunctionName();
-    auto catalogSet = clientContext->getCatalog()->getFunctions(clientContext->getTransaction());
-    auto entry = function::BuiltInFunctionsUtils::getFunctionCatalogEntry(
-        clientContext->getTransaction(), funcName, catalogSet);
+    auto entry = clientContext->getCatalog()->getFunctionEntry(clientContext->getTransaction(), funcName);
     if (entry->getType() != catalog::CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY) {
         throw common::BinderException(
             "Only standalone table functions can be called without return statement.");

--- a/src/binder/bind/bind_standalone_call_function.cpp
+++ b/src/binder/bind/bind_standalone_call_function.cpp
@@ -16,7 +16,8 @@ std::unique_ptr<BoundStatement> Binder::bindStandaloneCallFunction(
     auto& funcExpr =
         callStatement.getFunctionExpression()->constCast<parser::ParsedFunctionExpression>();
     auto funcName = funcExpr.getFunctionName();
-    auto entry = clientContext->getCatalog()->getFunctionEntry(clientContext->getTransaction(), funcName);
+    auto entry =
+        clientContext->getCatalog()->getFunctionEntry(clientContext->getTransaction(), funcName);
     if (entry->getType() != catalog::CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY) {
         throw common::BinderException(
             "Only standalone table functions can be called without return statement.");

--- a/src/binder/bind/bind_table_function.cpp
+++ b/src/binder/bind/bind_table_function.cpp
@@ -20,9 +20,7 @@ static void validateParameterType(const expression_vector& positionalParams) {
 
 BoundTableFunction Binder::bindTableFunc(std::string tableFuncName,
     const parser::ParsedExpression& expr, expression_vector& columns) {
-    auto functions = clientContext->getCatalog()->getFunctions(clientContext->getTransaction());
-    auto entry = BuiltInFunctionsUtils::getFunctionCatalogEntry(clientContext->getTransaction(),
-        tableFuncName, functions);
+    auto entry = clientContext->getCatalog()->getFunctionEntry(clientContext->getTransaction(), tableFuncName);
     expression_vector positionalParams;
     std::vector<LogicalType> positionalParamTypes;
     optional_params_t optionalParams;
@@ -38,7 +36,7 @@ BoundTableFunction Binder::bindTableFunc(std::string tableFuncName,
             optionalParams.emplace(childExpr.getAlias(), literalExpr->getValue());
         }
     }
-    auto func = BuiltInFunctionsUtils::matchFunction(tableFuncName, positionalParamTypes, entry);
+    auto func = BuiltInFunctionsUtils::matchFunction(tableFuncName, positionalParamTypes, entry->ptrCast<catalog::FunctionCatalogEntry>());
     validateParameterType(positionalParams);
     auto tableFunc = func->constPtrCast<TableFunction>();
     for (auto i = 0u; i < positionalParams.size(); ++i) {

--- a/src/binder/bind/bind_table_function.cpp
+++ b/src/binder/bind/bind_table_function.cpp
@@ -20,7 +20,8 @@ static void validateParameterType(const expression_vector& positionalParams) {
 
 BoundTableFunction Binder::bindTableFunc(std::string tableFuncName,
     const parser::ParsedExpression& expr, expression_vector& columns) {
-    auto entry = clientContext->getCatalog()->getFunctionEntry(clientContext->getTransaction(), tableFuncName);
+    auto entry = clientContext->getCatalog()->getFunctionEntry(clientContext->getTransaction(),
+        tableFuncName);
     expression_vector positionalParams;
     std::vector<LogicalType> positionalParamTypes;
     optional_params_t optionalParams;
@@ -36,7 +37,8 @@ BoundTableFunction Binder::bindTableFunc(std::string tableFuncName,
             optionalParams.emplace(childExpr.getAlias(), literalExpr->getValue());
         }
     }
-    auto func = BuiltInFunctionsUtils::matchFunction(tableFuncName, positionalParamTypes, entry->ptrCast<catalog::FunctionCatalogEntry>());
+    auto func = BuiltInFunctionsUtils::matchFunction(tableFuncName, positionalParamTypes,
+        entry->ptrCast<catalog::FunctionCatalogEntry>());
     validateParameterType(positionalParams);
     auto tableFunc = func->constPtrCast<TableFunction>();
     for (auto i = 0u; i < positionalParams.size(); ++i) {

--- a/src/binder/bind/copy/bind_copy_to.cpp
+++ b/src/binder/bind/copy/bind_copy_to.cpp
@@ -19,11 +19,10 @@ std::unique_ptr<BoundStatement> Binder::bindCopyToClause(const Statement& statem
     auto parsedQuery = copyToStatement.getStatement()->constPtrCast<RegularQuery>();
     auto query = bindQuery(*parsedQuery);
     auto columns = query->getStatementResult()->getColumns();
-    auto functions = clientContext->getCatalog()->getFunctions(clientContext->getTransaction());
     auto fileTypeStr = fileTypeInfo.fileTypeStr;
     auto name = common::stringFormat("COPY_{}", fileTypeStr);
-    auto exportFunc = function::BuiltInFunctionsUtils::matchFunction(
-        clientContext->getTransaction(), name, functions)
+    auto entry = clientContext->getCatalog()->getFunctionEntry(clientContext->getTransaction(), name);
+    auto exportFunc = function::BuiltInFunctionsUtils::matchFunction(name, entry->ptrCast<catalog::FunctionCatalogEntry>())
                           ->constPtrCast<function::ExportFunction>();
     for (auto& column : columns) {
         auto columnName = column->hasAlias() ? column->getAlias() : column->toString();

--- a/src/binder/bind/copy/bind_copy_to.cpp
+++ b/src/binder/bind/copy/bind_copy_to.cpp
@@ -21,8 +21,10 @@ std::unique_ptr<BoundStatement> Binder::bindCopyToClause(const Statement& statem
     auto columns = query->getStatementResult()->getColumns();
     auto fileTypeStr = fileTypeInfo.fileTypeStr;
     auto name = common::stringFormat("COPY_{}", fileTypeStr);
-    auto entry = clientContext->getCatalog()->getFunctionEntry(clientContext->getTransaction(), name);
-    auto exportFunc = function::BuiltInFunctionsUtils::matchFunction(name, entry->ptrCast<catalog::FunctionCatalogEntry>())
+    auto entry =
+        clientContext->getCatalog()->getFunctionEntry(clientContext->getTransaction(), name);
+    auto exportFunc = function::BuiltInFunctionsUtils::matchFunction(name,
+        entry->ptrCast<catalog::FunctionCatalogEntry>())
                           ->constPtrCast<function::ExportFunction>();
     for (auto& column : columns) {
         auto columnName = column->hasAlias() ? column->getAlias() : column->toString();

--- a/src/binder/bind/read/bind_in_query_call.cpp
+++ b/src/binder/bind/read/bind_in_query_call.cpp
@@ -26,7 +26,8 @@ std::unique_ptr<BoundReadingClause> Binder::bindInQueryCall(const ReadingClause&
     auto functionName = functionExpr->getFunctionName();
     std::unique_ptr<BoundReadingClause> boundReadingClause;
     expression_vector columns;
-    auto entry = clientContext->getCatalog()->getFunctionEntry(clientContext->getTransaction(), functionName);
+    auto entry = clientContext->getCatalog()->getFunctionEntry(clientContext->getTransaction(),
+        functionName);
     switch (entry->getType()) {
     case CatalogEntryType::TABLE_FUNCTION_ENTRY: {
         auto boundTableFunction = bindTableFunc(functionName, *functionExpr, columns);
@@ -49,7 +50,8 @@ std::unique_ptr<BoundReadingClause> Binder::bindInQueryCall(const ReadingClause&
                     literalExpr->getValue());
             }
         }
-        auto func = BuiltInFunctionsUtils::matchFunction(functionName, childrenTypes, entry->ptrCast<FunctionCatalogEntry>());
+        auto func = BuiltInFunctionsUtils::matchFunction(functionName, childrenTypes,
+            entry->ptrCast<FunctionCatalogEntry>());
         auto gdsFunc = func->constPtrCast<GDSFunction>()->copy();
         auto input = GDSBindInput();
         input.params = children;

--- a/src/binder/bind/read/bind_in_query_call.cpp
+++ b/src/binder/bind/read/bind_in_query_call.cpp
@@ -26,9 +26,7 @@ std::unique_ptr<BoundReadingClause> Binder::bindInQueryCall(const ReadingClause&
     auto functionName = functionExpr->getFunctionName();
     std::unique_ptr<BoundReadingClause> boundReadingClause;
     expression_vector columns;
-    auto catalogSet = clientContext->getCatalog()->getFunctions(clientContext->getTransaction());
-    auto entry = BuiltInFunctionsUtils::getFunctionCatalogEntry(clientContext->getTransaction(),
-        functionName, catalogSet);
+    auto entry = clientContext->getCatalog()->getFunctionEntry(clientContext->getTransaction(), functionName);
     switch (entry->getType()) {
     case CatalogEntryType::TABLE_FUNCTION_ENTRY: {
         auto boundTableFunction = bindTableFunc(functionName, *functionExpr, columns);
@@ -51,7 +49,7 @@ std::unique_ptr<BoundReadingClause> Binder::bindInQueryCall(const ReadingClause&
                     literalExpr->getValue());
             }
         }
-        auto func = BuiltInFunctionsUtils::matchFunction(functionName, childrenTypes, entry);
+        auto func = BuiltInFunctionsUtils::matchFunction(functionName, childrenTypes, entry->ptrCast<FunctionCatalogEntry>());
         auto gdsFunc = func->constPtrCast<GDSFunction>()->copy();
         auto input = GDSBindInput();
         input.params = children;

--- a/src/binder/bind_expression/bind_comparison_expression.cpp
+++ b/src/binder/bind_expression/bind_comparison_expression.cpp
@@ -42,7 +42,9 @@ std::shared_ptr<Expression> ExpressionBinder::bindComparisonExpression(
         childrenTypes.push_back(combinedType.copy());
     }
     auto entry = catalog->getFunctionEntry(transaction, functionName);
-    auto function = BuiltInFunctionsUtils::matchFunction(functionName, childrenTypes, entry->ptrCast<catalog::FunctionCatalogEntry>())->ptrCast<ScalarFunction>();
+    auto function = BuiltInFunctionsUtils::matchFunction(functionName, childrenTypes,
+        entry->ptrCast<catalog::FunctionCatalogEntry>())
+                        ->ptrCast<ScalarFunction>();
     expression_vector childrenAfterCast;
     for (auto i = 0u; i < children.size(); ++i) {
         if (children[i]->dataType != combinedType) {

--- a/src/binder/bind_expression/bind_function_expression.cpp
+++ b/src/binder/bind_expression/bind_function_expression.cpp
@@ -76,8 +76,10 @@ std::shared_ptr<Expression> ExpressionBinder::bindScalarFunctionExpression(
 
     auto entry = catalog->getFunctionEntry(transaction, functionName);
 
-    auto function =
-        BuiltInFunctionsUtils::matchFunction(functionName, childrenTypes, entry->ptrCast<FunctionCatalogEntry>())->ptrCast<ScalarFunction>()->copy();
+    auto function = BuiltInFunctionsUtils::matchFunction(functionName, childrenTypes,
+        entry->ptrCast<FunctionCatalogEntry>())
+                        ->ptrCast<ScalarFunction>()
+                        ->copy();
     if (children.size() == 2 && children[1]->expressionType == ExpressionType::LAMBDA) {
         if (!function->isListLambda) {
             throw BinderException(stringFormat("{} does not support lambda input.", functionName));
@@ -135,7 +137,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindRewriteFunctionExpression(
     auto childrenTypes = getTypes(children);
     auto functionName = funcExpr.getNormalizedFunctionName();
     auto entry = context->getCatalog()->getFunctionEntry(context->getTransaction(), functionName);
-    auto match = BuiltInFunctionsUtils::matchFunction(functionName, childrenTypes, entry->ptrCast<FunctionCatalogEntry>());
+    auto match = BuiltInFunctionsUtils::matchFunction(functionName, childrenTypes,
+        entry->ptrCast<FunctionCatalogEntry>());
     auto function = match->constPtrCast<RewriteFunction>();
     KU_ASSERT(function->rewriteFunc != nullptr);
     return function->rewriteFunc(children, this);
@@ -152,7 +155,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindAggregateFunctionExpression(
     }
     auto entry = context->getCatalog()->getFunctionEntry(context->getTransaction(), functionName);
     auto function = BuiltInFunctionsUtils::matchAggregateFunction(functionName, childrenTypes,
-        isDistinct, entry->ptrCast<FunctionCatalogEntry>())->copy();
+        isDistinct, entry->ptrCast<FunctionCatalogEntry>())
+                        ->copy();
     if (function.paramRewriteFunc) {
         function.paramRewriteFunc(children);
     }

--- a/src/binder/bind_expression/bind_subquery_expression.cpp
+++ b/src/binder/bind_expression/bind_subquery_expression.cpp
@@ -34,7 +34,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindSubqueryExpression(
         std::move(boundGraphPattern.queryGraphCollection), uniqueName, std::move(rawName));
     boundSubqueryExpr->setWhereExpression(boundGraphPattern.where);
     // Bind projection
-    auto entry = context->getCatalog()->getFunctionEntry(context->getTransaction(), CountStarFunction::name);
+    auto entry =
+        context->getCatalog()->getFunctionEntry(context->getTransaction(), CountStarFunction::name);
     auto function = BuiltInFunctionsUtils::matchAggregateFunction(CountStarFunction::name,
         std::vector<LogicalType>{}, false, entry->ptrCast<catalog::FunctionCatalogEntry>());
     auto bindData = std::make_unique<FunctionBindData>(LogicalType(function->returnTypeID));

--- a/src/binder/bind_expression/bind_subquery_expression.cpp
+++ b/src/binder/bind_expression/bind_subquery_expression.cpp
@@ -34,9 +34,9 @@ std::shared_ptr<Expression> ExpressionBinder::bindSubqueryExpression(
         std::move(boundGraphPattern.queryGraphCollection), uniqueName, std::move(rawName));
     boundSubqueryExpr->setWhereExpression(boundGraphPattern.where);
     // Bind projection
-    auto functions = context->getCatalog()->getFunctions(context->getTransaction());
+    auto entry = context->getCatalog()->getFunctionEntry(context->getTransaction(), CountStarFunction::name);
     auto function = BuiltInFunctionsUtils::matchAggregateFunction(CountStarFunction::name,
-        std::vector<LogicalType>{}, false, functions);
+        std::vector<LogicalType>{}, false, entry->ptrCast<catalog::FunctionCatalogEntry>());
     auto bindData = std::make_unique<FunctionBindData>(LogicalType(function->returnTypeID));
     auto countStarExpr =
         std::make_shared<AggregateFunctionExpression>(function->copy(), std::move(bindData),

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -229,8 +229,7 @@ void Binder::restoreScope(BinderScope prevScope) {
     scope = std::move(prevScope);
 }
 
-TableFunction Binder::getScanFunction(FileTypeInfo typeInfo,
-    const FileScanInfo& fileScanInfo) {
+TableFunction Binder::getScanFunction(FileTypeInfo typeInfo, const FileScanInfo& fileScanInfo) {
     Function* func = nullptr;
     std::vector<LogicalType> inputTypes;
     inputTypes.push_back(LogicalType::STRING());
@@ -239,23 +238,27 @@ TableFunction Binder::getScanFunction(FileTypeInfo typeInfo,
     switch (typeInfo.fileType) {
     case FileType::PARQUET: {
         auto entry = catalog->getFunctionEntry(transaction, ParquetScanFunction::name);
-        func = BuiltInFunctionsUtils::matchFunction(ParquetScanFunction::name, inputTypes, entry->ptrCast<FunctionCatalogEntry>());
+        func = BuiltInFunctionsUtils::matchFunction(ParquetScanFunction::name, inputTypes,
+            entry->ptrCast<FunctionCatalogEntry>());
     } break;
     case FileType::NPY: {
         auto entry = catalog->getFunctionEntry(transaction, NpyScanFunction::name);
-        func = BuiltInFunctionsUtils::matchFunction(NpyScanFunction::name, inputTypes, entry->ptrCast<FunctionCatalogEntry>());
+        func = BuiltInFunctionsUtils::matchFunction(NpyScanFunction::name, inputTypes,
+            entry->ptrCast<FunctionCatalogEntry>());
     } break;
     case FileType::CSV: {
         auto csvConfig = CSVReaderConfig::construct(fileScanInfo.options);
         auto name = csvConfig.parallel ? ParallelCSVScan::name : SerialCSVScan::name;
         auto entry = catalog->getFunctionEntry(transaction, name);
-        func = BuiltInFunctionsUtils::matchFunction(name, inputTypes, entry->ptrCast<FunctionCatalogEntry>());
+        func = BuiltInFunctionsUtils::matchFunction(name, inputTypes,
+            entry->ptrCast<FunctionCatalogEntry>());
     } break;
     case FileType::UNKNOWN: {
         try {
             auto name = common::stringFormat("{}_SCAN", typeInfo.fileTypeStr);
             auto entry = catalog->getFunctionEntry(transaction, name);
-            func = BuiltInFunctionsUtils::matchFunction(name, inputTypes, entry->ptrCast<FunctionCatalogEntry>());
+            func = BuiltInFunctionsUtils::matchFunction(name, inputTypes,
+                entry->ptrCast<FunctionCatalogEntry>());
         } catch (...) {
             if (typeInfo.fileTypeStr == "") {
                 throw common::BinderException{

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -23,6 +23,7 @@
 #include "storage/storage_utils.h"
 #include "storage/storage_version_info.h"
 #include "transaction/transaction.h"
+#include "function/function_collection.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -348,6 +349,10 @@ void Catalog::dropIndex(Transaction* transaction, table_id_t tableID,
     indexes->dropEntry(transaction, uniqueName, entry->getOID());
 }
 
+bool Catalog::containsFunction(const Transaction* transaction, const std::string& name) {
+    return functions->containsEntry(transaction, name);
+}
+
 void Catalog::addFunction(Transaction* transaction, CatalogEntryType entryType, std::string name,
     function::function_set functionSet) {
     if (functions->containsEntry(transaction, name)) {
@@ -358,29 +363,19 @@ void Catalog::addFunction(Transaction* transaction, CatalogEntryType entryType, 
 }
 
 void Catalog::dropFunction(Transaction* transaction, const std::string& name) {
-    const auto entry = functions->getEntry(transaction, name);
-    if (entry == nullptr) {
+    if (!containsFunction(transaction, name)) {
         throw CatalogException{stringFormat("function {} doesn't exist.", name)};
     }
+    auto entry = getFunctionEntry(transaction, name);
     functions->dropEntry(transaction, name, entry->getOID());
-}
-
-void Catalog::addBuiltInFunction(CatalogEntryType entryType, std::string name,
-    function::function_set functionSet) {
-    addFunction(&DUMMY_TRANSACTION, entryType, std::move(name), std::move(functionSet));
-}
-
-CatalogSet* Catalog::getFunctions(Transaction*) const {
-    return functions.get();
 }
 
 CatalogEntry* Catalog::getFunctionEntry(const Transaction* transaction,
     const std::string& name) const {
-    const auto catalogSet = functions.get();
-    if (!catalogSet->containsEntry(transaction, name)) {
+    if (!functions->containsEntry(transaction, name)) {
         throw CatalogException(stringFormat("function {} does not exist.", name));
     }
-    return catalogSet->getEntry(transaction, name);
+    return functions->getEntry(transaction, name);
 }
 
 std::vector<FunctionCatalogEntry*> Catalog::getFunctionEntries(
@@ -403,11 +398,12 @@ function::ScalarMacroFunction* Catalog::getScalarMacroFunction(const Transaction
         .getMacroFunction();
 }
 
+// addScalarMacroFunction
 void Catalog::addScalarMacroFunction(Transaction* transaction, std::string name,
     std::unique_ptr<function::ScalarMacroFunction> macro) {
-    auto scalarMacroCatalogEntry =
+    auto entry =
         std::make_unique<ScalarMacroCatalogEntry>(std::move(name), std::move(macro));
-    functions->createEntry(transaction, std::move(scalarMacroCatalogEntry));
+    functions->createEntry(transaction, std::move(entry));
 }
 
 std::vector<std::string> Catalog::getMacroNames(const Transaction* transaction) const {
@@ -494,7 +490,14 @@ void Catalog::readFromFile(const std::string& directory, VirtualFileSystem* fs,
 }
 
 void Catalog::registerBuiltInFunctions() {
-    function::BuiltInFunctionsUtils::createFunctions(&DUMMY_TRANSACTION, functions.get());
+    auto functionCollection = function::FunctionCollection::getFunctions();
+    for (auto i = 0u; functionCollection[i].name != nullptr; ++i) {
+        auto& f = functionCollection[i];
+        auto functionSet = f.getFunctionSetFunc();
+        functions->createEntry(&DUMMY_TRANSACTION,
+            std::make_unique<FunctionCatalogEntry>(f.catalogEntryType, f.name,
+                std::move(functionSet)));
+    }
 }
 
 std::unique_ptr<CatalogEntry> Catalog::createNodeTableEntry(Transaction*,

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -19,11 +19,11 @@
 #include "common/serializer/serializer.h"
 #include "common/string_format.h"
 #include "function/built_in_function_utils.h"
+#include "function/function_collection.h"
 #include "main/db_config.h"
 #include "storage/storage_utils.h"
 #include "storage/storage_version_info.h"
 #include "transaction/transaction.h"
-#include "function/function_collection.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -401,8 +401,7 @@ function::ScalarMacroFunction* Catalog::getScalarMacroFunction(const Transaction
 // addScalarMacroFunction
 void Catalog::addScalarMacroFunction(Transaction* transaction, std::string name,
     std::unique_ptr<function::ScalarMacroFunction> macro) {
-    auto entry =
-        std::make_unique<ScalarMacroCatalogEntry>(std::move(name), std::move(macro));
+    auto entry = std::make_unique<ScalarMacroCatalogEntry>(std::move(name), std::move(macro));
     functions->createEntry(transaction, std::move(entry));
 }
 

--- a/src/extension/extension.cpp
+++ b/src/extension/extension.cpp
@@ -120,8 +120,7 @@ void ExtensionUtils::registerTableFunction(main::Database& database,
     function::function_set functionSet;
     functionSet.push_back(std::move(function));
     auto catalog = database.getCatalog();
-    if (catalog->getFunctions(&transaction::DUMMY_TRANSACTION)
-            ->containsEntry(&transaction::DUMMY_TRANSACTION, name)) {
+    if (catalog->containsFunction(&transaction::DUMMY_TRANSACTION, name)) {
         return;
     }
     catalog->addFunction(&transaction::DUMMY_TRANSACTION,
@@ -153,8 +152,7 @@ std::string ExtensionUtils::getLocalPathForSharedLib(main::ClientContext* contex
 void ExtensionUtils::registerFunctionSet(main::Database& database, std::string name,
     function::function_set functionSet, catalog::CatalogEntryType functionType) {
     auto catalog = database.getCatalog();
-    if (catalog->getFunctions(&transaction::DUMMY_TRANSACTION)
-            ->containsEntry(&transaction::DUMMY_TRANSACTION, name)) {
+    if (catalog->containsFunction(&transaction::DUMMY_TRANSACTION, name)) {
         return;
     }
     catalog->addFunction(&transaction::DUMMY_TRANSACTION, functionType, std::move(name),

--- a/src/function/built_in_function_utils.cpp
+++ b/src/function/built_in_function_utils.cpp
@@ -20,7 +20,8 @@ static void validateNonEmptyCandidateFunctions(std::vector<Function*>& candidate
     const function::function_set& set);
 
 Function* BuiltInFunctionsUtils::matchFunction(const std::string& name,
-    const std::vector<LogicalType>& inputTypes, const catalog::FunctionCatalogEntry* functionEntry) {
+    const std::vector<LogicalType>& inputTypes,
+    const catalog::FunctionCatalogEntry* functionEntry) {
     auto& functionSet = functionEntry->getFunctionSet();
     std::vector<Function*> candidateFunctions;
     uint32_t minCost = UINT32_MAX;
@@ -47,7 +48,8 @@ Function* BuiltInFunctionsUtils::matchFunction(const std::string& name,
 }
 
 AggregateFunction* BuiltInFunctionsUtils::matchAggregateFunction(const std::string& name,
-    const std::vector<common::LogicalType>& inputTypes, bool isDistinct, const catalog::FunctionCatalogEntry* functionEntry) {
+    const std::vector<common::LogicalType>& inputTypes, bool isDistinct,
+    const catalog::FunctionCatalogEntry* functionEntry) {
     auto& functionSet = functionEntry->getFunctionSet();
     std::vector<AggregateFunction*> candidateFunctions;
     for (auto& function : functionSet) {

--- a/src/function/built_in_function_utils.cpp
+++ b/src/function/built_in_function_utils.cpp
@@ -1,13 +1,9 @@
 #include "function/built_in_function_utils.h"
 
 #include "catalog/catalog_entry/function_catalog_entry.h"
-#include "catalog/catalog_set.h"
 #include "common/exception/binder.h"
-#include "common/exception/catalog.h"
 #include "function/aggregate_function.h"
 #include "function/arithmetic/vector_arithmetic_functions.h"
-#include "function/function_collection.h"
-#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::catalog;
@@ -23,39 +19,8 @@ static void validateNonEmptyCandidateFunctions(std::vector<Function*>& candidate
     const std::string& name, const std::vector<LogicalType>& inputTypes,
     const function::function_set& set);
 
-void BuiltInFunctionsUtils::createFunctions(transaction::Transaction* transaction,
-    CatalogSet* catalogSet) {
-    auto functions = FunctionCollection::getFunctions();
-    for (auto i = 0u; functions[i].name != nullptr; ++i) {
-        auto functionSet = functions[i].getFunctionSetFunc();
-        catalogSet->createEntry(transaction,
-            std::make_unique<FunctionCatalogEntry>(functions[i].catalogEntryType, functions[i].name,
-                std::move(functionSet)));
-    }
-}
-
-catalog::CatalogEntry* BuiltInFunctionsUtils::getFunctionCatalogEntry(
-    transaction::Transaction* transaction, const std::string& name, CatalogSet* catalogSet) {
-    if (!catalogSet->containsEntry(transaction, name)) {
-        throw CatalogException(stringFormat("{} function does not exist.", name));
-    }
-    return catalogSet->getEntry(transaction, name);
-}
-
-Function* BuiltInFunctionsUtils::matchFunction(transaction::Transaction* transaction,
-    const std::string& name, CatalogSet* catalogSet) {
-    return matchFunction(transaction, name, std::vector<LogicalType>{}, catalogSet);
-}
-
-Function* BuiltInFunctionsUtils::matchFunction(transaction::Transaction* transaction,
-    const std::string& name, const std::vector<LogicalType>& inputTypes, CatalogSet* catalogSet) {
-    auto entry = getFunctionCatalogEntry(transaction, name, catalogSet);
-    return matchFunction(name, inputTypes, entry);
-}
-
 Function* BuiltInFunctionsUtils::matchFunction(const std::string& name,
-    const std::vector<LogicalType>& inputTypes, const catalog::CatalogEntry* catalogEntry) {
-    auto functionEntry = catalogEntry->constPtrCast<FunctionCatalogEntry>();
+    const std::vector<LogicalType>& inputTypes, const catalog::FunctionCatalogEntry* functionEntry) {
     auto& functionSet = functionEntry->getFunctionSet();
     std::vector<Function*> candidateFunctions;
     uint32_t minCost = UINT32_MAX;
@@ -82,10 +47,8 @@ Function* BuiltInFunctionsUtils::matchFunction(const std::string& name,
 }
 
 AggregateFunction* BuiltInFunctionsUtils::matchAggregateFunction(const std::string& name,
-    const std::vector<common::LogicalType>& inputTypes, bool isDistinct, CatalogSet* catalogSet) {
-    auto& functionSet = catalogSet->getEntry(&transaction::DUMMY_TRANSACTION, name)
-                            ->ptrCast<FunctionCatalogEntry>()
-                            ->getFunctionSet();
+    const std::vector<common::LogicalType>& inputTypes, bool isDistinct, const catalog::FunctionCatalogEntry* functionEntry) {
+    auto& functionSet = functionEntry->getFunctionSet();
     std::vector<AggregateFunction*> candidateFunctions;
     for (auto& function : functionSet) {
         auto aggregateFunction = function->ptrCast<AggregateFunction>();

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -1058,9 +1058,10 @@ static std::unique_ptr<FunctionBindData> castBindFunc(ScalarBindFuncInput input)
         std::vector<LogicalType> typeVec;
         typeVec.push_back(input.arguments[0]->getDataType().copy());
         try {
-            auto entry = input.context->getCatalog()->getFunctionEntry(input.context->getTransaction(), func->name);
-            auto match = BuiltInFunctionsUtils::matchFunction(
-                func->name, typeVec, entry->ptrCast<catalog::FunctionCatalogEntry>());
+            auto entry = input.context->getCatalog()->getFunctionEntry(
+                input.context->getTransaction(), func->name);
+            auto match = BuiltInFunctionsUtils::matchFunction(func->name, typeVec,
+                entry->ptrCast<catalog::FunctionCatalogEntry>());
             func->execFunc = match->constPtrCast<ScalarFunction>()->execFunc;
             return std::make_unique<function::CastFunctionBindData>(targetType.copy());
         } catch (...) { // NOLINT

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -1058,11 +1058,10 @@ static std::unique_ptr<FunctionBindData> castBindFunc(ScalarBindFuncInput input)
         std::vector<LogicalType> typeVec;
         typeVec.push_back(input.arguments[0]->getDataType().copy());
         try {
-            func->execFunc = BuiltInFunctionsUtils::matchFunction(input.context->getTransaction(),
-                func->name, typeVec,
-                input.context->getCatalog()->getFunctions(input.context->getTransaction()))
-                                 ->constPtrCast<ScalarFunction>()
-                                 ->execFunc;
+            auto entry = input.context->getCatalog()->getFunctionEntry(input.context->getTransaction(), func->name);
+            auto match = BuiltInFunctionsUtils::matchFunction(
+                func->name, typeVec, entry->ptrCast<catalog::FunctionCatalogEntry>());
+            func->execFunc = match->constPtrCast<ScalarFunction>()->execFunc;
             return std::make_unique<function::CastFunctionBindData>(targetType.copy());
         } catch (...) { // NOLINT
             // If there's no user defined casting function for the corresponding user defined type,

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -146,16 +146,22 @@ public:
 
     // ----------------------------- Functions ----------------------------
 
-    void addFunction(transaction::Transaction* transaction, CatalogEntryType entryType,
-        std::string name, function::function_set functionSet);
-    void dropFunction(transaction::Transaction* transaction, const std::string& name);
-    void addBuiltInFunction(CatalogEntryType entryType, std::string name,
-        function::function_set functionSet);
-    CatalogSet* getFunctions(transaction::Transaction* transaction) const;
+    // Check if function exists.
+    bool containsFunction(const transaction::Transaction* transaction,
+        const std::string& name);
+    // Get function entry by name.
+    // Note we cannot cast to FunctionEntry here because result could also be a MacroEntry.
     CatalogEntry* getFunctionEntry(const transaction::Transaction* transaction,
         const std::string& name) const;
+    // Get all function entries.
     std::vector<FunctionCatalogEntry*> getFunctionEntries(
         const transaction::Transaction* transaction) const;
+
+    // Add function with name.
+    void addFunction(transaction::Transaction* transaction, CatalogEntryType entryType,
+        std::string name, function::function_set functionSet);
+    // Drop function with name.
+    void dropFunction(transaction::Transaction* transaction, const std::string& name);
 
     // ----------------------------- Macro ----------------------------
 

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -147,8 +147,7 @@ public:
     // ----------------------------- Functions ----------------------------
 
     // Check if function exists.
-    bool containsFunction(const transaction::Transaction* transaction,
-        const std::string& name);
+    bool containsFunction(const transaction::Transaction* transaction, const std::string& name);
     // Get function entry by name.
     // Note we cannot cast to FunctionEntry here because result could also be a MacroEntry.
     CatalogEntry* getFunctionEntry(const transaction::Transaction* transaction,

--- a/src/include/function/built_in_function_utils.h
+++ b/src/include/function/built_in_function_utils.h
@@ -9,32 +9,24 @@ class Transaction;
 } // namespace transaction
 
 namespace catalog {
-class CatalogSet;
-class CatalogEntry;
+class FunctionCatalogEntry;
 } // namespace catalog
 
 namespace function {
 
 class BuiltInFunctionsUtils {
 public:
-    static void createFunctions(transaction::Transaction* transaction,
-        catalog::CatalogSet* catalogSet);
-
-    static catalog::CatalogEntry* getFunctionCatalogEntry(transaction::Transaction* transaction,
-        const std::string& name, catalog::CatalogSet* catalogSet);
-    static Function* matchFunction(transaction::Transaction* transaction, const std::string& name,
-        catalog::CatalogSet* catalogSet);
     // TODO(Ziyi): We should have a unified interface for matching table, aggregate and scalar
     // functions.
-    static Function* matchFunction(transaction::Transaction* transaction, const std::string& name,
-        const std::vector<common::LogicalType>& inputTypes, catalog::CatalogSet* catalogSet);
-    static Function* matchFunction(const std::string& name,
-        const std::vector<common::LogicalType>& inputTypes,
-        const catalog::CatalogEntry* catalogEntry);
+    static Function* matchFunction(const std::string& name, const catalog::FunctionCatalogEntry* catalogEntry) {
+        return matchFunction(name, {}, catalogEntry);
+    }
+    static Function* matchFunction(const std::string& name, const std::vector<common::LogicalType>& inputTypes,
+        const catalog::FunctionCatalogEntry* functionEntry);
 
     static AggregateFunction* matchAggregateFunction(const std::string& name,
         const std::vector<common::LogicalType>& inputTypes, bool isDistinct,
-        catalog::CatalogSet* catalogSet);
+        const catalog::FunctionCatalogEntry* functionEntry);
 
     static KUZU_API uint32_t getCastCost(common::LogicalTypeID inputTypeID,
         common::LogicalTypeID targetTypeID);

--- a/src/include/function/built_in_function_utils.h
+++ b/src/include/function/built_in_function_utils.h
@@ -18,10 +18,12 @@ class BuiltInFunctionsUtils {
 public:
     // TODO(Ziyi): We should have a unified interface for matching table, aggregate and scalar
     // functions.
-    static Function* matchFunction(const std::string& name, const catalog::FunctionCatalogEntry* catalogEntry) {
+    static Function* matchFunction(const std::string& name,
+        const catalog::FunctionCatalogEntry* catalogEntry) {
         return matchFunction(name, {}, catalogEntry);
     }
-    static Function* matchFunction(const std::string& name, const std::vector<common::LogicalType>& inputTypes,
+    static Function* matchFunction(const std::string& name,
+        const std::vector<common::LogicalType>& inputTypes,
         const catalog::FunctionCatalogEntry* functionEntry);
 
     static AggregateFunction* matchAggregateFunction(const std::string& name,

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -125,14 +125,14 @@ Database::~Database() {
 }
 
 void Database::addTableFunction(std::string name, function::function_set functionSet) {
-    catalog->addBuiltInFunction(CatalogEntryType::TABLE_FUNCTION_ENTRY, std::move(name),
-        std::move(functionSet));
+    catalog->addFunction(&DUMMY_TRANSACTION, CatalogEntryType::TABLE_FUNCTION_ENTRY,
+        std::move(name), std::move(functionSet));
 }
 
 void Database::addStandaloneCallFunction(std::string name,
     std::vector<std::unique_ptr<function::Function>> functionSet) {
-    catalog->addBuiltInFunction(CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY, std::move(name),
-        std::move(functionSet));
+    catalog->addFunction(&DUMMY_TRANSACTION, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY,
+               std::move(name), std::move(functionSet));
 }
 
 void Database::registerFileSystem(std::unique_ptr<FileSystem> fs) {

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -132,7 +132,7 @@ void Database::addTableFunction(std::string name, function::function_set functio
 void Database::addStandaloneCallFunction(std::string name,
     std::vector<std::unique_ptr<function::Function>> functionSet) {
     catalog->addFunction(&DUMMY_TRANSACTION, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY,
-               std::move(name), std::move(functionSet));
+        std::move(name), std::move(functionSet));
 }
 
 void Database::registerFileSystem(std::unique_ptr<FileSystem> fs) {

--- a/src/planner/plan/plan_port_db.cpp
+++ b/src/planner/plan/plan_port_db.cpp
@@ -29,8 +29,10 @@ std::unique_ptr<LogicalPlan> Planner::planExportDatabase(const BoundStatement& s
     StringUtils::toLower(fileTypeStr);
     auto copyToSuffix = "." + fileTypeStr;
     std::string name = common::stringFormat("COPY_{}", FileTypeUtils::toString(fileType));
-    auto entry = clientContext->getCatalog()->getFunctionEntry(clientContext->getTransaction(), name);
-    auto func = function::BuiltInFunctionsUtils::matchFunction(name, entry->ptrCast<FunctionCatalogEntry>());
+    auto entry =
+        clientContext->getCatalog()->getFunctionEntry(clientContext->getTransaction(), name);
+    auto func = function::BuiltInFunctionsUtils::matchFunction(name,
+        entry->ptrCast<FunctionCatalogEntry>());
     KU_ASSERT(func != nullptr);
     auto exportFunc = *func->constPtrCast<function::ExportFunction>();
     for (auto& exportTableData : *exportData) {

--- a/src/planner/plan/plan_port_db.cpp
+++ b/src/planner/plan/plan_port_db.cpp
@@ -28,10 +28,9 @@ std::unique_ptr<LogicalPlan> Planner::planExportDatabase(const BoundStatement& s
     auto fileTypeStr = FileTypeUtils::toString(fileType);
     StringUtils::toLower(fileTypeStr);
     auto copyToSuffix = "." + fileTypeStr;
-    auto functions = clientContext->getCatalog()->getFunctions(clientContext->getTransaction());
     std::string name = common::stringFormat("COPY_{}", FileTypeUtils::toString(fileType));
-    auto func = function::BuiltInFunctionsUtils::matchFunction(clientContext->getTransaction(),
-        name, functions);
+    auto entry = clientContext->getCatalog()->getFunctionEntry(clientContext->getTransaction(), name);
+    auto func = function::BuiltInFunctionsUtils::matchFunction(name, entry->ptrCast<FunctionCatalogEntry>());
     KU_ASSERT(func != nullptr);
     auto exportFunc = *func->constPtrCast<function::ExportFunction>();
     for (auto& exportTableData : *exportData) {

--- a/src/processor/map/create_factorized_table_scan.cpp
+++ b/src/processor/map/create_factorized_table_scan.cpp
@@ -24,9 +24,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createFTableScan(const expression_
     }
     auto bindData =
         std::make_unique<FTableScanBindData>(table, std::move(colIndices), maxMorselSize);
-    auto function = function::BuiltInFunctionsUtils::matchFunction(clientContext->getTransaction(),
-        FTableScan::name,
-        clientContext->getCatalog()->getFunctions(clientContext->getTransaction()));
+    auto functionEntry = clientContext->getCatalog()->getFunctionEntry(clientContext->getTransaction(), FTableScan::name);
+    auto function = function::BuiltInFunctionsUtils::matchFunction(FTableScan::name, functionEntry->ptrCast<catalog::FunctionCatalogEntry>());
     auto info = TableFunctionCallInfo();
     info.function = *ku_dynamic_cast<TableFunction*>(function);
     info.bindData = std::move(bindData);

--- a/src/processor/map/create_factorized_table_scan.cpp
+++ b/src/processor/map/create_factorized_table_scan.cpp
@@ -24,8 +24,10 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createFTableScan(const expression_
     }
     auto bindData =
         std::make_unique<FTableScanBindData>(table, std::move(colIndices), maxMorselSize);
-    auto functionEntry = clientContext->getCatalog()->getFunctionEntry(clientContext->getTransaction(), FTableScan::name);
-    auto function = function::BuiltInFunctionsUtils::matchFunction(FTableScan::name, functionEntry->ptrCast<catalog::FunctionCatalogEntry>());
+    auto functionEntry = clientContext->getCatalog()->getFunctionEntry(
+        clientContext->getTransaction(), FTableScan::name);
+    auto function = function::BuiltInFunctionsUtils::matchFunction(FTableScan::name,
+        functionEntry->ptrCast<catalog::FunctionCatalogEntry>());
     auto info = TableFunctionCallInfo();
     info.function = *ku_dynamic_cast<TableFunction*>(function);
     info.bindData = std::move(bindData);

--- a/test/main/udf_test.cpp
+++ b/test/main/udf_test.cpp
@@ -481,7 +481,7 @@ TEST_F(ApiTest, CreateUDFExceptionTest) {
         conn->removeUDFFunction("add6");
         FAIL();
     } catch (std::exception& e) {
-        ASSERT_EQ(std::string(e.what()), "Catalog exception: add6 does not exist in catalog.");
+        ASSERT_EQ(std::string(e.what()), "Catalog exception: function add6 doesn't exist.");
     }
 }
 

--- a/test/test_files/exceptions/binder/binder_error.test
+++ b/test/test_files/exceptions/binder/binder_error.test
@@ -547,7 +547,7 @@ Binder exception: Invalid number of arguments for macro ADD4.
 -LOG CopyToNPYFormat
 -STATEMENT COPY (MATCH (a:person) RETURN a) TO 'person.npy';
 ---- error
-Catalog exception: COPY_npy function does not exist.
+Catalog exception: function COPY_npy does not exist.
 
 -LOG InvalidImplicitCast
 -STATEMENT RETURN timestamp("2019-11-21") + "ok";

--- a/tools/python_api/test/test_udf.py
+++ b/tools/python_api/test/test_udf.py
@@ -198,10 +198,10 @@ def test_udf_remove(conn_db_readwrite: ConnDB) -> None:
 
     conn.create_function("myfunction", myfunction)
 
-    with pytest.raises(RuntimeError, match="Catalog exception: notmyfunction does not exist in catalog."):
+    with pytest.raises(RuntimeError, match="Catalog exception: function notmyfunction doesn't exist."):
         conn.remove_function("notmyfunction")
 
     conn.remove_function("myfunction")
 
-    with pytest.raises(RuntimeError, match="Catalog exception: list_create does not exist in catalog."):
+    with pytest.raises(RuntimeError, match="Catalog exception: function list_create doesn't exist."):
         conn.remove_function("list_create")

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -115,8 +115,7 @@ void EmbeddedShell::updateTableNames() {
 
 void EmbeddedShell::updateFunctionAndTypeNames() {
     functionAndTypeNames.clear();
-    auto function = database->catalog->getFunctions(&transaction::DUMMY_TRANSACTION);
-    for (auto& [_, entry] : function->getEntries(&transaction::DUMMY_TRANSACTION)) {
+    for (auto& entry : database->catalog->getFunctionEntries(&transaction::DUMMY_TRANSACTION)) {
         if (entry->getType() == catalog::CatalogEntryType::TABLE_FUNCTION_ENTRY) {
             tableFunctionNames.push_back(entry->getName());
         } else {


### PR DESCRIPTION
# Description

This is a followed-up PR of #4726. We now only expose FunctionEntry from catalog and hide FunctionCatalogSet. The same thing should be done for Macro but I kinda think it should first be moved as a separate CatalogSet. Right now in FunctionCatalogSet we have both `FunctionCatalogEntry` & `MacroCatalogEntry`.  Either they should be the same CatalogEntry or they belong to different CatalogSet. 

@acquamarin & @ray6080 we should discuss this.

Also @acquamarin can u test what will happen if we start doing
```
CALL macro_function() RETURN *
CALL scalar_function() RETURN *
RETURN table/gds_function()
```
I suspect we don't throw properly in some of these edge cases.


Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).