### PR TITLE
validate database name

### DIFF
--- a/src/common/file_system/virtual_file_system.cpp
+++ b/src/common/file_system/virtual_file_system.cpp
@@ -97,7 +97,7 @@ void VirtualFileSystem::validateDatabasePath(const std::string& filePath) {
         throw Exception("The first character of the database name must be a letter or underscore.");
     }
 
-    // Check subsequent characters for validity (letters, digits, underscores)
+    // Check subsequent characters for validity (letters, digits, underscores).
     for (auto& c : dbName) {
         if (!(std::isalnum(c) || c == '_')) {
             throw Exception(common::stringFormat("Invalid character: {} in the database name.", c));

--- a/src/include/common/file_system/virtual_file_system.h
+++ b/src/include/common/file_system/virtual_file_system.h
@@ -18,6 +18,9 @@ namespace common {
 class KUZU_API VirtualFileSystem final : public FileSystem {
     friend class storage::BufferManager;
 
+private:
+    static constexpr uint32_t MAX_DATABASE_NAME_LEN = 32;
+
 public:
     VirtualFileSystem();
     explicit VirtualFileSystem(std::string homeDir);
@@ -46,6 +49,8 @@ public:
     void syncFile(const FileInfo& fileInfo) const override;
 
     void cleanUP(main::ClientContext* context) override;
+
+    static void validateDatabasePath(const std::string& filePath);
 
 protected:
     void readFromFile(FileInfo& fileInfo, void* buffer, uint64_t numBytes,

--- a/src/include/common/file_system/virtual_file_system.h
+++ b/src/include/common/file_system/virtual_file_system.h
@@ -17,10 +17,7 @@ namespace common {
 
 class KUZU_API VirtualFileSystem final : public FileSystem {
     friend class storage::BufferManager;
-
-private:
-    static constexpr uint32_t MAX_DATABASE_NAME_LEN = 32;
-
+    
 public:
     VirtualFileSystem();
     explicit VirtualFileSystem(std::string homeDir);

--- a/src/include/common/file_system/virtual_file_system.h
+++ b/src/include/common/file_system/virtual_file_system.h
@@ -17,7 +17,7 @@ namespace common {
 
 class KUZU_API VirtualFileSystem final : public FileSystem {
     friend class storage::BufferManager;
-    
+
 public:
     VirtualFileSystem();
     explicit VirtualFileSystem(std::string homeDir);

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -100,6 +100,7 @@ void Database::initMembers(std::string_view dbPath, construct_bm_func_t initBmFu
     databasePath = StorageUtils::expandPath(&clientContext, dbPathStr);
 
     vfs = std::make_unique<VirtualFileSystem>(databasePath);
+    vfs->validateDatabasePath(databasePath);
 
     initAndLockDBDir();
     bufferManager = initBmFunc(*this);

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -92,7 +92,7 @@ TEST_F(CApiDatabaseTest, CreationHomeDir) {
     kuzu_database database;
     kuzu_connection connection;
     kuzu_state state;
-    auto databasePathCStr = (char*)"~/ku_test.db/";
+    auto databasePathCStr = (char*)"~/ku_test_db/";
     state = kuzu_database_init(databasePathCStr, defaultSystemConfig, &database);
     ASSERT_EQ(state, KuzuSuccess);
     state = kuzu_connection_init(&database, &connection);

--- a/test/graph_test/base_graph_test.cpp
+++ b/test/graph_test/base_graph_test.cpp
@@ -11,6 +11,21 @@ using namespace kuzu::main;
 namespace kuzu {
 namespace testing {
 
+void validateTestName(const std::string& name) {
+    for (auto& c : name) {
+        if (!(std::isalnum(c) || c == '_')) {
+            throw common::Exception{common::stringFormat("Invalid character: {} in test name.", c)};
+        }
+    }
+}
+
+std::string BaseGraphTest::getTestGroupAndName() {
+    auto testInfo = ::testing::UnitTest::GetInstance()->current_test_info();
+    auto testName = std::string(testInfo->test_case_name()) + "_" + std::string(testInfo->name());
+    validateTestName(testName);
+    return testName;
+}
+
 void TestHelper::executeScript(const std::string& cypherScript, Connection& conn) {
     std::cout << "cypherScript: " << cypherScript << std::endl;
     if (!std::filesystem::exists(cypherScript)) {

--- a/test/include/graph_test/base_graph_test.h
+++ b/test/include/graph_test/base_graph_test.h
@@ -92,11 +92,7 @@ protected:
         ASSERT_EQ(actualResult, expectedResult);
     }
 
-    static std::string getTestGroupAndName() {
-        const ::testing::TestInfo* const testInfo =
-            ::testing::UnitTest::GetInstance()->current_test_info();
-        return std::string(testInfo->test_case_name()) + "." + std::string(testInfo->name());
-    }
+    static std::string getTestGroupAndName();
 
 private:
     void setDatabasePath() {

--- a/test/main/connection_test.cpp
+++ b/test/main/connection_test.cpp
@@ -237,3 +237,33 @@ TEST_F(ApiTest, QueryWithHeadingNewline) {
     createDBAndConn();
     ASSERT_TRUE(conn->query("\n PROFILE RETURN 5; \n")->isSuccess());
 }
+
+static void checkErrMsg(std::string dbName, std::string err) {
+    try {
+        auto db = Database(dbName);
+    } catch (Exception& e) {
+        ASSERT_STREQ(e.what(), err.c_str());
+    } catch (...) {
+        FAIL();
+    }
+}
+
+static void checkNoException(std::string dbName) {
+    try {
+        auto db = Database(dbName);
+    } catch (...) {
+        FAIL();
+    }
+}
+
+TEST_F(ApiTest, DatabaseName) {
+    checkNoException("_dbna");
+    checkNoException("_dbna/");
+    checkNoException("test_name/");
+    checkNoException("test_name");
+    checkNoException("test_name_");
+    checkErrMsg("3db", "The first character of the database name must be a letter or underscore.");
+    checkErrMsg("!db/", "The first character of the database name must be a letter or underscore.");
+    checkErrMsg("d!b", "Invalid character: ! in the database name.");
+    checkErrMsg("d?b", "Invalid character: ? in the database name.");
+}

--- a/test/test_files/exceptions/parser/syntax_error.test
+++ b/test/test_files/exceptions/parser/syntax_error.test
@@ -2,7 +2,7 @@
 
 --
 
--CASE InvalidNotEqualOperator)
+-CASE InvalidNotEqualOperato
 -STATEMENT MATCH (a) WHERE a.age != 1 RETURN *;
 ---- error
 Parser exception: Unknown operation '!=' (you probably meant to use '<>', which is the operator for inequality testing.) (line: 1, offset: 22)

--- a/test/test_files/tck/match/match2.test
+++ b/test/test_files/tck/match/match2.test
@@ -32,7 +32,7 @@
 (0:0)-{_LABEL: T1, _ID: 2:0}->(1:0)
 
 # Matching a self-loop with an undirected relationship pattern
--CASE Scenario3&4
+-CASE Scenario3A4
 -STATEMENT CREATE NODE TABLE A(name STRING, PRIMARY KEY(name));
 ---- ok
 -STATEMENT CREATE REL TABLE T(FROM A TO A);

--- a/test/test_files/tck/match/match3.test
+++ b/test/test_files/tck/match/match3.test
@@ -140,7 +140,7 @@ Binder exception: Create node b1 with multiple node labels is not supported.
 
 # Undirected match in self-relationship graph
 # Undirected match of self-relationship in self-relationship graph
--CASE Scenario11&12
+-CASE Scenario11And12
 -SKIP
 -STATEMENT CREATE NODE TABLE A(ID SERIAL, PRIMARY KEY(ID));
 ---- ok
@@ -158,7 +158,7 @@ Binder exception: Create node b1 with multiple node labels is not supported.
 
 # Directed match on self-relationship graph
 # Directed match of self-relationship on self-relationship graph
--CASE Scenario13&14
+-CASE Scenario13And14
 -STATEMENT CREATE NODE TABLE A(ID SERIAL, PRIMARY KEY(ID));
 ---- ok
 -STATEMENT CREATE REL TABLE LOOP(FROM A TO A);
@@ -174,7 +174,7 @@ Binder exception: Create node b1 with multiple node labels is not supported.
 
 # Mixing directed and undirected pattern parts with self-relationship, simple
 # Mixing directed and undirected pattern parts with self-relationship, undirected
--CASE Scenario15&16
+-CASE Scenario15And16
 -SKIP
 -STATEMENT CREATE NODE TABLE A(ID SERIAL, PRIMARY KEY(ID));
 ---- ok
@@ -205,7 +205,7 @@ Binder exception: Create node b1 with multiple node labels is not supported.
 
 # handle cyclic patterns
 # Handling cyclic patterns when separated into two parts
--CASE Scenario17&18
+-CASE Scenario17And18
 -STATEMENT CREATE NODE TABLE T1(ID SERIAL, name STRING, PRIMARY KEY(ID));
 ---- ok
 -STATEMENT CREATE NODE TABLE T2(ID SERIAL, name STRING, PRIMARY KEY(ID));

--- a/test/test_files/tck/match/match4.test
+++ b/test/test_files/tck/match/match4.test
@@ -163,7 +163,7 @@ Binder exception: rs has data type REL[] but RECURSIVE_REL was expected.
 
 # Fail when asterisk operator is missing
 # Fail on negative bound
--CASE Scenario9&10
+-CASE Scenario9And10
 -STATEMENT CREATE NODE TABLE A(ID SERIAL, name STRING, PRIMARY KEY(ID));
 ---- ok
 -STATEMENT CREATE NODE TABLE B(ID SERIAL, name STRING, PRIMARY KEY(ID));

--- a/test/test_runner/test_parser.cpp
+++ b/test/test_runner/test_parser.cpp
@@ -42,8 +42,8 @@ void TestParser::genGroupName() const {
         1;
     const std::size_t subEnd = path.find_last_of('.') - 1;
     std::string relPath = path.substr(subStart, subEnd - subStart + 1);
-    std::replace(relPath.begin(), relPath.end(), '/', '~');
-    std::replace(relPath.begin(), relPath.end(), '\\', '~');
+    std::replace(relPath.begin(), relPath.end(), '/', '_');
+    std::replace(relPath.begin(), relPath.end(), '\\', '_');
     testGroup->group = relPath;
 }
 


### PR DESCRIPTION
This PR implements the validation of database name. We follow the postgres naming rule:

1. Database name can only start with letters(a-z|A-Z) or `_`
2. Subsequent characters can be letters, numbers or `_`