### PR TITLE
Fix compatibility with older version of MSVC runtime

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -574,17 +574,17 @@ jobs:
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
           make nodejstest
 
-      - name: Rust test
-        shell: cmd
-        run: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-          make rusttest
-
       - name: Java test
         shell: cmd
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
           make javatest
+
+      - name: Rust test
+        shell: cmd
+        run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+          make rusttest
 
       - name: Rust test with pre-built library
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,10 @@ if(MSVC)
     # This is a workaround for regex oom issue on windows in gtest.
     add_compile_definitions(_REGEX_MAX_STACK_COUNT=0)
     add_compile_definitions(_REGEX_MAX_COMPLEXITY_COUNT=0)
+    # Disable constexpr mutex constructor to avoid compatibility issues with 
+    # older versions of the MSVC runtime library
+    # See: https://github.com/microsoft/STL/wiki/Changelog#vs-2022-1710
+    add_compile_definitions(_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
     # TODO (bmwinger): Figure out if this can be set automatically by cmake,
     # or at least better integrated with user-specified options
     # For now, hardcode _AMD64_


### PR DESCRIPTION
This PR  disables constexpr mutex constructor to avoid compatibility issues with older versions of the MSVC runtime library

See: https://github.com/microsoft/STL/wiki/Changelog#vs-2022-1710