### PR TITLE
Implement show-indexes function

### DIFF
--- a/extension/fts/src/function/create_fts_index.cpp
+++ b/extension/fts/src/function/create_fts_index.cpp
@@ -234,9 +234,8 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput& /*output
     auto avgDocLen = numDocs == 0 ? 0 : static_cast<double>(sharedState.totalLen.load()) / numDocs;
     context.clientContext->getCatalog()->createIndex(context.clientContext->getTransaction(),
         std::make_unique<catalog::IndexCatalogEntry>(FTSIndexCatalogEntry::TYPE_NAME,
-            bindData.tableID, bindData.indexName,
-            std::make_unique<FTSIndexAuxInfo>(numDocs, avgDocLen, bindData.properties,
-                bindData.ftsConfig)));
+            bindData.tableID, bindData.indexName, bindData.properties,
+            std::make_unique<FTSIndexAuxInfo>(numDocs, avgDocLen, bindData.ftsConfig)));
     return 0;
 }
 

--- a/extension/fts/src/include/catalog/fts_index_catalog_entry.h
+++ b/extension/fts/src/include/catalog/fts_index_catalog_entry.h
@@ -12,17 +12,13 @@ namespace fts_extension {
 struct FTSIndexAuxInfo final : catalog::IndexAuxInfo {
     common::idx_t numDocs = 0;
     double avgDocLen = 0;
-    std::vector<std::string> properties;
     FTSConfig config;
 
-    FTSIndexAuxInfo(common::idx_t numDocs, double avgDocLen, std::vector<std::string> properties,
-        FTSConfig config)
-        : numDocs{numDocs}, avgDocLen{avgDocLen}, properties{std::move(properties)},
-          config{std::move(config)} {}
+    FTSIndexAuxInfo(common::idx_t numDocs, double avgDocLen, FTSConfig config)
+        : numDocs{numDocs}, avgDocLen{avgDocLen}, config{std::move(config)} {}
 
     FTSIndexAuxInfo(const FTSIndexAuxInfo& other)
-        : numDocs{other.numDocs}, avgDocLen{other.avgDocLen}, properties{other.properties},
-          config{other.config} {}
+        : numDocs{other.numDocs}, avgDocLen{other.avgDocLen}, config{other.config} {}
 
     std::shared_ptr<common::BufferedSerializer> serialize() const override;
     static std::unique_ptr<FTSIndexAuxInfo> deserialize(
@@ -33,7 +29,7 @@ struct FTSIndexAuxInfo final : catalog::IndexAuxInfo {
     }
 
     std::string toCypher(const catalog::IndexCatalogEntry& indexEntry,
-        main::ClientContext* context) override;
+        const main::ClientContext* context) const override;
 };
 
 struct FTSIndexCatalogEntry {

--- a/extension/fts/test/test_files/fts_small.test
+++ b/extension/fts/test/test_files/fts_small.test
@@ -283,3 +283,38 @@ Binder exception: Table: 0_docIdx3_appears_info already exists. Please drop or r
 -STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx4', ['content'])
 ---- error
 Binder exception: Table: 0_docIdx4_appears_in already exists. Please drop or rename the table before creating a full text search index.
+
+-CASE show_indexes
+-SKIP_IN_MEM
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
+---- ok
+-STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx', ['content', 'author', 'name'])
+---- ok
+-STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx1', ['content'])
+---- ok
+-STATEMENT CALL SHOW_INDEXES() RETURN *
+---- 2
+doc|docIdx1|FTS|[content]|True|CALL CREATE_FTS_INDEX('doc', 'docIdx1', ['content' ], stemmer := 'english');
+doc|docIdx|FTS|[content,author,name]|True|CALL CREATE_FTS_INDEX('doc', 'docIdx', ['content', 'author', 'name' ], stemmer := 'english');
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec', distFunc := 'l2');
+---- ok
+-STATEMENT CALL SHOW_INDEXES() RETURN *
+---- 3
+doc|docIdx1|FTS|[content]|True|CALL CREATE_FTS_INDEX('doc', 'docIdx1', ['content' ], stemmer := 'english');
+doc|docIdx|FTS|[content,author,name]|True|CALL CREATE_FTS_INDEX('doc', 'docIdx', ['content', 'author', 'name' ], stemmer := 'english');
+embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec', mu := 30, ml := 60, pu := 0.050000, distFunc := 'l2', alpha := 1.100000, efc := 200);
+-RELOADDB
+-STATEMENT CALL SHOW_INDEXES() RETURN *
+---- 3
+doc|docIdx1|FTS|[content]|False|
+doc|docIdx|FTS|[content,author,name]|False|
+embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec', mu := 30, ml := 60, pu := 0.050000, distFunc := 'l2', alpha := 1.100000, efc := 200);
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
+---- ok
+-STATEMENT CALL SHOW_INDEXES() RETURN *
+---- 3
+doc|docIdx1|FTS|[content]|True|CALL CREATE_FTS_INDEX('doc', 'docIdx1', ['content' ], stemmer := 'english');
+doc|docIdx|FTS|[content,author,name]|True|CALL CREATE_FTS_INDEX('doc', 'docIdx', ['content', 'author', 'name' ], stemmer := 'english');
+embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec', mu := 30, ml := 60, pu := 0.050000, distFunc := 'l2', alpha := 1.100000, efc := 200);

--- a/src/catalog/catalog_entry/hnsw_index_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/hnsw_index_catalog_entry.cpp
@@ -15,7 +15,6 @@ std::shared_ptr<common::BufferedSerializer> HNSWIndexAuxInfo::serialize() const 
     auto serializer = common::Serializer(bufferWriter);
     serializer.serializeValue(upperRelTableID);
     serializer.serializeValue(lowerRelTableID);
-    serializer.serializeValue(columnName);
     serializer.serializeValue(upperEntryPoint);
     serializer.serializeValue(lowerEntryPoint);
     config.serialize(serializer);
@@ -26,22 +25,20 @@ std::unique_ptr<HNSWIndexAuxInfo> HNSWIndexAuxInfo::deserialize(
     std::unique_ptr<common::BufferReader> reader) {
     common::table_id_t upperRelTableID = common::INVALID_TABLE_ID;
     common::table_id_t lowerRelTableID = common::INVALID_TABLE_ID;
-    std::string columnName;
     common::offset_t upperEntryPoint = common::INVALID_OFFSET;
     common::offset_t lowerEntryPoint = common::INVALID_OFFSET;
     common::Deserializer deSer{std::move(reader)};
     deSer.deserializeValue(upperRelTableID);
     deSer.deserializeValue(lowerRelTableID);
-    deSer.deserializeValue(columnName);
     deSer.deserializeValue(upperEntryPoint);
     deSer.deserializeValue(lowerEntryPoint);
     auto config = storage::HNSWIndexConfig::deserialize(deSer);
-    return std::make_unique<HNSWIndexAuxInfo>(upperRelTableID, lowerRelTableID, columnName,
-        upperEntryPoint, lowerEntryPoint, std::move(config));
+    return std::make_unique<HNSWIndexAuxInfo>(upperRelTableID, lowerRelTableID, upperEntryPoint,
+        lowerEntryPoint, std::move(config));
 }
 
 std::string HNSWIndexAuxInfo::toCypher(const IndexCatalogEntry& indexEntry,
-    main::ClientContext* context) {
+    const main::ClientContext* context) const {
     std::string cypher;
     auto catalog = context->getCatalog();
     auto tableName =
@@ -49,9 +46,9 @@ std::string HNSWIndexAuxInfo::toCypher(const IndexCatalogEntry& indexEntry,
             ->getName();
     auto distFuncName = storage::HNSWIndexConfig::distFuncToString(config.distFunc);
     cypher += common::stringFormat("CALL CREATE_HNSW_INDEX('{}', '{}', '{}', mu := {}, ml := {}, "
-                                   "pu := {}, distFunc := '{}', alpha := {}, efc := {});\n",
-        indexEntry.getIndexName(), tableName, columnName, config.mu, config.ml, config.pu,
-        distFuncName, config.alpha, config.efc);
+                                   "pu := {}, distFunc := '{}', alpha := {}, efc := {});",
+        indexEntry.getIndexName(), tableName, indexEntry.getProperties()[0], config.mu, config.ml,
+        config.pu, distFuncName, config.alpha, config.efc);
     return cypher;
 }
 

--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -37,22 +37,23 @@ namespace kuzu {
 namespace function {
 
 #define SCALAR_FUNCTION_BASE(_PARAM, _NAME)                                                        \
-    {_PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
 #define SCALAR_FUNCTION(_PARAM) SCALAR_FUNCTION_BASE(_PARAM, _PARAM::name)
 #define SCALAR_FUNCTION_ALIAS(_PARAM) SCALAR_FUNCTION_BASE(_PARAM::alias, _PARAM::name)
 #define REWRITE_FUNCTION(_PARAM)                                                                   \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY }
 #define AGGREGATE_FUNCTION(_PARAM)                                                                 \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY }
 #define EXPORT_FUNCTION(_PARAM)                                                                    \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY }
 #define TABLE_FUNCTION(_PARAM)                                                                     \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY }
 #define STANDALONE_TABLE_FUNCTION(_PARAM)                                                          \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY }
 #define ALGORITHM_FUNCTION(_PARAM)                                                                 \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY}
-#define FINAL_FUNCTION {nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY }
+#define FINAL_FUNCTION                                                                             \
+    { nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
 
 FunctionCollection* FunctionCollection::getFunctions() {
     static FunctionCollection functions[] = {

--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -37,23 +37,22 @@ namespace kuzu {
 namespace function {
 
 #define SCALAR_FUNCTION_BASE(_PARAM, _NAME)                                                        \
-    { _PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
 #define SCALAR_FUNCTION(_PARAM) SCALAR_FUNCTION_BASE(_PARAM, _PARAM::name)
 #define SCALAR_FUNCTION_ALIAS(_PARAM) SCALAR_FUNCTION_BASE(_PARAM::alias, _PARAM::name)
 #define REWRITE_FUNCTION(_PARAM)                                                                   \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY}
 #define AGGREGATE_FUNCTION(_PARAM)                                                                 \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY}
 #define EXPORT_FUNCTION(_PARAM)                                                                    \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY}
 #define TABLE_FUNCTION(_PARAM)                                                                     \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY}
 #define STANDALONE_TABLE_FUNCTION(_PARAM)                                                          \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY}
 #define ALGORITHM_FUNCTION(_PARAM)                                                                 \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY }
-#define FINAL_FUNCTION                                                                             \
-    { nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY}
+#define FINAL_FUNCTION {nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
 
 FunctionCollection* FunctionCollection::getFunctions() {
     static FunctionCollection functions[] = {
@@ -219,7 +218,7 @@ FunctionCollection* FunctionCollection::getFunctions() {
         TABLE_FUNCTION(ShowAttachedDatabasesFunction), TABLE_FUNCTION(ShowSequencesFunction),
         TABLE_FUNCTION(ShowFunctionsFunction), TABLE_FUNCTION(BMInfoFunction),
         TABLE_FUNCTION(QueryHNSWIndexFunction), TABLE_FUNCTION(ShowLoadedExtensionsFunction),
-        TABLE_FUNCTION(ShowOfficialExtensionsFunction),
+        TABLE_FUNCTION(ShowOfficialExtensionsFunction), TABLE_FUNCTION(ShowIndexesFunction),
 
         // Standalone Table functions
         STANDALONE_TABLE_FUNCTION(ClearWarningsFunction),

--- a/src/function/table/call/CMakeLists.txt
+++ b/src/function/table/call/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(kuzu_table_call
         table_info.cpp
         show_sequences.cpp
         show_functions.cpp
+        show_indexes.cpp
         show_loaded_extensions.cpp
         show_official_extensions.cpp)
 

--- a/src/function/table/call/hnsw/create_hnsw_index.cpp
+++ b/src/function/table/call/hnsw/create_hnsw_index.cpp
@@ -15,8 +15,8 @@ namespace function {
 CreateHNSWSharedState::CreateHNSWSharedState(const CreateHNSWIndexBindData& bindData)
     : SimpleTableFuncSharedState{bindData.maxOffset}, name{bindData.indexName},
       nodeTable{bindData.context->getStorageManager()
-                    ->getTable(bindData.tableEntry->getTableID())
-                    ->cast<storage::NodeTable>()},
+              ->getTable(bindData.tableEntry->getTableID())
+              ->cast<storage::NodeTable>()},
       numNodes{bindData.numNodes}, bindData{&bindData} {
     hnswIndex = std::make_unique<storage::InMemHNSWIndex>(bindData.context, nodeTable,
         bindData.columnID, bindData.config.copy());
@@ -94,11 +94,14 @@ static void finalizeFunc(const processor::ExecutionContext* context,
                 storage::HNSWIndexUtils::getLowerGraphTableName(bindData->indexName))
             ->getTableID();
     auto auxInfo = std::make_unique<catalog::HNSWIndexAuxInfo>(upperRelTableID, lowerRelTableID,
-        hnswSharedState->nodeTable.getColumn(bindData->columnID).getName(),
+
         index->getUpperEntryPoint(), index->getLowerEntryPoint(), bindData->config.copy());
     auto indexEntry =
         std::make_unique<catalog::IndexCatalogEntry>(catalog::HNSWIndexCatalogEntry::TYPE_NAME,
-            bindData->tableEntry->getTableID(), bindData->indexName, std::move(auxInfo));
+            bindData->tableEntry->getTableID(), bindData->indexName,
+            std::vector<std::string>{
+                hnswSharedState->nodeTable.getColumn(bindData->columnID).getName()},
+            std::move(auxInfo));
     catalog->createIndex(transaction, std::move(indexEntry));
 }
 

--- a/src/function/table/call/hnsw/create_hnsw_index.cpp
+++ b/src/function/table/call/hnsw/create_hnsw_index.cpp
@@ -15,8 +15,8 @@ namespace function {
 CreateHNSWSharedState::CreateHNSWSharedState(const CreateHNSWIndexBindData& bindData)
     : SimpleTableFuncSharedState{bindData.maxOffset}, name{bindData.indexName},
       nodeTable{bindData.context->getStorageManager()
-              ->getTable(bindData.tableEntry->getTableID())
-              ->cast<storage::NodeTable>()},
+                    ->getTable(bindData.tableEntry->getTableID())
+                    ->cast<storage::NodeTable>()},
       numNodes{bindData.numNodes}, bindData{&bindData} {
     hnswIndex = std::make_unique<storage::InMemHNSWIndex>(bindData.context, nodeTable,
         bindData.columnID, bindData.config.copy());

--- a/src/function/table/call/show_indexes.cpp
+++ b/src/function/table/call/show_indexes.cpp
@@ -76,7 +76,7 @@ static binder::expression_vector bindColumns(binder::Binder& binder) {
     columnTypes.emplace_back(LogicalType::STRING());
     columnNames.emplace_back("property names");
     columnTypes.emplace_back(LogicalType::LIST(LogicalType::STRING()));
-    columnNames.emplace_back("dependency loaded");
+    columnNames.emplace_back("extension loaded");
     columnTypes.emplace_back(LogicalType::BOOL());
     columnNames.emplace_back("index definition");
     columnTypes.emplace_back(LogicalType::STRING());

--- a/src/function/table/call/show_indexes.cpp
+++ b/src/function/table/call/show_indexes.cpp
@@ -1,0 +1,123 @@
+#include "binder/binder.h"
+#include "catalog/catalog.h"
+#include "catalog/catalog_entry/index_catalog_entry.h"
+#include "function/table/simple_table_functions.h"
+
+using namespace kuzu::catalog;
+using namespace kuzu::common;
+using namespace kuzu::main;
+
+namespace kuzu {
+namespace function {
+
+struct IndexInfo {
+    std::string tableName;
+    std::string indexName;
+    std::string indexType;
+    std::vector<std::string> properties;
+    bool dependencyLoaded;
+    std::string indexDefinition;
+
+    IndexInfo(std::string tableName, std::string indexName, std::string indexType,
+        std::vector<std::string> properties, bool dependencyLoaded, std::string indexDefinition)
+        : tableName{std::move(tableName)}, indexName{std::move(indexName)},
+          indexType{std::move(indexType)}, properties{std::move(properties)},
+          dependencyLoaded{dependencyLoaded}, indexDefinition{std::move(indexDefinition)} {}
+};
+
+struct ShowIndexesBindData final : SimpleTableFuncBindData {
+    std::vector<IndexInfo> indexesInfo;
+
+    ShowIndexesBindData(std::vector<IndexInfo> indexesInfo, binder::expression_vector columns,
+        offset_t maxOffset)
+        : SimpleTableFuncBindData{std::move(columns), maxOffset},
+          indexesInfo{std::move(indexesInfo)} {}
+
+    std::unique_ptr<TableFuncBindData> copy() const override {
+        return std::make_unique<ShowIndexesBindData>(*this);
+    }
+};
+
+static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput& output) {
+    auto& dataChunk = output.dataChunk;
+    const auto sharedState = input.sharedState->ptrCast<SimpleTableFuncSharedState>();
+    const auto morsel = sharedState->getMorsel();
+    if (!morsel.hasMoreToOutput()) {
+        return 0;
+    }
+    auto& indexesInfo = input.bindData->constPtrCast<ShowIndexesBindData>()->indexesInfo;
+    auto numTuplesToOutput = morsel.endOffset - morsel.startOffset;
+    auto& propertyVector = dataChunk.getValueVectorMutable(3);
+    auto propertyDataVec = ListVector::getDataVector(&propertyVector);
+    for (auto i = 0u; i < numTuplesToOutput; i++) {
+        auto indexInfo = indexesInfo[morsel.startOffset + i];
+        dataChunk.getValueVectorMutable(0).setValue(i, indexInfo.tableName);
+        dataChunk.getValueVectorMutable(1).setValue(i, indexInfo.indexName);
+        dataChunk.getValueVectorMutable(2).setValue(i, indexInfo.indexType);
+        auto listEntry = ListVector::addList(&propertyVector, indexInfo.properties.size());
+        for (auto j = 0u; j < indexInfo.properties.size(); j++) {
+            propertyDataVec->setValue(listEntry.offset + j, indexInfo.properties[j]);
+        }
+        propertyVector.setValue(i, listEntry);
+        dataChunk.getValueVectorMutable(4).setValue(i, indexInfo.dependencyLoaded);
+        dataChunk.getValueVectorMutable(5).setValue(i, indexInfo.indexDefinition);
+    }
+    return numTuplesToOutput;
+}
+
+static binder::expression_vector bindColumns(binder::Binder& binder) {
+    std::vector<std::string> columnNames;
+    std::vector<LogicalType> columnTypes;
+    columnNames.emplace_back("table name");
+    columnTypes.emplace_back(LogicalType::STRING());
+    columnNames.emplace_back("index name");
+    columnTypes.emplace_back(LogicalType::STRING());
+    columnNames.emplace_back("index type");
+    columnTypes.emplace_back(LogicalType::STRING());
+    columnNames.emplace_back("property names");
+    columnTypes.emplace_back(LogicalType::LIST(LogicalType::STRING()));
+    columnNames.emplace_back("dependency loaded");
+    columnTypes.emplace_back(LogicalType::BOOL());
+    columnNames.emplace_back("index definition");
+    columnTypes.emplace_back(LogicalType::STRING());
+    return binder.createVariables(columnNames, columnTypes);
+}
+
+static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* context,
+    const TableFuncBindInput* input) {
+    std::vector<IndexInfo> indexesInfo;
+    auto catalog = context->getCatalog();
+    auto indexEntries = catalog->getIndexEntries(context->getTransaction());
+    for (auto indexEntry : indexEntries) {
+        auto tableName =
+            catalog->getTableCatalogEntry(context->getTransaction(), indexEntry->getTableID())
+                ->getName();
+        auto indexName = indexEntry->getIndexName();
+        auto indexType = indexEntry->getIndexType();
+        auto properties = indexEntry->getProperties();
+        auto dependencyLoaded = indexEntry->isLoaded();
+        std::string indexDefinition;
+        if (dependencyLoaded) {
+            auto& auxInfo = indexEntry->getAuxInfo();
+            indexDefinition = auxInfo.toCypher(*indexEntry, context);
+        }
+        indexesInfo.emplace_back(std::move(tableName), std::move(indexName), std::move(indexType),
+            std::move(properties), dependencyLoaded, std::move(indexDefinition));
+    }
+    return std::make_unique<ShowIndexesBindData>(indexesInfo, bindColumns(*input->binder),
+        indexesInfo.size());
+}
+
+function_set ShowIndexesFunction::getFunctionSet() {
+    function_set functionSet;
+    auto function = std::make_unique<TableFunction>(name, std::vector<common::LogicalTypeID>{});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = initEmptyLocalState;
+    functionSet.push_back(std::move(function));
+    return functionSet;
+}
+
+} // namespace function
+} // namespace kuzu

--- a/src/include/catalog/catalog_entry/hnsw_index_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/hnsw_index_catalog_entry.h
@@ -13,22 +13,21 @@ struct HNSWIndexAuxInfo final : IndexAuxInfo {
 
     common::table_id_t upperRelTableID = common::INVALID_TABLE_ID;
     common::table_id_t lowerRelTableID = common::INVALID_TABLE_ID;
-    std::string columnName;
     common::offset_t upperEntryPoint = common::INVALID_OFFSET;
     common::offset_t lowerEntryPoint = common::INVALID_OFFSET;
     storage::HNSWIndexConfig config;
 
     HNSWIndexAuxInfo(common::table_id_t upperRelTableID, common::table_id_t lowerRelTableID,
-        std::string columnName, common::offset_t upperEntryPoint, common::offset_t lowerEntryPoint,
+        common::offset_t upperEntryPoint, common::offset_t lowerEntryPoint,
         storage::HNSWIndexConfig config)
         : upperRelTableID{upperRelTableID}, lowerRelTableID{lowerRelTableID},
-          columnName{std::move(columnName)}, upperEntryPoint{upperEntryPoint},
-          lowerEntryPoint{lowerEntryPoint}, config{std::move(config)} {}
+          upperEntryPoint{upperEntryPoint}, lowerEntryPoint{lowerEntryPoint},
+          config{std::move(config)} {}
 
     HNSWIndexAuxInfo(const HNSWIndexAuxInfo& other)
         : upperRelTableID{other.upperRelTableID}, lowerRelTableID{other.lowerRelTableID},
-          columnName{other.columnName}, upperEntryPoint{other.upperEntryPoint},
-          lowerEntryPoint{other.lowerEntryPoint}, config{other.config.copy()} {}
+          upperEntryPoint{other.upperEntryPoint}, lowerEntryPoint{other.lowerEntryPoint},
+          config{other.config.copy()} {}
 
     std::shared_ptr<common::BufferedSerializer> serialize() const override;
     static std::unique_ptr<HNSWIndexAuxInfo> deserialize(
@@ -39,7 +38,7 @@ struct HNSWIndexAuxInfo final : IndexAuxInfo {
     }
 
     std::string toCypher(const IndexCatalogEntry& indexEntry,
-        main::ClientContext* context) override;
+        const main::ClientContext* context) const override;
 };
 
 struct HNSWIndexCatalogEntry {

--- a/src/include/function/table/simple_table_functions.h
+++ b/src/include/function/table/simple_table_functions.h
@@ -164,5 +164,11 @@ struct ShowOfficialExtensionsFunction final : SimpleTableFunction {
     static function_set getFunctionSet();
 };
 
+struct ShowIndexesFunction final : SimpleTableFunction {
+    static constexpr const char* name = "SHOW_INDEXES";
+
+    static function_set getFunctionSet();
+};
+
 } // namespace function
 } // namespace kuzu

--- a/test/test_files/function/hnsw/small.test
+++ b/test/test_files/function/hnsw/small.test
@@ -161,3 +161,6 @@ Binder exception: _e_hnsw_index_LOWER already exists in catalog.
 499
 581
 58
+-STATEMENT CALL SHOW_INDEXES() RETURN *
+---- 1
+embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec', mu := 30, ml := 60, pu := 0.050000, distFunc := 'dotproduct', alpha := 1.100000, efc := 200);


### PR DESCRIPTION
This PR implements the `show_indexes` call function.
Usage:
```
CALL SHOW_INDEXES() RETURN *
```
This function returns all indexes currently available in the system, including those fields:
| **Field Name**        | **Description**                                                                 |
|------------------------|---------------------------------------------------------------------------------|
| **table name**         | The table name on which the index is built.                                    |
| **index name**         | The name of the index.                                                         |
| **index type**         | The type of the index (e.g., `hnsw`, `fts`).                                   |
| **property names**     | The properties of the table on which the index is built.                       |
| **dependency loaded**  | Indicates whether the depended extension is loaded (`true` or `false`).          |
| **index description**  | The Cypher query used to create the index.                                     |

For indexes which depends on an extension:
1. The extension is loaded:
The `dependency loaded` column will be true, and the index description will also be shown.
2. The extension is unloaded:
The `dependency loaded` column will be false, and the index description is not available.
