### PR TITLE
Fix rust tests on rustc 1.82+

### DIFF
--- a/tools/rust_api/build.rs
+++ b/tools/rust_api/build.rs
@@ -17,7 +17,11 @@ fn link_libraries() {
     if cfg!(windows) && link_mode() == "dylib" {
         println!("cargo:rustc-link-lib=dylib=kuzu_shared");
     } else {
-        println!("cargo:rustc-link-lib={}=kuzu", link_mode());
+        if link_mode() == "dylib" {
+            println!("cargo:rustc-link-lib={}=kuzu", link_mode());
+        } else {
+            println!("cargo:rustc-link-lib=static:+whole-archive=kuzu");
+        }
     }
     if link_mode() == "static" {
         if cfg!(windows) {
@@ -30,21 +34,25 @@ fn link_libraries() {
             println!("cargo:rustc-link-lib=dylib=stdc++");
         }
 
-        println!("cargo:rustc-link-lib=static=utf8proc");
-        println!("cargo:rustc-link-lib=static=antlr4_cypher");
-        println!("cargo:rustc-link-lib=static=antlr4_runtime");
-        println!("cargo:rustc-link-lib=static=re2");
-        println!("cargo:rustc-link-lib=static=fastpfor");
-        println!("cargo:rustc-link-lib=static=parquet");
-        println!("cargo:rustc-link-lib=static=thrift");
-        println!("cargo:rustc-link-lib=static=snappy");
-        println!("cargo:rustc-link-lib=static=zstd");
-        println!("cargo:rustc-link-lib=static=miniz");
-        println!("cargo:rustc-link-lib=static=mbedtls");
-        println!("cargo:rustc-link-lib=static=brotlidec");
-        println!("cargo:rustc-link-lib=static=brotlicommon");
-        println!("cargo:rustc-link-lib=static=lz4");
-        println!("cargo:rustc-link-lib=static=roaring_bitmap");
+        for lib in [
+            "utf8proc",
+            "antlr4_cypher",
+            "antlr4_runtime",
+            "re2",
+            "fastpfor",
+            "parquet",
+            "thrift",
+            "snappy",
+            "zstd",
+            "miniz",
+            "mbedtls",
+            "brotlidec",
+            "brotlicommon",
+            "lz4",
+            "roaring_bitmap",
+        ] {
+            println!("cargo:rustc-link-lib=static:+whole-archive={}", lib);
+        }
     }
 }
 


### PR DESCRIPTION
See https://releases.rs/docs/1.82.0/
Rustc used to pass the whole-archive linker flag when building tests but no longer does.
It's now passed manually to our static libs since it's not clear how to only do that for tests and it doesn't seem to have an impact on the size of the rust example executable, so it's probably fine to just enable it unconditionally.

As far as I can tell it's just a quirk of how the tests are built. The issue doesn't effect release builds at all (tested just with the rust example).
CI is still using older versions of rust (for context, latest is 1.84; 1.82 was released in October 2024)