### PR TITLE
Support casted literals for new column default value

### DIFF
--- a/src/binder/expression/expression_util.cpp
+++ b/src/binder/expression/expression_util.cpp
@@ -5,6 +5,7 @@
 #include "binder/expression/literal_expression.h"
 #include "binder/expression/node_rel_expression.h"
 #include "binder/expression/parameter_expression.h"
+#include "binder/expression/scalar_function_expression.h"
 #include "common/exception/binder.h"
 #include "common/types/value/nested.h"
 
@@ -428,6 +429,27 @@ Value ExpressionUtil::evaluateAsLiteralValue(const Expression& expr) {
         KU_UNREACHABLE;
     }
     return value;
+}
+
+bool ExpressionUtil::isLiteralOrCastedLiteral(const Expression& expr) {
+    if (canEvaluateAsLiteral(expr)) {
+        return true;
+    }
+    if (isCastExpr(expr)) {
+        KU_ASSERT(expr.getNumChildren() > 0);
+        return canEvaluateAsLiteral(*expr.getChild(0));
+    }
+    return false;
+}
+
+bool ExpressionUtil::isCastExpr(const Expression& expr) {
+    if (expr.expressionType == common::ExpressionType::FUNCTION) {
+        const auto& funcExpr = expr.constCast<binder::ScalarFunctionExpression>();
+        if (funcExpr.getFunction().name.starts_with("CAST")) {
+            return true;
+        }
+    }
+    return false;
 }
 
 } // namespace binder

--- a/src/expression_evaluator/expression_evaluator.cpp
+++ b/src/expression_evaluator/expression_evaluator.cpp
@@ -1,5 +1,7 @@
 #include "expression_evaluator/expression_evaluator.h"
 
+#include "binder/expression/expression_util.h"
+
 using namespace kuzu::common;
 
 namespace kuzu {
@@ -33,6 +35,14 @@ void ExpressionEvaluator::resolveResultStateFromChildren(
     resultVector->setState(std::make_shared<DataChunkState>());
     resultVector->state->initOriginalAndSelectedSize(1);
     resultVector->state->setToFlat();
+}
+
+void ExpressionEvaluator::updateCount(uint64_t newCount) {
+    if (binder::ExpressionUtil::isCastExpr(*expression)) {
+        KU_ASSERT(children.size() == 1);
+        children[0]->updateCount(newCount);
+    }
+    localState.count = newCount;
 }
 
 } // namespace evaluator

--- a/src/include/binder/expression/expression_util.h
+++ b/src/include/binder/expression/expression_util.h
@@ -62,6 +62,10 @@ struct KUZU_API ExpressionUtil {
     static bool canEvaluateAsLiteral(const Expression& expr);
 
     static common::Value evaluateAsLiteralValue(const Expression& expr);
+
+    static bool isLiteralOrCastedLiteral(const Expression& expr);
+
+    static bool isCastExpr(const Expression& expr);
 };
 
 } // namespace binder

--- a/src/include/expression_evaluator/expression_evaluator.h
+++ b/src/include/expression_evaluator/expression_evaluator.h
@@ -40,6 +40,8 @@ public:
           children{cloneVector(other.children)} {}
     virtual ~ExpressionEvaluator() = default;
 
+    void updateCount(uint64_t newCount);
+
     EvaluatorType getEvaluatorType() const { return type; }
 
     std::shared_ptr<binder::Expression> getExpression() const { return expression; }

--- a/src/include/function/unary_function_executor.h
+++ b/src/include/function/unary_function_executor.h
@@ -154,6 +154,8 @@ struct UnaryFunctionExecutor {
                     }
                 }
             }
+            auto& resultSelVector = result.state->getSelVectorUnsafe();
+            resultSelVector.setSelSize(operandSelVector.getSelSize());
         }
     }
 

--- a/src/processor/operator/ddl/alter.cpp
+++ b/src/processor/operator/ddl/alter.cpp
@@ -1,6 +1,6 @@
 #include "processor/operator/ddl/alter.h"
 
-#include "binder/expression/scalar_function_expression.h"
+#include "binder/expression/expression_util.h"
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
@@ -89,20 +89,6 @@ static bool skipAlter(ConflictAction action, const skip_alter_on_conflict& skipA
     }
 }
 
