### PR TITLE
Extension repo url

### DIFF
--- a/src/binder/bind/bind_extension.cpp
+++ b/src/binder/bind/bind_extension.cpp
@@ -42,7 +42,7 @@ std::unique_ptr<BoundStatement> Binder::bindExtension(const Statement& statement
     std::string path = extensionStatement->getPath();
     switch (extensionStatement->getAction()) {
     case ExtensionAction::INSTALL:
-        common::StringUtils::toLower(path);
+        bindInstallExtension(extensionStatement);
         break;
     case ExtensionAction::LOAD:
         bindLoadExtension(extensionStatement);

--- a/src/binder/bind/bind_extension.cpp
+++ b/src/binder/bind/bind_extension.cpp
@@ -2,6 +2,7 @@
 #include "binder/bound_extension_statement.h"
 #include "common/exception/binder.h"
 #include "common/file_system/local_file_system.h"
+#include "common/string_utils.h"
 #include "extension/extension.h"
 #include "parser/extension_statement.h"
 
@@ -38,9 +39,10 @@ static void bindLoadExtension(const ExtensionStatement* extensionStatement) {
 
 std::unique_ptr<BoundStatement> Binder::bindExtension(const Statement& statement) {
     auto extensionStatement = statement.constPtrCast<ExtensionStatement>();
+    std::string path = extensionStatement->getPath();
     switch (extensionStatement->getAction()) {
     case ExtensionAction::INSTALL:
-        bindInstallExtension(extensionStatement);
+        common::StringUtils::toLower(path);
         break;
     case ExtensionAction::LOAD:
         bindLoadExtension(extensionStatement);
@@ -48,8 +50,11 @@ std::unique_ptr<BoundStatement> Binder::bindExtension(const Statement& statement
     default:
         KU_UNREACHABLE;
     }
+    if (ExtensionUtils::isOfficialExtension(extensionStatement->getPath())) {
+        common::StringUtils::toLower(path);
+    }
     return std::make_unique<BoundExtensionStatement>(extensionStatement->getAction(),
-        extensionStatement->getPath());
+        std::move(path));
 }
 
 } // namespace binder

--- a/src/extension/extension.cpp
+++ b/src/extension/extension.cpp
@@ -68,8 +68,9 @@ std::string ExtensionSourceUtils::toString(ExtensionSource source) {
 }
 
 ExtensionRepoInfo ExtensionUtils::getExtensionLibRepoInfo(const std::string& extensionName) {
-    auto extensionURL = common::stringFormat(EXTENSION_FILE_REPO, KUZU_EXTENSION_VERSION,
-        getPlatform(), extensionName, getExtensionFileName(extensionName));
+    auto extensionURL =
+        common::stringFormat(EXTENSION_FILE_REPO, KUZU_EXTENSION_VERSION, getPlatform(),
+            common::StringUtils::getLower(extensionName), getExtensionFileName(extensionName));
     return getExtensionRepoInfo(extensionURL);
 }
 

--- a/src/extension/extension.cpp
+++ b/src/extension/extension.cpp
@@ -68,9 +68,8 @@ std::string ExtensionSourceUtils::toString(ExtensionSource source) {
 }
 
 ExtensionRepoInfo ExtensionUtils::getExtensionLibRepoInfo(const std::string& extensionName) {
-    auto extensionURL =
-        common::stringFormat(EXTENSION_FILE_REPO, KUZU_EXTENSION_VERSION, getPlatform(),
-            common::StringUtils::getLower(extensionName), getExtensionFileName(extensionName));
+    auto extensionURL = common::stringFormat(EXTENSION_FILE_REPO, KUZU_EXTENSION_VERSION,
+        getPlatform(), extensionName, getExtensionFileName(extensionName));
     return getExtensionRepoInfo(extensionURL);
 }
 

--- a/tools/python_api/test/test_extension.py
+++ b/tools/python_api/test/test_extension.py
@@ -57,7 +57,7 @@ def test_extension_install_httpfs(conn_db_readwrite: ConnDB, tmpdir: str, extens
     urllib.request.urlretrieve(download_url, temp_path)
 
     conn, _ = conn_db_readwrite
-    conn.execute("INSTALL httpfs")
+    conn.execute("INSTALL hTtpFs")
 
     assert Path.exists(extension_path)
 


### PR DESCRIPTION
Fix the generation of extension repo url.
If the user installs extension using upper case extension name:
```
INSTALL EXTENSION JSON;
```
Master generated an incorrect extension url because of the upper case `JSON`.
This PR normalize extension names when generating URLs.