### PR TITLE
Use MemoryManager to allocate undo buffer

### DIFF
--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -210,8 +210,8 @@ Transaction Transaction::getDummyTransactionFromExistingOne(const Transaction& o
         other.minUncommittedNodeOffsets, other.maxCommittedNodeOffsets);
 }
 
-auto DUMMY_TRANSACTION = Transaction(TransactionType::DUMMY);
-auto DUMMY_CHECKPOINT_TRANSACTION = Transaction(TransactionType::CHECKPOINT,
+Transaction DUMMY_TRANSACTION = Transaction(TransactionType::DUMMY);
+Transaction DUMMY_CHECKPOINT_TRANSACTION = Transaction(TransactionType::CHECKPOINT,
     Transaction::DUMMY_TRANSACTION_ID, Transaction::START_TRANSACTION_ID - 1);
 
 } // namespace transaction

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -21,7 +21,7 @@ Transaction::Transaction(main::ClientContext& clientContext, TransactionType tra
       commitTS{common::INVALID_TRANSACTION}, forceCheckpoint{false} {
     this->clientContext = &clientContext;
     localStorage = std::make_unique<storage::LocalStorage>(clientContext);
-    undoBuffer = std::make_unique<storage::UndoBuffer>(this);
+    undoBuffer = std::make_unique<storage::UndoBuffer>(clientContext.getMemoryManager());
     currentTS = common::Timestamp::getCurrentTimestamp().value;
     // Note that the use of `this` should be safe here as there is no inheritance.
     for (auto entry : clientContext.getCatalog()->getNodeTableEntries(this)) {
@@ -65,7 +65,7 @@ void Transaction::commit(storage::WAL* wal) const {
 
 void Transaction::rollback(storage::WAL* wal) const {
     localStorage->rollback();
-    undoBuffer->rollback();
+    undoBuffer->rollback(this);
     if (isWriteTransaction() && shouldLogToWAL()) {
         KU_ASSERT(wal);
         wal->logRollback();
@@ -210,8 +210,8 @@ Transaction Transaction::getDummyTransactionFromExistingOne(const Transaction& o
         other.minUncommittedNodeOffsets, other.maxCommittedNodeOffsets);
 }
 
-Transaction DUMMY_TRANSACTION = Transaction(TransactionType::DUMMY);
-Transaction DUMMY_CHECKPOINT_TRANSACTION = Transaction(TransactionType::CHECKPOINT,
+auto DUMMY_TRANSACTION = Transaction(TransactionType::DUMMY);
+auto DUMMY_CHECKPOINT_TRANSACTION = Transaction(TransactionType::CHECKPOINT,
     Transaction::DUMMY_TRANSACTION_ID, Transaction::START_TRANSACTION_ID - 1);
 
 } // namespace transaction


### PR DESCRIPTION
# Description

Make use of `MemoryManager` for allocating undo buffers.

Additionally, apply `const` and `static` qualifiers where appropriate.