### PR TITLE
Fix ApiTest.Interrupt

### DIFF
--- a/test/main/connection_test.cpp
+++ b/test/main/connection_test.cpp
@@ -56,9 +56,6 @@ TEST_F(ApiTest, ParallelConnect) {
 
 // TODO: FIX-ME. See Issue #4431.
 TEST_F(ApiTest, Interrupt) {
-    // set query timeout mainly so we can tell when the query starts
-    static constexpr uint64_t queryTimeout = 100000;
-    conn->setQueryTimeOut(queryTimeout);
     std::thread longRunningQueryThread(executeLongRunningQuery, conn.get());
     std::atomic<bool> finished_executing{false};
     std::thread interruptingThread([&]() {

--- a/test/main/connection_test.cpp
+++ b/test/main/connection_test.cpp
@@ -54,7 +54,6 @@ TEST_F(ApiTest, ParallelConnect) {
     }
 }
 
-// TODO: FIX-ME. See Issue #4431.
 TEST_F(ApiTest, Interrupt) {
     std::thread longRunningQueryThread(executeLongRunningQuery, conn.get());
     std::atomic<bool> finished_executing{false};


### PR DESCRIPTION
# Description

It's possible for the connection thread to not start until after `interrupt()` is called, which clears the interrupt flag. Add a new thread that repeatedly calls `interrupt()` until the query terminates.

Fixes https://github.com/kuzudb/kuzu/issues/4431

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).