### PR TITLE
Fix race condition in random engine

### DIFF
--- a/src/common/random_engine.cpp
+++ b/src/common/random_engine.cpp
@@ -14,10 +14,12 @@ RandomEngine::RandomEngine(uint64_t seed, uint64_t stream) : randomState(RandomS
 }
 
 uint32_t RandomEngine::nextRandomInteger() {
+    std::unique_lock xLck{mtx};
     return randomState.pcg();
 }
 
 uint32_t RandomEngine::nextRandomInteger(uint32_t upper) {
+    std::unique_lock xLck{mtx};
     return randomState.pcg(upper);
 }
 

--- a/src/include/common/random_engine.h
+++ b/src/include/common/random_engine.h
@@ -25,6 +25,7 @@ public:
     uint32_t nextRandomInteger(uint32_t upper);
 
 private:
+    std::mutex mtx;
     RandomState randomState;
 };
 

--- a/src/include/common/random_engine.h
+++ b/src/include/common/random_engine.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "pcg_random.hpp"
 
 namespace kuzu {

--- a/src/include/function/uuid/functions/gen_random_uuid.h
+++ b/src/include/function/uuid/functions/gen_random_uuid.h
@@ -10,7 +10,7 @@ namespace function {
 struct GenRandomUUID {
     static void operation(common::ku_uuid_t& input, void* dataPtr) {
         input = common::UUID::generateRandomUUID(
-            reinterpret_cast<FunctionBindData*>(dataPtr)->clientContext->getRandomEngine());
+            static_cast<FunctionBindData*>(dataPtr)->clientContext->getRandomEngine());
     }
 };
 

--- a/test/test_files/function/uuid.test
+++ b/test/test_files/function/uuid.test
@@ -103,3 +103,12 @@ Conversion exception: Invalid UUID: 11111111111111111
 -STATEMENT RETURN UUID("0");
 ---- error
 Conversion exception: Invalid UUID: 0
+
+-CASE LargeRandomUUID
+-STATEMENT CREATE NODE TABLE test(id INT64 PRIMARY KEY);
+---- ok
+-STATEMENT COPY test FROM (UNWIND range(1, 200000) AS id RETURN id);
+---- ok
+-STATEMENT MATCH (t:test) WITH DISTINCT gen_random_uuid() as u RETURN count(*);
+---- 1
+200000


### PR DESCRIPTION
# Description

`pcg()` is not thread safe. Fixed by locking for now.

The ideal way to fix this is to let each function holds its own local state, which holds a `RandomEngine` with a unique seed. This would require changes to ExpressionEvaluator and function interface, which is non-trivial. See issue https://github.com/kuzudb/kuzu/issues/4828