### PR TITLE
Fixed nodejs progress test randomly failing on arm64

### DIFF
--- a/tools/nodejs_api/src_cpp/include/node_progress_bar_display.h
+++ b/tools/nodejs_api/src_cpp/include/node_progress_bar_display.h
@@ -2,6 +2,7 @@
 
 #include "common/task_system/progress_bar_display.h"
 #include <napi.h>
+#include <shared_mutex>
 
 using namespace kuzu;
 using namespace common;
@@ -22,4 +23,5 @@ public:
 
 private:
     std::unordered_map<uint64_t, Napi::ThreadSafeFunction> queryCallbacks;
+    std::shared_mutex callbackMutex;
 };

--- a/tools/nodejs_api/src_cpp/include/node_progress_bar_display.h
+++ b/tools/nodejs_api/src_cpp/include/node_progress_bar_display.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <shared_mutex>
+
 #include "common/task_system/progress_bar_display.h"
 #include <napi.h>
-#include <shared_mutex>
 
 using namespace kuzu;
 using namespace common;

--- a/tools/nodejs_api/test/test_connection.js
+++ b/tools/nodejs_api/test/test_connection.js
@@ -381,43 +381,42 @@ describe("Progress", function () {
         assert.isTrue(progressCalled);
     });
 
-    // TODO: Fix this test: see issue #5458
-    // it("should execute multiple valid querys with progress", async function () {
-    //     let progressCalled = false;
-    //     const progressCallback = (pipelineProgress, numPipelinesFinished, numPipelines) => {
-    //         progressCalled = true;
-    //         assert.isNumber(pipelineProgress);
-    //         assert.isNumber(numPipelinesFinished);
-    //         assert.isNumber(numPipelines);
-    //     };
-    //     let progressCalled2 = false;
-    //     const progressCallback2 = (pipelineProgress, numPipelinesFinished, numPipelines) => {
-    //         progressCalled2 = true;
-    //         assert.isNumber(pipelineProgress);
-    //         assert.isNumber(numPipelinesFinished);
-    //         assert.isNumber(numPipelines);
-    //     };
-    //     const promise = conn.query("MATCH (a:person) RETURN COUNT(*)", progressCallback);
-    //     const promise2 = conn.query("MATCH (a:person) RETURN COUNT(*)", progressCallback2);
-    //     const queryResult = await promise;
-    //     const queryResult2 = await promise2;
-    //     assert.exists(queryResult);
-    //     assert.equal(queryResult.constructor.name, "QueryResult");
-    //     assert.isTrue(queryResult.hasNext());
-    //     const tuple = await queryResult.getNext();
-    //     assert.exists(tuple);
-    //     assert.exists(tuple["COUNT_STAR()"]);
-    //     assert.equal(tuple["COUNT_STAR()"], 8);
-    //     assert.isTrue(progressCalled);
-    //     assert.exists(queryResult2);
-    //     assert.equal(queryResult2.constructor.name, "QueryResult");
-    //     assert.isTrue(queryResult2.hasNext());
-    //     const tuple2 = await queryResult2.getNext();
-    //     assert.exists(tuple2);
-    //     assert.exists(tuple2["COUNT_STAR()"]);
-    //     assert.equal(tuple2["COUNT_STAR()"], 8);
-    //     assert.isTrue(progressCalled2);
-    // });
+    it("should execute multiple valid querys with progress", async function () {
+        let progressCalled = false;
+        const progressCallback = (pipelineProgress, numPipelinesFinished, numPipelines) => {
+            progressCalled = true;
+            assert.isNumber(pipelineProgress);
+            assert.isNumber(numPipelinesFinished);
+            assert.isNumber(numPipelines);
+        };
+        let progressCalled2 = false;
+        const progressCallback2 = (pipelineProgress, numPipelinesFinished, numPipelines) => {
+            progressCalled2 = true;
+            assert.isNumber(pipelineProgress);
+            assert.isNumber(numPipelinesFinished);
+            assert.isNumber(numPipelines);
+        };
+        const promise = conn.query("MATCH (a:person)-[:knows]->(b:person) WHERE a <> b RETURN COUNT(*)", progressCallback);
+        const promise2 = conn.query("MATCH (a:person)-[:knows]->(b:person) WHERE a <> b RETURN COUNT(*)", progressCallback2);
+        const queryResult = await promise;
+        const queryResult2 = await promise2;
+        assert.exists(queryResult);
+        assert.equal(queryResult.constructor.name, "QueryResult");
+        assert.isTrue(queryResult.hasNext());
+        const tuple = await queryResult.getNext();
+        assert.exists(tuple);
+        assert.exists(tuple["COUNT_STAR()"]);
+        assert.equal(tuple["COUNT_STAR()"], 14);
+        assert.isTrue(progressCalled);
+        assert.exists(queryResult2);
+        assert.equal(queryResult2.constructor.name, "QueryResult");
+        assert.isTrue(queryResult2.hasNext());
+        const tuple2 = await queryResult2.getNext();
+        assert.exists(tuple2);
+        assert.exists(tuple2["COUNT_STAR()"]);
+        assert.equal(tuple2["COUNT_STAR()"], 14);
+        assert.isTrue(progressCalled2);
+    });
 
     it("should throw error if the progress callback is not a function for query", async function () {
         try {


### PR DESCRIPTION
# Description

Query progress tracking for nodejs api was using an unordered_map to store query callbacks for when multiple queries are called at once. However, an unordered_map is not thread-safe so rarely there was data loss, and the callback was occasionally not saved correctly. Added a shared_mutex for the callback map to allow for shared reading between threads but locking for writing to the callback map.

Fixes #4548

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).