### PR TITLE
Add checkpoint configuration parameters to the API bindings

### DIFF
--- a/tools/java_api/src/jni/kuzu_java.cpp
+++ b/tools/java_api/src/jni/kuzu_java.cpp
@@ -262,7 +262,7 @@ JNIEXPORT jlong JNICALL Java_com_kuzudb_Native_kuzu_1database_1init(JNIEnv* env,
     systemConfig.maxDBSize = max_db_size == 0 ? systemConfig.maxDBSize : max_db_size;
     systemConfig.autoCheckpoint = auto_checkpoint;
     systemConfig.checkpointThreshold =
-        checkpoint_threshold >= 0 ? systemConfig.checkpointThreshold : checkpoint_threshold;
+        checkpoint_threshold >= 0 ? checkpoint_threshold : systemConfig.checkpointThreshold;
     try {
         Database* db = new Database(path, systemConfig);
         uint64_t address = reinterpret_cast<uint64_t>(db);

--- a/tools/java_api/src/jni/kuzu_java.cpp
+++ b/tools/java_api/src/jni/kuzu_java.cpp
@@ -262,7 +262,7 @@ JNIEXPORT jlong JNICALL Java_com_kuzudb_Native_kuzu_1database_1init(JNIEnv* env,
     systemConfig.maxDBSize = max_db_size == 0 ? systemConfig.maxDBSize : max_db_size;
     systemConfig.autoCheckpoint = auto_checkpoint;
     systemConfig.checkpointThreshold =
-        checkpoint_threshold == -1 ? systemConfig.checkpointThreshold : checkpoint_threshold;
+        checkpoint_threshold >= 0 ? systemConfig.checkpointThreshold : checkpoint_threshold;
     try {
         Database* db = new Database(path, systemConfig);
         uint64_t address = reinterpret_cast<uint64_t>(db);

--- a/tools/java_api/src/jni/kuzu_java.cpp
+++ b/tools/java_api/src/jni/kuzu_java.cpp
@@ -251,7 +251,7 @@ JNIEXPORT void JNICALL Java_com_kuzudb_Native_kuzu_1native_1reload_1library(JNIE
 
 JNIEXPORT jlong JNICALL Java_com_kuzudb_Native_kuzu_1database_1init(JNIEnv* env, jclass,
     jstring database_path, jlong buffer_pool_size, jboolean enable_compression, jboolean read_only,
-    jlong max_db_size) {
+    jlong max_db_size, jboolean auto_checkpoint, jlong checkpoint_threshold) {
 
     const char* path = env->GetStringUTFChars(database_path, JNI_FALSE);
     uint64_t buffer = static_cast<uint64_t>(buffer_pool_size);
@@ -260,6 +260,9 @@ JNIEXPORT jlong JNICALL Java_com_kuzudb_Native_kuzu_1database_1init(JNIEnv* env,
     systemConfig.enableCompression = enable_compression;
     systemConfig.readOnly = read_only;
     systemConfig.maxDBSize = max_db_size == 0 ? systemConfig.maxDBSize : max_db_size;
+    systemConfig.autoCheckpoint = auto_checkpoint;
+    systemConfig.checkpointThreshold =
+        checkpoint_threshold == -1 ? systemConfig.checkpointThreshold : checkpoint_threshold;
     try {
         Database* db = new Database(path, systemConfig);
         uint64_t address = reinterpret_cast<uint64_t>(db);

--- a/tools/java_api/src/main/java/com/kuzudb/Database.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Database.java
@@ -1,7 +1,8 @@
 package com.kuzudb;
 
 /**
- * The Database class is the main class of KuzuDB. It manages all database components.
+ * The Database class is the main class of KuzuDB. It manages all database
+ * components.
  */
 public class Database implements AutoCloseable {
     long db_ref;
@@ -11,9 +12,12 @@ public class Database implements AutoCloseable {
     boolean enableCompression = true;
     boolean destroyed = false;
     boolean readOnly = false;
+    boolean autoCheckpoint = true;
+    long checkpointThreshold;
 
     /**
-     * Creates a database object. The database will be created in memory with default settings.
+     * Creates a database object. The database will be created in memory with
+     * default settings.
      */
     public Database() {
         this("");
@@ -22,34 +26,51 @@ public class Database implements AutoCloseable {
     /**
      * Creates a database object.
      *
-     * @param databasePath: Database path. If the database does not already exist, it will be created.
+     * @param databasePath: Database path. If the database does not already exist,
+     *                      it will be created.
      */
     public Database(String databasePath) {
         this.db_path = databasePath;
         this.buffer_size = 0;
         this.max_db_size = 0;
-        db_ref = Native.kuzu_database_init(databasePath, 0, true, false, max_db_size);
+        this.checkpointThreshold = -1;
+        db_ref = Native.kuzu_database_init(databasePath, 0, true, false, max_db_size, autoCheckpoint,
+                checkpointThreshold);
     }
 
     /**
      * Creates a database object.
      *
-     * @param databasePath:      Database path. If the path is empty, or equal to `:memory:`, the database will be created in
-     *                           memory.
-     * @param bufferPoolSize:    Max size of the buffer pool in bytes.
-     * @param enableCompression: Enable compression in storage.
-     * @param readOnly:          Open the database in READ_ONLY mode.
-     * @param maxDBSize:         The maximum size of the database in bytes. Note that this is introduced
-     *                           temporarily for now to get around with the default 8TB mmap address space limit some
-     *                           environment.
+     * @param databasePath:       Database path. If the path is empty, or equal to
+     *                            `:memory:`, the database will be created in
+     *                            memory.
+     * @param bufferPoolSize:     Max size of the buffer pool in bytes.
+     * @param enableCompression:  Enable compression in storage.
+     * @param readOnly:           Open the database in READ_ONLY mode.
+     * @param maxDBSize:          The maximum size of the database in bytes. Note
+     *                            that this is introduced
+     *                            temporarily for now to get around with the default
+     *                            8TB mmap address space limit some
+     *                            environment.
+     * @param autoCheckpoint      If true, the database will automatically
+     *                            checkpoint when the size of
+     *                            the WAL file exceeds the checkpoint threshold.
+     * @param checkpointThreshold The threshold of the WAL file size in bytes. When
+     *                            the size of the
+     *                            WAL file exceeds this threshold, the database will
+     *                            checkpoint if autoCheckpoint is true.
      */
-    public Database(String databasePath, long bufferPoolSize, boolean enableCompression, boolean readOnly, long maxDBSize) {
+    public Database(String databasePath, long bufferPoolSize, boolean enableCompression, boolean readOnly,
+            long maxDBSize, boolean autoCheckpoint, long checkpointThreshold) {
         this.db_path = databasePath;
         this.buffer_size = bufferPoolSize;
         this.enableCompression = enableCompression;
         this.readOnly = readOnly;
         this.max_db_size = maxDBSize;
-        db_ref = Native.kuzu_database_init(databasePath, bufferPoolSize, enableCompression, readOnly, maxDBSize);
+        this.autoCheckpoint = autoCheckpoint;
+        this.checkpointThreshold = checkpointThreshold;
+        db_ref = Native.kuzu_database_init(databasePath, bufferPoolSize, enableCompression, readOnly, maxDBSize,
+                autoCheckpoint, checkpointThreshold);
     }
 
     /**
@@ -63,9 +84,11 @@ public class Database implements AutoCloseable {
     }
 
     /**
-     * Close the database and release the underlying resources. This method is invoked automatically on objects managed by the try-with-resources statement.
+     * Close the database and release the underlying resources. This method is
+     * invoked automatically on objects managed by the try-with-resources statement.
      *
-     * @throws ObjectRefDestroyedException If the database instance has been destroyed.
+     * @throws ObjectRefDestroyedException If the database instance has been
+     *                                     destroyed.
      */
     @Override
     public void close() throws ObjectRefDestroyedException {
@@ -75,7 +98,8 @@ public class Database implements AutoCloseable {
     /**
      * Destroy the database instance.
      *
-     * @throws ObjectRefDestroyedException If the database instance has been destroyed.
+     * @throws ObjectRefDestroyedException If the database instance has been
+     *                                     destroyed.
      */
     private void destroy() throws ObjectRefDestroyedException {
         checkNotDestroyed();

--- a/tools/java_api/src/main/java/com/kuzudb/Native.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Native.java
@@ -68,7 +68,8 @@ public class Native {
 
     // Database
     protected static native long kuzu_database_init(String database_path, long buffer_pool_size,
-            boolean enable_compression, boolean read_only, long max_db_size);
+            boolean enable_compression, boolean read_only, long max_db_size, boolean auto_checkpoint,
+            long checkpoint_threshold);
 
     protected static native void kuzu_database_destroy(Database db);
 

--- a/tools/java_api/src/test/java/com/kuzudb/DatabaseTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/DatabaseTest.java
@@ -25,7 +25,9 @@ public class DatabaseTest extends TestBase {
                 1 << 28 /* 256 MB */,
                 true /* compression */,
                 false /* readOnly */,
-                1 << 30 /* 1 GB */)) {
+                1 << 30 /* 1 GB */,
+                true /* autoCheckpoint */,
+                1 << 24 /* 16 MB */)) {
             // Database will be automatically destroyed after this block
         } catch (Exception e) {
             fail("DBCreationAndDestroyWithArgs failed: " + e.getMessage());

--- a/tools/java_api/src/test/java/com/kuzudb/DatabaseTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/DatabaseTest.java
@@ -9,13 +9,13 @@ import java.nio.file.Path;
 
 public class DatabaseTest extends TestBase {
     @TempDir
-    static Path tempDir;
+    static Path tmpDir;
 
     @Test
     void DBCreationAndDestroyWithArgs() {
         String dbPath = "";
         try {
-            dbPath = tempDir.toFile().getAbsolutePath();
+            dbPath = tmpDir.toFile().getAbsolutePath();
         } catch (Exception e) {
             fail("Cannot get database path: " + e.getMessage());
         }
@@ -48,7 +48,7 @@ public class DatabaseTest extends TestBase {
     void DBCreationAndDestroyWithPathOnly() {
         String dbPath = "";
         try {
-            dbPath = tempDir.toFile().getAbsolutePath();
+            dbPath = tmpDir.toFile().getAbsolutePath();
         } catch (Exception e) {
             fail("Cannot get database path: " + e.getMessage());
         }
@@ -56,8 +56,8 @@ public class DatabaseTest extends TestBase {
         try (Database database = new Database(dbPath)) {
             // check default config
             QueryResult result = conn.query("CALL current_setting('checkpoint_threshold') RETURN *");
-            Long checkpointThreshold = Long.parseLong(result.getNext().getValue(0).toString());
-            assertTrue(checkpointThreshold > 0);
+            String checkpointThresholdStr = result.getNext().getValue(0).toString();
+            assertTrue(Long.parseLong(checkpointThresholdStr) > 0);
         } catch (Exception e) {
             fail("DBCreationAndDestroyWithPathOnly failed: " + e.getMessage());
         }

--- a/tools/nodejs_api/src_cpp/include/node_database.h
+++ b/tools/nodejs_api/src_cpp/include/node_database.h
@@ -30,7 +30,7 @@ private:
     bool readOnly;
     uint64_t maxDBSize;
     bool autoCheckpoint;
-    uint64_t checkpointThreshold;
+    int64_t checkpointThreshold;
     std::shared_ptr<Database> database;
 };
 

--- a/tools/nodejs_api/src_cpp/include/node_database.h
+++ b/tools/nodejs_api/src_cpp/include/node_database.h
@@ -29,6 +29,8 @@ private:
     bool enableCompression;
     bool readOnly;
     uint64_t maxDBSize;
+    bool autoCheckpoint;
+    uint64_t checkpointThreshold;
     std::shared_ptr<Database> database;
 };
 

--- a/tools/nodejs_api/src_cpp/node_database.cpp
+++ b/tools/nodejs_api/src_cpp/node_database.cpp
@@ -23,6 +23,8 @@ NodeDatabase::NodeDatabase(const Napi::CallbackInfo& info) : Napi::ObjectWrap<No
     enableCompression = info[2].As<Napi::Boolean>().Value();
     readOnly = info[3].As<Napi::Boolean>().Value();
     maxDBSize = info[4].As<Napi::Number>().Int64Value();
+    autoCheckpoint = info[5].As<Napi::Boolean>().Value();
+    checkpointThreshold = info[6].As<Napi::Number>().Int64Value();
 }
 
 Napi::Value NodeDatabase::InitAsync(const Napi::CallbackInfo& info) {
@@ -47,6 +49,10 @@ void NodeDatabase::InitCppDatabase() {
     systemConfig.readOnly = readOnly;
     if (maxDBSize > 0) {
         systemConfig.maxDBSize = maxDBSize;
+    }
+    systemConfig.autoCheckpoint = autoCheckpoint;
+    if (checkpointThreshold != std::numeric_limits<uint64_t>::max()) {
+        systemConfig.checkpointThreshold = checkpointThreshold;
     }
     this->database = std::make_shared<Database>(databasePath, systemConfig);
 }

--- a/tools/nodejs_api/src_cpp/node_database.cpp
+++ b/tools/nodejs_api/src_cpp/node_database.cpp
@@ -51,7 +51,7 @@ void NodeDatabase::InitCppDatabase() {
         systemConfig.maxDBSize = maxDBSize;
     }
     systemConfig.autoCheckpoint = autoCheckpoint;
-    if (checkpointThreshold != std::numeric_limits<uint64_t>::max()) {
+    if (checkpointThreshold >= 0) {
         systemConfig.checkpointThreshold = checkpointThreshold;
     }
     this->database = std::make_shared<Database>(databasePath, systemConfig);

--- a/tools/nodejs_api/src_js/database.js
+++ b/tools/nodejs_api/src_js/database.js
@@ -25,7 +25,7 @@ class Database {
     enableCompression = true,
     readOnly = false,
     maxDBSize = 0,
-    autoCheckpoint = false,
+    autoCheckpoint = true,
     checkpointThreshold = -1
   ) {
     if (!databasePath) {

--- a/tools/nodejs_api/src_js/database.js
+++ b/tools/nodejs_api/src_js/database.js
@@ -24,7 +24,9 @@ class Database {
     bufferManagerSize = 0,
     enableCompression = true,
     readOnly = false,
-    maxDBSize = 0
+    maxDBSize = 0,
+    autoCheckpoint = false,
+    checkpointThreshold = -1
   ) {
     if (!databasePath) {
       databasePath = ":memory:";
@@ -38,14 +40,20 @@ class Database {
     if (typeof maxDBSize !== "number" || maxDBSize < 0) {
       throw new Error("Max DB size must be a positive integer.");
     }
+    if (typeof checkpointThreshold !== "number" || maxDBSize < -1) {
+      throw new Error("Checkpoint threshold must be a positive integer.");
+    }
     bufferManagerSize = Math.floor(bufferManagerSize);
     maxDBSize = Math.floor(maxDBSize);
+    checkpointThreshold = Math.floor(checkpointThreshold);
     this._database = new KuzuNative.NodeDatabase(
       databasePath,
       bufferManagerSize,
       enableCompression,
       readOnly,
-      maxDBSize
+      maxDBSize,
+      autoCheckpoint,
+      checkpointThreshold
     );
     this._isInitialized = false;
     this._initPromise = null;

--- a/tools/nodejs_api/test/test_database.js
+++ b/tools/nodejs_api/test/test_database.js
@@ -65,6 +65,12 @@ describe("Database constructor", function () {
     assert.exists(testDb._database);
     assert.isTrue(testDb._isInitialized);
     assert.notExists(testDb._initPromise);
+
+    // check default config
+    let res = await conn.query("CALL current_setting('checkpoint_threshold') RETURN *");
+    assert.equal(res.getNumTuples(), 1);
+    const tuple = await res.getNext();
+    assert.isTrue(tuple["checkpoint_threshold"] > 0);
   });
 
   it("should create a database with auto checkpoint configured", async function () {

--- a/tools/python_api/src_cpp/include/py_database.h
+++ b/tools/python_api/src_cpp/include/py_database.h
@@ -18,7 +18,8 @@ public:
     static uint64_t getStorageVersion();
 
     explicit PyDatabase(const std::string& databasePath, uint64_t bufferPoolSize,
-        uint64_t maxNumThreads, bool compression, bool readOnly, uint64_t maxDBSize);
+        uint64_t maxNumThreads, bool compression, bool readOnly, uint64_t maxDBSize,
+        bool autoCheckpoint, uint64_t checkpointThreshold);
 
     ~PyDatabase();
 

--- a/tools/python_api/src_cpp/include/py_database.h
+++ b/tools/python_api/src_cpp/include/py_database.h
@@ -19,7 +19,7 @@ public:
 
     explicit PyDatabase(const std::string& databasePath, uint64_t bufferPoolSize,
         uint64_t maxNumThreads, bool compression, bool readOnly, uint64_t maxDBSize,
-        bool autoCheckpoint, uint64_t checkpointThreshold);
+        bool autoCheckpoint, int64_t checkpointThreshold);
 
     ~PyDatabase();
 

--- a/tools/python_api/src_cpp/py_database.cpp
+++ b/tools/python_api/src_cpp/py_database.cpp
@@ -11,10 +11,12 @@ using namespace kuzu::common;
 
 void PyDatabase::initialize(py::handle& m) {
     py::class_<PyDatabase>(m, "Database")
-        .def(py::init<const std::string&, uint64_t, uint64_t, bool, bool, uint64_t>(),
+        .def(py::init<const std::string&, uint64_t, uint64_t, bool, bool, uint64_t, bool,
+                 uint64_t>(),
             py::arg("database_path"), py::arg("buffer_pool_size") = 0,
             py::arg("max_num_threads") = 0, py::arg("compression") = true,
-            py::arg("read_only") = false, py::arg("max_db_size") = (uint64_t)1 << 43)
+            py::arg("read_only") = false, py::arg("max_db_size") = (uint64_t)1 << 43,
+            py::arg("auto_checkpoint") = true, py::arg("checkpoint_threshold") = (uint64_t)1 << 24)
         .def("scan_node_table_as_int64", &PyDatabase::scanNodeTable<std::int64_t>,
             py::arg("table_name"), py::arg("prop_name"), py::arg("indices"), py::arg("np_array"),
             py::arg("num_threads"))
@@ -44,9 +46,10 @@ uint64_t PyDatabase::getStorageVersion() {
 }
 
 PyDatabase::PyDatabase(const std::string& databasePath, uint64_t bufferPoolSize,
-    uint64_t maxNumThreads, bool compression, bool readOnly, uint64_t maxDBSize) {
-    auto systemConfig =
-        SystemConfig(bufferPoolSize, maxNumThreads, compression, readOnly, maxDBSize);
+    uint64_t maxNumThreads, bool compression, bool readOnly, uint64_t maxDBSize,
+    bool autoCheckpoint, uint64_t checkpointThreshold) {
+    auto systemConfig = SystemConfig(bufferPoolSize, maxNumThreads, compression, readOnly,
+        maxDBSize, autoCheckpoint, checkpointThreshold);
     database = std::make_unique<Database>(databasePath, systemConfig);
     database->addTableFunction(kuzu::PandasScanFunction::name,
         kuzu::PandasScanFunction::getFunctionSet());

--- a/tools/python_api/src_cpp/py_database.cpp
+++ b/tools/python_api/src_cpp/py_database.cpp
@@ -11,12 +11,12 @@ using namespace kuzu::common;
 
 void PyDatabase::initialize(py::handle& m) {
     py::class_<PyDatabase>(m, "Database")
-        .def(py::init<const std::string&, uint64_t, uint64_t, bool, bool, uint64_t, bool,
-                 uint64_t>(),
+        .def(
+            py::init<const std::string&, uint64_t, uint64_t, bool, bool, uint64_t, bool, int64_t>(),
             py::arg("database_path"), py::arg("buffer_pool_size") = 0,
             py::arg("max_num_threads") = 0, py::arg("compression") = true,
             py::arg("read_only") = false, py::arg("max_db_size") = (uint64_t)1 << 43,
-            py::arg("auto_checkpoint") = true, py::arg("checkpoint_threshold") = (uint64_t)1 << 24)
+            py::arg("auto_checkpoint") = true, py::arg("checkpoint_threshold") = -1)
         .def("scan_node_table_as_int64", &PyDatabase::scanNodeTable<std::int64_t>,
             py::arg("table_name"), py::arg("prop_name"), py::arg("indices"), py::arg("np_array"),
             py::arg("num_threads"))
@@ -47,9 +47,12 @@ uint64_t PyDatabase::getStorageVersion() {
 
 PyDatabase::PyDatabase(const std::string& databasePath, uint64_t bufferPoolSize,
     uint64_t maxNumThreads, bool compression, bool readOnly, uint64_t maxDBSize,
-    bool autoCheckpoint, uint64_t checkpointThreshold) {
+    bool autoCheckpoint, int64_t checkpointThreshold) {
     auto systemConfig = SystemConfig(bufferPoolSize, maxNumThreads, compression, readOnly,
-        maxDBSize, autoCheckpoint, checkpointThreshold);
+        maxDBSize, autoCheckpoint);
+    if (checkpointThreshold >= 0) {
+        systemConfig.checkpointThreshold = static_cast<uint64_t>(checkpointThreshold);
+    }
     database = std::make_unique<Database>(databasePath, systemConfig);
     database->addTableFunction(kuzu::PandasScanFunction::name,
         kuzu::PandasScanFunction::getFunctionSet());

--- a/tools/python_api/src_py/database.py
+++ b/tools/python_api/src_py/database.py
@@ -36,7 +36,7 @@ class Database:
         read_only: bool = False,
         max_db_size: int = (1 << 43),
         auto_checkpoint: bool = True,
-        checkpoint_threshold: int = (1 << 24),  # 16MB
+        checkpoint_threshold: int = -1,
     ):
         """
         Parameters

--- a/tools/python_api/src_py/database.py
+++ b/tools/python_api/src_py/database.py
@@ -35,6 +35,8 @@ class Database:
         lazy_init: bool = False,
         read_only: bool = False,
         max_db_size: int = (1 << 43),
+        auto_checkpoint: bool = True,
+        checkpoint_threshold: int = (1 << 24),  # 16MB
     ):
         """
         Parameters
@@ -73,6 +75,14 @@ class Database:
              a better solution later. The value is default to 1 << 43 (8TB) under 64-bit
              environment and 1GB under 32-bit one.
 
+        auto_checkpoint: bool
+            If true, the database will automatically checkpoint when the size of
+            the WAL file exceeds the checkpoint threshold.
+
+        checkpoint_threshold: int
+            The threshold of the WAL file size in bytes. When the size of the
+            WAL file exceeds this threshold, the database will checkpoint if autoCheckpoint is true.
+
         """
         if database_path is None:
             database_path = ":memory:"
@@ -85,6 +95,8 @@ class Database:
         self.compression = compression
         self.read_only = read_only
         self.max_db_size = max_db_size
+        self.auto_checkpoint = auto_checkpoint
+        self.checkpoint_threshold = checkpoint_threshold
         self.is_closed = False
 
         self._database: Any = None  # (type: _kuzu.Database from pybind11)
@@ -147,6 +159,8 @@ class Database:
                 self.compression,
                 self.read_only,
                 self.max_db_size,
+                self.auto_checkpoint,
+                self.checkpoint_threshold,
             )
 
     def get_torch_geometric_remote_backend(

--- a/tools/rust_api/include/kuzu_rs.h
+++ b/tools/rust_api/include/kuzu_rs.h
@@ -95,7 +95,7 @@ inline uint32_t logical_type_get_decimal_scale(const kuzu::common::LogicalType& 
 /* Database */
 std::unique_ptr<kuzu::main::Database> new_database(std::string_view databasePath,
     uint64_t bufferPoolSize, uint64_t maxNumThreads, bool enableCompression, bool readOnly,
-    uint64_t maxDBSize, bool autoCheckpoint, uint64_t checkpointThreshold);
+    uint64_t maxDBSize, bool autoCheckpoint, int64_t checkpointThreshold);
 
 void database_set_logging_level(kuzu::main::Database& database, const std::string& level);
 

--- a/tools/rust_api/include/kuzu_rs.h
+++ b/tools/rust_api/include/kuzu_rs.h
@@ -95,7 +95,7 @@ inline uint32_t logical_type_get_decimal_scale(const kuzu::common::LogicalType& 
 /* Database */
 std::unique_ptr<kuzu::main::Database> new_database(std::string_view databasePath,
     uint64_t bufferPoolSize, uint64_t maxNumThreads, bool enableCompression, bool readOnly,
-    uint64_t maxDBSize);
+    uint64_t maxDBSize, bool autoCheckpoint, uint64_t checkpointThreshold);
 
 void database_set_logging_level(kuzu::main::Database& database, const std::string& level);
 

--- a/tools/rust_api/src/database.rs
+++ b/tools/rust_api/src/database.rs
@@ -36,7 +36,7 @@ pub struct SystemConfig {
     /// The maximum size of the database. Defaults to 8TB
     max_db_size: u64,
     /// If true, the database will automatically checkpoint when the size of the WAL file exceeds the checkpoint threshold.
-    auto_checkpoint : bool,
+    auto_checkpoint: bool,
     /// The threshold of the WAL file size in bytes. When the size of the WAL file exceeds this threshold, the database will checkpoint if autoCheckpoint is true.
     checkpoint_threshold: u64,
 }
@@ -50,8 +50,8 @@ impl Default for SystemConfig {
             read_only: false,
             // This is a little weird, but it's a temporary interface
             max_db_size: u32::MAX as u64,
-            auto_checkpoint : true,
-            checkpoint_threshold: u64::MAX as u64
+            auto_checkpoint: true,
+            checkpoint_threshold: u64::MAX as u64,
         }
     }
 }
@@ -197,26 +197,38 @@ mod tests {
     #[test]
     fn test_database_auto_checkpoint() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), SystemConfig::default().auto_checkpoint(false))?;
+        let db = Database::new(
+            temp_dir.path(),
+            SystemConfig::default().auto_checkpoint(false),
+        )?;
         let conn = Connection::new(&db)?;
-        let result = conn
-            .query("CALL current_setting('auto_checkpoint') RETURN *");
-        assert_eq!(result?.next().unwrap()[0], Value::String("False".to_string()));
+        let result = conn.query("CALL current_setting('auto_checkpoint') RETURN *");
+        assert_eq!(
+            result?.next().unwrap()[0],
+            Value::String("False".to_string())
+        );
         // check default checkpoint threshold
-        let result = conn
-            .query("CALL current_setting('checkpoint_threshold') RETURN *");
-        assert_eq!(result?.next().unwrap()[0], Value::String("16777216".to_string()));
+        let result = conn.query("CALL current_setting('checkpoint_threshold') RETURN *");
+        assert_eq!(
+            result?.next().unwrap()[0],
+            Value::String("16777216".to_string())
+        );
         Ok(())
     }
 
     #[test]
     fn test_database_checkpoint_threshold() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), SystemConfig::default().checkpoint_threshold(1234))?;
+        let db = Database::new(
+            temp_dir.path(),
+            SystemConfig::default().checkpoint_threshold(1234),
+        )?;
         let conn = Connection::new(&db)?;
-        let result = conn
-            .query("CALL current_setting('checkpoint_threshold') RETURN *");
-        assert_eq!(result?.next().unwrap()[0], Value::String("1234".to_string()));
+        let result = conn.query("CALL current_setting('checkpoint_threshold') RETURN *");
+        assert_eq!(
+            result?.next().unwrap()[0],
+            Value::String("1234".to_string())
+        );
         Ok(())
     }
 

--- a/tools/rust_api/src/database.rs
+++ b/tools/rust_api/src/database.rs
@@ -38,7 +38,7 @@ pub struct SystemConfig {
     /// If true, the database will automatically checkpoint when the size of the WAL file exceeds the checkpoint threshold.
     auto_checkpoint: bool,
     /// The threshold of the WAL file size in bytes. When the size of the WAL file exceeds this threshold, the database will checkpoint if autoCheckpoint is true.
-    checkpoint_threshold: u64,
+    checkpoint_threshold: i64,
 }
 
 impl Default for SystemConfig {
@@ -81,7 +81,7 @@ impl SystemConfig {
         self.auto_checkpoint = auto_checkpoint;
         self
     }
-    pub fn checkpoint_threshold(mut self, checkpoint_threshold: u64) -> Self {
+    pub fn checkpoint_threshold(mut self, checkpoint_threshold: i64) -> Self {
         self.checkpoint_threshold = checkpoint_threshold;
         self
     }

--- a/tools/rust_api/src/database.rs
+++ b/tools/rust_api/src/database.rs
@@ -51,7 +51,7 @@ impl Default for SystemConfig {
             // This is a little weird, but it's a temporary interface
             max_db_size: u32::MAX as u64,
             auto_checkpoint: true,
-            checkpoint_threshold: u64::MAX as u64,
+            checkpoint_threshold: -1 as i64,
         }
     }
 }

--- a/tools/rust_api/src/database.rs
+++ b/tools/rust_api/src/database.rs
@@ -35,6 +35,10 @@ pub struct SystemConfig {
     read_only: bool,
     /// The maximum size of the database. Defaults to 8TB
     max_db_size: u64,
+    /// If true, the database will automatically checkpoint when the size of the WAL file exceeds the checkpoint threshold.
+    auto_checkpoint : bool,
+    /// The threshold of the WAL file size in bytes. When the size of the WAL file exceeds this threshold, the database will checkpoint if autoCheckpoint is true.
+    checkpoint_threshold: u64,
 }
 
 impl Default for SystemConfig {
@@ -46,6 +50,8 @@ impl Default for SystemConfig {
             read_only: false,
             // This is a little weird, but it's a temporary interface
             max_db_size: u32::MAX as u64,
+            auto_checkpoint : true,
+            checkpoint_threshold: u64::MAX as u64
         }
     }
 }
@@ -71,6 +77,14 @@ impl SystemConfig {
         self.max_db_size = max_db_size;
         self
     }
+    pub fn auto_checkpoint(mut self, auto_checkpoint: bool) -> Self {
+        self.auto_checkpoint = auto_checkpoint;
+        self
+    }
+    pub fn checkpoint_threshold(mut self, checkpoint_threshold: u64) -> Self {
+        self.checkpoint_threshold = checkpoint_threshold;
+        self
+    }
 }
 
 pub(crate) const IN_MEMORY_DB_NAME: &str = ":memory:";
@@ -92,6 +106,8 @@ impl Database {
                 config.enable_compression,
                 config.read_only,
                 config.max_db_size,
+                config.auto_checkpoint,
+                config.checkpoint_threshold,
             )?),
         })
     }
@@ -118,6 +134,7 @@ mod tests {
 
     use crate::connection::Connection;
     use crate::database::{Database, SystemConfig};
+    use crate::value::Value;
     use std::collections::HashSet;
 
     #[test]
@@ -174,6 +191,32 @@ mod tests {
             Database::new(temp_dir.path(), SystemConfig::default().max_db_size(0))
                 .expect_err("0 is not a valid max DB size");
         }
+        Ok(())
+    }
+
+    #[test]
+    fn test_database_auto_checkpoint() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let db = Database::new(temp_dir.path(), SystemConfig::default().auto_checkpoint(false))?;
+        let conn = Connection::new(&db)?;
+        let result = conn
+            .query("CALL current_setting('auto_checkpoint') RETURN *");
+        assert_eq!(result?.next().unwrap()[0], Value::String("False".to_string()));
+        // check default checkpoint threshold
+        let result = conn
+            .query("CALL current_setting('checkpoint_threshold') RETURN *");
+        assert_eq!(result?.next().unwrap()[0], Value::String("16777216".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn test_database_checkpoint_threshold() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let db = Database::new(temp_dir.path(), SystemConfig::default().checkpoint_threshold(1234))?;
+        let conn = Connection::new(&db)?;
+        let result = conn
+            .query("CALL current_setting('checkpoint_threshold') RETURN *");
+        assert_eq!(result?.next().unwrap()[0], Value::String("1234".to_string()));
         Ok(())
     }
 

--- a/tools/rust_api/src/ffi.rs
+++ b/tools/rust_api/src/ffi.rs
@@ -158,7 +158,7 @@ pub(crate) mod ffi {
             readOnly: bool,
             maxDBSize: u64,
             auto_checkpoint: bool,
-            checkpoint_threshold: u64,
+            checkpoint_threshold: i64,
         ) -> Result<UniquePtr<Database>>;
 
     }

--- a/tools/rust_api/src/ffi.rs
+++ b/tools/rust_api/src/ffi.rs
@@ -157,6 +157,8 @@ pub(crate) mod ffi {
             enableCompression: bool,
             readOnly: bool,
             maxDBSize: u64,
+            auto_checkpoint : bool,
+            checkpoint_threshold: u64,
         ) -> Result<UniquePtr<Database>>;
 
     }

--- a/tools/rust_api/src/ffi.rs
+++ b/tools/rust_api/src/ffi.rs
@@ -157,7 +157,7 @@ pub(crate) mod ffi {
             enableCompression: bool,
             readOnly: bool,
             maxDBSize: u64,
-            auto_checkpoint : bool,
+            auto_checkpoint: bool,
             checkpoint_threshold: u64,
         ) -> Result<UniquePtr<Database>>;
 

--- a/tools/rust_api/src/kuzu_rs.cpp
+++ b/tools/rust_api/src/kuzu_rs.cpp
@@ -67,7 +67,7 @@ std::unique_ptr<std::vector<kuzu::common::LogicalType>> logical_type_get_struct_
 
 std::unique_ptr<Database> new_database(std::string_view databasePath, uint64_t bufferPoolSize,
     uint64_t maxNumThreads, bool enableCompression, bool readOnly, uint64_t maxDBSize,
-    bool autoCheckpoint, uint64_t checkpointThreshold) {
+    bool autoCheckpoint, int64_t checkpointThreshold) {
     auto systemConfig = SystemConfig();
     if (bufferPoolSize > 0) {
         systemConfig.bufferPoolSize = bufferPoolSize;
@@ -81,7 +81,7 @@ std::unique_ptr<Database> new_database(std::string_view databasePath, uint64_t b
         systemConfig.maxDBSize = maxDBSize;
     }
     systemConfig.autoCheckpoint = autoCheckpoint;
-    if (checkpointThreshold != std::numeric_limits<uint64_t>::max()) {
+    if (checkpointThreshold >= 0) {
         systemConfig.checkpointThreshold = checkpointThreshold;
     }
     return std::make_unique<Database>(databasePath, systemConfig);

--- a/tools/rust_api/src/kuzu_rs.cpp
+++ b/tools/rust_api/src/kuzu_rs.cpp
@@ -66,7 +66,8 @@ std::unique_ptr<std::vector<kuzu::common::LogicalType>> logical_type_get_struct_
 }
 
 std::unique_ptr<Database> new_database(std::string_view databasePath, uint64_t bufferPoolSize,
-    uint64_t maxNumThreads, bool enableCompression, bool readOnly, uint64_t maxDBSize) {
+    uint64_t maxNumThreads, bool enableCompression, bool readOnly, uint64_t maxDBSize,
+    bool autoCheckpoint, uint64_t checkpointThreshold) {
     auto systemConfig = SystemConfig();
     if (bufferPoolSize > 0) {
         systemConfig.bufferPoolSize = bufferPoolSize;
@@ -78,6 +79,10 @@ std::unique_ptr<Database> new_database(std::string_view databasePath, uint64_t b
     systemConfig.enableCompression = enableCompression;
     if (maxDBSize != -1u) {
         systemConfig.maxDBSize = maxDBSize;
+    }
+    systemConfig.autoCheckpoint = autoCheckpoint;
+    if (checkpointThreshold != std::numeric_limits<uint64_t>::max()) {
+        systemConfig.checkpointThreshold = checkpointThreshold;
     }
     return std::make_unique<Database>(databasePath, systemConfig);
 }


### PR DESCRIPTION
# Description

Add `auto_checkpoint` and `checkpoint_threshold` configurations to the API bindings.

Fixes #4575 

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).