### PR TITLE
Support alter for rel groups

### DIFF
--- a/extension/fts/test/test_files/error.test
+++ b/extension/fts/test/test_files/error.test
@@ -77,7 +77,7 @@ Binder exception: DROP_FTS_INDEX is only supported in auto transaction mode.
 ---- 0
 -STATEMENT ALTER TABLE STUDENT DROP name;
 ---- error
-Catalog exception: Cannot drop a property in a table with indexes.
+Binder exception: Cannot drop property name in table STUDENT because it is used in one or more indexes. Please remove the associated indexes before attempting to drop this property.
 -STATEMENT ALTER TABLE STUDENT ADD length int64;
 ---- ok
 -STATEMENT DROP TABLE STUDENT

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -151,13 +151,6 @@ void Binder::validateOrderByFollowedBySkipOrLimitInWithClause(
     }
 }
 
-void Binder::validateTableExist(const std::string& tableName) const {
-    if (!clientContext->getCatalog()->containsTable(clientContext->getTransaction(), tableName,
-            clientContext->shouldUseInternalCatalogEntry())) {
-        throw BinderException("Table " + tableName + " does not exist.");
-    }
-}
-
 std::string Binder::getUniqueExpressionName(const std::string& name) {
     return "_" + std::to_string(lastExpressionId++) + "_" + name;
 }

--- a/src/catalog/catalog_entry/rel_table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_table_catalog_entry.cpp
@@ -18,12 +18,12 @@ bool RelTableCatalogEntry::isParent(table_id_t tableID) {
     return srcTableID == tableID || dstTableID == tableID;
 }
 
