### PR TITLE
Skip header detection if detected number of columns doesn't match

### DIFF
--- a/dataset/csv-edge-case-tests/header-num-columns-mismatch.csv
+++ b/dataset/csv-edge-case-tests/header-num-columns-mismatch.csv
@@ -1,0 +1,2 @@
+abc def hello world
+1 2 hello world 5 6

--- a/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
@@ -458,6 +458,13 @@ bool SerialCSVReader::detectHeader(
     // In this case, User didn't set Header, but we detected a Header, use the detected header to
     // set the name and type.
     if (sniffHeaderDriver.detectedHeader) {
+        // If the detected header has fewer columns that expected, treat it as if no header was
+        // detected
+        if (sniffHeaderDriver.header.size() < detectedTypes.size()) {
+            sniffHeaderDriver.detectedHeader = false;
+            return false;
+        }
+
         for (auto i = 0u; i < detectedTypes.size(); i++) {
             detectedTypes[i].first = sniffHeaderDriver.header[i].first;
         }

--- a/test/test_files/csv/edge_cases.test
+++ b/test/test_files/csv/edge_cases.test
@@ -95,3 +95,12 @@ abc"def
 -STATEMENT LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/all_types/inf_nan_null.csv" RETURN *
 ---- 1
 [42.000000,999.000000,inf,-inf,-42.000000]|[42.000000,,inf,-inf,,-42.000000]
+
+-CASE HeaderNumColumnsSmallerThanActual
+-STATEMENT create node table values(val1 int32, val2 int32, val3 string, val4 string, primary key(val1))
+---- ok
+-STATEMENT copy values from "${KUZU_ROOT_DIRECTORY}/dataset/csv-edge-case-tests/header-num-columns-mismatch.csv"(delim = ' ')
+---- ok
+-STATEMENT MATCH (v:values) RETURN v.*;
+---- error
+Binder exception: Number of columns mismatch. Expected 4 but got 6.

--- a/test/test_files/csv/edge_cases.test
+++ b/test/test_files/csv/edge_cases.test
@@ -100,7 +100,5 @@ abc"def
 -STATEMENT create node table values(val1 int32, val2 int32, val3 string, val4 string, primary key(val1))
 ---- ok
 -STATEMENT copy values from "${KUZU_ROOT_DIRECTORY}/dataset/csv-edge-case-tests/header-num-columns-mismatch.csv"(delim = ' ')
----- ok
--STATEMENT MATCH (v:values) RETURN v.*;
 ---- error
 Binder exception: Number of columns mismatch. Expected 4 but got 6.


### PR DESCRIPTION
# Description

If a header is auto-detected but the number of columns in the header doesn't match the number of detected columns in the CSV, skip header detection (previously we crashed due to out of bounds access).

Fixes #4719

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).