### PR TITLE
Refactor extensionUtils apis

### DIFF
--- a/extension/delta/src/main/delta_extension.cpp
+++ b/extension/delta/src/main/delta_extension.cpp
@@ -10,7 +10,7 @@ namespace delta_extension {
 
 void DeltaExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    ADD_TABLE_FUNC(DeltaScanFunction);
+    extension::ExtensionUtils::addTableFunc<DeltaScanFunction>(db);
     httpfs::S3DownloadOptions::registerExtensionOptions(&db);
     httpfs::S3DownloadOptions::setEnvValue(context);
 }

--- a/extension/duckdb/src/function/clear_cache.cpp
+++ b/extension/duckdb/src/function/clear_cache.cpp
@@ -37,11 +37,15 @@ static std::unique_ptr<TableFuncBindData> clearCacheBindFunc(const ClientContext
         1 /* maxOffset */);
 }
 
-ClearCacheFunction::ClearCacheFunction() : TableFunction{name, std::vector<LogicalTypeID>{}} {
-    tableFunc = clearCacheTableFunc;
-    bindFunc = clearCacheBindFunc;
-    initSharedStateFunc = SimpleTableFunction::initSharedState;
-    initLocalStateFunc = SimpleTableFunction::initEmptyLocalState;
+function_set ClearCacheFunction::getFunctionSet() {
+    function_set functionSet;
+    auto function = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{});
+    function->tableFunc = clearCacheTableFunc;
+    function->bindFunc = clearCacheBindFunc;
+    function->initSharedStateFunc = SimpleTableFunction::initSharedState;
+    function->initLocalStateFunc = SimpleTableFunction::initEmptyLocalState;
+    functionSet.push_back(std::move(function));
+    return functionSet;
 }
 
 } // namespace duckdb_extension

--- a/extension/duckdb/src/include/function/clear_cache.h
+++ b/extension/duckdb/src/include/function/clear_cache.h
@@ -22,8 +22,7 @@ struct ClearCacheBindData final : function::SimpleTableFuncBindData {
 
 struct ClearCacheFunction final : function::TableFunction {
     static constexpr const char* name = "clear_attached_db_cache";
-
-    ClearCacheFunction();
+    static function::function_set getFunctionSet();
 };
 
 } // namespace duckdb_extension

--- a/extension/duckdb/src/storage/duckdb_storage.cpp
+++ b/extension/duckdb/src/storage/duckdb_storage.cpp
@@ -4,7 +4,6 @@
 
 #include "binder/bound_attach_info.h"
 #include "catalog/duckdb_catalog.h"
-#include "common/exception/runtime.h"
 #include "common/file_system/virtual_file_system.h"
 #include "common/string_utils.h"
 #include "connector/connector_factory.h"
@@ -38,11 +37,9 @@ std::unique_ptr<main::AttachedDatabase> attachDuckDB(std::string dbName, std::st
         std::move(duckdbCatalog), std::move(connector));
 }
 
