### PR TITLE
Fix rel group insert

### DIFF
--- a/src/binder/bind/bind_updating_clause.cpp
+++ b/src/binder/bind/bind_updating_clause.cpp
@@ -171,8 +171,8 @@ void Binder::bindInsertNode(std::shared_ptr<NodeExpression> node,
     infos.push_back(std::move(insertInfo));
 }
 
-static TableCatalogEntry* tryPruneMultiLabeled(const RelExpression& rel,
-    table_id_t srcTableID, table_id_t dstTableID) {
+static TableCatalogEntry* tryPruneMultiLabeled(const RelExpression& rel, table_id_t srcTableID,
+    table_id_t dstTableID) {
     std::vector<TableCatalogEntry*> candidates;
     for (auto& entry : rel.getEntries()) {
         KU_ASSERT(entry->getType() == CatalogEntryType::REL_TABLE_ENTRY);
@@ -182,7 +182,8 @@ static TableCatalogEntry* tryPruneMultiLabeled(const RelExpression& rel,
         }
     }
     if (candidates.size() != 1) {
-        throw BinderException(stringFormat("Create rel {} with multiple rel labels is not supported.", rel.toString()));
+        throw BinderException(stringFormat(
+            "Create rel {} with multiple rel labels is not supported.", rel.toString()));
     }
     return nullptr;
 }
@@ -190,7 +191,8 @@ static TableCatalogEntry* tryPruneMultiLabeled(const RelExpression& rel,
 void Binder::bindInsertRel(std::shared_ptr<RelExpression> rel,
     std::vector<BoundInsertInfo>& infos) {
     if (rel->isBoundByMultiLabeledNode()) {
-        throw BinderException(stringFormat("Create rel {} bound by multiple node labels is not supported.", rel->toString()));
+        throw BinderException(stringFormat(
+            "Create rel {} bound by multiple node labels is not supported.", rel->toString()));
     }
     if (rel->getDirectionType() == RelDirectionType::BOTH) {
         throw BinderException(stringFormat("Create undirected relationship is not supported. "
@@ -208,7 +210,8 @@ void Binder::bindInsertRel(std::shared_ptr<RelExpression> rel,
         entry = tryPruneMultiLabeled(*rel, srcTableID, dstTableID);
         // LCOV_EXCL_START
         if (entry == nullptr) {
-            throw BinderException(stringFormat("Cannot find a valid label in {} to create. This should not happen."));
+            throw BinderException(
+                stringFormat("Cannot find a valid label in {} to create. This should not happen."));
         }
         // LCOV_EXCL_STOP
     }

--- a/src/binder/bind/bind_updating_clause.cpp
+++ b/src/binder/bind/bind_updating_clause.cpp
@@ -8,6 +8,7 @@
 #include "binder/query/updating_clause/bound_set_clause.h"
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
+#include "catalog/catalog_entry/rel_table_catalog_entry.h"
 #include "common/assert.h"
 #include "common/exception/binder.h"
 #include "common/string_format.h"
@@ -120,11 +121,6 @@ std::vector<BoundInsertInfo> Binder::bindInsertInfos(QueryGraphCollection& query
         }
         for (auto j = 0u; j < queryGraph->getNumQueryRels(); ++j) {
             auto rel = queryGraph->getQueryRel(j);
-            if (rel->getDirectionType() == RelDirectionType::BOTH) {
-                throw BinderException(
-                    stringFormat("Create undirected relationship is not supported. Try create 2 "
-                                 "directed relationships instead."));
-            }
             if (rel->getVariableName().empty()) { // Always create anonymous rel.
                 bindInsertRel(rel, result);
                 continue;
@@ -175,20 +171,53 @@ void Binder::bindInsertNode(std::shared_ptr<NodeExpression> node,
     infos.push_back(std::move(insertInfo));
 }
 
+static TableCatalogEntry* tryPruneMultiLabeled(const RelExpression& rel,
+    table_id_t srcTableID, table_id_t dstTableID) {
+    std::vector<TableCatalogEntry*> candidates;
+    for (auto& entry : rel.getEntries()) {
+        KU_ASSERT(entry->getType() == CatalogEntryType::REL_TABLE_ENTRY);
+        auto& relEntry = entry->constCast<RelTableCatalogEntry>();
+        if (relEntry.getSrcTableID() == srcTableID && relEntry.getDstTableID() == dstTableID) {
+            candidates.push_back(entry);
+        }
+    }
+    if (candidates.size() != 1) {
+        throw BinderException(stringFormat("Create rel {} with multiple rel labels is not supported.", rel.toString()));
+    }
+    return nullptr;
+}
+
 void Binder::bindInsertRel(std::shared_ptr<RelExpression> rel,
     std::vector<BoundInsertInfo>& infos) {
-    if (rel->isMultiLabeled() || rel->isBoundByMultiLabeledNode()) {
-        throw BinderException(
-            "Create rel " + rel->toString() +
-            " with multiple rel labels or bound by multiple node labels is not supported.");
+    if (rel->isBoundByMultiLabeledNode()) {
+        throw BinderException(stringFormat("Create rel {} bound by multiple node labels is not supported.", rel->toString()));
+    }
+    if (rel->getDirectionType() == RelDirectionType::BOTH) {
+        throw BinderException(stringFormat("Create undirected relationship is not supported. "
+                                           "Try create 2 directed relationships instead."));
     }
     if (ExpressionUtil::isRecursiveRelPattern(*rel)) {
         throw BinderException(stringFormat("Cannot create recursive rel {}.", rel->toString()));
     }
-    rel->setEntries(std::vector<TableCatalogEntry*>{rel->getEntries()[0]});
-    auto entry = rel->getSingleEntry();
+    TableCatalogEntry* entry = nullptr;
+    if (!rel->isMultiLabeled()) {
+        entry = rel->getSingleEntry();
+    } else {
+        auto srcTableID = rel->getSrcNode()->getSingleEntry()->getTableID();
+        auto dstTableID = rel->getDstNode()->getSingleEntry()->getTableID();
+        entry = tryPruneMultiLabeled(*rel, srcTableID, dstTableID);
+        // LCOV_EXCL_START
+        if (entry == nullptr) {
+            throw BinderException(stringFormat("Cannot find a valid label in {} to create. This should not happen."));
+        }
+        // LCOV_EXCL_STOP
+    }
+    rel->setEntries(std::vector<TableCatalogEntry*>{entry});
     auto insertInfo = BoundInsertInfo(TableType::REL, rel);
-    insertInfo.columnExprs = rel->getPropertyExprs();
+    // Because we might prune entries, some property exprs may belong to pruned entry
+    for (auto& p : entry->getProperties()) {
+        insertInfo.columnExprs.push_back(rel->getPropertyExpression(p.getName()));
+    }
     insertInfo.columnDataExprs =
         bindInsertColumnDataExprs(rel->getPropertyDataExprRef(), entry->getProperties());
     infos.push_back(std::move(insertInfo));
@@ -269,7 +298,6 @@ std::unique_ptr<BoundUpdatingClause> Binder::bindDeleteClause(
         } else if (ExpressionUtil::isRelPattern(*pattern)) {
             // LCOV_EXCL_START
             if (deleteClause.getDeleteClauseType() == DeleteNodeType::DETACH_DELETE) {
-                // TODO(Xiyang): Dummy check here. Make sure this is the correct semantic.
                 throw BinderException("Detach delete on rel tables is not supported.");
             }
             // LCOV_EXCL_STOP

--- a/test/test_files/exceptions/multi_label_update.test
+++ b/test/test_files/exceptions/multi_label_update.test
@@ -7,6 +7,10 @@
 ---- error
 Binder exception: Create node a with multiple node labels is not supported.
 
+-STATEMENT MATCH (a), (b:organisation) CREATE (a)-[e:studyAt|:workAt]->(b)
+---- error
+Binder exception: Create rel e with multiple rel labels is not supported.
+
 -STATEMENT MATCH (a:person), (b:organisation) CREATE (a)-[e:studyAt|:workAt]->(b)
 ---- error
-Binder exception: Create rel e with multiple rel labels or bound by multiple node labels is not supported.
+Binder exception: Create rel e with multiple rel labels is not supported.

--- a/test/test_files/rel_group/edge_cases.test
+++ b/test/test_files/rel_group/edge_cases.test
@@ -29,7 +29,6 @@ Runtime exception: Cannot alter table Knows_PersonA_PersonB because it is refere
 ---- 0
 
 -CASE DuplicateRelTable
--SKIP
 -STATEMENT CREATE NODE TABLE PersonA (id INT64 PRIMARY KEY);
 ---- ok
 -STATEMENT CREATE NODE TABLE PersonB (id INT64 PRIMARY KEY);
@@ -52,7 +51,6 @@ Binder exception: Table Know2 already exists.
 2|Know2|REL|local(kuzu)|
 
 -CASE DuplicateFromToPairs
--SKIP
 -STATEMENT CREATE NODE TABLE PersonA (id INT64 PRIMARY KEY);
 ---- ok
 -STATEMENT CREATE NODE TABLE PersonB (id INT64 PRIMARY KEY);

--- a/test/test_files/rel_group/edge_cases.test
+++ b/test/test_files/rel_group/edge_cases.test
@@ -9,6 +9,17 @@
 ---- ok
 -STATEMENT CREATE REL TABLE Knows(FROM PersonA TO PersonA, FROM PersonA TO PersonB, data STRING);
 ---- ok
+-STATEMENT CREATE (:PersonA {id:0}), (:PersonB {id:0})
+---- ok
+-STATEMENT MATCH (p1:PersonA {id:0}), (p2:PersonB {id:0}) CREATE (p1)-[e:Knows]->(p2)
+---- ok
+-STATEMENT MATCH (p1 {id:0}), (p2 {id:0}) CREATE (p1)-[e:Knows]->(p2)
+---- error
+Binder exception: Create rel e bound by multiple node labels is not supported.
+-STATEMENT MATCH (a)-[]->(b) RETURN a.id, b.id
+---- 1
+0|0
+
 -STATEMENT ALTER TABLE Knows_PersonA_PersonB DROP data;
 ---- error
 Runtime exception: Cannot alter table Knows_PersonA_PersonB because it is referenced by table Knows.
@@ -17,8 +28,8 @@ Runtime exception: Cannot alter table Knows_PersonA_PersonB because it is refere
 -STATEMENT CALL table_info("Knows") RETURN *;
 ---- 0
 
-
 -CASE DuplicateRelTable
+-SKIP
 -STATEMENT CREATE NODE TABLE PersonA (id INT64 PRIMARY KEY);
 ---- ok
 -STATEMENT CREATE NODE TABLE PersonB (id INT64 PRIMARY KEY);
@@ -41,6 +52,7 @@ Binder exception: Table Know2 already exists.
 2|Know2|REL|local(kuzu)|
 
 -CASE DuplicateFromToPairs
+-SKIP
 -STATEMENT CREATE NODE TABLE PersonA (id INT64 PRIMARY KEY);
 ---- ok
 -STATEMENT CREATE NODE TABLE PersonB (id INT64 PRIMARY KEY);


### PR DESCRIPTION
# Description

This PR makes sure we can insert a relationship if its bound nodes is single labeled (which will uniquely identify a relationship table). This makes sure we can insert into a relationship table while using rel group name.

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).