-static bool isLiteralOrCastedLiteral(const Expression& expr) {
-    if (expr.expressionType == common::ExpressionType::LITERAL) {
-        return true;
-    }
-    if (expr.expressionType == common::ExpressionType::FUNCTION) {
-        const auto& funcExpr = expr.constCast<binder::ScalarFunctionExpression>();
-        if (funcExpr.getFunction().name.starts_with("CAST")) {
-            KU_ASSERT(funcExpr.getNumChildren() > 0);
-            return funcExpr.getChild(0)->expressionType == common::ExpressionType::LITERAL;
-        }
-    }
-    return false;
-}
-
 static bool checkAddPropertyConflicts(TableCatalogEntry* tableEntry, const BoundAlterInfo& info) {
     const auto* extraInfo = info.extraInfo->constPtrCast<BoundExtraAddPropertyInfo>();
     validatePropertyNotExist(info.onConflict, tableEntry, extraInfo->propertyDefinition.getName());
@@ -110,7 +96,7 @@ static bool checkAddPropertyConflicts(TableCatalogEntry* tableEntry, const Bound
     // Eventually, we want to support non-constant default on rel tables, but it is non-trivial
     // due to FWD/BWD storage
     if (tableEntry->getType() == CatalogEntryType::REL_TABLE_ENTRY &&
-        !isLiteralOrCastedLiteral(*extraInfo->boundDefault)) {
+        !ExpressionUtil::isLiteralOrCastedLiteral(*extraInfo->boundDefault)) {
         throw RuntimeException(
             "Cannot set a non-constant default value when adding columns on REL tables.");
     }

--- a/src/processor/operator/partitioner.cpp
+++ b/src/processor/operator/partitioner.cpp
@@ -143,7 +143,7 @@ void Partitioner::executeInternal(ExecutionContext* context) {
             auto evaluator = dataInfo.columnEvaluators[i].get();
             switch (dataInfo.evaluateTypes[i]) {
             case ColumnEvaluateType::DEFAULT: {
-                evaluator->getLocalStateUnsafe().count = numRels;
+                evaluator->updateCount(numRels);
                 evaluator->evaluate();
             } break;
             default: {

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -83,7 +83,7 @@ void NodeBatchInsert::executeInternal(ExecutionContext* context) {
             switch (nodeInfo->evaluateTypes[i]) {
             case ColumnEvaluateType::DEFAULT: {
                 auto& defaultEvaluator = nodeInfo->columnEvaluators[i];
-                defaultEvaluator->getLocalStateUnsafe().count = numTuples;
+                defaultEvaluator->updateCount(numTuples);
                 defaultEvaluator->evaluate();
             } break;
             case ColumnEvaluateType::CAST: {

--- a/src/storage/predicate/column_predicate.cpp
+++ b/src/storage/predicate/column_predicate.cpp
@@ -2,7 +2,6 @@
 
 #include "binder/expression/expression_util.h"
 #include "binder/expression/literal_expression.h"
-#include "binder/expression/scalar_function_expression.h"
 #include "storage/predicate/constant_predicate.h"
 #include "storage/predicate/null_predicate.h"
 

--- a/src/storage/predicate/column_predicate.cpp
+++ b/src/storage/predicate/column_predicate.cpp
@@ -1,5 +1,6 @@
 #include "storage/predicate/column_predicate.h"
 
+#include "binder/expression/expression_util.h"
 #include "binder/expression/literal_expression.h"
 #include "binder/expression/scalar_function_expression.h"
 #include "storage/predicate/constant_predicate.h"
@@ -36,12 +37,9 @@ static bool isColumnRef(ExpressionType type) {
 }
 
 static bool isCastedColumnRef(const Expression& expr) {
-    if (expr.expressionType == ExpressionType::FUNCTION) {
-        const auto& funcExpr = expr.constCast<ScalarFunctionExpression>();
-        if (funcExpr.getFunction().name.starts_with("CAST")) {
-            KU_ASSERT(funcExpr.getNumChildren() > 0);
-            return isColumnRef(funcExpr.getChild(0)->expressionType);
-        }
+    if (ExpressionUtil::isCastExpr(expr)) {
+        KU_ASSERT(expr.getNumChildren() > 0);
+        return isColumnRef(expr.getChild(0)->expressionType);
     }
     return false;
 }

--- a/src/storage/store/column_chunk_data.cpp
+++ b/src/storage/store/column_chunk_data.cpp
@@ -471,7 +471,7 @@ void ColumnChunkData::populateWithDefaultVal(ExpressionEvaluator& defaultEvaluat
     while (numValuesAppended < numValuesToPopulate) {
         const auto numValuesToAppend =
             std::min(DEFAULT_VECTOR_CAPACITY, numValuesToPopulate - numValuesAppended);
-        defaultEvaluator.getLocalStateUnsafe().count = numValuesToAppend;
+        defaultEvaluator.updateCount(numValuesToAppend);
         defaultEvaluator.evaluate();
         auto resultVector = defaultEvaluator.resultVector.get();
         KU_ASSERT(resultVector->state->getSelVector().getSelSize() == numValuesToAppend);

--- a/test/test_files/ddl/ddl.test
+++ b/test/test_files/ddl/ddl.test
@@ -131,6 +131,16 @@ Binder exception: Table knows does not exist.
 ---- ok
 -STATEMENT MATCH (c:Comment) RETURN SUM(c.propx);
 ---- 1
+-STATEMENT alter table Comment add propy float default 5.4;
+---- ok
+-STATEMENT alter table Comment add propz int32 default 5;
+---- ok
+-STATEMENT MATCH (c:Comment) RETURN DISTINCT c.propy
+---- 1
+5.4
+-STATEMENT MATCH (c:Comment) RETURN DISTINCT c.propz
+---- 1
+5
 
 -STATEMENT MATCH (c:Comment) WHERE c.propx <> 1 RETURN COUNT(*);
 ---- 1

--- a/test/test_files/ddl/ddl.test
+++ b/test/test_files/ddl/ddl.test
@@ -1,4 +1,4 @@
--DATASET CSV tinysnb
+-DATASET CSV empty
 --
 
 -CASE DropAndCreateTables
@@ -131,17 +131,17 @@ Binder exception: Table knows does not exist.
 ---- ok
 -STATEMENT MATCH (c:Comment) RETURN SUM(c.propx);
 ---- 1
--STATEMENT alter table Comment add propy float default 5.4;
+
+-STATEMENT alter table Comment add propi float default 5.4;
 ---- ok
--STATEMENT alter table Comment add propz int32 default 5;
+-STATEMENT alter table Comment add propj int32 default 5;
 ---- ok
--STATEMENT MATCH (c:Comment) RETURN DISTINCT c.propy
+-STATEMENT MATCH (c:Comment) RETURN DISTINCT c.propi
 ---- 1
-5.4
--STATEMENT MATCH (c:Comment) RETURN DISTINCT c.propz
+5.400000
+-STATEMENT MATCH (c:Comment) RETURN DISTINCT c.propj
 ---- 1
 5
-
 -STATEMENT MATCH (c:Comment) WHERE c.propx <> 1 RETURN COUNT(*);
 ---- 1
 0
@@ -164,10 +164,12 @@ Binder exception: Table knows does not exist.
 ---- ok
 
 -STATEMENT CALL TABLE_INFO('Comment') RETURN *;
----- 3
+---- 5
 0|id|INT64|NULL|True
 1|propx|INT64|NULL|False
-2|propy|INT64|1|False
+2|propi|FLOAT|5.4|False
+3|propj|INT32|5|False
+4|propy|INT64|1|False
 
 -CASE AddRelProperty
 -STATEMENT create node table Comment (id int64, PRIMARY KEY (id));

--- a/test/test_files/ddl/ddl.test
+++ b/test/test_files/ddl/ddl.test
@@ -1,4 +1,4 @@
--DATASET CSV empty
+-DATASET CSV tinysnb
 --
 
 -CASE DropAndCreateTables


### PR DESCRIPTION
# Description

- Avoid throwing unsupported error if default value is a casted literal
- Update expression evaluator so that for default evaluators the correct output sel size is returned

Fixes https://github.com/kuzudb/kuzu/issues/4782

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).