-bool RelTableCatalogEntry::hasParentRelGroup(Catalog* catalog,
+bool RelTableCatalogEntry::hasParentRelGroup(const Catalog* catalog,
     const transaction::Transaction* transaction) const {
     return getParentRelGroup(catalog, transaction) != nullptr;
 }
 
-RelGroupCatalogEntry* RelTableCatalogEntry::getParentRelGroup(Catalog* catalog,
+RelGroupCatalogEntry* RelTableCatalogEntry::getParentRelGroup(const Catalog* catalog,
     const transaction::Transaction* transaction) const {
     for (auto& relGroup : catalog->getRelGroupEntries(transaction)) {
         if (relGroup->isParent(getTableID())) {
@@ -41,15 +41,15 @@ RelMultiplicity RelTableCatalogEntry::getMultiplicity(RelDataDirection direction
     return direction == RelDataDirection::FWD ? dstMultiplicity : srcMultiplicity;
 }
 
-std::vector<common::RelDataDirection> RelTableCatalogEntry::getRelDataDirections() const {
+std::vector<RelDataDirection> RelTableCatalogEntry::getRelDataDirections() const {
     switch (storageDirection) {
-    case common::ExtendDirection::FWD: {
+    case ExtendDirection::FWD: {
         return {RelDataDirection::FWD};
     }
-    case common::ExtendDirection::BWD: {
+    case ExtendDirection::BWD: {
         return {RelDataDirection::BWD};
     }
-    case common::ExtendDirection::BOTH: {
+    case ExtendDirection::BOTH: {
         return {RelDataDirection::FWD, RelDataDirection::BWD};
     }
     default: {
@@ -124,21 +124,21 @@ std::string RelTableCatalogEntry::toCypher(main::ClientContext* clientContext) c
     auto transaction = clientContext->getTransaction();
     auto srcTableName = catalog->getTableCatalogEntry(transaction, srcTableID)->getName();
     auto dstTableName = catalog->getTableCatalogEntry(transaction, dstTableID)->getName();
-    auto srcMultiStr = srcMultiplicity == common::RelMultiplicity::MANY ? "MANY" : "ONE";
-    auto dstMultiStr = dstMultiplicity == common::RelMultiplicity::MANY ? "MANY" : "ONE";
+    auto srcMultiStr = srcMultiplicity == RelMultiplicity::MANY ? "MANY" : "ONE";
+    auto dstMultiStr = dstMultiplicity == RelMultiplicity::MANY ? "MANY" : "ONE";
     std::string tableInfo =
         stringFormat("CREATE REL TABLE {} (FROM {} TO {}, ", getName(), srcTableName, dstTableName);
     ss << tableInfo << propertyCollection.toCypher() << srcMultiStr << "_" << dstMultiStr << ");";
     return ss.str();
 }
 
-common::ExtendDirection RelTableCatalogEntry::getStorageDirection() const {
+ExtendDirection RelTableCatalogEntry::getStorageDirection() const {
     return storageDirection;
 }
 
 std::unique_ptr<BoundExtraCreateCatalogEntryInfo> RelTableCatalogEntry::getBoundExtraCreateInfo(
     transaction::Transaction*) const {
-    return std::make_unique<binder::BoundExtraCreateRelTableInfo>(srcMultiplicity, dstMultiplicity,
+    return std::make_unique<BoundExtraCreateRelTableInfo>(srcMultiplicity, dstMultiplicity,
         storageDirection, srcTableID, dstTableID, copyVector(propertyCollection.getDefinitions()));
 }
 

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -205,7 +205,6 @@ void CatalogSet::alterTableEntry(const Transaction* transaction,
     }
 }
 
-
 void CatalogSet::alterRelGroupEntry(Transaction* transaction,
     const binder::BoundAlterInfo& alterInfo) {
     if (alterInfo.alterType != AlterType::RENAME_TABLE) {

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -278,7 +278,9 @@ public:
         const BoundProjectionBody& boundProjectionBody);
     static bool isOrderByKeyTypeSupported(const common::LogicalType& dataType);
 
-    void validateTableExist(const std::string& tableName) const;
+    void validateTableExists(const std::string& name) const;
+    void validateNoIndexOnProperty(const std::string& tableName,
+        const std::string& propertyName) const;
     /*** helpers ***/
     std::string getUniqueExpressionName(const std::string& name);
 

--- a/src/include/binder/ddl/bound_alter_info.h
+++ b/src/include/binder/ddl/bound_alter_info.h
@@ -19,6 +19,10 @@ struct BoundExtraAlterInfo {
     const TARGET& constCast() const {
         return common::ku_dynamic_cast<const TARGET&>(*this);
     }
+    template<class TARGET>
+    TARGET& cast() {
+        return common::ku_dynamic_cast<TARGET&>(*this);
+    }
 
     virtual std::unique_ptr<BoundExtraAlterInfo> copy() const = 0;
 };

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -66,11 +66,11 @@ public:
     TableCatalogEntry* getTableCatalogEntry(const transaction::Transaction* transaction,
         common::table_id_t tableID) const;
     // Get all node table entries.
-    std::vector<NodeTableCatalogEntry*> getNodeTableEntries(transaction::Transaction* transaction,
-        bool useInternal = true) const;
+    std::vector<NodeTableCatalogEntry*> getNodeTableEntries(
+        const transaction::Transaction* transaction, bool useInternal = true) const;
     // Get all rel table entries.
-    std::vector<RelTableCatalogEntry*> getRelTableEntries(transaction::Transaction* transaction,
-        bool useInternal = true) const;
+    std::vector<RelTableCatalogEntry*> getRelTableEntries(
+        const transaction::Transaction* transaction, bool useInternal = true) const;
     // Get all table entries.
     std::vector<TableCatalogEntry*> getTableEntries(
         const transaction::Transaction* transaction) const;
@@ -83,17 +83,22 @@ public:
     // Drop table entry with id.
     void dropTableEntry(transaction::Transaction* transaction, common::table_id_t tableID);
     // Drop table entry.
-    void dropTableEntry(transaction::Transaction* transaction, TableCatalogEntry* entry);
+    void dropTableEntry(transaction::Transaction* transaction, const TableCatalogEntry* entry);
     // Alter table entry.
     void alterTableEntry(transaction::Transaction* transaction, const binder::BoundAlterInfo& info);
+    // Alter a rel group entry
+    // alterTableEntry() still needs to be called separately for each member of the group
+    void alterRelGroupEntry(transaction::Transaction* transaction,
+        const binder::BoundAlterInfo& info);
 
     // ----------------------------- Rel groups ----------------------------
 
     // Check if rel group entry exists.
-    bool containsRelGroup(const transaction::Transaction* transaction, const std::string& name);
+    bool containsRelGroup(const transaction::Transaction* transaction,
+        const std::string& name) const;
     // Get rel group entry with name.
     RelGroupCatalogEntry* getRelGroupEntry(const transaction::Transaction* transaction,
-        const std::string& name);
+        const std::string& name) const;
     // Get all rel group entries.
     std::vector<RelGroupCatalogEntry*> getRelGroupEntries(
         const transaction::Transaction* transaction) const;
@@ -104,7 +109,8 @@ public:
     // Drop rel group entry.
     void dropRelGroupEntry(transaction::Transaction* transaction, common::oid_t id);
     // Drop rel group entry.
-    void dropRelGroupEntry(transaction::Transaction* transaction, RelGroupCatalogEntry* entry);
+    void dropRelGroupEntry(transaction::Transaction* transaction,
+        const RelGroupCatalogEntry* entry);
 
     // ----------------------------- Sequences ----------------------------
 
@@ -113,7 +119,7 @@ public:
         const std::string& name) const;
     // Get sequence entry with name.
     SequenceCatalogEntry* getSequenceEntry(const transaction::Transaction* transaction,
-        const std::string& name, bool useInternalSeq = true) const;
+        const std::string& sequenceName, bool useInternalSeq = true) const;
     // Get sequence entry with id.
     SequenceCatalogEntry* getSequenceEntry(const transaction::Transaction* transaction,
         common::sequence_id_t sequenceID) const;
@@ -164,7 +170,8 @@ public:
     // ----------------------------- Functions ----------------------------
 
     // Check if function exists.
-    bool containsFunction(const transaction::Transaction* transaction, const std::string& name);
+    bool containsFunction(const transaction::Transaction* transaction,
+        const std::string& name) const;
     // Get function entry by name.
     // Note we cannot cast to FunctionEntry here because result could also be a MacroEntry.
     CatalogEntry* getFunctionEntry(const transaction::Transaction* transaction,
@@ -213,9 +220,9 @@ private:
     CatalogEntry* createRelTableEntry(transaction::Transaction* transaction,
         const binder::BoundCreateTableInfo& info);
 
-    void createSerialSequence(transaction::Transaction* transaction, TableCatalogEntry* entry,
+    void createSerialSequence(transaction::Transaction* transaction, const TableCatalogEntry* entry,
         bool isInternal);
-    void dropSerialSequence(transaction::Transaction* transaction, TableCatalogEntry* entry);
+    void dropSerialSequence(transaction::Transaction* transaction, const TableCatalogEntry* entry);
 
 protected:
     std::unique_ptr<CatalogSet> tables;

--- a/src/include/catalog/catalog_entry/rel_group_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/rel_group_catalog_entry.h
@@ -27,11 +27,15 @@ public:
     std::string toCypher(main::ClientContext* clientContext) const override;
 
     binder::BoundCreateTableInfo getBoundCreateTableInfo(transaction::Transaction* transaction,
-        Catalog* catalog, bool isInternal) const;
+        const Catalog* catalog, bool isInternal) const;
 
     static std::string getChildTableName(const std::string& groupName, const std::string& srcName,
         const std::string& dstName) {
         return groupName + "_" + srcName + "_" + dstName;
+    }
+
+    std::unique_ptr<RelGroupCatalogEntry> copy() const {
+        return std::make_unique<RelGroupCatalogEntry>(getName(), relTableIDs);
     }
 
 private:

--- a/src/include/catalog/catalog_entry/rel_table_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/rel_table_catalog_entry.h
@@ -27,8 +27,9 @@ public:
     }
 
     bool isParent(common::table_id_t tableID) override;
-    bool hasParentRelGroup(Catalog* catalog, const transaction::Transaction* transaction) const;
-    RelGroupCatalogEntry* getParentRelGroup(Catalog* catalog,
+    bool hasParentRelGroup(const Catalog* catalog,
+        const transaction::Transaction* transaction) const;
+    RelGroupCatalogEntry* getParentRelGroup(const Catalog* catalog,
         const transaction::Transaction* transaction) const;
 
     common::TableType getTableType() const override { return common::TableType::REL; }

--- a/src/include/catalog/catalog_set.h
+++ b/src/include/catalog/catalog_set.h
@@ -33,7 +33,10 @@ public:
         std::unique_ptr<CatalogEntry> entry);
     void dropEntry(transaction::Transaction* transaction, const std::string& name,
         common::oid_t oid);
-    void alterEntry(const transaction::Transaction* transaction,
+
+    void alterTableEntry(const transaction::Transaction* transaction,
+        const binder::BoundAlterInfo& alterInfo);
+    void alterRelGroupEntry(transaction::Transaction* transaction,
         const binder::BoundAlterInfo& alterInfo);
 
     CatalogEntrySet getEntries(const transaction::Transaction* transaction);

--- a/src/include/processor/operator/ddl/alter.h
+++ b/src/include/processor/operator/ddl/alter.h
@@ -55,6 +55,9 @@ public:
     }
 
 private:
+    void alterTable(const ExecutionContext* context, const binder::BoundAlterInfo& alterInfo) const;
+    void alterRelGroupChildren(const ExecutionContext* context) const;
+
     binder::BoundAlterInfo info;
     std::unique_ptr<evaluator::ExpressionEvaluator> defaultValueEvaluator;
 };

--- a/src/include/processor/operator/ddl/drop.h
+++ b/src/include/processor/operator/ddl/drop.h
@@ -39,9 +39,9 @@ public:
     }
 
 private:
-    void dropSequence(main::ClientContext* context);
-    void dropTable(main::ClientContext* context);
-    void dropRelGroup(main::ClientContext* context);
+    void dropSequence(const main::ClientContext* context);
+    void dropTable(const main::ClientContext* context);
+    void dropRelGroup(const main::ClientContext* context);
 
 private:
     parser::DropInfo dropInfo;

--- a/src/include/storage/wal/wal.h
+++ b/src/include/storage/wal/wal.h
@@ -39,6 +39,7 @@ public:
     // own WAL record
     void logCreateCatalogEntryRecord(catalog::CatalogEntry* catalogEntry, bool isInternal);
     void logDropCatalogEntryRecord(uint64_t entryID, catalog::CatalogEntryType type);
+    void logAlterRelGroupEntryRecord(const binder::BoundAlterInfo* alterInfo);
     void logAlterTableEntryRecord(const binder::BoundAlterInfo* alterInfo);
     void logUpdateSequenceRecord(common::sequence_id_t sequenceID, uint64_t kCount);
 

--- a/src/include/storage/wal/wal_record.h
+++ b/src/include/storage/wal/wal_record.h
@@ -28,6 +28,7 @@ enum class WALRecordType : uint8_t {
     DROP_CATALOG_ENTRY_RECORD = 16,
     ALTER_TABLE_ENTRY_RECORD = 17,
     UPDATE_SEQUENCE_RECORD = 18,
+    ALTER_REL_GROUP_ENTRY_RECORD = 19,
     TABLE_INSERTION_RECORD = 30,
     NODE_DELETION_RECORD = 31,
     NODE_UDPATE_RECORD = 32,
@@ -137,6 +138,20 @@ struct AlterTableEntryRecord final : WALRecord {
 
     void serialize(common::Serializer& serializer) const override;
     static std::unique_ptr<AlterTableEntryRecord> deserialize(common::Deserializer& deserializer);
+};
+
+struct AlterRelGroupEntryRecord final : WALRecord {
+    const binder::BoundAlterInfo* alterInfo;
+    std::unique_ptr<binder::BoundAlterInfo> ownedAlterInfo;
+
+    AlterRelGroupEntryRecord()
+        : WALRecord{WALRecordType::ALTER_REL_GROUP_ENTRY_RECORD}, alterInfo{nullptr} {}
+    explicit AlterRelGroupEntryRecord(const binder::BoundAlterInfo* alterInfo)
+        : WALRecord{WALRecordType::ALTER_REL_GROUP_ENTRY_RECORD}, alterInfo{alterInfo} {}
+
+    void serialize(common::Serializer& serializer) const override;
+    static std::unique_ptr<AlterRelGroupEntryRecord> deserialize(
+        common::Deserializer& deserializer);
 };
 
 struct UpdateSequenceRecord final : WALRecord {

--- a/src/include/storage/wal_replayer.h
+++ b/src/include/storage/wal_replayer.h
@@ -19,6 +19,7 @@ private:
     void replayCreateCatalogEntryRecord(const WALRecord& walRecord) const;
     void replayDropCatalogEntryRecord(const WALRecord& walRecord) const;
     void replayAlterTableEntryRecord(const WALRecord& walRecord) const;
+    void replayAlterRelGroupEntryRecord(const WALRecord& walRecord) const;
     void replayTableInsertionRecord(const WALRecord& walRecord) const;
     void replayNodeDeletionRecord(const WALRecord& walRecord) const;
     void replayNodeUpdateRecord(const WALRecord& walRecord) const;

--- a/src/processor/operator/ddl/alter.cpp
+++ b/src/processor/operator/ddl/alter.cpp
@@ -1,6 +1,8 @@
 #include "processor/operator/ddl/alter.h"
 
 #include "catalog/catalog.h"
+#include "catalog/catalog_entry/node_table_catalog_entry.h"
+#include "catalog/catalog_entry/rel_group_catalog_entry.h"
 #include "common/enums/alter_type.h"
 #include "storage/storage_manager.h"
 #include "storage/store/table.h"
@@ -12,7 +14,8 @@ namespace processor {
 
 using skip_alter_on_conflict = std::function<bool()>;
 
-bool skipAlter(common::ConflictAction action, const skip_alter_on_conflict& skipAlterOnConflict) {
+static bool skipAlter(common::ConflictAction action,
+    const skip_alter_on_conflict& skipAlterOnConflict) {
     switch (action) {
     case common::ConflictAction::ON_CONFLICT_THROW:
         return false;
@@ -23,46 +26,154 @@ bool skipAlter(common::ConflictAction action, const skip_alter_on_conflict& skip
     }
 }
 
+void Alter::alterRelGroupChildren(const ExecutionContext* context) const {
+    auto catalog = context->clientContext->getCatalog();
+    auto transaction = context->clientContext->getTransaction();
+    const auto* relGroupEntry = catalog->getRelGroupEntry(transaction, info.tableName);
+    for (auto tableID : relGroupEntry->getRelTableIDs()) {
+        const auto* tableEntry = catalog->getTableCatalogEntry(transaction, tableID);
+        BoundAlterInfo tableAlterInfo = info.copy();
+        tableAlterInfo.tableName = tableEntry->getName();
+        if (tableAlterInfo.alterType == common::AlterType::RENAME_TABLE) {
+            KU_ASSERT(tableAlterInfo.tableName.starts_with(relGroupEntry->getName()));
+            // table name is in format {rel_group_name}{suffix}
+            // rename to {new_rel_group_name}{suffix}
+            auto& renameInfo = tableAlterInfo.extraInfo->cast<BoundExtraRenameTableInfo>();
+            auto tableNameSuffix = tableEntry->getName().substr(relGroupEntry->getName().size());
+            renameInfo.newName.append(tableNameSuffix);
+        }
+        alterTable(context, tableAlterInfo);
+    }
+}
+
 void Alter::executeDDLInternal(ExecutionContext* context) {
     auto catalog = context->clientContext->getCatalog();
     auto transaction = context->clientContext->getTransaction();
-    switch (info.alterType) {
-    case common::AlterType::ADD_PROPERTY: {
-        if (skipAlter(info.onConflict, [&]() {
-                return catalog->getTableCatalogEntry(transaction, info.tableName)
-                    ->containsProperty(info.extraInfo->constCast<BoundExtraAddPropertyInfo>()
-                                           .propertyDefinition.getName());
-            })) {
-            return;
-        }
+    if (catalog->containsTable(transaction, info.tableName)) {
+        // entry is a table
+        alterTable(context, info);
+    } else {
+        // if the entry isn't a table it should be a rel group
+        alterRelGroupChildren(context);
+        catalog->alterRelGroupEntry(transaction, info);
+    }
+}
+
+using on_conflict_throw_action = std::function<void()>;
+
+static void validateProperty(common::ConflictAction action,
+    const on_conflict_throw_action& throwAction) {
+    switch (action) {
+    case common::ConflictAction::ON_CONFLICT_THROW: {
+        throwAction();
     } break;
-    case common::AlterType::DROP_PROPERTY: {
-        if (skipAlter(info.onConflict, [&]() {
-                return !catalog->getTableCatalogEntry(transaction, info.tableName)
-                            ->containsProperty(
-                                info.extraInfo->constCast<BoundExtraDropPropertyInfo>()
-                                    .propertyName);
-            })) {
-            return;
-        }
-    } break;
-    default:
+    case common::ConflictAction::ON_CONFLICT_DO_NOTHING:
         break;
+    default:
+        KU_UNREACHABLE;
+    }
+}
+
+static void validatePropertyExist(common::ConflictAction action,
+    catalog::TableCatalogEntry* tableEntry, const std::string& propertyName) {
+    validateProperty(action, [&tableEntry, &propertyName]() {
+        if (!tableEntry->containsProperty(propertyName)) {
+            throw common::RuntimeException(
+                tableEntry->getName() + " table does not have property " + propertyName + ".");
+        }
+    });
+}
+
+static void validatePropertyNotExist(common::ConflictAction action,
+    catalog::TableCatalogEntry* tableEntry, const std::string& propertyName) {
+    validateProperty(action, [&tableEntry, &propertyName] {
+        if (tableEntry->containsProperty(propertyName)) {
+            throw common::RuntimeException(
+                tableEntry->getName() + " table already has property " + propertyName + ".");
+        }
+    });
+}
+
+static bool checkAddPropertyConflicts(catalog::TableCatalogEntry* tableEntry,
+    const BoundAlterInfo& info) {
+    const auto* extraInfo = info.extraInfo->constPtrCast<BoundExtraAddPropertyInfo>();
+    validatePropertyNotExist(info.onConflict, tableEntry, extraInfo->propertyDefinition.getName());
+
+    // Eventually, we want to support non-constant default on rel tables, but it is non-trivial
+    // due
+    // to FWD/BWD storage
+    if (tableEntry->getType() == catalog::CatalogEntryType::REL_TABLE_ENTRY &&
+        extraInfo->boundDefault->expressionType != common::ExpressionType::LITERAL) {
+        throw common::RuntimeException(
+            "Cannot set a non-constant default value when adding columns on REL tables.");
+    }
+
+    return skipAlter(info.onConflict, [&]() {
+        return tableEntry->containsProperty(
+            info.extraInfo->constCast<BoundExtraAddPropertyInfo>().propertyDefinition.getName());
+    });
+}
+
+static bool checkDropPropertyConflicts(catalog::TableCatalogEntry* tableEntry,
+    const BoundAlterInfo& info) {
+    const auto* extraInfo = info.extraInfo->constPtrCast<BoundExtraDropPropertyInfo>();
+    validatePropertyExist(info.onConflict, tableEntry, extraInfo->propertyName);
+
+    if (tableEntry->getTableType() == common::TableType::NODE &&
+        tableEntry->constCast<catalog::NodeTableCatalogEntry>().getPrimaryKeyName() ==
+            extraInfo->propertyName) {
+        throw common::RuntimeException("Cannot drop primary key of a node table.");
+    }
+
+    return skipAlter(info.onConflict, [&]() {
+        return !tableEntry->containsProperty(
+            info.extraInfo->constCast<BoundExtraDropPropertyInfo>().propertyName);
+    });
+}
+
+static bool checkRenamePropertyConflicts(catalog::TableCatalogEntry* tableEntry,
+    const BoundAlterInfo& info) {
+    const auto* extraInfo = info.extraInfo->constPtrCast<BoundExtraRenamePropertyInfo>();
+    validatePropertyExist(common::ConflictAction::ON_CONFLICT_THROW, tableEntry,
+        extraInfo->oldName);
+    validatePropertyNotExist(common::ConflictAction::ON_CONFLICT_THROW, tableEntry,
+        extraInfo->newName);
+    return false;
+}
+
+static bool checkConflicts(catalog::TableCatalogEntry* tableEntry, const BoundAlterInfo& info) {
+    switch (info.alterType) {
+    case common::AlterType::ADD_PROPERTY:
+        return checkAddPropertyConflicts(tableEntry, info);
+    case common::AlterType::DROP_PROPERTY:
+        return checkDropPropertyConflicts(tableEntry, info);
+    case common::AlterType::RENAME_PROPERTY:
+        return checkRenamePropertyConflicts(tableEntry, info);
+    default:
+        return false;
+    }
+}
+
+void Alter::alterTable(const ExecutionContext* context, const BoundAlterInfo& alterInfo) const {
+    auto catalog = context->clientContext->getCatalog();
+    auto transaction = context->clientContext->getTransaction();
+
+    auto entry = catalog->getTableCatalogEntry(transaction, alterInfo.tableName);
+    if (checkConflicts(entry, alterInfo)) {
+        return;
     }
     const auto storageManager = context->clientContext->getStorageManager();
-    catalog->alterTableEntry(transaction, info);
+    catalog->alterTableEntry(transaction, alterInfo);
     if (info.alterType == common::AlterType::ADD_PROPERTY) {
         auto& boundAddPropInfo = info.extraInfo->constCast<BoundExtraAddPropertyInfo>();
         KU_ASSERT(defaultValueEvaluator);
-        auto entry = catalog->getTableCatalogEntry(transaction, info.tableName);
-        auto& addedProp = entry->getProperty(boundAddPropInfo.propertyDefinition.getName());
+        auto* alteredEntry = catalog->getTableCatalogEntry(transaction, alterInfo.tableName);
+        auto& addedProp = alteredEntry->getProperty(boundAddPropInfo.propertyDefinition.getName());
         storage::TableAddColumnState state{addedProp, *defaultValueEvaluator};
-        storageManager->getTable(entry->getTableID())
-            ->addColumn(context->clientContext->getTransaction(), state);
+        storageManager->getTable(alteredEntry->getTableID())->addColumn(transaction, state);
     } else if (info.alterType == common::AlterType::DROP_PROPERTY) {
-        const auto schema = context->clientContext->getCatalog()->getTableCatalogEntry(
-            context->clientContext->getTransaction(), info.tableName);
-        storageManager->getTable(schema->getTableID())->dropColumn();
+        auto* alteredEntry = catalog->getTableCatalogEntry(transaction, alterInfo.tableName);
+        storageManager->getTable(alteredEntry->getTableID())->dropColumn();
     }
 }
 

--- a/src/processor/operator/ddl/drop.cpp
+++ b/src/processor/operator/ddl/drop.cpp
@@ -46,7 +46,7 @@ void Drop::executeDDLInternal(ExecutionContext* context) {
     }
 }
 
-void Drop::dropSequence(main::ClientContext* context) {
+void Drop::dropSequence(const main::ClientContext* context) {
     auto catalog = context->getCatalog();
     auto transaction = context->getTransaction();
     if (!catalog->containsSequence(transaction, dropInfo.name)) {
@@ -66,7 +66,7 @@ void Drop::dropSequence(main::ClientContext* context) {
     entryDropped = true;
 }
 
-void Drop::dropTable(main::ClientContext* context) {
+void Drop::dropTable(const main::ClientContext* context) {
     auto catalog = context->getCatalog();
     auto transaction = context->getTransaction();
     auto entry = catalog->getTableCatalogEntry(transaction, dropInfo.name);
@@ -96,7 +96,7 @@ void Drop::dropTable(main::ClientContext* context) {
     entryDropped = true;
 }
 
-void Drop::dropRelGroup(main::ClientContext* context) {
+void Drop::dropRelGroup(const main::ClientContext* context) {
     auto catalog = context->getCatalog();
     auto transaction = context->getTransaction();
     auto entry = catalog->getRelGroupEntry(transaction, dropInfo.name);

--- a/src/storage/undo_buffer.cpp
+++ b/src/storage/undo_buffer.cpp
@@ -262,14 +262,14 @@ void UndoBuffer::rollbackCatalogEntryRecord(const uint8_t* record) {
     const auto& [catalogSet, catalogEntry] = *reinterpret_cast<CatalogEntryRecord const*>(record);
     const auto entryToRollback = catalogEntry->getNext();
     KU_ASSERT(entryToRollback);
-//<<<<<<< HEAD
-//=======
-//    const auto entryType = entryToRollback->getType();
-//    if (entryType == CatalogEntryType::NODE_TABLE_ENTRY ||
-//        entryType == CatalogEntryType::REL_TABLE_ENTRY) {
-//        entryToRollback->ptrCast<TableCatalogEntry>()->resetAlterInfo();
-//    }
-//>>>>>>> 966b0aaec (Add support for alter on rel groups)
+    //<<<<<<< HEAD
+    //=======
+    //    const auto entryType = entryToRollback->getType();
+    //    if (entryType == CatalogEntryType::NODE_TABLE_ENTRY ||
+    //        entryType == CatalogEntryType::REL_TABLE_ENTRY) {
+    //        entryToRollback->ptrCast<TableCatalogEntry>()->resetAlterInfo();
+    //    }
+    //>>>>>>> 966b0aaec (Add support for alter on rel groups)
     if (entryToRollback->getNext()) {
         // If entryToRollback has a newer entry (next) in the version chain. Simple remove
         // entryToRollback from the chain.

--- a/src/storage/undo_buffer.cpp
+++ b/src/storage/undo_buffer.cpp
@@ -262,6 +262,14 @@ void UndoBuffer::rollbackCatalogEntryRecord(const uint8_t* record) {
     const auto& [catalogSet, catalogEntry] = *reinterpret_cast<CatalogEntryRecord const*>(record);
     const auto entryToRollback = catalogEntry->getNext();
     KU_ASSERT(entryToRollback);
+//<<<<<<< HEAD
+//=======
+//    const auto entryType = entryToRollback->getType();
+//    if (entryType == CatalogEntryType::NODE_TABLE_ENTRY ||
+//        entryType == CatalogEntryType::REL_TABLE_ENTRY) {
+//        entryToRollback->ptrCast<TableCatalogEntry>()->resetAlterInfo();
+//    }
+//>>>>>>> 966b0aaec (Add support for alter on rel groups)
     if (entryToRollback->getNext()) {
         // If entryToRollback has a newer entry (next) in the version chain. Simple remove
         // entryToRollback from the chain.

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -76,6 +76,12 @@ void WAL::logDropCatalogEntryRecord(table_id_t tableID, CatalogEntryType type) {
     addNewWALRecordNoLock(walRecord);
 }
 
+void WAL::logAlterRelGroupEntryRecord(const BoundAlterInfo* alterInfo) {
+    std::unique_lock<std::mutex> lck{mtx};
+    AlterRelGroupEntryRecord walRecord(alterInfo);
+    addNewWALRecordNoLock(walRecord);
+}
+
 void WAL::logAlterTableEntryRecord(const BoundAlterInfo* alterInfo) {
     std::unique_lock<std::mutex> lck{mtx};
     AlterTableEntryRecord walRecord(alterInfo);

--- a/src/storage/wal_replayer.cpp
+++ b/src/storage/wal_replayer.cpp
@@ -108,6 +108,9 @@ void WALReplayer::replayWALRecord(const WALRecord& walRecord) const {
     case WALRecordType::ALTER_TABLE_ENTRY_RECORD: {
         replayAlterTableEntryRecord(walRecord);
     } break;
+    case WALRecordType::ALTER_REL_GROUP_ENTRY_RECORD: {
+        replayAlterRelGroupEntryRecord(walRecord);
+    } break;
     case WALRecordType::UPDATE_SEQUENCE_RECORD: {
         replayUpdateSequenceRecord(walRecord);
     } break;
@@ -186,6 +189,13 @@ void WALReplayer::replayDropCatalogEntryRecord(const WALRecord& walRecord) const
         KU_UNREACHABLE;
     }
     }
+}
+
+void WALReplayer::replayAlterRelGroupEntryRecord(const WALRecord& walRecord) const {
+    auto binder = Binder(&clientContext);
+    auto& alterEntryRecord = walRecord.constCast<AlterTableEntryRecord>();
+    clientContext.getCatalog()->alterRelGroupEntry(clientContext.getTransaction(),
+        *alterEntryRecord.ownedAlterInfo);
 }
 
 void WALReplayer::replayAlterTableEntryRecord(const WALRecord& walRecord) const {

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -103,13 +103,9 @@ void Transaction::pushCreateDropCatalogEntry(CatalogSet& catalogSet, CatalogEntr
         if (catalogEntry.getType() == CatalogEntryType::DUMMY_ENTRY) {
             KU_ASSERT(catalogEntry.isDeleted());
             wal->logCreateCatalogEntryRecord(newCatalogEntry, isInternal);
-        } else {
-            // Must be ALTER.
-            throw common::RuntimeException("Alter rel group is not supported.");
-            //            KU_ASSERT(catalogEntry.getType() == newCatalogEntry->getType());
-            //            const auto& tableEntry = catalogEntry.constCast<TableCatalogEntry>();
-            //            wal->logAlterTableEntryRecord(tableEntry.getAlterInfo());
         }
+        // Otherwise must be ALTER. We don't do anything in this case since the only operation
+        // we need on rel groups is RENAME which only requires create/drop
     } break;
     case CatalogEntryType::SEQUENCE_ENTRY: {
         KU_ASSERT(
@@ -137,7 +133,6 @@ void Transaction::pushCreateDropCatalogEntry(CatalogSet& catalogSet, CatalogEntr
         case CatalogEntryType::REL_TABLE_ENTRY:
         case CatalogEntryType::REL_GROUP_ENTRY:
         case CatalogEntryType::SEQUENCE_ENTRY: {
-            // TODO(Guodong): support alter rel group.
             wal->logDropCatalogEntryRecord(catalogEntry.getOID(), catalogEntry.getType());
         } break;
         case CatalogEntryType::INDEX_ENTRY:

--- a/test/test_files/ddl/ddl.test
+++ b/test/test_files/ddl/ddl.test
@@ -532,7 +532,7 @@ Binder exception: Duplicated column name: name, column name must be unique.
 0|a
 -STATEMENT ALTER TABLE A ADD name STRING;
 ---- error
-Binder exception: A table already has property name.
+Runtime exception: A table already has property name.
 -STATEMENT ALTER TABLE A DROP name;
 ---- 1
 Table A altered.

--- a/test/test_files/ddl/sequence.test
+++ b/test/test_files/ddl/sequence.test
@@ -231,7 +231,7 @@ Catalog exception: nextval: reached maximum value of sequence "test" 3
 23217646816
 -STATEMENT alter table replyOf add propx int64 default nextval('test2');
 ---- error
-Binder exception: Cannot set a non-constant default value when adding columns on REL tables.
+Runtime exception: Cannot set a non-constant default value when adding columns on REL tables.
 
 -CASE DefaultSharedSequence
 -STATEMENT CREATE SEQUENCE shared;

--- a/test/test_files/exceptions/binder/binder_error.test
+++ b/test/test_files/exceptions/binder/binder_error.test
@@ -446,17 +446,17 @@ Binder exception: Table person1 does not exist.
 -LOG DropNonExistedColumn
 -STATEMENT alter table person drop random
 ---- error
-Binder exception: person table does not have property random.
+Runtime exception: person table does not have property random.
 
 -LOG DropPrimaryKeyColumn
 -STATEMENT alter table person drop ID
 ---- error
-Binder exception: Cannot drop primary key of a node table.
+Runtime exception: Cannot drop primary key of a node table.
 
 -LOG AddPropertyDuplicateName
 -STATEMENT alter table person add fName STRING
 ---- error
-Binder exception: person table already has property fName.
+Runtime exception: person table already has property fName.
 
 -LOG AddPropertyUnmatchedDefaultValueType
 -STATEMENT alter table person add intCol INT64 DEFAULT '3.2'
@@ -481,7 +481,7 @@ Binder exception: Table person1 does not exist.
 -LOG RenamePropertyDuplicateName
 -STATEMENT alter table person rename fName to gender
 ---- error
-Binder exception: person table already has property gender.
+Runtime exception: person table already has property gender.
 
 -LOG InvalidArrayNumElements
 -STATEMENT create node table test1(ID INT64, marks INT64[0], PRIMARY KEY(ID))

--- a/test/test_files/rel_group/basic.test
+++ b/test/test_files/rel_group/basic.test
@@ -2,7 +2,7 @@
 
 --
 
--CASE RelGroupTest1
+-CASE SimpleMatch
 -STATEMENT MATCH (a)-[e:knows]->(b) WHERE a.ID = 0 AND b.ID = 2 RETURN label(e), label(b), b.*
 ---- 3
 knows|personB|2|Bob
@@ -30,12 +30,8 @@ knows|personC|2|Bob
 knows|personC|2|Bob
 likes|personB|2|Bob
 likes|personA|2|Bob
--STATEMENT COPY knows FROM "a.csv";
----- error
-Binder exception: The table knows has multiple FROM and TO pairs defined in the schema. A specific pair of FROM and TO options is expected when copying data into the knows table.
--STATEMENT DROP TABLE knows_personA_personB;
----- error
-Binder exception: Cannot delete relationship table knows_personA_personB because it is referenced by relationship group knows.
+
+-CASE Drop
 -STATEMENT CALL show_tables() RETURN *;
 ---- 5
 0|personA|NODE|local(kuzu)|
@@ -43,6 +39,9 @@ Binder exception: Cannot delete relationship table knows_personA_personB because
 2|personC|NODE|local(kuzu)|
 0|knows|REL|local(kuzu)|
 1|likes|REL|local(kuzu)|
+-STATEMENT DROP TABLE knows_personA_personB;
+---- error
+Binder exception: Cannot delete relationship table knows_personA_personB because it is referenced by relationship group knows.
 -STATEMENT DROP TABLE knows;
 ---- ok
 -STATEMENT CALL show_tables() RETURN *;
@@ -57,44 +56,62 @@ Binder exception: Table knows does not exist.
 -STATEMENT MATCH (a:personA)-[e:knows_personA_personB]->(b) RETURN COUNT(*)
 ---- error
 Binder exception: Table knows_personA_personB does not exist.
--STATEMENT ALTER TABLE likes_personA_personB RENAME TO likes_A_B;
----- ok
 
--CASE X
--SKIP
+-CASE Alter
 -STATEMENT ALTER TABLE likes RENAME TO hates;
----- ok
+ ---- ok
 -STATEMENT CALL show_tables() RETURN *;
----- 6
+---- 5
 0|personA|NODE|local(kuzu)|
 1|personB|NODE|local(kuzu)|
 2|personC|NODE|local(kuzu)|
-7|likes_A_B|REL|local(kuzu)|
-8|likes_personB_personA|REL|local(kuzu)|
-0|hates|REL_GROUP|local(kuzu)|
+0|knows|REL|local(kuzu)|
+1|hates|REL|local(kuzu)|
 -STATEMENT MATCH (a:personA)-[e:hates]->(b:personB) WHERE a.ID = 0 RETURN label(e), label(b), b.*
 ---- 3
-likes_A_B|personB|2|Bob
-likes_A_B|personB|3|Carol
-likes_A_B|personB|5|Dan
+hates|personB|2|Bob
+hates|personB|3|Carol
+hates|personB|5|Dan
 -STATEMENT ALTER TABLE hates ADD age INT;
----- error
-Binder exception: Cannot add property on table hates with type REL_GROUP.
--STATEMENT ALTER TABLE hates DROP age;
----- error
-Binder exception: Cannot drop property on table hates with type REL_GROUP.
--STATEMENT ALTER TABLE hates RENAME age TO s;
----- error
-Binder exception: Cannot rename property on table hates with type REL_GROUP.
--STATEMENT ALTER TABLE likes_A_B RENAME date TO s;
 ---- ok
--STATEMENT CALL table_info("likes_A_B") RETURN *;
+-STATEMENT MATCH (a:personA)-[e:hates]->(b:personB) WHERE a.ID = 0 RETURN e.age
+---- 3 # default values are null
+
+
+
+-STATEMENT ALTER TABLE hates RENAME age TO s;
+---- ok
+-STATEMENT MATCH (a:personA)-[e:hates]->(b:personB) WHERE a.ID = 0 RETURN e.s
+---- 3
+
+
+
+-STATEMENT ALTER TABLE hates DROP s;
+---- ok
+-STATEMENT MATCH (a:personA)-[e:hates]->(b:personB) RETURN e.s
+---- error
+Binder exception: Cannot find property s for e.
+-STATEMENT ALTER TABLE hates RENAME TO likes;
+---- ok
+-STATEMENT CALL show_tables() RETURN *;
+---- 5
+0|personA|NODE|local(kuzu)|
+1|personB|NODE|local(kuzu)|
+2|personC|NODE|local(kuzu)|
+0|knows|REL|local(kuzu)|
+1|likes|REL|local(kuzu)|
+-STATEMENT MATCH (a:personA)-[e:likes]->(b:personB) WHERE a.ID = 0 RETURN label(e), label(b), b.*
+---- 3
+likes|personB|2|Bob
+likes|personB|3|Carol
+likes|personB|5|Dan
+-STATEMENT ALTER TABLE likes_personA_personB RENAME date TO s;
+---- ok
+-STATEMENT CALL table_info("likes_personA_personB") RETURN *;
 ---- 1
 1|s|DATE|NULL|both
 
-
 -CASE DMLCreateWithSRCandDEST
-
 -STATEMENT CREATE (a);
 ---- error
 Binder exception: Create node a with multiple node labels is not supported.
@@ -114,7 +131,6 @@ Binder exception: Create node a with multiple node labels is not supported.
 1145|1919|personA|personB|likes
 
 -CASE COPYWithFROMTO
-
 -STATEMENT create rel table test (FROM personA TO personA, FROM personA To personB, date DATE);
 ---- ok
 -STATEMENT COPY test FROM '${KUZU_ROOT_DIRECTORY}/dataset/rel-group/edge.csv';

--- a/test/test_files/transaction/ddl/ddl_empty.test
+++ b/test/test_files/transaction/ddl/ddl_empty.test
@@ -139,3 +139,313 @@ Binder exception: Cannot find property since for k.
 2
 3
 4
+
+-CASE RenameRelGroupCommit
+-STATEMENT CREATE NODE TABLE base1(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE NODE TABLE base2(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE REL TABLE test(FROM base1 TO base1, FROM base1 TO base2);
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT ALTER TABLE test RENAME TO test1;
+---- ok
+-STATEMENT COMMIT;
+---- ok
+-STATEMENT CALL SHOW_TABLES() RETURN *;
+---- 3
+0|base1|NODE|local(kuzu)|
+1|base2|NODE|local(kuzu)|
+0|test1|REL|local(kuzu)|
+
+-CASE RenameRelGroupRollback
+-STATEMENT CREATE NODE TABLE base1(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE NODE TABLE base2(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE REL TABLE test(FROM base1 TO base1, FROM base1 TO base2);
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT ALTER TABLE test RENAME TO test1;
+---- ok
+-STATEMENT ROLLBACK;
+---- ok
+-STATEMENT CALL SHOW_TABLES() RETURN *;
+---- 3
+0|base1|NODE|local(kuzu)|
+1|base2|NODE|local(kuzu)|
+0|test|REL|local(kuzu)|
+
+-CASE RenameRelGroupCommitRecovery
+-STATEMENT CREATE NODE TABLE base1(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE NODE TABLE base2(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE REL TABLE test(FROM base1 TO base1, FROM base1 TO base2);
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT ALTER TABLE test RENAME TO test1;
+---- ok
+-STATEMENT COMMIT;
+---- ok
+-STATEMENT CALL SHOW_TABLES() RETURN *;
+---- 3
+0|base1|NODE|local(kuzu)|
+1|base2|NODE|local(kuzu)|
+0|test1|REL|local(kuzu)|
+-RELOADDB
+-STATEMENT CALL SHOW_TABLES() RETURN *;
+---- 3
+0|base1|NODE|local(kuzu)|
+1|base2|NODE|local(kuzu)|
+0|test1|REL|local(kuzu)|
+
+-CASE RenameRelGroupRollbackRecovery
+-STATEMENT CREATE NODE TABLE base1(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE NODE TABLE base2(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE REL TABLE test(FROM base1 TO base1, FROM base1 TO base2);
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT ALTER TABLE test RENAME TO test1;
+---- ok
+-STATEMENT ROLLBACK;
+---- ok
+-STATEMENT CALL SHOW_TABLES() RETURN *;
+---- 3
+0|base1|NODE|local(kuzu)|
+1|base2|NODE|local(kuzu)|
+0|test|REL|local(kuzu)|
+-RELOADDB
+-STATEMENT CALL SHOW_TABLES() RETURN *;
+---- 3
+0|base1|NODE|local(kuzu)|
+1|base2|NODE|local(kuzu)|
+0|test|REL|local(kuzu)|
+
+-CASE RenameRelGroupPropertyCommit
+-STATEMENT CREATE NODE TABLE base1(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE NODE TABLE base2(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE REL TABLE test(FROM base1 TO base1, FROM base1 TO base2, prop1 INT64);
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT ALTER TABLE test RENAME prop1 TO prop2;
+---- ok
+-STATEMENT COMMIT;
+---- ok
+-STATEMENT CALL table_info("test") RETURN *;
+---- 1
+1|prop2|INT64|NULL|both
+
+-CASE RenameRelGroupPropertyRollback
+-STATEMENT CREATE NODE TABLE base1(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE NODE TABLE base2(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE REL TABLE test(FROM base1 TO base1, FROM base1 TO base2, prop1 INT64);
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT ALTER TABLE test RENAME prop1 TO prop2;
+---- ok
+-STATEMENT ROLLBACK;
+---- ok
+-STATEMENT CALL table_info("test") RETURN *;
+---- 1
+1|prop1|INT64|NULL|both
+
+-CASE RenameRelGroupPropertyCommitRecovery
+-STATEMENT CREATE NODE TABLE base1(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE NODE TABLE base2(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE REL TABLE test(FROM base1 TO base1, FROM base1 TO base2, prop1 INT64);
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT ALTER TABLE test RENAME prop1 TO prop2;
+---- ok
+-STATEMENT COMMIT;
+---- ok
+-STATEMENT CALL table_info("test") RETURN *;
+---- 1
+1|prop2|INT64|NULL|both
+-RELOADDB
+-STATEMENT CALL table_info("test") RETURN *;
+---- 1
+1|prop2|INT64|NULL|both
+
+-CASE RenameRelGroupPropertyRollbackRecovery
+-STATEMENT CREATE NODE TABLE base1(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE NODE TABLE base2(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE REL TABLE test(FROM base1 TO base1, FROM base1 TO base2, prop1 INT64);
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT ALTER TABLE test RENAME prop1 TO prop2;
+---- ok
+-STATEMENT ROLLBACK;
+---- ok
+-STATEMENT CALL table_info("test") RETURN *;
+---- 1
+1|prop1|INT64|NULL|both
+-RELOADDB
+-STATEMENT CALL table_info("test") RETURN *;
+---- 1
+1|prop1|INT64|NULL|both
+
+-CASE AddDropRelGroupPropertyCommit
+-STATEMENT CREATE NODE TABLE base1(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE NODE TABLE base2(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE REL TABLE test(FROM base1 TO base1, FROM base1 TO base2);
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT ALTER TABLE test ADD prop1 INT64;
+---- ok
+-STATEMENT COMMIT;
+---- ok
+-STATEMENT CALL table_info("test") RETURN *;
+---- 1
+1|prop1|INT64|NULL|both
+
+-CASE AddDropRelGroupPropertyRollback
+-STATEMENT CREATE NODE TABLE base1(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE NODE TABLE base2(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE REL TABLE test(FROM base1 TO base1, FROM base1 TO base2);
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT ALTER TABLE test ADD prop1 INT64;
+---- ok
+-STATEMENT ROLLBACK;
+---- ok
+-STATEMENT CALL table_info("test") RETURN *;
+---- 0
+
+-CASE AddDropRelGroupPropertyCommitRecovery
+-STATEMENT CREATE NODE TABLE base1(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE NODE TABLE base2(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE REL TABLE test(FROM base1 TO base1, FROM base1 TO base2);
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT ALTER TABLE test ADD prop1 INT64;
+---- ok
+-STATEMENT COMMIT;
+---- ok
+-STATEMENT CALL table_info("test") RETURN *;
+---- 1
+1|prop1|INT64|NULL|both
+-RELOADDB
+-STATEMENT CALL table_info("test") RETURN *;
+---- 1
+1|prop1|INT64|NULL|both
+
+-CASE AddDropRelGroupPropertyRollbackRecovery
+-STATEMENT CREATE NODE TABLE base1(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE NODE TABLE base2(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE REL TABLE test(FROM base1 TO base1, FROM base1 TO base2);
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT ALTER TABLE test ADD prop1 INT64;
+---- ok
+-STATEMENT ROLLBACK;
+---- ok
+-STATEMENT CALL table_info("test") RETURN *;
+---- 0
+-RELOADDB
+-STATEMENT CALL table_info("test") RETURN *;
+---- 0
+
+-CASE DropRelGroupPropertyCommit
+-STATEMENT CREATE NODE TABLE base1(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE NODE TABLE base2(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE REL TABLE test(FROM base1 TO base1, FROM base1 TO base2, prop1 INT64);
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT ALTER TABLE test DROP prop1;
+---- ok
+-STATEMENT COMMIT;
+---- ok
+-STATEMENT CALL table_info("test") RETURN *;
+---- 0
+
+-CASE DropRelGroupPropertyRollback
+-STATEMENT CREATE NODE TABLE base1(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE NODE TABLE base2(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE REL TABLE test(FROM base1 TO base1, FROM base1 TO base2, prop1 INT64);
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT ALTER TABLE test DROP prop1;
+---- ok
+-STATEMENT ROLLBACK;
+---- ok
+-STATEMENT CALL table_info("test") RETURN *;
+---- 1
+1|prop1|INT64|NULL|both
+
+-CASE DropRelGroupPropertyCommitRecovery
+-STATEMENT CREATE NODE TABLE base1(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE NODE TABLE base2(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE REL TABLE test(FROM base1 TO base1, FROM base1 TO base2, prop1 INT64);
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT ALTER TABLE test DROP prop1;
+---- ok
+-STATEMENT COMMIT;
+---- ok
+-STATEMENT CALL table_info("test") RETURN *;
+---- 0
+-RELOADDB
+-STATEMENT CALL table_info("test") RETURN *;
+---- 0
+
+-CASE DropRelGroupPropertyRollbackRecovery
+-STATEMENT CREATE NODE TABLE base1(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE NODE TABLE base2(id INT64, primary key(id));
+---- ok
+-STATEMENT CREATE REL TABLE test(FROM base1 TO base1, FROM base1 TO base2, prop1 INT64);
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT ALTER TABLE test DROP prop1;
+---- ok
+-STATEMENT ROLLBACK;
+---- ok
+-STATEMENT CALL table_info("test") RETURN *;
+---- 1
+1|prop1|INT64|NULL|both
+-RELOADDB
+-STATEMENT CALL table_info("test") RETURN *;
+---- 1
+1|prop1|INT64|NULL|both

--- a/test/test_files/transaction/recovery/rollback.test
+++ b/test/test_files/transaction/recovery/rollback.test
@@ -39,3 +39,42 @@ Binder exception: Table person does not exist.
 -STATEMENT CREATE NODE TABLE person(id INT64, name STRING, PRIMARY KEY(id));
 ---- error
 Binder exception: person already exists in catalog.
+
+-CASE RelGroupAlterRollbackAndRecovery
+-STATEMENT CREATE NODE TABLE person(id INT64, name STRING, PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE NODE TABLE person1(id INT64, name STRING, PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE REL TABLE group knows(FROM person TO person, FROM person To person1, age INT64);
+---- ok
+-STATEMENT CREATE (:person {id: 1, name: "Alice"})
+---- ok
+-STATEMENT MATCH (a:person), (b:person) CREATE (a)-[:knows {age: 12}]->(b)
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT ALTER TABLE knows RENAME age to year
+---- ok
+-STATEMENT ALTER TABLE knows RENAME TO likes
+---- ok
+-STATEMENT ROLLBACK;
+---- ok
+-RELOADDB
+-STATEMENT MATCH (a:person)-[k:knows]->(b:person) RETURN k.age
+---- 1
+12
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT ALTER TABLE knows ADD year INT
+---- ok
+-STATEMENT ALTER TABLE knows DROP age
+---- ok
+-STATEMENT ROLLBACK;
+---- ok
+-RELOADDB
+-STATEMENT MATCH (a:person)-[k:knows]->(b:person) RETURN k.year
+---- error
+Binder exception: Cannot find property year for k.
+-STATEMENT MATCH (a:person)-[k:knows]->(b:person) RETURN k.age
+---- 1
+12


### PR DESCRIPTION
# Description

- Support `ALTER` on rel groups, propagating the changes to the child tables
- Move most validation functions for alter from binder to alter operator

TODOs:
- Add more tests
  - [ ] WAL replaying alter (there's a single test in `rollback.test`)
  - [ ] Alter conflict handling on rel groups

Fixed #4762 as well.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).