### PR TITLE
Fix import/export database with reloaddb

### DIFF
--- a/extension/fts/test/test_files/fts_small.test
+++ b/extension/fts/test/test_files/fts_small.test
@@ -356,3 +356,29 @@ student|studentIdx|FTS|[name]|True|CALL CREATE_FTS_INDEX('student', 'studentIdx'
 -STATEMENT CALL SHOW_INDEXES() WHERE `table name` = 'student' RETURN *
 ---- 1
 student|studentIdx|FTS|[firstName]|True|CALL CREATE_FTS_INDEX('student', 'studentIdx', ['firstName'], stemmer := 'english');
+
+-CASE FTSWithPortDBUnloadedExtension
+-SKIP_IN_MEM
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
+---- ok
+-STATEMENT CALL CREATE_FTS_INDEX('doc', 'docIdx', ['content', 'author', 'name'])
+---- ok
+-STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'Alice') RETURN _node.ID, score
+---- 2
+0|0.271133
+3|0.209476
+-RELOADDB
+-STATEMENT EXPORT DATABASE '${KUZU_EXPORT_DB_DIRECTORY}_fts/fts_small_export_test'
+---- ok
+-RELOADDB
+-STATEMENT IMPORT DATABASE '${KUZU_EXPORT_DB_DIRECTORY}_fts/fts_small_export_test'
+---- ok
+-STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'Alice') RETURN _node.ID, score
+---- error
+Catalog exception: function QUERY_FTS_INDEX is not defined. This function exists in the FTS extension. You can install and load the extension by running 'INSTALL FTS; LOAD EXTENSION FTS;'.
+-STATEMENT LOAD EXTENSION "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
+---- ok
+-STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'Alice') RETURN _node.ID, score
+---- 2
+0|0.271133
+3|0.209476

--- a/src/catalog/catalog_entry/index_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/index_catalog_entry.cpp
@@ -23,9 +23,14 @@ void IndexCatalogEntry::serialize(common::Serializer& serializer) const {
     serializer.write(tableID);
     serializer.write(indexName);
     serializer.serializeVector(propertyIDs);
-    const auto bufferedWriter = auxInfo->serialize();
-    serializer.write<uint64_t>(bufferedWriter->getSize());
-    serializer.write(bufferedWriter->getData().data.get(), bufferedWriter->getSize());
+    if (isLoaded()) {
+        const auto bufferedWriter = auxInfo->serialize();
+        serializer.write<uint64_t>(bufferedWriter->getSize());
+        serializer.write(bufferedWriter->getData().data.get(), bufferedWriter->getSize());
+    } else {
+        serializer.write(auxBufferSize);
+        serializer.write(auxBuffer.get(), auxBufferSize);
+    }
 }
 
 std::unique_ptr<IndexCatalogEntry> IndexCatalogEntry::deserialize(

--- a/src/include/catalog/catalog_entry/index_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/index_catalog_entry.h
@@ -64,7 +64,7 @@ public:
     static std::unique_ptr<IndexCatalogEntry> deserialize(common::Deserializer& deserializer);
 
     std::string toCypher(main::ClientContext* context) const override {
-        return auxInfo->toCypher(*this, context);
+        return isLoaded() ? auxInfo->toCypher(*this, context) : "";
     }
     std::unique_ptr<IndexCatalogEntry> copy() const {
         return std::make_unique<IndexCatalogEntry>(type, tableID, indexName, propertyIDs,


### PR DESCRIPTION
Fix the case when we export an index with its dependent extension not loaded.