### PR TITLE
Refactor export db

### DIFF
--- a/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
@@ -85,9 +85,7 @@ binder::BoundCreateTableInfo RelGroupCatalogEntry::getBoundCreateTableInfo(
         std::move(extraInfo), isInternal);
 }
 
-static std::string getFromToStr(table_id_t tableID, const ClientContext* context) {
-    auto catalog = context->getCatalog();
-    auto transaction = context->getTransaction();
+static std::string getFromToStr(table_id_t tableID, Catalog* catalog, const transaction::Transaction* transaction) {
     auto& entry =
         catalog->getTableCatalogEntry(transaction, tableID)->constCast<RelTableCatalogEntry>();
     auto srcTableName =
@@ -97,22 +95,19 @@ static std::string getFromToStr(table_id_t tableID, const ClientContext* context
     return stringFormat("FROM {} TO {}", srcTableName, dstTableName);
 }
 
-std::string RelGroupCatalogEntry::toCypher(ClientContext* clientContext) const {
+std::string RelGroupCatalogEntry::toCypher(ClientContext* context) const {
+    auto catalog = context->getCatalog();
+    auto transaction = context->getTransaction();
     std::stringstream ss;
-    ss << stringFormat("CREATE REL TABLE {} ( ", getName());
+    ss << stringFormat("CREATE REL TABLE {} (", getName());
     KU_ASSERT(!relTableIDs.empty());
-    ss << getFromToStr(relTableIDs[0], clientContext);
+    ss << getFromToStr(relTableIDs[0], catalog, transaction);
     for (auto i = 1u; i < relTableIDs.size(); ++i) {
-        ss << stringFormat(", {}", getFromToStr(relTableIDs[i], clientContext));
+        ss << stringFormat(", {}", getFromToStr(relTableIDs[i], catalog, transaction));
     }
-    auto childRelEntry = clientContext->getCatalog()->getTableCatalogEntry(
-        clientContext->getTransaction(), relTableIDs[0]);
-    if (childRelEntry->getNumProperties() > 1) { // skip internal id property.
-        auto propertyStr = stringFormat(", {}", childRelEntry->propertiesToCypher());
-        propertyStr.resize(propertyStr.size() - 1);
-        ss << propertyStr;
-    }
-    ss << ");";
+    auto childEntry = catalog->getTableCatalogEntry(
+        transaction, relTableIDs[0])->ptrCast<RelTableCatalogEntry>();
+    ss << ", " << childEntry->propertiesToCypher() << childEntry->getMultiplicityStr() << ");";
     return ss.str();
 }
 

--- a/src/catalog/catalog_entry/rel_table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_table_catalog_entry.cpp
@@ -118,17 +118,19 @@ std::unique_ptr<TableCatalogEntry> RelTableCatalogEntry::copy() const {
     return other;
 }
 
+std::string RelTableCatalogEntry::getMultiplicityStr() const {
+    return RelMultiplicityUtils::toString(srcMultiplicity) + "_" + RelMultiplicityUtils::toString(dstMultiplicity);
+}
+
 std::string RelTableCatalogEntry::toCypher(main::ClientContext* clientContext) const {
     std::stringstream ss;
     auto catalog = clientContext->getCatalog();
     auto transaction = clientContext->getTransaction();
     auto srcTableName = catalog->getTableCatalogEntry(transaction, srcTableID)->getName();
     auto dstTableName = catalog->getTableCatalogEntry(transaction, dstTableID)->getName();
-    auto srcMultiStr = srcMultiplicity == RelMultiplicity::MANY ? "MANY" : "ONE";
-    auto dstMultiStr = dstMultiplicity == RelMultiplicity::MANY ? "MANY" : "ONE";
     std::string tableInfo =
         stringFormat("CREATE REL TABLE {} (FROM {} TO {}, ", getName(), srcTableName, dstTableName);
-    ss << tableInfo << propertyCollection.toCypher() << srcMultiStr << "_" << dstMultiStr << ");";
+    ss << tableInfo << propertiesToCypher() << getMultiplicityStr() << ");";
     return ss.str();
 }
 

--- a/src/catalog/property_definition_collection.cpp
+++ b/src/catalog/property_definition_collection.cpp
@@ -93,6 +93,7 @@ std::string PropertyDefinitionCollection::toCypher() const {
     std::stringstream ss;
     for (auto& [_, def] : definitions) {
         auto& dataType = def.getType();
+        // Avoid exporting internal ID
         if (dataType.getPhysicalType() == PhysicalTypeID::INTERNAL_ID) {
             continue;
         }

--- a/src/include/catalog/catalog_entry/rel_table_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/rel_table_catalog_entry.h
@@ -49,6 +49,7 @@ public:
 
     std::unique_ptr<TableCatalogEntry> copy() const override;
 
+    std::string getMultiplicityStr() const;
     std::string toCypher(main::ClientContext* clientContext) const override;
 
 private:


### PR DESCRIPTION
# Description

Avoid write internal ID column in exported copy.cypher.

Add multiplicity when exporting rel group. 

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).