### PR TITLE
Use the most significant bits for partitioning in the HashAggregate

### DIFF
--- a/src/include/processor/operator/aggregate/hash_aggregate.h
+++ b/src/include/processor/operator/aggregate/hash_aggregate.h
@@ -117,6 +117,7 @@ public:
     std::atomic<size_t> numThreadsFinishedProducing;
     std::atomic<size_t> numThreads;
     storage::MemoryManager* memoryManager;
+    uint8_t shiftForPartitioning;
 };
 
 struct HashAggregateLocalState {


### PR DESCRIPTION
Instead of the least significant

A small but fairly important thing I missed in #4655; I ran a few quick benchmarks and it gave a speedup of up to 20% (128 thread 2x EPYC 7551)

Using the least significant bits meant that only a fraction of the slots in a given partition would match the hashes. Because we're using linear probing the performance wasn't previously too terrible as the hash table would still get filled, however it would have been increasing the average number of probes needed when inserting or looking up values in the table.

| Query | master | new |
| --- | --- | --- |
| `MATCH (h:hits) WHERE h.SearchPhrase <> '' RETURN h.SearchPhrase, COUNT(*) AS c ORDER BY c DESC LIMIT 10;` | 0.89s | 0.84s |
| `MATCH (h:hits) WHERE h.SearchPhrase <> '' RETURN h.SearchEngineID, h.SearchPhrase, COUNT(*) AS c ORDER BY c DESC LIMIT 10;` | 0.5s | 0.45s |
| `MATCH (h:hits) RETURN h.UserID, COUNT(*) ORDER BY COUNT(*) DESC LIMIT 10;` | 0.93s | 0.73s |
| `MATCH (h:hits) RETURN h.UserID, h.SearchPhrase, COUNT(*) ORDER BY COUNT(*) DESC LIMIT 10;` | 1.17s | 0.98s |
