### PR TITLE
Raise error when fts is built on non-string property

### DIFF
--- a/extension/fts/src/function/create_fts_index.cpp
+++ b/extension/fts/src/function/create_fts_index.cpp
@@ -51,6 +51,10 @@ static std::vector<std::string> bindProperties(const catalog::NodeTableCatalogEn
             throw BinderException{stringFormat("Property: {} does not exist in table {}.",
                 propertyName, entry.getName())};
         }
+        if (entry.getProperty(entry.getPropertyIdx(propertyName)).getType() !=
+            LogicalType::STRING()) {
+            throw BinderException{"Full text search index can only be built on string properties."};
+        }
         result.push_back(std::move(propertyName));
     }
     return result;

--- a/extension/fts/test/test_files/fts_small.test
+++ b/extension/fts/test/test_files/fts_small.test
@@ -103,6 +103,12 @@ Binder exception: Unrecognized stemmer 'german1'. Supported stemmers are: ['arab
 -STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx5', ['content', 'author', 'name'], test := 'nOne')
 ---- error
 Binder exception: Unrecognized optional parameter: test
+-LOG CreateFTSOnNonStringProp
+-STATEMENT CREATE NODE TABLE teacher (ID INT64, age INT64, PRIMARY KEY(ID))
+---- ok
+-STATEMENT CALL CREATE_FTS_INDEX('teacher', 'teacherIdx', ['age'])
+---- error
+Binder exception: Full text search index can only be built on string properties.
 -LOG CreateFTSIncorrectParamType
 -STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx5', ['content', 'author', 'name'], stemmer := 25)
 ---- error


### PR DESCRIPTION
This PR make fts throw an exception when built on non-string properties.