### PR TITLE
Revert "Fix rust tests on rustc 1.82+"

### DIFF
--- a/tools/rust_api/build.rs
+++ b/tools/rust_api/build.rs
@@ -17,11 +17,7 @@ fn link_libraries() {
     if cfg!(windows) && link_mode() == "dylib" {
         println!("cargo:rustc-link-lib=dylib=kuzu_shared");
     } else {
-        if link_mode() == "dylib" {
-            println!("cargo:rustc-link-lib={}=kuzu", link_mode());
-        } else {
-            println!("cargo:rustc-link-lib=static:+whole-archive=kuzu");
-        }
+        println!("cargo:rustc-link-lib={}=kuzu", link_mode());
     }
     if link_mode() == "static" {
         if cfg!(windows) {
@@ -34,25 +30,21 @@ fn link_libraries() {
             println!("cargo:rustc-link-lib=dylib=stdc++");
         }
 
-        for lib in [
-            "utf8proc",
-            "antlr4_cypher",
-            "antlr4_runtime",
-            "re2",
-            "fastpfor",
-            "parquet",
-            "thrift",
-            "snappy",
-            "zstd",
-            "miniz",
-            "mbedtls",
-            "brotlidec",
-            "brotlicommon",
-            "lz4",
-            "roaring_bitmap",
-        ] {
-            println!("cargo:rustc-link-lib=static:+whole-archive={}", lib);
-        }
+        println!("cargo:rustc-link-lib=static=utf8proc");
+        println!("cargo:rustc-link-lib=static=antlr4_cypher");
+        println!("cargo:rustc-link-lib=static=antlr4_runtime");
+        println!("cargo:rustc-link-lib=static=re2");
+        println!("cargo:rustc-link-lib=static=fastpfor");
+        println!("cargo:rustc-link-lib=static=parquet");
+        println!("cargo:rustc-link-lib=static=thrift");
+        println!("cargo:rustc-link-lib=static=snappy");
+        println!("cargo:rustc-link-lib=static=zstd");
+        println!("cargo:rustc-link-lib=static=miniz");
+        println!("cargo:rustc-link-lib=static=mbedtls");
+        println!("cargo:rustc-link-lib=static=brotlidec");
+        println!("cargo:rustc-link-lib=static=brotlicommon");
+        println!("cargo:rustc-link-lib=static=lz4");
+        println!("cargo:rustc-link-lib=static=roaring_bitmap");
     }
 }
 


### PR DESCRIPTION
Reverts kuzudb/kuzu#4774

I'm not sure why this passed initially, but the CI keeps failing because using `+whole-archive` with `+bundled` (set by default) was unstable until rust 1.74 and I guess the macos CI is using an older version.
Maybe some caching meant it didn't get properly rebuilt for that PR.

I think the fix might just be that to support rust 1.82+ we need to drop support for <1.74 (and upgrade the rust compiler used in the macOS CI).