-DuckDBStorageExtension::DuckDBStorageExtension(main::Database* database)
+DuckDBStorageExtension::DuckDBStorageExtension(main::Database* db)
     : StorageExtension{attachDuckDB} {
-    auto duckDBClearCacheFunction = std::make_unique<ClearCacheFunction>();
-    extension::ExtensionUtils::registerTableFunction(*database,
-        std::move(duckDBClearCacheFunction));
+    extension::ExtensionUtils::addTableFunc<ClearCacheFunction>(*db);
 }
 
 bool DuckDBStorageExtension::canHandleDB(std::string dbType_) const {

--- a/extension/fts/src/fts_extension.cpp
+++ b/extension/fts/src/fts_extension.cpp
@@ -1,7 +1,6 @@
 #include "fts_extension.h"
 
 #include "catalog/catalog.h"
-#include "catalog/catalog_entry/index_catalog_entry.h"
 #include "catalog/fts_index_catalog_entry.h"
 #include "common/serializer/buffered_reader.h"
 #include "function/create_fts_index.h"
@@ -14,6 +13,8 @@
 namespace kuzu {
 namespace fts_extension {
 
+using namespace extension;
+
 static void initFTSEntries(const transaction::Transaction* transaction, catalog::Catalog& catalog) {
     for (auto& indexEntry : catalog.getIndexEntries(transaction)) {
         if (indexEntry->getIndexType() == FTSIndexCatalogEntry::TYPE_NAME) {
@@ -24,10 +25,10 @@ static void initFTSEntries(const transaction::Transaction* transaction, catalog:
 
 void FTSExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    ADD_SCALAR_FUNC(StemFunction);
-    ADD_GDS_FUNC(QueryFTSFunction);
-    db.addStandaloneCallFunction(CreateFTSFunction::name, CreateFTSFunction::getFunctionSet());
-    db.addStandaloneCallFunction(DropFTSFunction::name, DropFTSFunction::getFunctionSet());
+    ExtensionUtils::addScalarFunc<StemFunction>(db);
+    ExtensionUtils::addGDSFunc<QueryFTSFunction>(db);
+    ExtensionUtils::addStandaloneTableFunc<CreateFTSFunction>(db);
+    ExtensionUtils::addStandaloneTableFunc<DropFTSFunction>(db);
     initFTSEntries(context->getTransaction(), *db.getCatalog());
 }
 

--- a/extension/fts/test/test_files/fts_small.test
+++ b/extension/fts/test/test_files/fts_small.test
@@ -7,6 +7,8 @@
 -CASE fts_search_simple
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
 ---- ok
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
+---- ok
 -STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx', ['content', 'author', 'name'])
 ---- ok
 -LOG SingleKeyWordUpperCase

--- a/extension/iceberg/src/iceberg_extension.cpp
+++ b/extension/iceberg/src/iceberg_extension.cpp
@@ -1,6 +1,5 @@
 #include "iceberg_extension.h"
 
-#include "function/duckdb_scan.h"
 #include "function/iceberg_functions.h"
 #include "main/client_context.h"
 #include "main/database.h"
@@ -9,11 +8,13 @@
 namespace kuzu {
 namespace iceberg_extension {
 
+using namespace kuzu::extension;
+
 void IcebergExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    ADD_TABLE_FUNC(IcebergScanFunction);
-    ADD_TABLE_FUNC(IcebergMetadataFunction);
-    ADD_TABLE_FUNC(IcebergSnapshotsFunction);
+    extension::ExtensionUtils::addTableFunc<IcebergScanFunction>(db);
+    extension::ExtensionUtils::addTableFunc<IcebergMetadataFunction>(db);
+    extension::ExtensionUtils::addTableFunc<IcebergSnapshotsFunction>(db);
     httpfs::S3DownloadOptions::registerExtensionOptions(&db);
     httpfs::S3DownloadOptions::setEnvValue(context);
 }

--- a/extension/json/src/functions/table_functions/json_scan.cpp
+++ b/extension/json/src/functions/table_functions/json_scan.cpp
@@ -833,7 +833,7 @@ static decltype(auto) getWarningDataVectors(const DataChunk& chunk, column_id_t 
 
     std::vector<ValueVector*> ret;
     for (column_id_t i = chunk.getNumValueVectors() - numWarningColumns;
-         i < chunk.getNumValueVectors(); ++i) {
+        i < chunk.getNumValueVectors(); ++i) {
         ret.push_back(&chunk.getValueVectorMutable(i));
     }
     return ret;
@@ -897,7 +897,8 @@ static void finalizeFunc(const processor::ExecutionContext* ctx,
         jsonSharedState->populateErrorFunc);
 }
 
-std::unique_ptr<TableFunction> JsonScan::getFunction() {
+function_set JsonScan::getFunctionSet() {
+    function_set functionSet;
     auto func = std::make_unique<TableFunction>(name, std::vector{LogicalTypeID::STRING});
     func->tableFunc = tableFunc;
     func->bindFunc = bindFunc;
@@ -905,7 +906,8 @@ std::unique_ptr<TableFunction> JsonScan::getFunction() {
     func->initLocalStateFunc = initLocalState;
     func->progressFunc = progressFunc;
     func->finalizeFunc = finalizeFunc;
-    return func;
+    functionSet.push_back(std::move(func));
+    return functionSet;
 }
 
 } // namespace json_extension

--- a/extension/json/src/functions/table_functions/json_scan.cpp
+++ b/extension/json/src/functions/table_functions/json_scan.cpp
@@ -833,7 +833,7 @@ static decltype(auto) getWarningDataVectors(const DataChunk& chunk, column_id_t 
 
     std::vector<ValueVector*> ret;
     for (column_id_t i = chunk.getNumValueVectors() - numWarningColumns;
-        i < chunk.getNumValueVectors(); ++i) {
+         i < chunk.getNumValueVectors(); ++i) {
         ret.push_back(&chunk.getValueVectorMutable(i));
     }
     return ret;

--- a/extension/json/src/include/json_scan.h
+++ b/extension/json/src/include/json_scan.h
@@ -8,7 +8,7 @@ namespace json_extension {
 struct JsonScan {
     static constexpr const char* name = "JSON_SCAN";
 
-    static std::unique_ptr<function::TableFunction> getFunction();
+    static function::function_set getFunctionSet();
 };
 
 } // namespace json_extension

--- a/extension/json/src/json_extension.cpp
+++ b/extension/json/src/json_extension.cpp
@@ -1,7 +1,5 @@
 #include "json_extension.h"
 
-#include "catalog/catalog.h"
-#include "common/types/types.h"
 #include "json_creation_functions.h"
 #include "json_export.h"
 #include "json_extract_functions.h"
@@ -14,28 +12,30 @@
 namespace kuzu {
 namespace json_extension {
 
+using namespace kuzu::extension;
+
 static void addJsonCreationFunction(main::Database& db) {
-    ADD_SCALAR_FUNC(ToJsonFunction);
-    ADD_SCALAR_FUNC_ALIAS(JsonQuoteFunction);
-    ADD_SCALAR_FUNC_ALIAS(ArrayToJsonFunction);
-    ADD_SCALAR_FUNC_ALIAS(RowToJsonFunction);
-    ADD_SCALAR_FUNC_ALIAS(CastToJsonFunction);
-    ADD_SCALAR_FUNC(JsonArrayFunction);
-    ADD_SCALAR_FUNC(JsonObjectFunction);
-    ADD_SCALAR_FUNC(JsonMergePatchFunction);
+    ExtensionUtils::addScalarFunc<ToJsonFunction>(db);
+    ExtensionUtils::addScalarFuncAlias<JsonQuoteFunction>(db);
+    ExtensionUtils::addScalarFuncAlias<ArrayToJsonFunction>(db);
+    ExtensionUtils::addScalarFuncAlias<RowToJsonFunction>(db);
+    ExtensionUtils::addScalarFuncAlias<CastToJsonFunction>(db);
+    ExtensionUtils::addScalarFunc<JsonArrayFunction>(db);
+    ExtensionUtils::addScalarFunc<JsonObjectFunction>(db);
+    ExtensionUtils::addScalarFunc<JsonMergePatchFunction>(db);
 }
 
 static void addJsonExtractFunction(main::Database& db) {
-    ADD_SCALAR_FUNC(JsonExtractFunction);
+    ExtensionUtils::addScalarFunc<JsonExtractFunction>(db);
 }
 
 static void addJsonScalarFunction(main::Database& db) {
-    ADD_SCALAR_FUNC(JsonArrayLengthFunction);
-    ADD_SCALAR_FUNC(JsonContainsFunction);
-    ADD_SCALAR_FUNC(JsonKeysFunction);
-    ADD_SCALAR_FUNC(JsonStructureFunction);
-    ADD_SCALAR_FUNC(JsonValidFunction);
-    ADD_SCALAR_FUNC(MinifyJsonFunction);
+    ExtensionUtils::addScalarFunc<JsonArrayLengthFunction>(db);
+    ExtensionUtils::addScalarFunc<JsonContainsFunction>(db);
+    ExtensionUtils::addScalarFunc<JsonKeysFunction>(db);
+    ExtensionUtils::addScalarFunc<JsonStructureFunction>(db);
+    ExtensionUtils::addScalarFunc<JsonValidFunction>(db);
+    ExtensionUtils::addScalarFunc<MinifyJsonFunction>(db);
 }
 
 void JsonExtension::load(main::ClientContext* context) {
@@ -45,8 +45,8 @@ void JsonExtension::load(main::ClientContext* context) {
     addJsonCreationFunction(db);
     addJsonExtractFunction(db);
     addJsonScalarFunction(db);
-    ADD_SCALAR_FUNC(JsonExportFunction);
-    extension::ExtensionUtils::registerTableFunction(db, JsonScan::getFunction());
+    ExtensionUtils::addScalarFunc<JsonExportFunction>(db);
+    ExtensionUtils::addTableFunc<JsonScan>(db);
 }
 
 } // namespace json_extension

--- a/extension/postgres/src/storage/postgres_storage.cpp
+++ b/extension/postgres/src/storage/postgres_storage.cpp
@@ -42,8 +42,7 @@ std::unique_ptr<main::AttachedDatabase> attachPostgres(std::string dbName, std::
 
 PostgresStorageExtension::PostgresStorageExtension(main::Database* database)
     : StorageExtension{attachPostgres} {
-    auto clearCacheFunction = std::make_unique<duckdb_extension::ClearCacheFunction>();
-    extension::ExtensionUtils::registerTableFunction(*database, std::move(clearCacheFunction));
+    extension::ExtensionUtils::addTableFunc<duckdb_extension::ClearCacheFunction>(*database);
 }
 
 bool PostgresStorageExtension::canHandleDB(std::string dbType_) const {

--- a/extension/sqlite/src/storage/sqlite_storage.cpp
+++ b/extension/sqlite/src/storage/sqlite_storage.cpp
@@ -36,8 +36,7 @@ std::unique_ptr<main::AttachedDatabase> attachSqlite(std::string dbName, std::st
 
 SqliteStorageExtension::SqliteStorageExtension(main::Database* database)
     : StorageExtension{attachSqlite} {
-    auto clearCacheFunction = std::make_unique<duckdb_extension::ClearCacheFunction>();
-    extension::ExtensionUtils::registerTableFunction(*database, std::move(clearCacheFunction));
+    extension::ExtensionUtils::addTableFunc<duckdb_extension::ClearCacheFunction>(*database);
 }
 
 bool SqliteStorageExtension::canHandleDB(std::string dbType_) const {

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -237,8 +237,8 @@ CatalogEntry* Catalog::createRelGroupEntry(Transaction* transaction,
     for (auto& childInfo : extraInfo->infos) {
         KU_ASSERT(childInfo.hasParent);
         relTableIDs.push_back(createRelTableEntry(transaction, childInfo)
-                                  ->ptrCast<TableCatalogEntry>()
-                                  ->getTableID());
+                ->ptrCast<TableCatalogEntry>()
+                ->getTableID());
     }
     auto entry = std::make_unique<RelGroupCatalogEntry>(info.tableName, std::move(relTableIDs));
     relGroups->createEntry(transaction, std::move(entry));

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -237,8 +237,8 @@ CatalogEntry* Catalog::createRelGroupEntry(Transaction* transaction,
     for (auto& childInfo : extraInfo->infos) {
         KU_ASSERT(childInfo.hasParent);
         relTableIDs.push_back(createRelTableEntry(transaction, childInfo)
-                ->ptrCast<TableCatalogEntry>()
-                ->getTableID());
+                                  ->ptrCast<TableCatalogEntry>()
+                                  ->getTableID());
     }
     auto entry = std::make_unique<RelGroupCatalogEntry>(info.tableName, std::move(relTableIDs));
     relGroups->createEntry(transaction, std::move(entry));

--- a/src/extension/extension.cpp
+++ b/src/extension/extension.cpp
@@ -1,15 +1,11 @@
 #include "extension/extension.h"
 
-#include "catalog/catalog.h"
 #include "common/exception/io.h"
 #include "common/file_system/virtual_file_system.h"
 #include "common/string_format.h"
 #include "common/string_utils.h"
 #include "common/system_message.h"
-#include "function/table_functions.h"
 #include "main/client_context.h"
-#include "main/database.h"
-#include "transaction/transaction.h"
 #ifdef _WIN32
 
 #include "windows.h"
@@ -125,19 +121,6 @@ std::string ExtensionUtils::getLocalExtensionDir(main::ClientContext* context,
     return common::stringFormat("{}{}", context->getExtensionDir(), extensionName);
 }
 
-void ExtensionUtils::registerTableFunction(main::Database& database,
-    std::unique_ptr<function::TableFunction> function) {
-    auto name = function->name;
-    function::function_set functionSet;
-    functionSet.push_back(std::move(function));
-    auto catalog = database.getCatalog();
-    if (catalog->containsFunction(&transaction::DUMMY_TRANSACTION, name)) {
-        return;
-    }
-    catalog->addFunction(&transaction::DUMMY_TRANSACTION,
-        catalog::CatalogEntryType::TABLE_FUNCTION_ENTRY, std::move(name), std::move(functionSet));
-}
-
 std::string ExtensionUtils::appendLibSuffix(const std::string& libName) {
     auto os = getOS();
     std::string suffix;
@@ -158,16 +141,6 @@ std::string ExtensionUtils::getLocalPathForSharedLib(main::ClientContext* contex
 
 std::string ExtensionUtils::getLocalPathForSharedLib(main::ClientContext* context) {
     return common::stringFormat("{}common/", context->getExtensionDir());
-}
-
-void ExtensionUtils::registerFunctionSet(main::Database& database, std::string name,
-    function::function_set functionSet, catalog::CatalogEntryType functionType) {
-    auto catalog = database.getCatalog();
-    if (catalog->containsFunction(&transaction::DUMMY_TRANSACTION, name)) {
-        return;
-    }
-    catalog->addFunction(&transaction::DUMMY_TRANSACTION, functionType, std::move(name),
-        std::move(functionSet));
 }
 
 bool ExtensionUtils::isOfficialExtension(const std::string& extension) {

--- a/src/extension/extension.cpp
+++ b/src/extension/extension.cpp
@@ -1,7 +1,6 @@
 #include "extension/extension.h"
 
 #include "common/exception/io.h"
-#include "common/file_system/virtual_file_system.h"
 #include "common/string_format.h"
 #include "common/string_utils.h"
 #include "common/system_message.h"

--- a/src/include/main/database.h
+++ b/src/include/main/database.h
@@ -101,14 +101,6 @@ public:
      */
     KUZU_API ~Database();
 
-    // TODO(Ziyi): Instead of exposing a dedicated API for adding a new function, we should consider
-    // add function through the extension module.
-    KUZU_API void addTableFunction(std::string name,
-        std::vector<std::unique_ptr<function::Function>> functionSet);
-
-    KUZU_API void addStandaloneCallFunction(std::string name,
-        std::vector<std::unique_ptr<function::Function>> functionSet);
-
     KUZU_API void registerFileSystem(std::unique_ptr<common::FileSystem> fs);
 
     KUZU_API void registerStorageExtension(std::string name,

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -13,7 +13,6 @@
 
 #include "common/exception/exception.h"
 #include "common/file_system/virtual_file_system.h"
-#include "extension/extension.h"
 #include "main/db_config.h"
 #include "processor/processor.h"
 #include "storage/storage_extension.h"
@@ -122,17 +121,6 @@ Database::~Database() {
             transactionManager->checkpoint(clientContext);
         } catch (...) {} // NOLINT
     }
-}
-
-void Database::addTableFunction(std::string name, function::function_set functionSet) {
-    catalog->addFunction(&DUMMY_TRANSACTION, CatalogEntryType::TABLE_FUNCTION_ENTRY,
-        std::move(name), std::move(functionSet));
-}
-
-void Database::addStandaloneCallFunction(std::string name,
-    std::vector<std::unique_ptr<function::Function>> functionSet) {
-    catalog->addFunction(&DUMMY_TRANSACTION, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY,
-        std::move(name), std::move(functionSet));
 }
 
 void Database::registerFileSystem(std::unique_ptr<FileSystem> fs) {

--- a/tools/python_api/src_cpp/py_database.cpp
+++ b/tools/python_api/src_cpp/py_database.cpp
@@ -2,10 +2,10 @@
 
 #include <memory>
 
+#include "extension/extension.h"
 #include "include/cached_import/py_cached_import.h"
 #include "main/version.h"
 #include "pandas/pandas_scan.h"
-#include "pyarrow/pyarrow_scan.h"
 
 using namespace kuzu::common;
 
@@ -54,8 +54,7 @@ PyDatabase::PyDatabase(const std::string& databasePath, uint64_t bufferPoolSize,
         systemConfig.checkpointThreshold = static_cast<uint64_t>(checkpointThreshold);
     }
     database = std::make_unique<Database>(databasePath, systemConfig);
-    database->addTableFunction(kuzu::PandasScanFunction::name,
-        kuzu::PandasScanFunction::getFunctionSet());
+    kuzu::extension::ExtensionUtils::addTableFunc<kuzu::PandasScanFunction>(*database);
     storageDriver = std::make_unique<kuzu::main::StorageDriver>(database.get());
     py::gil_scoped_acquire acquire;
     if (kuzu::importCache.get() == nullptr) {


### PR DESCRIPTION
This PR replaces the macros for adding scalar/table/gds functions with a set of c++ functions.
Removed:
```
ADD_SCALAR_FUNC
ADD_SCALAR_FUNC_ALIAS
ADD_GDS_FUNC
ADD_TABLE_FUNC
```
Added:
```
void addTableFunc(main::Database& database)
void addStandaloneTableFunc(main::Database& database)
void addScalarFunc(main::Database& database)
void addScalarFuncAlias(main::Database& database)
void addGDSFunc(main::Database& database)
```