### PR TITLE
Update API docs: QueryResult getNext() reuses the same underlying flat tuple

### DIFF
--- a/src/include/c_api/kuzu.h
+++ b/src/include/c_api/kuzu.h
@@ -676,6 +676,9 @@ KUZU_C_API kuzu_state kuzu_query_result_get_query_summary(kuzu_query_result* que
 KUZU_C_API bool kuzu_query_result_has_next(kuzu_query_result* query_result);
 /**
  * @brief Returns the next tuple in the query result. Throws an exception if there is no more tuple.
+ * Note that to reduce resource allocation, all calls to kuzu_query_result_get_next() reuse the same
+ * FlatTuple object. Since its contents will be overwritten, please complete processing a FlatTuple
+ * or make a copy of its data before calling kuzu_query_result_get_next() again.
  * @param query_result The query result instance to return.
  * @param[out] out_flat_tuple The output parameter that will hold the next tuple.
  * @return The state indicating the success or failure of the operation.

--- a/src/include/main/query_result.h
+++ b/src/include/main/query_result.h
@@ -95,7 +95,10 @@ public:
 
     std::unique_ptr<QueryResult> nextQueryResult;
     /**
-     * @return next flat tuple in the query result.
+     * @return next flat tuple in the query result. Note that to reduce resource allocation, all
+     * calls to getNext() reuse the same FlatTuple object. Since its contents will be overwritten,
+     * please complete processing a FlatTuple or make a copy of its data before calling getNext()
+     * again.
      */
     KUZU_API std::shared_ptr<processor::FlatTuple> getNext();
     /**

--- a/tools/java_api/src/main/java/com/kuzudb/QueryResult.java
+++ b/tools/java_api/src/main/java/com/kuzudb/QueryResult.java
@@ -136,7 +136,10 @@ public class QueryResult implements AutoCloseable {
     }
 
     /**
-     * Get the next tuple.
+     * Get the next tuple. Note that to reduce resource allocation, all calls to
+     * getNext() reuse the same FlatTuple object. Since its contents will be
+     * overwritten, please complete processing a FlatTuple or make a copy of its
+     * data before calling getNext() again.
      *
      * @return The next tuple.
      * @throws ObjectRefDestroyedException If the query result has been destroyed.


### PR DESCRIPTION
# Description

In the C, C++, and Java APIs, `QueryResult::getNext()` returns references to the output flat tuple. Additionally, the same flat tuple object is reused for each call to `getNext()` meaning that each call to `getNext()` will overwrite the return result of the previous call to `getNext()`. This PR updates the API docs to document this behaviour.

Fixes https://github.com/kuzudb/kuzu/issues/4814

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).