### PR TITLE
Make propertyID global unique

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(Kuzu VERSION 0.7.1.9 LANGUAGES CXX C)
+project(Kuzu VERSION 0.7.2.0 LANGUAGES CXX C)
 
 option(SINGLE_THREADED "Single-threaded mode" FALSE)
 if(SINGLE_THREADED)

--- a/extension/fts/src/function/create_fts_index.cpp
+++ b/extension/fts/src/function/create_fts_index.cpp
@@ -51,7 +51,7 @@ static std::vector<std::string> bindProperties(const catalog::NodeTableCatalogEn
             throw BinderException{stringFormat("Property: {} does not exist in table {}.",
                 propertyName, entry.getName())};
         }
-        if (entry.getProperty(entry.getPropertyIdx(propertyName)).getType() !=
+        if (entry.getProperty(entry.getPropertyID(propertyName)).getType() !=
             LogicalType::STRING()) {
             throw BinderException{"Full text search index can only be built on string properties."};
         }

--- a/src/binder/bind/bind_updating_clause.cpp
+++ b/src/binder/bind/bind_updating_clause.cpp
@@ -145,7 +145,7 @@ std::vector<BoundInsertInfo> Binder::bindInsertInfos(QueryGraphCollection& query
 static void validatePrimaryKeyExistence(const NodeTableCatalogEntry* nodeTableEntry,
     const NodeExpression& node, const expression_vector& defaultExprs) {
     auto primaryKeyName = nodeTableEntry->getPrimaryKeyName();
-    auto pkeyDefaultExpr = defaultExprs.at(nodeTableEntry->getPrimaryKeyIdx());
+    auto pkeyDefaultExpr = defaultExprs.at(nodeTableEntry->getPrimaryKeyID());
     if (!node.hasPropertyDataExpr(primaryKeyName) &&
         ExpressionUtil::isNullLiteral(*pkeyDefaultExpr)) {
         throw BinderException(stringFormat("Create node {} expects primary key {} as input.",

--- a/src/binder/bind/copy/bind_copy_from.cpp
+++ b/src/binder/bind/copy/bind_copy_from.cpp
@@ -152,7 +152,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRelFrom(const Statement& stateme
     expression_vector columnExprs{srcOffset, dstOffset, offset};
     std::vector<ColumnEvaluateType> evaluateTypes{ColumnEvaluateType::REFERENCE,
         ColumnEvaluateType::REFERENCE, ColumnEvaluateType::REFERENCE};
-    auto& properties = relTableEntry->getProperties();
+    auto properties = relTableEntry->getProperties();
     for (auto i = 1u; i < properties.size(); ++i) { // skip internal ID
         auto& property = properties[i];
         auto [evaluateType, column] =

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -60,8 +60,8 @@ bool TableCatalogEntry::containsProperty(const std::string& propertyName) const 
     return propertyCollection.contains(propertyName);
 }
 
-idx_t TableCatalogEntry::getPropertyIdx(const std::string& propertyName) const {
-    return propertyCollection.getIdx(propertyName);
+idx_t TableCatalogEntry::getPropertyID(const std::string& propertyName) const {
+    return propertyCollection.getPropertyID(propertyName);
 }
 
 const PropertyDefinition& TableCatalogEntry::getProperty(const std::string& propertyName) const {

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -60,7 +60,7 @@ bool TableCatalogEntry::containsProperty(const std::string& propertyName) const 
     return propertyCollection.contains(propertyName);
 }
 
-idx_t TableCatalogEntry::getPropertyID(const std::string& propertyName) const {
+property_id_t TableCatalogEntry::getPropertyID(const std::string& propertyName) const {
     return propertyCollection.getPropertyID(propertyName);
 }
 

--- a/src/common/arrow/arrow_row_batch.cpp
+++ b/src/common/arrow/arrow_row_batch.cpp
@@ -407,13 +407,13 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::REL>(ArrowVector* ve
         RelVal::getLabelVal(value));
     appendValue(vector->childData[3].get(), StructType::getFieldType(type, 3),
         RelVal::getIDVal(value));
-    std::int64_t propertyId = 4;
+    common::property_id_t propertyID = 4;
     auto numProperties = RelVal::getNumProperties(value);
     for (auto i = 0u; i < numProperties; i++) {
         auto val = RelVal::getPropertyVal(value, i);
-        appendValue(vector->childData[propertyId].get(), StructType::getFieldType(type, propertyId),
+        appendValue(vector->childData[propertyID].get(), StructType::getFieldType(type, propertyID),
             val);
-        propertyId++;
+        propertyID++;
     }
 }
 

--- a/src/common/serializer/serializer.cpp
+++ b/src/common/serializer/serializer.cpp
@@ -1,5 +1,7 @@
 #include "common/serializer/serializer.h"
 
+#include <map>
+
 #include "common/assert.h"
 
 namespace kuzu {

--- a/src/common/serializer/serializer.cpp
+++ b/src/common/serializer/serializer.cpp
@@ -1,7 +1,5 @@
 #include "common/serializer/serializer.h"
 
-#include <map>
-
 #include "common/assert.h"
 
 namespace kuzu {

--- a/src/function/table/call/table_info.cpp
+++ b/src/function/table/call/table_info.cpp
@@ -125,7 +125,7 @@ static std::vector<PropertyInfo> getForeignPropertyInfos(TableCatalogEntry* entr
     std::vector<PropertyInfo> infos;
     for (auto& def : entry->getProperties()) {
         auto info = getInfo(def);
-        info.propertyID = entry->getPropertyIdx(def.getName());
+        info.propertyID = entry->getPropertyID(def.getName());
         infos.push_back(std::move(info));
     }
     return infos;
@@ -136,7 +136,7 @@ static std::vector<PropertyInfo> getNodePropertyInfos(NodeTableCatalogEntry* ent
     auto primaryKeyName = entry->getPrimaryKeyName();
     for (auto& def : entry->getProperties()) {
         auto info = getInfo(def);
-        info.propertyID = entry->getPropertyIdx(def.getName());
+        info.propertyID = entry->getPropertyID(def.getName());
         info.extraInfo = std::make_unique<ExtraNodePropertyInfo>(primaryKeyName == def.getName());
         infos.push_back(std::move(info));
     }
@@ -150,7 +150,7 @@ static std::vector<PropertyInfo> getRelPropertyInfos(RelTableCatalogEntry* entry
             continue;
         }
         auto info = getInfo(def);
-        info.propertyID = entry->getPropertyIdx(def.getName());
+        info.propertyID = entry->getPropertyID(def.getName());
         info.extraInfo = std::make_unique<ExtraRelPropertyInfo>(
             ExtendDirectionUtil::toString(entry->getStorageDirection()));
         infos.push_back(std::move(info));

--- a/src/include/binder/expression/property_expression.h
+++ b/src/include/binder/expression/property_expression.h
@@ -36,7 +36,7 @@ public:
     PropertyExpression(const PropertyExpression& other)
         : Expression{expressionType_, other.dataType.copy(), other.uniqueName},
           propertyName{other.propertyName}, uniqueVarName{other.uniqueVarName},
-          rawVariableName{other.rawVariableName}, infos{copyMap(other.infos)} {}
+          rawVariableName{other.rawVariableName}, infos{copyUnorderedMap(other.infos)} {}
 
     // Construct from a virtual property, i.e. no propertyID available.
     static std::unique_ptr<PropertyExpression> construct(common::LogicalType type,

--- a/src/include/catalog/catalog_entry/node_table_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/node_table_catalog_entry.h
@@ -23,7 +23,7 @@ public:
     common::TableType getTableType() const override { return common::TableType::NODE; }
 
     std::string getPrimaryKeyName() const { return primaryKeyName; }
-    common::property_id_t getPrimaryKeyIdx() const {
+    common::property_id_t getPrimaryKeyID() const {
         return propertyCollection.getPropertyID(primaryKeyName);
     }
     const binder::PropertyDefinition& getPrimaryKeyDefinition() const {

--- a/src/include/catalog/catalog_entry/node_table_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/node_table_catalog_entry.h
@@ -23,7 +23,9 @@ public:
     common::TableType getTableType() const override { return common::TableType::NODE; }
 
     std::string getPrimaryKeyName() const { return primaryKeyName; }
-    common::idx_t getPrimaryKeyIdx() const { return propertyCollection.getIdx(primaryKeyName); }
+    common::property_id_t getPrimaryKeyIdx() const {
+        return propertyCollection.getPropertyID(primaryKeyName);
+    }
     const binder::PropertyDefinition& getPrimaryKeyDefinition() const {
         return getProperty(primaryKeyName);
     }

--- a/src/include/catalog/catalog_entry/table_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/table_catalog_entry.h
@@ -50,12 +50,12 @@ public:
     common::column_id_t getMaxColumnID() const;
     void vacuumColumnIDs(common::column_id_t nextColumnID);
     std::string propertiesToCypher() const;
-    const std::vector<binder::PropertyDefinition>& getProperties() const {
+    std::vector<binder::PropertyDefinition> getProperties() const {
         return propertyCollection.getDefinitions();
     }
     common::idx_t getNumProperties() const { return propertyCollection.size(); }
     bool containsProperty(const std::string& propertyName) const;
-    common::idx_t getPropertyIdx(const std::string& propertyName) const;
+    common::idx_t getPropertyID(const std::string& propertyName) const;
     const binder::PropertyDefinition& getProperty(const std::string& propertyName) const;
     const binder::PropertyDefinition& getProperty(common::idx_t idx) const;
     virtual common::column_id_t getColumnID(const std::string& propertyName) const;

--- a/src/include/catalog/catalog_entry/table_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/table_catalog_entry.h
@@ -55,7 +55,7 @@ public:
     }
     common::idx_t getNumProperties() const { return propertyCollection.size(); }
     bool containsProperty(const std::string& propertyName) const;
-    common::idx_t getPropertyID(const std::string& propertyName) const;
+    common::property_id_t getPropertyID(const std::string& propertyName) const;
     const binder::PropertyDefinition& getProperty(const std::string& propertyName) const;
     const binder::PropertyDefinition& getProperty(common::idx_t idx) const;
     virtual common::column_id_t getColumnID(const std::string& propertyName) const;

--- a/src/include/catalog/property_definition_collection.h
+++ b/src/include/catalog/property_definition_collection.h
@@ -8,22 +8,22 @@ namespace catalog {
 
 class PropertyDefinitionCollection {
 public:
-    PropertyDefinitionCollection() : nextColumnID{0} {}
+    PropertyDefinitionCollection() : nextColumnID{0}, nextPropertyID{0} {}
     explicit PropertyDefinitionCollection(common::column_id_t nextColumnID)
-        : nextColumnID{nextColumnID} {}
+        : nextColumnID{nextColumnID}, nextPropertyID{0} {}
     EXPLICIT_COPY_DEFAULT_MOVE(PropertyDefinitionCollection);
 
     common::idx_t size() const { return definitions.size(); }
 
-    bool contains(const std::string& name) const { return nameToPropertyIdxMap.contains(name); }
+    bool contains(const std::string& name) const { return nameToPropertyIDMap.contains(name); }
 
-    const std::vector<binder::PropertyDefinition>& getDefinitions() const { return definitions; }
+    std::vector<binder::PropertyDefinition> getDefinitions() const;
     const binder::PropertyDefinition& getDefinition(const std::string& name) const;
     const binder::PropertyDefinition& getDefinition(common::idx_t idx) const;
     common::column_id_t getMaxColumnID() const;
     common::column_id_t getColumnID(const std::string& name) const;
-    common::column_id_t getColumnID(common::idx_t idx) const;
-    common::idx_t getIdx(const std::string& name) const;
+    common::column_id_t getColumnID(common::property_id_t propertyID) const;
+    common::property_id_t getPropertyID(const std::string& name) const;
     void vacuumColumnIDs(common::column_id_t nextColumnID);
 
     void add(const binder::PropertyDefinition& definition);
@@ -37,14 +37,16 @@ public:
 
 private:
     PropertyDefinitionCollection(const PropertyDefinitionCollection& other)
-        : nextColumnID{other.nextColumnID}, definitions{copyVector(other.definitions)},
-          columnIDs{other.columnIDs}, nameToPropertyIdxMap{other.nameToPropertyIdxMap} {}
+        : nextColumnID{other.nextColumnID}, nextPropertyID{other.nextPropertyID},
+          definitions{copyMap(other.definitions)}, columnIDs{other.columnIDs},
+          nameToPropertyIDMap{other.nameToPropertyIDMap} {}
 
 private:
     common::column_id_t nextColumnID;
-    std::vector<binder::PropertyDefinition> definitions;
-    std::vector<common::column_id_t> columnIDs;
-    common::case_insensitive_map_t<common::idx_t> nameToPropertyIdxMap;
+    common::property_id_t nextPropertyID;
+    std::map<common::property_id_t, binder::PropertyDefinition> definitions;
+    std::unordered_map<common::property_id_t, common::column_id_t> columnIDs;
+    common::case_insensitive_map_t<common::property_id_t> nameToPropertyIDMap;
 };
 
 } // namespace catalog

--- a/src/include/common/copy_constructors.h
+++ b/src/include/common/copy_constructors.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <map>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -110,8 +111,17 @@ static std::vector<std::unique_ptr<T>> cloneVector(const std::vector<std::unique
 }
 
 template<typename K, typename V>
-static std::unordered_map<K, V> copyMap(const std::unordered_map<K, V>& objects) {
+static std::unordered_map<K, V> copyUnorderedMap(const std::unordered_map<K, V>& objects) {
     std::unordered_map<K, V> result;
+    for (auto& [k, v] : objects) {
+        result.insert({k, v.copy()});
+    }
+    return result;
+}
+
+template<typename K, typename V>
+static std::map<K, V> copyMap(const std::map<K, V>& objects) {
+    std::map<K, V> result;
     for (auto& [k, v] : objects) {
         result.insert({k, v.copy()});
     }

--- a/src/include/common/serializer/deserializer.h
+++ b/src/include/common/serializer/deserializer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -40,7 +41,32 @@ public:
     }
 
     template<typename T1, typename T2>
-    void deserializeUnorderedMap(std::unordered_map<T1, std::unique_ptr<T2>>& values) {
+    void deserializeMap(std::map<T1, T2>& values) {
+        uint64_t mapSize = 0;
+        deserializeValue<uint64_t>(mapSize);
+        for (auto i = 0u; i < mapSize; i++) {
+            T1 key;
+            deserializeValue<T1>(key);
+            auto val = T2::deserialize(*this);
+            values.emplace(key, std::move(val));
+        }
+    }
+
+    template<typename T1, typename T2>
+    void deserializeUnorderedMap(std::unordered_map<T1, T2>& values) {
+        uint64_t mapSize = 0;
+        deserializeValue<uint64_t>(mapSize);
+        for (auto i = 0u; i < mapSize; i++) {
+            T1 key;
+            deserializeValue<T1>(key);
+            T2 val;
+            deserializeValue(val);
+            values.emplace(key, std::move(val));
+        }
+    }
+
+    template<typename T1, typename T2>
+    void deserializeUnorderedMapOfPtrs(std::unordered_map<T1, std::unique_ptr<T2>>& values) {
         uint64_t mapSize = 0;
         deserializeValue<uint64_t>(mapSize);
         values.reserve(mapSize);

--- a/src/include/common/serializer/serializer.h
+++ b/src/include/common/serializer/serializer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -42,7 +43,27 @@ public:
     }
 
     template<typename T1, typename T2>
-    void serializeUnorderedMap(const std::unordered_map<T1, std::unique_ptr<T2>>& values) {
+    void serializeMap(const std::map<T1, T2>& values) {
+        uint64_t mapSize = values.size();
+        serializeValue(mapSize);
+        for (auto& value : values) {
+            serializeValue(value.first);
+            value.second.serialize(*this);
+        }
+    }
+
+    template<typename T1, typename T2>
+    void serializeUnorderedMap(const std::unordered_map<T1, T2>& values) {
+        uint64_t mapSize = values.size();
+        serializeValue(mapSize);
+        for (auto& value : values) {
+            serializeValue(value.first);
+            serializeValue<T2>(value.second);
+        }
+    }
+
+    template<typename T1, typename T2>
+    void serializeUnorderedMapOfPtrs(const std::unordered_map<T1, std::unique_ptr<T2>>& values) {
         uint64_t mapSize = values.size();
         serializeValue(mapSize);
         for (auto& value : values) {

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -39,6 +39,7 @@ constexpr file_idx_t INVALID_FILE_IDX = UINT32_MAX;
 using page_group_idx_t = uint32_t;
 using frame_group_idx_t = page_group_idx_t;
 using column_id_t = uint32_t;
+using property_id_t = uint32_t;
 constexpr column_id_t INVALID_COLUMN_ID = UINT32_MAX;
 constexpr column_id_t ROW_IDX_COLUMN_ID = INVALID_COLUMN_ID - 1;
 using idx_t = uint32_t;

--- a/src/include/processor/operator/persistent/delete_executor.h
+++ b/src/include/processor/operator/persistent/delete_executor.h
@@ -114,7 +114,7 @@ public:
         common::table_id_map_t<NodeTableDeleteInfo> tableInfos)
         : NodeDeleteExecutor(std::move(info)), tableInfos{std::move(tableInfos)} {}
     MultiLabelNodeDeleteExecutor(const MultiLabelNodeDeleteExecutor& other)
-        : NodeDeleteExecutor(other), tableInfos{copyMap(other.tableInfos)} {}
+        : NodeDeleteExecutor(other), tableInfos{copyUnorderedMap(other.tableInfos)} {}
 
     void init(ResultSet* resultSet, ExecutionContext*) override;
     void delete_(ExecutionContext* context) override;

--- a/src/include/processor/operator/persistent/set_executor.h
+++ b/src/include/processor/operator/persistent/set_executor.h
@@ -88,7 +88,7 @@ public:
     MultiLabelNodeSetExecutor(NodeSetInfo info, common::table_id_map_t<NodeTableSetInfo> tableInfos)
         : NodeSetExecutor{std::move(info)}, tableInfos{std::move(tableInfos)} {}
     MultiLabelNodeSetExecutor(const MultiLabelNodeSetExecutor& other)
-        : NodeSetExecutor{other}, tableInfos{copyMap(other.tableInfos)} {}
+        : NodeSetExecutor{other}, tableInfos{copyUnorderedMap(other.tableInfos)} {}
 
     void set(ExecutionContext* context) override;
 
@@ -180,7 +180,7 @@ public:
     MultiLabelRelSetExecutor(RelSetInfo info, common::table_id_map_t<RelTableSetInfo> tableInfos)
         : RelSetExecutor{std::move(info)}, tableInfos{std::move(tableInfos)} {}
     MultiLabelRelSetExecutor(const MultiLabelRelSetExecutor& other)
-        : RelSetExecutor{other}, tableInfos{copyMap(other.tableInfos)} {}
+        : RelSetExecutor{other}, tableInfos{copyUnorderedMap(other.tableInfos)} {}
 
     void set(ExecutionContext* context) override;
 

--- a/src/include/processor/operator/scan/offset_scan_node_table.h
+++ b/src/include/processor/operator/scan/offset_scan_node_table.h
@@ -27,8 +27,7 @@ public:
 
     std::unique_ptr<PhysicalOperator> clone() override {
         return std::make_unique<OffsetScanNodeTable>(info.copy(),
-            copyUnorderedMap(tableIDToNodeInfo), id,
-            printInfo->copy());
+            copyUnorderedMap(tableIDToNodeInfo), id, printInfo->copy());
     }
 
 private:

--- a/src/include/processor/operator/scan/offset_scan_node_table.h
+++ b/src/include/processor/operator/scan/offset_scan_node_table.h
@@ -26,7 +26,8 @@ public:
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> clone() override {
-        return std::make_unique<OffsetScanNodeTable>(info.copy(), copyMap(tableIDToNodeInfo), id,
+        return std::make_unique<OffsetScanNodeTable>(info.copy(),
+            copyUnorderedMap(tableIDToNodeInfo), id,
             printInfo->copy());
     }
 

--- a/src/processor/operator/scan/scan_multi_rel_tables.cpp
+++ b/src/processor/operator/scan/scan_multi_rel_tables.cpp
@@ -109,8 +109,7 @@ bool ScanMultiRelTable::getNextTuplesInternal(ExecutionContext* context) {
 
 std::unique_ptr<PhysicalOperator> ScanMultiRelTable::clone() {
     return make_unique<ScanMultiRelTable>(info.copy(), directionInfo.copy(),
-        copyUnorderedMap(scanners),
-        children[0]->clone(), id, printInfo->copy());
+        copyUnorderedMap(scanners), children[0]->clone(), id, printInfo->copy());
 }
 
 void ScanMultiRelTable::resetState() {

--- a/src/processor/operator/scan/scan_multi_rel_tables.cpp
+++ b/src/processor/operator/scan/scan_multi_rel_tables.cpp
@@ -108,7 +108,8 @@ bool ScanMultiRelTable::getNextTuplesInternal(ExecutionContext* context) {
 }
 
 std::unique_ptr<PhysicalOperator> ScanMultiRelTable::clone() {
-    return make_unique<ScanMultiRelTable>(info.copy(), directionInfo.copy(), copyMap(scanners),
+    return make_unique<ScanMultiRelTable>(info.copy(), directionInfo.copy(),
+        copyUnorderedMap(scanners),
         children[0]->clone(), id, printInfo->copy());
 }
 

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -202,8 +202,7 @@ NodeTable::NodeTable(const StorageManager* storageManager,
       versionRecordHandler(this) {
     const auto maxColumnID = nodeTableEntry->getMaxColumnID();
     columns.resize(maxColumnID + 1);
-    for (auto i = 0u; i < nodeTableEntry->getNumProperties(); i++) {
-        auto& property = nodeTableEntry->getProperty(i);
+    for (auto& property : nodeTableEntry->getProperties()) {
         const auto columnID = nodeTableEntry->getColumnID(property.getName());
         const auto columnName =
             StorageUtils::getColumnName(property.getName(), StorageUtils::ColumnType::DEFAULT, "");
@@ -485,7 +484,7 @@ void NodeTable::commit(Transaction* transaction, LocalTable* localTable) {
     // 2. Set deleted flag for tuples that are deleted in local storage.
     row_idx_t numLocalRows = 0u;
     for (auto localNodeGroupIdx = 0u; localNodeGroupIdx < localNodeTable.getNumNodeGroups();
-         localNodeGroupIdx++) {
+        localNodeGroupIdx++) {
         const auto localNodeGroup = localNodeTable.getNodeGroup(localNodeGroupIdx);
         if (localNodeGroup->hasDeletions(transaction)) {
             // TODO(Guodong): Assume local storage is small here. Should optimize the loop away by

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -484,7 +484,7 @@ void NodeTable::commit(Transaction* transaction, LocalTable* localTable) {
     // 2. Set deleted flag for tuples that are deleted in local storage.
     row_idx_t numLocalRows = 0u;
     for (auto localNodeGroupIdx = 0u; localNodeGroupIdx < localNodeTable.getNumNodeGroups();
-        localNodeGroupIdx++) {
+         localNodeGroupIdx++) {
         const auto localNodeGroup = localNodeTable.getNodeGroup(localNodeGroupIdx);
         if (localNodeGroup->hasDeletions(transaction)) {
             // TODO(Guodong): Assume local storage is small here. Should optimize the loop away by

--- a/src/storage/store/rel_table_data.cpp
+++ b/src/storage/store/rel_table_data.cpp
@@ -96,8 +96,7 @@ void RelTableData::initPropertyColumns(const TableCatalogEntry* tableEntry) {
     auto nbrIDColumn = std::make_unique<InternalIDColumn>(nbrIDColName, dataFH, memoryManager,
         shadowFile, enableCompression);
     columns[NBR_ID_COLUMN_ID] = std::move(nbrIDColumn);
-    for (auto i = 0u; i < tableEntry->getNumProperties(); i++) {
-        auto& property = tableEntry->getProperty(i);
+    for (auto& property : tableEntry->getProperties()) {
         const auto columnID = tableEntry->getColumnID(property.getName());
         const auto colName = StorageUtils::getColumnName(property.getName(),
             StorageUtils::ColumnType::DEFAULT, RelDirectionUtils::relDirectionToString(direction));


### PR DESCRIPTION
This PR makes the propertyID global unique which is need by indexCatalogEntry.
Once a property is created in the system, its propertyID never changes.

Our ultimate goal is to unify the columnID with the propertyID, however the backend still reindexes the columnID when we alter the table:
```
if (hasChanges) {
        // Deleted columns are vaccumed and not checkpointed or serialized.
        std::vector<column_id_t> columnIDs;
        columnIDs.push_back(0);
        for (auto& property : tableEntry->getProperties()) {
            columnIDs.push_back(tableEntry->getColumnID(property.getName()));
        }
        for (auto& directedRelData : directedRelData) {
            directedRelData->checkpoint(columnIDs);
        }
        tableEntry->vacuumColumnIDs(1);
        hasChanges = false;
    }
```
We should consider removing the columnID, so both frontend and backend can use the propertyID.