### PR TITLE
Error on long list in list lambda

### DIFF
--- a/src/expression_evaluator/lambda_evaluator.cpp
+++ b/src/expression_evaluator/lambda_evaluator.cpp
@@ -51,6 +51,20 @@ void ListLambdaEvaluator::init(const ResultSet& resultSet, ClientContext* client
 void ListLambdaEvaluator::evaluate() {
     KU_ASSERT(children.size() == 1);
     children[0]->evaluate();
+    for (auto& param : params) {
+        if (param->dataType.getLogicalTypeID() == LogicalTypeID::LIST) {
+            for (auto i = 0u; i < param->state->getSelSize(); i++) {
+                auto lst = param->getValue<list_entry_t>(param->state->getSelVector()[i]);
+                if (lst.size > DEFAULT_VECTOR_CAPACITY) {
+                    throw common::RuntimeException{
+                        common::stringFormat("Lists with size greater than: {} is not "
+                                             "supported in list lambda functions.",
+                            DEFAULT_VECTOR_CAPACITY),
+                    };
+                }
+            }
+        }
+    }
     execFunc(params, *resultVector, &bindData);
 }
 

--- a/src/expression_evaluator/lambda_evaluator.cpp
+++ b/src/expression_evaluator/lambda_evaluator.cpp
@@ -48,9 +48,9 @@ void ListLambdaEvaluator::init(const ResultSet& resultSet, ClientContext* client
     bindData = ListLambdaBindData{lambdaParamEvaluators, paramIndices, lambdaRootEvaluator.get()};
 }
 
-void ListLambdaEvaluator::evaluate() {
-    KU_ASSERT(children.size() == 1);
-    children[0]->evaluate();
+// TODO(Ziyi): we currently do not support evaluating a list with size > DEFAULT_VECTOR_CAPACITY in
+// lambda.
+static void validateListLen(std::vector<std::shared_ptr<ValueVector>> params) {
     for (auto& param : params) {
         if (param->dataType.getLogicalTypeID() == LogicalTypeID::LIST) {
             for (auto i = 0u; i < param->state->getSelSize(); i++) {
@@ -65,6 +65,12 @@ void ListLambdaEvaluator::evaluate() {
             }
         }
     }
+}
+
+void ListLambdaEvaluator::evaluate() {
+    KU_ASSERT(children.size() == 1);
+    children[0]->evaluate();
+    validateListLen(params);
     execFunc(params, *resultVector, &bindData);
 }
 

--- a/test/test_files/function/lambda/list_filter.test
+++ b/test/test_files/function/lambda/list_filter.test
@@ -83,5 +83,5 @@ Binder exception: LIST_FILTER requires the result type of lambda expression be B
 []
 [10,6,7]
 -STATEMENT unwind range(1, 5000) as t with collect(t) as lst return list_filter(lst, x->x > 3);
----- error
+---- error(regex)
 Runtime exception: Lists with size greater than: [0-9]+ is not supported in list lambda functions.

--- a/test/test_files/function/lambda/list_filter.test
+++ b/test/test_files/function/lambda/list_filter.test
@@ -82,3 +82,6 @@ Binder exception: LIST_FILTER requires the result type of lambda expression be B
 [6,7]
 []
 [10,6,7]
+-STATEMENT unwind range(1, 5000) as t with collect(t) as lst return list_filter(lst, x->x > 3);
+---- error
+Runtime exception: Lists with size greater than: 2048 is not supported in list lambda functions.

--- a/test/test_files/function/lambda/list_filter.test
+++ b/test/test_files/function/lambda/list_filter.test
@@ -84,4 +84,4 @@ Binder exception: LIST_FILTER requires the result type of lambda expression be B
 [10,6,7]
 -STATEMENT unwind range(1, 5000) as t with collect(t) as lst return list_filter(lst, x->x > 3);
 ---- error
-Runtime exception: Lists with size greater than: 2048 is not supported in list lambda functions.
+Runtime exception: Lists with size greater than: [0-9]+ is not supported in list lambda functions.

--- a/test/test_files/function/lambda/list_reduce.test
+++ b/test/test_files/function/lambda/list_reduce.test
@@ -54,5 +54,5 @@ a:b:a:c:a:b:a:d:a:b:a:c:a:b:a:
 ---- 1
 d:c:b:a:b:c:d:
 -STATEMENT unwind range(1, 5000) as t with collect(t) as lst return list_reduce(lst, (x, y) -> y+x+y);
----- error
-Runtime exception: Lists with size greater than: 2048 is not supported in list lambda functions.
+---- error(regex)
+Runtime exception: Lists with size greater than: [0-9]+ is not supported in list lambda functions.

--- a/test/test_files/function/lambda/list_reduce.test
+++ b/test/test_files/function/lambda/list_reduce.test
@@ -53,3 +53,6 @@ a:b:a:c:a:b:a:d:a:b:a:c:a:b:a:
 -STATEMENT RETURN LIST_REDUCE(['a:', 'b:', 'c:', 'd:'], (x, y) -> y+x+y)
 ---- 1
 d:c:b:a:b:c:d:
+-STATEMENT unwind range(1, 5000) as t with collect(t) as lst return list_reduce(lst, (x, y) -> y+x+y);
+---- error
+Runtime exception: Lists with size greater than: 2048 is not supported in list lambda functions.

--- a/test/test_files/function/lambda/list_transform.test
+++ b/test/test_files/function/lambda/list_transform.test
@@ -91,5 +91,5 @@ Binder exception: The second argument of LIST_TRANSFORM should be a lambda expre
 ---- 1
 [8,12,10]
 -STATEMENT unwind range(1, 5000) as t with collect(t) as lst return list_transform(lst, x->x+1);
----- error
-Runtime exception: Lists with size greater than: 2048 is not supported in list lambda functions.
+---- error(regex)
+Runtime exception: Lists with size greater than: [0-9]+ is not supported in list lambda functions.

--- a/test/test_files/function/lambda/list_transform.test
+++ b/test/test_files/function/lambda/list_transform.test
@@ -90,3 +90,6 @@ Binder exception: The second argument of LIST_TRANSFORM should be a lambda expre
 -STATEMENT RETURN LIST_TRANSFORM(['KUZU', 'DUCKDB', 'NEO4J'], x-> size(x)+size(x))
 ---- 1
 [8,12,10]
+-STATEMENT unwind range(1, 5000) as t with collect(t) as lst return list_transform(lst, x->x+1);
+---- error
+Runtime exception: Lists with size greater than: 2048 is not supported in list lambda functions.


### PR DESCRIPTION
Throws an exception when the list used in lambda is longer than DEFAULT_VECTOR_CAPACITY