### PR TITLE
Fix mismatched column IDs during insert and copy after drop and add columns

### DIFF
--- a/src/include/processor/operator/persistent/batch_insert.h
+++ b/src/include/processor/operator/persistent/batch_insert.h
@@ -16,13 +16,16 @@ struct BatchInsertInfo {
     catalog::TableCatalogEntry* tableEntry;
     bool compressionEnabled;
 
+    std::vector<common::column_id_t> insertColumnIDs;
     std::vector<common::column_id_t> outputDataColumns;
     std::vector<common::column_id_t> warningDataColumns;
 
     BatchInsertInfo(catalog::TableCatalogEntry* tableEntry, bool compressionEnabled,
-        common::column_id_t numOutputDataColumns, common::column_id_t numWarningDataColumns)
+        std::vector<common::column_id_t> insertColumnIDs, common::column_id_t numOutputDataColumns,
+        common::column_id_t numWarningDataColumns)
         : tableEntry{tableEntry}, compressionEnabled{compressionEnabled},
-          outputDataColumns(numOutputDataColumns), warningDataColumns(numWarningDataColumns) {
+          insertColumnIDs{std::move(insertColumnIDs)}, outputDataColumns(numOutputDataColumns),
+          warningDataColumns(numWarningDataColumns) {
         std::iota(outputDataColumns.begin(), outputDataColumns.end(), 0);
         std::iota(warningDataColumns.begin(), warningDataColumns.end(), outputDataColumns.size());
     }

--- a/src/include/processor/operator/persistent/insert_executor.h
+++ b/src/include/processor/operator/persistent/insert_executor.h
@@ -62,7 +62,7 @@ public:
         : info{std::move(info)}, tableInfo{std::move(tableInfo)} {}
     EXPLICIT_COPY_DEFAULT_MOVE(NodeInsertExecutor);
 
-    void init(ResultSet* resultSet, ExecutionContext* context);
+    void init(ResultSet* resultSet, const ExecutionContext* context);
 
     void setNodeIDVectorToNonNull() const;
     common::nodeID_t insert(transaction::Transaction* transaction);
@@ -75,7 +75,7 @@ private:
     NodeInsertExecutor(const NodeInsertExecutor& other)
         : info{other.info.copy()}, tableInfo{other.tableInfo.copy()} {}
 
-    bool checkConflict(transaction::Transaction* transaction) const;
+    bool checkConflict(const transaction::Transaction* transaction) const;
 
 private:
     NodeInsertInfo info;
@@ -128,7 +128,7 @@ public:
         : info{std::move(info)}, tableInfo{std::move(tableInfo)} {}
     EXPLICIT_COPY_DEFAULT_MOVE(RelInsertExecutor);
 
-    void init(ResultSet* resultSet, ExecutionContext* context);
+    void init(ResultSet* resultSet, const ExecutionContext* context);
 
     common::internalID_t insert(transaction::Transaction* transaction);
 

--- a/src/include/processor/operator/persistent/node_batch_insert.h
+++ b/src/include/processor/operator/persistent/node_batch_insert.h
@@ -42,18 +42,18 @@ struct NodeBatchInsertInfo final : BatchInsertInfo {
     std::vector<common::ColumnEvaluateType> evaluateTypes;
 
     NodeBatchInsertInfo(catalog::TableCatalogEntry* tableEntry, bool compressionEnabled,
-        std::vector<common::LogicalType> columnTypes,
+        std::vector<common::column_id_t> columnIDs, std::vector<common::LogicalType> columnTypes,
         std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> columnEvaluators,
         std::vector<common::ColumnEvaluateType> evaluateTypes,
         common::column_id_t numWarningDataColumns)
-        : BatchInsertInfo{tableEntry, compressionEnabled,
+        : BatchInsertInfo{tableEntry, compressionEnabled, std::move(columnIDs),
               static_cast<common::column_id_t>(columnTypes.size() - numWarningDataColumns),
               numWarningDataColumns},
           columnTypes{std::move(columnTypes)}, columnEvaluators{std::move(columnEvaluators)},
           evaluateTypes{std::move(evaluateTypes)} {}
 
     NodeBatchInsertInfo(const NodeBatchInsertInfo& other)
-        : BatchInsertInfo{other.tableEntry, other.compressionEnabled,
+        : BatchInsertInfo{other.tableEntry, other.compressionEnabled, other.insertColumnIDs,
               static_cast<common::column_id_t>(other.outputDataColumns.size()),
               static_cast<common::column_id_t>(other.warningDataColumns.size())},
           columnTypes{common::LogicalType::copy(other.columnTypes)},
@@ -147,7 +147,7 @@ private:
 
     void copyToNodeGroup(transaction::Transaction* transaction, storage::MemoryManager* mm) const;
 
-    NodeBatchInsertErrorHandler createErrorHandler(ExecutionContext* context);
+    NodeBatchInsertErrorHandler createErrorHandler(ExecutionContext* context) const;
 
     void writeAndResetNodeGroup(transaction::Transaction* transaction,
         std::unique_ptr<storage::ChunkedNodeGroup>& nodeGroup,

--- a/src/include/processor/operator/persistent/rel_batch_insert.h
+++ b/src/include/processor/operator/persistent/rel_batch_insert.h
@@ -44,15 +44,15 @@ struct RelBatchInsertInfo final : BatchInsertInfo {
 
     RelBatchInsertInfo(catalog::TableCatalogEntry* tableEntry, bool compressionEnabled,
         common::RelDataDirection direction, uint64_t partitioningIdx,
-        common::column_id_t offsetColumnID, std::vector<common::LogicalType> columnTypes,
-        common::column_id_t numWarningDataColumns)
-        : BatchInsertInfo{tableEntry, compressionEnabled,
+        common::column_id_t offsetColumnID, std::vector<common::column_id_t> columnIDs,
+        std::vector<common::LogicalType> columnTypes, common::column_id_t numWarningDataColumns)
+        : BatchInsertInfo{tableEntry, compressionEnabled, std::move(columnIDs),
               static_cast<common::column_id_t>(columnTypes.size() - numWarningDataColumns),
               numWarningDataColumns},
           direction{direction}, partitioningIdx{partitioningIdx},
           boundNodeOffsetColumnID{offsetColumnID}, columnTypes{std::move(columnTypes)} {}
     RelBatchInsertInfo(const RelBatchInsertInfo& other)
-        : BatchInsertInfo{other.tableEntry, other.compressionEnabled,
+        : BatchInsertInfo{other.tableEntry, other.compressionEnabled, other.insertColumnIDs,
               static_cast<common::column_id_t>(other.outputDataColumns.size()),
               static_cast<common::column_id_t>(other.warningDataColumns.size())},
           direction{other.direction}, partitioningIdx{other.partitioningIdx},
@@ -104,7 +104,7 @@ public:
             resultSetDescriptor->copy(), id, printInfo->copy(), progressSharedState);
     }
 
-    void updateProgress(ExecutionContext* context);
+    void updateProgress(const ExecutionContext* context) const;
 
 private:
     static void appendNodeGroup(transaction::Transaction* transaction,

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -86,7 +86,7 @@ private:
     std::unique_ptr<PhysicalOperator> mapImportDatabase(planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapIndexLookup(planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapIntersect(planner::LogicalOperator* logicalOperator);
-    std::unique_ptr<PhysicalOperator> mapInsert(planner::LogicalOperator* logicalOperator);
+    std::unique_ptr<PhysicalOperator> mapInsert(const planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapLimit(planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapMerge(planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapMultiplicityReducer(
@@ -115,7 +115,7 @@ private:
         std::shared_ptr<PartitionerSharedState> partitionerSharedState,
         std::shared_ptr<BatchInsertSharedState> sharedState,
         const planner::LogicalCopyFrom& copyFrom, common::RelDataDirection direction,
-        std::vector<common::LogicalType> columnTypes);
+        std::vector<common::column_id_t> columnIDs, std::vector<common::LogicalType> columnTypes);
 
     std::unique_ptr<ResultCollector> createResultCollector(common::AccumulateType accumulateType,
         const binder::expression_vector& expressions, planner::Schema* schema,
@@ -163,9 +163,9 @@ private:
         planner::Schema* inSchema, planner::Schema* outSchema,
         std::unique_ptr<PhysicalOperator> prevOperator);
 
-    NodeInsertExecutor getNodeInsertExecutor(const planner::LogicalInsertInfo* info,
+    NodeInsertExecutor getNodeInsertExecutor(const planner::LogicalInsertInfo* boundInfo,
         const planner::Schema& inSchema, const planner::Schema& outSchema) const;
-    RelInsertExecutor getRelInsertExecutor(const planner::LogicalInsertInfo* info,
+    RelInsertExecutor getRelInsertExecutor(const planner::LogicalInsertInfo* boundInfo,
         const planner::Schema& inSchema, const planner::Schema& outSchema) const;
     std::unique_ptr<NodeSetExecutor> getNodeSetExecutor(const binder::BoundSetPropertyInfo& info,
         const planner::Schema& schema) const;

--- a/src/include/storage/local_storage/local_node_table.h
+++ b/src/include/storage/local_storage/local_node_table.h
@@ -13,7 +13,10 @@ class MemoryManager;
 
 class LocalNodeTable final : public LocalTable {
 public:
-    explicit LocalNodeTable(Table& table);
+    static std::vector<common::LogicalType> getNodeTableColumnTypes(
+        const catalog::TableCatalogEntry& table);
+
+    LocalNodeTable(const catalog::TableCatalogEntry* tableEntry, Table& table);
     DELETE_COPY_AND_MOVE(LocalNodeTable);
 
     bool insert(transaction::Transaction* transaction, TableInsertState& insertState) override;
@@ -24,28 +27,28 @@ public:
     uint64_t getEstimatedMemUsage() override;
 
     common::offset_t validateUniquenessConstraint(const transaction::Transaction* transaction,
-        const common::ValueVector& pkVector);
+        const common::ValueVector& pkVector) const;
 
     common::TableType getTableType() const override { return common::TableType::NODE; }
 
     void clear() override;
 
     common::row_idx_t getNumTotalRows() override { return nodeGroups.getNumTotalRows(); }
-    common::node_group_idx_t getNumNodeGroups() { return nodeGroups.getNumNodeGroups(); }
+    common::node_group_idx_t getNumNodeGroups() const { return nodeGroups.getNumNodeGroups(); }
 
-    NodeGroup* getNodeGroup(common::node_group_idx_t nodeGroupIdx) {
+    NodeGroup* getNodeGroup(common::node_group_idx_t nodeGroupIdx) const {
         return nodeGroups.getNodeGroup(nodeGroupIdx);
     }
     NodeGroupCollection& getNodeGroups() { return nodeGroups; }
 
     bool lookupPK(const transaction::Transaction* transaction, const common::ValueVector* keyVector,
-        common::offset_t& result);
+        common::offset_t& result) const;
 
     TableStats getStats() const { return nodeGroups.getStats(); }
 
 private:
     void initLocalHashIndex();
-    bool isVisible(const transaction::Transaction* transaction, common::offset_t offset);
+    bool isVisible(const transaction::Transaction* transaction, common::offset_t offset) const;
 
 private:
     PageCursor overflowCursor;

--- a/src/include/storage/local_storage/local_rel_table.h
+++ b/src/include/storage/local_storage/local_rel_table.h
@@ -32,9 +32,7 @@ struct DirectedCSRIndex {
 
 class LocalRelTable final : public LocalTable {
 public:
-    static std::vector<common::LogicalType> getTypesForLocalRelTable(const RelTable& table);
-
-    explicit LocalRelTable(Table& table);
+    LocalRelTable(const catalog::TableCatalogEntry* tableEntry, Table& table);
 
     bool insert(transaction::Transaction* transaction, TableInsertState& state) override;
     bool update(transaction::Transaction* transaction, TableUpdateState& state) override;
@@ -48,8 +46,8 @@ public:
 
     common::TableType getTableType() const override { return common::TableType::REL; }
 
-    void initializeScan(TableScanState& state);
-    bool scan(transaction::Transaction* transaction, TableScanState& state) const;
+    static void initializeScan(TableScanState& state);
+    bool scan(const transaction::Transaction* transaction, TableScanState& state) const;
 
     void clear() override {
         localNodeGroup.reset();
@@ -82,8 +80,8 @@ public:
         common::column_id_t columnID);
 
 private:
-    common::row_idx_t findMatchingRow(transaction::Transaction* transaction,
-        const std::vector<row_idx_vec_t*>& rowIndicesToCheck, common::offset_t relOffset);
+    common::row_idx_t findMatchingRow(const transaction::Transaction* transaction,
+        const std::vector<row_idx_vec_t*>& rowIndicesToCheck, common::offset_t relOffset) const;
 
 private:
     // We don't duplicate local rel tuples. Tuples are stored same as node tuples.

--- a/src/include/storage/stats/table_stats.h
+++ b/src/include/storage/stats/table_stats.h
@@ -18,10 +18,20 @@ public:
     void incrementCardinality(common::cardinality_t increment) { cardinality += increment; }
 
     void merge(const TableStats& other) {
+        std::vector<common::column_id_t> columnIDs;
+        for (auto i = 0u; i < columnStats.size(); i++) {
+            columnIDs.push_back(i);
+        }
+        merge(columnIDs, other);
+    }
+
+    void merge(const std::vector<common::column_id_t>& columnIDs, const TableStats& other) {
         cardinality += other.cardinality;
-        KU_ASSERT(columnStats.size() == other.columnStats.size());
-        for (auto i = 0u; i < columnStats.size(); ++i) {
-            columnStats[i].merge(other.columnStats[i]);
+        KU_ASSERT(columnIDs.size() == other.columnStats.size());
+        for (auto i = 0u; i < columnIDs.size(); ++i) {
+            auto columnID = columnIDs[i];
+            KU_ASSERT(columnID < columnStats.size());
+            columnStats[columnID].merge(other.columnStats[i]);
         }
     }
 
@@ -33,6 +43,9 @@ public:
     }
 
     void update(const std::vector<common::ValueVector*>& vectors,
+        size_t numColumns = std::numeric_limits<size_t>::max());
+    void update(const std::vector<common::column_id_t>& columnIDs,
+        const std::vector<common::ValueVector*>& vectors,
         size_t numColumns = std::numeric_limits<size_t>::max());
 
     ColumnStats& addNewColumn(const common::LogicalType& dataType) {

--- a/src/include/storage/store/csr_node_group.h
+++ b/src/include/storage/store/csr_node_group.h
@@ -187,12 +187,13 @@ public:
         TableScanState& state) const override;
 
     void appendChunkedCSRGroup(const transaction::Transaction* transaction,
-        ChunkedCSRNodeGroup& chunkedGroup);
-    void append(const transaction::Transaction* transaction, common::offset_t boundOffsetInGroup,
+        const std::vector<common::column_id_t>& columnIDs, ChunkedCSRNodeGroup& chunkedGroup);
+    void append(const transaction::Transaction* transaction,
+        const std::vector<common::column_id_t>& columnIDs, common::offset_t boundOffsetInGroup,
         const std::vector<ColumnChunk*>& chunks, common::row_idx_t startRowInChunks,
         common::row_idx_t numRows);
 
-    void update(transaction::Transaction* transaction, CSRNodeGroupScanSource source,
+    void update(const transaction::Transaction* transaction, CSRNodeGroupScanSource source,
         common::row_idx_t rowIdxInGroup, common::column_id_t columnID,
         const common::ValueVector& propertyVector);
     bool delete_(const transaction::Transaction* transaction, CSRNodeGroupScanSource source,
@@ -216,8 +217,8 @@ public:
 private:
     void initScanForCommittedPersistent(const transaction::Transaction* transaction,
         RelTableScanState& relScanState, CSRNodeGroupScanState& nodeGroupScanState) const;
-    void initScanForCommittedInMem(RelTableScanState& relScanState,
-        CSRNodeGroupScanState& nodeGroupScanState) const;
+    static void initScanForCommittedInMem(RelTableScanState& relScanState,
+        CSRNodeGroupScanState& nodeGroupScanState);
 
     void updateCSRIndex(common::offset_t boundNodeOffsetInGroup, common::row_idx_t startRow,
         common::length_t length) const;
@@ -245,16 +246,16 @@ private:
         const CSRNodeGroupCheckpointState& csrState);
 
     void collectRegionChangesAndUpdateHeaderLength(const common::UniqLock& lock, CSRRegion& region,
-        const CSRNodeGroupCheckpointState& csrState);
+        const CSRNodeGroupCheckpointState& csrState) const;
     void collectInMemRegionChangesAndUpdateHeaderLength(const common::UniqLock& lock,
-        CSRRegion& region, const CSRNodeGroupCheckpointState& csrState);
+        CSRRegion& region, const CSRNodeGroupCheckpointState& csrState) const;
     void collectOnDiskRegionChangesAndUpdateHeaderLength(const common::UniqLock& lock,
         CSRRegion& region, const CSRNodeGroupCheckpointState& csrState) const;
 
     std::vector<CSRRegion> collectLeafRegionsAndCSRLength(const common::UniqLock& lock,
-        const CSRNodeGroupCheckpointState& csrState);
-    void collectPersistentUpdatesInRegion(CSRRegion& region, common::offset_t leftCSROffset,
-        common::offset_t rightCSROffset) const;
+        const CSRNodeGroupCheckpointState& csrState) const;
+    void collectPersistentUpdatesInRegion(CSRRegion& region,
+        const CSRNodeGroupCheckpointState& csrState) const;
 
     common::row_idx_t getNumDeletionsForNodeInPersistentData(common::offset_t nodeOffset,
         const CSRNodeGroupCheckpointState& csrState) const;
@@ -269,10 +270,10 @@ private:
         const std::vector<CSRRegion>& leafRegions, const CSRRegion& region);
 
     void checkpointColumn(const common::UniqLock& lock, common::column_id_t columnID,
-        const CSRNodeGroupCheckpointState& csrState, const std::vector<CSRRegion>& regions);
+        const CSRNodeGroupCheckpointState& csrState, const std::vector<CSRRegion>& regions) const;
     ChunkCheckpointState checkpointColumnInRegion(const common::UniqLock& lock,
         common::column_id_t columnID, const CSRNodeGroupCheckpointState& csrState,
-        const CSRRegion& region);
+        const CSRRegion& region) const;
     void checkpointCSRHeaderColumns(const CSRNodeGroupCheckpointState& csrState) const;
     void finalizeCheckpoint(const common::UniqLock& lock);
 

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -116,9 +116,10 @@ public:
     const std::vector<common::LogicalType>& getDataTypes() const { return dataTypes; }
     NodeGroupDataFormat getFormat() const { return format; }
     common::row_idx_t append(const transaction::Transaction* transaction,
-        ChunkedNodeGroup& chunkedGroup, common::row_idx_t startRowIdx,
-        common::row_idx_t numRowsToAppend);
+        const std::vector<common::column_id_t>& columnIDs, ChunkedNodeGroup& chunkedGroup,
+        common::row_idx_t startRowIdx, common::row_idx_t numRowsToAppend);
     common::row_idx_t append(const transaction::Transaction* transaction,
+        const std::vector<common::column_id_t>& columnIDs,
         const std::vector<ColumnChunk*>& chunkedGroup, common::row_idx_t startRowIdx,
         common::row_idx_t numRowsToAppend);
     void append(const transaction::Transaction* transaction,
@@ -136,21 +137,21 @@ public:
         TableScanState& state) const;
 
     virtual NodeGroupScanResult scan(transaction::Transaction* transaction, TableScanState& state,
-        common::offset_t startOffset, common::offset_t numNodes) const;
+        common::offset_t startOffset, common::offset_t numRowsToScan) const;
 
-    bool lookup(const common::UniqLock& lock, transaction::Transaction* transaction,
-        const TableScanState& state);
-    bool lookup(transaction::Transaction* transaction, const TableScanState& state);
+    bool lookup(const common::UniqLock& lock, const transaction::Transaction* transaction,
+        const TableScanState& state) const;
+    bool lookup(const transaction::Transaction* transaction, const TableScanState& state) const;
 
-    void update(transaction::Transaction* transaction, common::row_idx_t rowIdxInGroup,
+    void update(const transaction::Transaction* transaction, common::row_idx_t rowIdxInGroup,
         common::column_id_t columnID, const common::ValueVector& propertyVector);
     bool delete_(const transaction::Transaction* transaction, common::row_idx_t rowIdxInGroup);
 
-    bool hasDeletions(const transaction::Transaction* transaction);
+    bool hasDeletions(const transaction::Transaction* transaction) const;
     virtual void addColumn(transaction::Transaction* transaction,
         TableAddColumnState& addColumnState, FileHandle* dataFH, ColumnStats* newColumnStats);
 
-    void flush(transaction::Transaction* transaction, FileHandle& dataFH);
+    void flush(const transaction::Transaction* transaction, FileHandle& dataFH);
 
     void applyFuncToChunkedGroups(version_record_handler_op_t func, common::row_idx_t startRow,
         common::row_idx_t numRows, common::transaction_t commitTS) const;
@@ -158,17 +159,17 @@ public:
 
     virtual void checkpoint(MemoryManager& memoryManager, NodeGroupCheckpointState& state);
 
-    uint64_t getEstimatedMemoryUsage();
+    uint64_t getEstimatedMemoryUsage() const;
 
     virtual void serialize(common::Serializer& serializer);
     static std::unique_ptr<NodeGroup> deserialize(MemoryManager& memoryManager,
         common::Deserializer& deSer);
 
-    common::node_group_idx_t getNumChunkedGroups() {
+    common::node_group_idx_t getNumChunkedGroups() const {
         const auto lock = chunkedGroups.lock();
         return chunkedGroups.getNumGroups(lock);
     }
-    ChunkedNodeGroup* getChunkedNodeGroup(common::node_group_idx_t groupIdx) {
+    ChunkedNodeGroup* getChunkedNodeGroup(common::node_group_idx_t groupIdx) const {
         const auto lock = chunkedGroups.lock();
         return chunkedGroups.getGroup(lock, groupIdx);
     }
@@ -182,17 +183,23 @@ public:
         return common::ku_dynamic_cast<const TARGETT&>(*this);
     }
 
-    bool isVisible(const transaction::Transaction* transaction, common::row_idx_t rowIdxInGroup);
+    bool isVisible(const transaction::Transaction* transaction,
+        common::row_idx_t rowIdxInGroup) const;
     bool isVisibleNoLock(const transaction::Transaction* transaction,
-        common::row_idx_t rowIdxInGroup);
-    bool isDeleted(const transaction::Transaction* transaction, common::offset_t offsetInGroup);
-    bool isInserted(const transaction::Transaction* transaction, common::offset_t offsetInGroup);
+        common::row_idx_t rowIdxInGroup) const;
+    bool isDeleted(const transaction::Transaction* transaction,
+        common::offset_t offsetInGroup) const;
+    bool isInserted(const transaction::Transaction* transaction,
+        common::offset_t offsetInGroup) const;
 
     common::node_group_idx_t getNodeGroupIdx() const { return nodeGroupIdx; }
 
 protected:
     static constexpr auto INVALID_CHUNKED_GROUP_IDX = UINT32_MAX;
     static constexpr auto INVALID_START_ROW_IDX = UINT64_MAX;
+
+protected:
+    void checkpointDataTypesNoLock(const NodeGroupCheckpointState& state);
 
 private:
     std::pair<common::idx_t, common::row_idx_t> findChunkedGroupIdxFromRowIdxNoLock(
@@ -202,11 +209,11 @@ private:
     ChunkedNodeGroup* findChunkedGroupFromRowIdxNoLock(common::row_idx_t rowIdx) const;
 
     std::unique_ptr<ChunkedNodeGroup> checkpointInMemOnly(MemoryManager& memoryManager,
-        const common::UniqLock& lock, NodeGroupCheckpointState& state);
+        const common::UniqLock& lock, const NodeGroupCheckpointState& state) const;
     std::unique_ptr<ChunkedNodeGroup> checkpointInMemAndOnDisk(MemoryManager& memoryManager,
-        const common::UniqLock& lock, NodeGroupCheckpointState& state);
+        const common::UniqLock& lock, NodeGroupCheckpointState& state) const;
     std::unique_ptr<VersionInfo> checkpointVersionInfo(const common::UniqLock& lock,
-        const transaction::Transaction* transaction);
+        const transaction::Transaction* transaction) const;
 
     template<ResidencyState SCAN_RESIDENCY_STATE>
     common::row_idx_t getNumResidentRows(const common::UniqLock& lock) const;
@@ -217,7 +224,7 @@ private:
 
     virtual NodeGroupScanResult scanInternal(const common::UniqLock& lock,
         transaction::Transaction* transaction, TableScanState& state, common::offset_t startOffset,
-        common::offset_t numNodes) const;
+        common::offset_t numRowsToScan) const;
 
 protected:
     common::node_group_idx_t nodeGroupIdx;

--- a/src/include/storage/store/rel_table_data.h
+++ b/src/include/storage/store/rel_table_data.h
@@ -21,7 +21,7 @@ struct CSRHeaderColumns {
     std::unique_ptr<Column> length;
 };
 
-class PersistentVersionRecordHandler : public VersionRecordHandler {
+class PersistentVersionRecordHandler final : public VersionRecordHandler {
 public:
     explicit PersistentVersionRecordHandler(RelTableData* relTableData);
 
@@ -36,7 +36,7 @@ private:
     RelTableData* relTableData;
 };
 
-class InMemoryVersionRecordHandler : public VersionRecordHandler {
+class InMemoryVersionRecordHandler final : public VersionRecordHandler {
 public:
     explicit InMemoryVersionRecordHandler(RelTableData* relTableData);
 
@@ -84,7 +84,7 @@ public:
     NodeGroup* getNodeGroup(common::node_group_idx_t nodeGroupIdx) const {
         return nodeGroups->getNodeGroup(nodeGroupIdx, true /*mayOutOfBound*/);
     }
-    NodeGroup* getOrCreateNodeGroup(transaction::Transaction* transaction,
+    NodeGroup* getOrCreateNodeGroup(const transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx) const {
         return nodeGroups->getOrCreateNodeGroup(transaction, nodeGroupIdx,
             NodeGroupDataFormat::CSR);
@@ -96,7 +96,7 @@ public:
 
     void checkpoint(const std::vector<common::column_id_t>& columnIDs);
 
-    void pushInsertInfo(transaction::Transaction* transaction, const CSRNodeGroup& nodeGroup,
+    void pushInsertInfo(const transaction::Transaction* transaction, const CSRNodeGroup& nodeGroup,
         common::row_idx_t numRows_, CSRNodeGroupScanSource source);
 
     void serialize(common::Serializer& serializer) const;
@@ -137,7 +137,7 @@ private:
         return types;
     }
 
-    const VersionRecordHandler* getVersionRecordHandler(CSRNodeGroupScanSource source);
+    const VersionRecordHandler* getVersionRecordHandler(CSRNodeGroupScanSource source) const;
 
 private:
     FileHandle* dataFH;

--- a/src/include/storage/store/table.h
+++ b/src/include/storage/store/table.h
@@ -70,10 +70,10 @@ struct TableScanState {
 };
 
 struct TableInsertState {
-    const std::vector<common::ValueVector*>& propertyVectors;
+    std::vector<common::ValueVector*> propertyVectors;
 
-    explicit TableInsertState(const std::vector<common::ValueVector*>& propertyVectors)
-        : propertyVectors{propertyVectors} {}
+    explicit TableInsertState(std::vector<common::ValueVector*> propertyVectors)
+        : propertyVectors{std::move(propertyVectors)} {}
     virtual ~TableInsertState() = default;
 
     template<typename T>
@@ -156,7 +156,8 @@ public:
         TableAddColumnState& addColumnState) = 0;
     void dropColumn() { setHasChanges(); }
 
-    virtual void commit(transaction::Transaction* transaction, LocalTable* localTable) = 0;
+    virtual void commit(transaction::Transaction* transaction,
+        catalog::TableCatalogEntry* tableEntry, LocalTable* localTable) = 0;
     virtual void checkpoint(common::Serializer& ser, catalog::TableCatalogEntry* tableEntry) = 0;
     virtual void rollbackCheckpoint() = 0;
 

--- a/src/processor/map/map_insert.cpp
+++ b/src/processor/map/map_insert.cpp
@@ -66,7 +66,7 @@ RelInsertExecutor PlanMapper::getRelInsertExecutor(const LogicalInsertInfo* boun
     return RelInsertExecutor(std::move(info), std::move(tableInfo));
 }
 
-std::unique_ptr<PhysicalOperator> PlanMapper::mapInsert(LogicalOperator* logicalOperator) {
+std::unique_ptr<PhysicalOperator> PlanMapper::mapInsert(const LogicalOperator* logicalOperator) {
     auto& logicalInsert = logicalOperator->constCast<LogicalInsert>();
     auto inSchema = logicalInsert.getChild(0)->getSchema();
     auto outSchema = logicalInsert.getSchema();
@@ -85,7 +85,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapInsert(LogicalOperator* logical
             KU_UNREACHABLE;
         }
     }
-    binder::expression_vector expressions;
+    expression_vector expressions;
     for (auto& info : logicalInsert.getInfos()) {
         for (auto& expr : info.columnExprs) {
             expressions.push_back(expr);

--- a/src/processor/operator/persistent/insert_executor.cpp
+++ b/src/processor/operator/persistent/insert_executor.cpp
@@ -24,7 +24,7 @@ void NodeInsertInfo::updateNodeID(nodeID_t nodeID) const {
     nodeIDVector->setValue<nodeID_t>(pos, nodeID);
 }
 
-common::nodeID_t NodeInsertInfo::getNodeID() const {
+nodeID_t NodeInsertInfo::getNodeID() const {
     auto& nodeIDSelVector = nodeIDVector->state->getSelVector();
     KU_ASSERT(nodeIDSelVector.getSelSize() == 1);
     if (nodeIDVector->isNull(nodeIDSelVector[0])) {
@@ -41,12 +41,12 @@ void NodeTableInsertInfo::init(const ResultSet& resultSet, main::ClientContext* 
     pkVector = columnDataVectors[table->getPKColumnID()];
 }
 
-void NodeInsertExecutor::init(ResultSet* resultSet, ExecutionContext* context) {
+void NodeInsertExecutor::init(ResultSet* resultSet, const ExecutionContext* context) {
     info.init(*resultSet);
     tableInfo.init(*resultSet, context->clientContext);
 }
 
-static void writeColumnVector(ValueVector* columnVector, ValueVector* dataVector) {
+static void writeColumnVector(ValueVector* columnVector, const ValueVector* dataVector) {
     auto& columnSelVector = columnVector->state->getSelVector();
     auto& dataSelVector = dataVector->state->getSelVector();
     KU_ASSERT(columnSelVector.getSelSize() == 1 && dataSelVector.getSelSize() == 1);
@@ -88,7 +88,7 @@ void NodeInsertExecutor::setNodeIDVectorToNonNull() const {
     info.nodeIDVector->setNull(info.nodeIDVector->state->getSelVector()[0], false);
 }
 
-common::nodeID_t NodeInsertExecutor::insert(Transaction* transaction) {
+nodeID_t NodeInsertExecutor::insert(Transaction* transaction) {
     for (auto& evaluator : tableInfo.columnDataEvaluators) {
         evaluator->evaluate();
     }
@@ -110,7 +110,7 @@ void NodeInsertExecutor::skipInsert() const {
     writeColumnVectors(info.columnVectors, tableInfo.columnDataVectors);
 }
 
-bool NodeInsertExecutor::checkConflict(Transaction* transaction) const {
+bool NodeInsertExecutor::checkConflict(const Transaction* transaction) const {
     if (info.conflictAction == ConflictAction::ON_CONFLICT_DO_NOTHING) {
         auto offset =
             tableInfo.table->validateUniquenessConstraint(transaction, tableInfo.columnDataVectors);
@@ -142,7 +142,7 @@ void RelTableInsertInfo::init(const ResultSet& resultSet, main::ClientContext* c
     }
 }
 
-common::internalID_t RelTableInsertInfo::getRelID() const {
+internalID_t RelTableInsertInfo::getRelID() const {
     auto relIDVector = columnDataVectors[0];
     auto& nodeIDSelVector = relIDVector->state->getSelVector();
     KU_ASSERT(nodeIDSelVector.getSelSize() == 1);
@@ -152,12 +152,12 @@ common::internalID_t RelTableInsertInfo::getRelID() const {
     return relIDVector->getValue<nodeID_t>(nodeIDSelVector[0]);
 }
 
-void RelInsertExecutor::init(ResultSet* resultSet, ExecutionContext* context) {
+void RelInsertExecutor::init(ResultSet* resultSet, const ExecutionContext* context) {
     info.init(*resultSet);
     tableInfo.init(*resultSet, context->clientContext);
 }
 
-internalID_t RelInsertExecutor::insert(transaction::Transaction* transaction) {
+internalID_t RelInsertExecutor::insert(Transaction* transaction) {
     KU_ASSERT(info.srcNodeIDVector->state->getSelVector().getSelSize() == 1);
     KU_ASSERT(info.dstNodeIDVector->state->getSelVector().getSelSize() == 1);
     auto srcNodeIDPos = info.srcNodeIDVector->state->getSelVector()[0];

--- a/src/storage/stats/table_stats.cpp
+++ b/src/storage/stats/table_stats.cpp
@@ -20,11 +20,22 @@ TableStats::TableStats(const TableStats& other) : cardinality{other.cardinality}
 }
 
 void TableStats::update(const std::vector<common::ValueVector*>& vectors, size_t numColumns) {
+    std::vector<common::column_id_t> dummyColumnIDs;
+    for (auto i = 0u; i < vectors.size(); ++i) {
+        dummyColumnIDs.push_back(i);
+    }
+    update(dummyColumnIDs, vectors, numColumns);
+}
+
+void TableStats::update(const std::vector<common::column_id_t>& columnIDs,
+    const std::vector<common::ValueVector*>& vectors, size_t numColumns) {
+    KU_ASSERT(columnIDs.size() == vectors.size());
     size_t numColumnsToUpdate = std::min(numColumns, vectors.size());
 
-    KU_ASSERT(numColumnsToUpdate == columnStats.size());
     for (auto i = 0u; i < numColumnsToUpdate; ++i) {
-        columnStats[i].update(vectors[i]);
+        auto columnID = columnIDs[i];
+        KU_ASSERT(columnID < columnStats.size());
+        columnStats[columnID].update(vectors[i]);
     }
     const auto numValues = vectors[0]->state->getSelVector().getSelSize();
     for (auto i = 1u; i < numColumnsToUpdate; ++i) {

--- a/src/storage/store/in_mem_chunked_node_group_collection.cpp
+++ b/src/storage/store/in_mem_chunked_node_group_collection.cpp
@@ -22,7 +22,7 @@ void InMemChunkedNodeGroupCollection::append(MemoryManager& memoryManager,
         auto& lastChunkedGroup = chunkedGroups.back();
         auto numRowsToAppendInGroup = std::min(numRowsToAppend - numRowsAppended,
             ChunkedNodeGroup::CHUNK_CAPACITY - lastChunkedGroup->getNumRows());
-        lastChunkedGroup->append(&transaction::DUMMY_TRANSACTION, vectors, startRowInVectors,
+        lastChunkedGroup->append(&DUMMY_TRANSACTION, vectors, startRowInVectors,
             numRowsToAppendInGroup);
         if (lastChunkedGroup->getNumRows() == ChunkedNodeGroup::CHUNK_CAPACITY) {
             lastChunkedGroup->setUnused(memoryManager);

--- a/test/test_files/ddl/ddl_empty.test
+++ b/test/test_files/ddl/ddl_empty.test
@@ -1,0 +1,101 @@
+-DATASET CSV empty
+--
+
+-CASE InsertNodeAfterDropAddCol
+-STATEMENT CREATE NODE TABLE person(id INT64 PRIMARY KEY, name STRING);
+---- ok
+-STATEMENT CREATE (:person {id: 10, name: 'A'});
+---- ok
+-STATEMENT MATCH (n:person) RETURN n.id, n.name
+---- 1
+10|A
+-STATEMENT ALTER TABLE person DROP name;
+---- ok
+-STATEMENT ALTER TABLE person ADD age INT64;
+---- ok
+-STATEMENT CREATE (:person {id: 20, age: 20});
+---- ok
+-STATEMENT MATCH (n:person) RETURN n.id, n.age
+---- 2
+10|
+20|20
+
+-CASE InsertRelAfterDropAddCol
+-STATEMENT CREATE NODE TABLE person(id INT64 PRIMARY KEY, name STRING);
+---- ok
+-STATEMENT CREATE REL TABLE knows(FROM person TO person, since INT64);
+---- ok
+-STATEMENT CREATE (:person {id: 10, name: 'A'});
+---- ok
+-STATEMENT CREATE (:person {id: 20, name: 'B'});
+---- ok
+-STATEMENT CREATE (:person {id: 30, name: 'C'});
+---- ok
+-STATEMENT MATCH (a:person {id: 10}), (b:person {id: 20}) CREATE (a)-[e:knows {since: 1900}]->(b);
+---- ok
+-STATEMENT MATCH (a:person {id: 20}), (b:person {id: 30}) CREATE (a)-[e:knows {since: 2000}]->(b);
+---- ok
+-STATEMENT MATCH (a:person)-[e:knows]->(b:person) RETURN e.since, b.id;
+---- 2
+1900|20
+2000|30
+-STATEMENT ALTER TABLE knows DROP since;
+---- ok
+-STATEMENT ALTER TABLE knows ADD weight FLOAT;
+---- ok
+-STATEMENT MATCH (a:person)-[e:knows]->(b:person) RETURN e.weight, b.id;
+---- 2
+|20
+|30
+-STATEMENT MATCH (a:person {id: 10}), (b:person {id: 20}) CREATE (a)-[e:knows {weight: 19.2}]->(b);
+---- ok
+-STATEMENT MATCH (a:person {id: 20}), (b:person {id: 30}) CREATE (a)-[e:knows {weight: 20.2}]->(b);
+---- ok
+-STATEMENT MATCH (a:person)-[e:knows]->(b:person) RETURN e.weight, b.id;
+---- 4
+19.200001|20
+20.200001|30
+|20
+|30
+
+-CASE CopyNodeAfterDropAddCol
+-STATEMENT CREATE NODE TABLE User(name STRING, alias STRING, PRIMARY KEY (name));
+---- ok
+-STATEMENT CREATE (:User {name: 'Alice', alias: 'A'});
+---- ok
+-STATEMENT ALTER TABLE User DROP alias;
+---- ok
+-STATEMENT ALTER TABLE User ADD age INT64;
+---- ok
+-STATEMENT COPY User FROM '${KUZU_ROOT_DIRECTORY}/dataset/demo-db/csv/user.csv';
+---- ok
+-STATEMENT MATCH (n:User) RETURN n.name, n.age;
+---- 5
+Alice|
+Adam|30
+Karissa|40
+Zhang|50
+Noura|25
+
+-CASE CopyRelAfterDropAddCol
+-STATEMENT CREATE NODE TABLE User(name STRING, age INT64, PRIMARY KEY (name));
+---- ok
+-STATEMENT CREATE REL TABLE Follows(FROM User TO User, comment STRING);
+---- ok
+-STATEMENT COPY User FROM '${KUZU_ROOT_DIRECTORY}/dataset/demo-db/csv/user.csv';
+---- ok
+-STATEMENT MATCH (a:User {name: 'Zhang'}), (b:User {name: 'Adam'}) CREATE (a)-[:Follows {comment: 'platform is tiktok'}]->(b);
+---- ok
+-STATEMENT ALTER TABLE Follows DROP comment;
+---- ok
+-STATEMENT ALTER TABLE Follows ADD since INT64;
+---- ok
+-STATEMENT COPY Follows FROM '${KUZU_ROOT_DIRECTORY}/dataset/demo-db/csv/follows.csv';
+---- ok
+-STATEMENT MATCH (a:User)-[e:Follows]->(b:User) RETURN a.name, e.since, b.name;
+---- 5
+Adam|2020|Karissa
+Adam|2020|Zhang
+Karissa|2021|Zhang
+Zhang|2022|Noura
+Zhang||Adam

--- a/test/test_files/issue/issue7.test
+++ b/test/test_files/issue/issue7.test
@@ -297,3 +297,23 @@ Binder exception: Table T19 does not exist.
 ---- ok
 -STATEMENT MATCH (n0)-[r0]-(n1{k20:true}), (n2)-[r1]-(n3{k20:true}), (n4)<-[r2]-(n5), (n5{k39:false})-[r3]->(n2{k41:false}) WHERE (((r2.id) <> (r3.id)) AND true) RETURN n2.id as a0, r1.id as a1, n3.id as a2;
 ---- 0
+
+-CASE issue4783
+-STATEMENT CREATE NODE TABLE Person(id INT64, PRIMARY KEY (id));
+---- ok
+-STATEMENT CREATE NODE TABLE IF NOT EXISTS Movie(id INT64, name STRING, PRIMARY KEY (id));
+---- ok
+-STATEMENT CREATE rel table knows(from person to person, from person to movie, age int64, comment string);
+---- ok
+-STATEMENT CREATE (:person {id: 12});
+---- ok
+-STATEMENT CREATE (:movie {id: 12, name: 'm'});
+---- ok
+-STATEMENT CREATE (:person {id: 25});
+---- ok
+-STATEMENT CREATE (:movie {id: 25, name: 'z'});
+---- ok
+-STATEMENT alter table knows drop age;
+---- ok
+-STATEMENT match (a:person), (b:person) where a.id = 25 and b.id = 12 create (a)-[:knows {comment: -8696457900372165364}]->(b);
+---- ok


### PR DESCRIPTION
# Description

Drop column can cause mismatched column IDs when inserting or copying into tables. The main reason is due to that we don't remove the dropped column immediately until checkpoint. The fix introduces column ids when appending into the table.

Fix #4777 and #4783