### PR TITLE
Fix zone maps for is/is not null

### DIFF
--- a/src/storage/predicate/column_predicate.cpp
+++ b/src/storage/predicate/column_predicate.cpp
@@ -85,7 +85,7 @@ static std::unique_ptr<ColumnPredicate> tryConvertToConstColumnPredicate(const E
 static std::unique_ptr<ColumnPredicate> tryConvertToIsNull(const Expression& column,
     const Expression& predicate) {
     // we only convert simple predicates
-    if (isColumnOrCastedColumnRef(*predicate.getChild(0))) {
+    if (isColumnOrCastedColumnRef(*predicate.getChild(0)) && column == *predicate.getChild(0)) {
         return std::make_unique<ColumnNullPredicate>(column.toString(), ExpressionType::IS_NULL);
     }
     return nullptr;
@@ -93,7 +93,7 @@ static std::unique_ptr<ColumnPredicate> tryConvertToIsNull(const Expression& col
 
 static std::unique_ptr<ColumnPredicate> tryConvertToIsNotNull(const Expression& column,
     const Expression& predicate) {
-    if (isColumnOrCastedColumnRef(*predicate.getChild(0))) {
+    if (isColumnOrCastedColumnRef(*predicate.getChild(0)) && column == *predicate.getChild(0)) {
         return std::make_unique<ColumnNullPredicate>(column.toString(),
             ExpressionType::IS_NOT_NULL);
     }

--- a/test/test_files/filter/node.test
+++ b/test/test_files/filter/node.test
@@ -35,9 +35,12 @@
 -LOG NullCheckBool
 -STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.isStudent=null
 ---- ok
--STATEMENT MATCH (a:person) WHERE a.isStudent IS NULL RETURN COUNT(*)
+-STATEMENT MATCH (a:person) RETURN COUNT(*)
 ---- 1
-1
+9
+-STATEMENT MATCH (a:person) WHERE a.isStudent IS NULL RETURN a.ID, a.fName, a.gender, a.isWorker, a.age
+---- 1
+0|Alice|1|False|90
 -STATEMENT MATCH (a:person) WHERE a.isStudent IS NOT NULL RETURN COUNT(*)
 ---- 1
 8


### PR DESCRIPTION
# Description

When adding predicates to check for zone map, we didn't check if the column matched the predicate column. For example if we had a table with columns A, B, C and predicate `C is null`, we would incorrectly add predicates `A is null`, `B is null`, `C is null` since we didn't actually do a check on the column. This PR fixes the bug.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).