### PR TITLE
Remove alterInfo from TableCatalogEntry

### DIFF
--- a/src/include/catalog/catalog_entry/table_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/table_catalog_entry.h
@@ -41,12 +41,6 @@ public:
 
     virtual function::TableFunction getScanFunction() { KU_UNREACHABLE; }
 
-    binder::BoundAlterInfo* getAlterInfo() const { return alterInfo.get(); }
-    void resetAlterInfo() { alterInfo = nullptr; }
-    void setAlterInfo(const binder::BoundAlterInfo& alterInfo_) {
-        alterInfo = std::make_unique<binder::BoundAlterInfo>(alterInfo_.copy());
-    }
-
     common::column_id_t getMaxColumnID() const;
     void vacuumColumnIDs(common::column_id_t nextColumnID);
     std::string propertiesToCypher() const;
@@ -82,7 +76,6 @@ protected:
 protected:
     std::string comment;
     PropertyDefinitionCollection propertyCollection;
-    std::unique_ptr<binder::BoundAlterInfo> alterInfo;
 };
 
 struct TableCatalogEntryHasher {

--- a/src/include/catalog/catalog_set.h
+++ b/src/include/catalog/catalog_set.h
@@ -33,7 +33,7 @@ public:
         std::unique_ptr<CatalogEntry> entry);
     void dropEntry(transaction::Transaction* transaction, const std::string& name,
         common::oid_t oid);
-    void alterEntry(transaction::Transaction* transaction, const binder::BoundAlterInfo& alterInfo);
+    void alterEntry(const transaction::Transaction* transaction, const binder::BoundAlterInfo& alterInfo);
 
     CatalogEntrySet getEntries(const transaction::Transaction* transaction);
     CatalogEntry* getEntryOfOID(const transaction::Transaction* transaction, common::oid_t oid);

--- a/src/include/transaction/transaction.h
+++ b/src/include/transaction/transaction.h
@@ -4,6 +4,9 @@
 #include "common/types/types.h"
 
 namespace kuzu {
+namespace binder {
+struct BoundAlterInfo;
+}
 namespace catalog {
 class CatalogEntry;
 class CatalogSet;
@@ -110,8 +113,10 @@ public:
         return maxCommittedNodeOffsets.at(tableID) + getLocalRowIdx(tableID, uncommittedOffset);
     }
 
-    void pushCatalogEntry(catalog::CatalogSet& catalogSet, catalog::CatalogEntry& catalogEntry,
-        bool isInternal, bool skipLoggingToWAL = false) const;
+    void pushCreateDropCatalogEntry(catalog::CatalogSet& catalogSet,
+        catalog::CatalogEntry& catalogEntry, bool isInternal, bool skipLoggingToWAL = false) const;
+    void pushAlterCatalogEntry(catalog::CatalogSet& catalogSet, catalog::CatalogEntry& catalogEntry,
+        const binder::BoundAlterInfo& alterInfo) const;
     void pushSequenceChange(catalog::SequenceCatalogEntry* sequenceEntry, int64_t kCount,
         const catalog::SequenceRollbackData& data) const;
     void pushInsertInfo(common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,

--- a/src/storage/undo_buffer.cpp
+++ b/src/storage/undo_buffer.cpp
@@ -262,12 +262,6 @@ void UndoBuffer::rollbackCatalogEntryRecord(const uint8_t* record) {
     const auto& [catalogSet, catalogEntry] = *reinterpret_cast<CatalogEntryRecord const*>(record);
     const auto entryToRollback = catalogEntry->getNext();
     KU_ASSERT(entryToRollback);
-    const auto entryType = entryToRollback->getType();
-    if (entryType == CatalogEntryType::NODE_TABLE_ENTRY ||
-        entryType == CatalogEntryType::REL_TABLE_ENTRY ||
-        entryType == CatalogEntryType::REL_GROUP_ENTRY) {
-        entryToRollback->ptrCast<TableCatalogEntry>()->resetAlterInfo();
-    }
     if (entryToRollback->getNext()) {
         // If entryToRollback has a newer entry (next) in the version chain. Simple remove
         // entryToRollback from the chain.


### PR DESCRIPTION
# Description

This is a refactoring to get rid of `alterInfo` in `TableCatalogEntry` by separating the push of catalog entry into undo buffer due to create/drop and alter.