### PR TITLE
Fix bugs found during vector size testing

### DIFF
--- a/src/expression_evaluator/case_evaluator.cpp
+++ b/src/expression_evaluator/case_evaluator.cpp
@@ -56,7 +56,9 @@ bool CaseExpressionEvaluator::select(SelectionVector& selVector) {
         auto selVectorPos = selVector[i];
         auto resultVectorPos = resultVector->state->getSelVector()[i];
         selectedPosBuffer[numSelectedValues] = selVectorPos;
-        numSelectedValues += resultVector->getValue<bool>(resultVectorPos);
+        const bool selectCurrentValue =
+            !resultVector->isNull(resultVectorPos) && resultVector->getValue<bool>(resultVectorPos);
+        numSelectedValues += selectCurrentValue;
     }
     selVector.setSelSize(numSelectedValues);
     return numSelectedValues > 0;

--- a/src/expression_evaluator/case_evaluator.cpp
+++ b/src/expression_evaluator/case_evaluator.cpp
@@ -28,7 +28,8 @@ void CaseExpressionEvaluator::evaluate() {
     filledMask.reset();
     for (auto& alternativeEvaluator : alternativeEvaluators) {
         auto whenSelVector = alternativeEvaluator.whenSelVector.get();
-        auto hasAtLeastOneValue = alternativeEvaluator.whenEvaluator->select(*whenSelVector);
+        // the sel vector is already set to filtered in init()
+        auto hasAtLeastOneValue = alternativeEvaluator.whenEvaluator->select(*whenSelVector, false);
         if (!hasAtLeastOneValue) {
             continue;
         }
@@ -47,7 +48,7 @@ void CaseExpressionEvaluator::evaluate() {
     fillAll(elseEvaluator->resultVector.get());
 }
 
-bool CaseExpressionEvaluator::select(SelectionVector& selVector) {
+bool CaseExpressionEvaluator::selectInternal(SelectionVector& selVector) {
     evaluate();
     KU_ASSERT(resultVector->state->getSelVector().getSelSize() == selVector.getSelSize());
     auto numSelectedValues = 0u;

--- a/src/expression_evaluator/expression_evaluator.cpp
+++ b/src/expression_evaluator/expression_evaluator.cpp
@@ -35,5 +35,14 @@ void ExpressionEvaluator::resolveResultStateFromChildren(
     resultVector->state->setToFlat();
 }
 
+bool ExpressionEvaluator::select(common::SelectionVector& selVector,
+    bool shouldSetSelVectorToFiltered) {
+    bool ret = selectInternal(selVector);
+    if (shouldSetSelVectorToFiltered && selVector.isUnfiltered()) {
+        selVector.setToFiltered();
+    }
+    return ret;
+}
+
 } // namespace evaluator
 } // namespace kuzu

--- a/src/expression_evaluator/function_evaluator.cpp
+++ b/src/expression_evaluator/function_evaluator.cpp
@@ -32,7 +32,7 @@ void FunctionExpressionEvaluator::evaluate() {
     }
 }
 
-bool FunctionExpressionEvaluator::select(SelectionVector& selVector) {
+bool FunctionExpressionEvaluator::selectInternal(SelectionVector& selVector) {
     for (auto& child : children) {
         child->evaluate();
     }

--- a/src/expression_evaluator/literal_evaluator.cpp
+++ b/src/expression_evaluator/literal_evaluator.cpp
@@ -21,7 +21,7 @@ void LiteralExpressionEvaluator::evaluate() {
     }
 }
 
-bool LiteralExpressionEvaluator::select(SelectionVector&) {
+bool LiteralExpressionEvaluator::selectInternal(SelectionVector&) {
     KU_ASSERT(resultVector->dataType.getLogicalTypeID() == LogicalTypeID::BOOL);
     auto pos = resultVector->state->getSelVector()[0];
     KU_ASSERT(pos == 0u);

--- a/src/expression_evaluator/reference_evaluator.cpp
+++ b/src/expression_evaluator/reference_evaluator.cpp
@@ -11,7 +11,7 @@ inline static bool isTrue(ValueVector& vector, uint64_t pos) {
     return !vector.isNull(pos) && vector.getValue<bool>(pos);
 }
 
-bool ReferenceExpressionEvaluator::select(SelectionVector& selVector) {
+bool ReferenceExpressionEvaluator::selectInternal(SelectionVector& selVector) {
     uint64_t numSelectedValues = 0;
     auto selectedBuffer = resultVector->state->getSelVectorUnsafe().getMutableBuffer();
     if (resultVector->state->getSelVector().isUnfiltered()) {

--- a/src/function/list/list_reverse_function.cpp
+++ b/src/function/list/list_reverse_function.cpp
@@ -10,6 +10,7 @@ struct ListReverse {
     static inline void operation(common::list_entry_t& input, common::list_entry_t& result,
         common::ValueVector& inputVector, common::ValueVector& resultVector) {
         auto inputDataVector = common::ListVector::getDataVector(&inputVector);
+        ListVector::resizeDataVector(&resultVector, ListVector::getDataVectorSize(&inputVector));
         auto resultDataVector = common::ListVector::getDataVector(&resultVector);
         result = input; // reverse does not change
         for (auto i = 0u; i < input.size; i++) {

--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -247,16 +247,15 @@ std::unique_ptr<VertexScanState> OnDiskGraph::prepareVertexScan(
 bool OnDiskGraphNbrScanState::InnerIterator::next(evaluator::ExpressionEvaluator* predicate) {
     bool hasAtLeastOneSelectedValue = false;
     do {
+        restoreSelVector(*tableScanState->outState);
         if (!relTable->scan(context->getTransaction(), *tableScanState)) {
             return false;
         }
+        saveSelVector(*tableScanState->outState);
         if (predicate != nullptr) {
             hasAtLeastOneSelectedValue =
-                predicate->select(tableScanState->outState->getSelVectorUnsafe());
-            if (!tableScanState->outState->isFlat() &&
-                tableScanState->outState->getSelVector().isUnfiltered()) {
-                tableScanState->outState->getSelVectorUnsafe().setToFiltered();
-            }
+                predicate->select(tableScanState->outState->getSelVectorUnsafe(),
+                    !tableScanState->outState->isFlat());
         } else {
             hasAtLeastOneSelectedValue = tableScanState->outState->getSelVector().getSelSize() > 0;
         }

--- a/src/include/expression_evaluator/case_evaluator.h
+++ b/src/include/expression_evaluator/case_evaluator.h
@@ -50,7 +50,7 @@ public:
 
     void evaluate() override;
 
-    bool select(common::SelectionVector& selVector) override;
+    bool selectInternal(common::SelectionVector& selVector) override;
 
     std::unique_ptr<ExpressionEvaluator> clone() override {
         return std::make_unique<CaseExpressionEvaluator>(expression,

--- a/src/include/expression_evaluator/expression_evaluator.h
+++ b/src/include/expression_evaluator/expression_evaluator.h
@@ -51,7 +51,7 @@ public:
 
     virtual void evaluate() = 0;
 
-    virtual bool select(common::SelectionVector& selVector) = 0;
+    bool select(common::SelectionVector& selVector, bool shouldSetSelVectorToFiltered);
 
     virtual std::unique_ptr<ExpressionEvaluator> clone() = 0;
 
@@ -75,6 +75,8 @@ protected:
         storage::MemoryManager* memoryManager) = 0;
 
     void resolveResultStateFromChildren(const std::vector<ExpressionEvaluator*>& inputEvaluators);
+
+    virtual bool selectInternal(common::SelectionVector& selVector) = 0;
 
 public:
     std::shared_ptr<common::ValueVector> resultVector;

--- a/src/include/expression_evaluator/function_evaluator.h
+++ b/src/include/expression_evaluator/function_evaluator.h
@@ -15,7 +15,7 @@ public:
 
     void evaluate() override;
 
-    bool select(common::SelectionVector& selVector) override;
+    bool selectInternal(common::SelectionVector& selVector) override;
 
     std::unique_ptr<ExpressionEvaluator> clone() override {
         return std::make_unique<FunctionExpressionEvaluator>(expression, cloneVector(children));

--- a/src/include/expression_evaluator/lambda_evaluator.h
+++ b/src/include/expression_evaluator/lambda_evaluator.h
@@ -21,7 +21,7 @@ public:
 
     void evaluate() override {}
 
-    bool select(common::SelectionVector&) override { KU_UNREACHABLE; }
+    bool selectInternal(common::SelectionVector&) override { KU_UNREACHABLE; }
 
     std::unique_ptr<ExpressionEvaluator> clone() override {
         return std::make_unique<LambdaParamEvaluator>(expression);
@@ -63,7 +63,7 @@ public:
 
     void evaluate() override;
 
-    bool select(common::SelectionVector&) override { KU_UNREACHABLE; }
+    bool selectInternal(common::SelectionVector&) override { KU_UNREACHABLE; }
 
     std::unique_ptr<ExpressionEvaluator> clone() override {
         auto result = std::make_unique<ListLambdaEvaluator>(expression, cloneVector(children));

--- a/src/include/expression_evaluator/literal_evaluator.h
+++ b/src/include/expression_evaluator/literal_evaluator.h
@@ -16,7 +16,7 @@ public:
 
     void evaluate() override;
 
-    bool select(common::SelectionVector& selVector) override;
+    bool selectInternal(common::SelectionVector& selVector) override;
 
     std::unique_ptr<ExpressionEvaluator> clone() override {
         return std::make_unique<LiteralExpressionEvaluator>(expression, value);

--- a/src/include/expression_evaluator/path_evaluator.h
+++ b/src/include/expression_evaluator/path_evaluator.h
@@ -23,7 +23,7 @@ public:
 
     void evaluate() override;
 
-    bool select(common::SelectionVector& /*selVector*/) override { KU_UNREACHABLE; }
+    bool selectInternal(common::SelectionVector& /*selVector*/) override { KU_UNREACHABLE; }
 
     std::unique_ptr<ExpressionEvaluator> clone() override {
         return make_unique<PathExpressionEvaluator>(expression, cloneVector(children));

--- a/src/include/expression_evaluator/pattern_evaluator.h
+++ b/src/include/expression_evaluator/pattern_evaluator.h
@@ -16,7 +16,7 @@ public:
 
     void evaluate() override;
 
-    bool select(common::SelectionVector&) override { KU_UNREACHABLE; }
+    bool selectInternal(common::SelectionVector&) override { KU_UNREACHABLE; }
 
     std::unique_ptr<ExpressionEvaluator> clone() override {
         return std::make_unique<PatternExpressionEvaluator>(expression, cloneVector(children));

--- a/src/include/expression_evaluator/reference_evaluator.h
+++ b/src/include/expression_evaluator/reference_evaluator.h
@@ -19,7 +19,7 @@ public:
 
     void evaluate() override {}
 
-    bool select(common::SelectionVector& selVector) override;
+    bool selectInternal(common::SelectionVector& selVector) override;
 
     std::unique_ptr<ExpressionEvaluator> clone() override {
         return std::make_unique<ReferenceExpressionEvaluator>(expression, isResultFlat_, dataPos);

--- a/src/include/function/unary_function_executor.h
+++ b/src/include/function/unary_function_executor.h
@@ -122,6 +122,7 @@ struct UnaryFunctionExecutor {
             }
         } else {
             if (operand.hasNoNullsGuarantee()) {
+                result.setAllNonNull();
                 if (operandSelVector.isUnfiltered()) {
                     for (auto i = 0u; i < operandSelVector.getSelSize(); i++) {
                         executeOnValue<OPERAND_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(operand, i,

--- a/src/include/graph/on_disk_graph.h
+++ b/src/include/graph/on_disk_graph.h
@@ -11,6 +11,7 @@
 #include "graph.h"
 #include "graph_entry.h"
 #include "main/client_context.h"
+#include "processor/operator/filtering_operator.h"
 #include "storage/store/node_table.h"
 #include "storage/store/rel_table.h"
 
@@ -37,7 +38,7 @@ public:
 
     void startScan(common::RelDataDirection direction);
 
-    class InnerIterator {
+    class InnerIterator : public processor::SelVectorOverWriter {
     public:
         InnerIterator(const main::ClientContext* context, storage::RelTable* relTable,
             std::unique_ptr<storage::RelTableScanState> tableScanState);

--- a/src/include/processor/operator/persistent/reader/csv/base_csv_reader.h
+++ b/src/include/processor/operator/persistent/reader/csv/base_csv_reader.h
@@ -44,6 +44,10 @@ class BaseCSVReader {
     friend class SniffCSVNameAndTypeDriver;
 
 public:
+    // 1st element is number of successfully parsed rows
+    // 2nd element is number of failed to parse rows
+    using parse_result_t = std::pair<uint64_t, uint64_t>;
+
     BaseCSVReader(const std::string& filePath, common::idx_t fileIdx, common::CSVOption option,
         CSVColumnInfo columnInfo, main::ClientContext* context,
         LocalFileErrorHandler* errorHandler);
@@ -83,11 +87,11 @@ protected:
         std::vector<uint64_t>& escapePositions);
 
     //! Read BOM and header.
-    uint64_t handleFirstBlock();
+    parse_result_t handleFirstBlock();
 
     //! If this finds a BOM, it advances `position`.
     void readBOM();
-    uint64_t readHeader();
+    parse_result_t readHeader();
     //! Reads a new buffer from the CSV file.
     //! Uses the start value to ensure the current value stays within the buffer.
     //! Modifies the start value to point to the new start of the current value.
@@ -104,7 +108,7 @@ protected:
     void handleCopyException(const std::string& message, bool mustThrow = false);
 
     template<typename Driver>
-    uint64_t parseCSV(Driver&);
+    parse_result_t parseCSV(Driver&);
 
     inline bool isNewLine(char c) { return c == '\n' || c == '\r'; }
 
@@ -114,7 +118,7 @@ protected:
     void skipCurrentLine();
 
     void resetNumRowsInCurrentBlock();
-    void increaseNumRowsInCurrentBlock(uint64_t numRows);
+    void increaseNumRowsInCurrentBlock(uint64_t numRows, uint64_t numErrors);
     uint64_t getNumRowsInCurrentBlock() const;
     uint32_t getRowOffsetInCurrentBlock() const;
 

--- a/src/include/storage/store/column_chunk_data.h
+++ b/src/include/storage/store/column_chunk_data.h
@@ -383,10 +383,7 @@ public:
     static std::unique_ptr<NullChunkData> deserialize(MemoryManager& mm,
         common::Deserializer& deSer);
 
-    common::NullMask getNullMask() const {
-        return common::NullMask(std::span(getData<uint64_t>(), capacity / 64),
-            !noNullsGuaranteedInMem());
-    }
+    common::NullMask getNullMask() const;
 };
 
 class InternalIDChunkData final : public ColumnChunkData {

--- a/src/processor/operator/filter.cpp
+++ b/src/processor/operator/filter.cpp
@@ -28,10 +28,8 @@ bool Filter::getNextTuplesInternal(ExecutionContext* context) {
             return false;
         }
         saveSelVector(*state);
-        hasAtLeastOneSelectedValue = expressionEvaluator->select(state->getSelVectorUnsafe());
-        if (!state->isFlat() && state->getSelVector().isUnfiltered()) {
-            state->getSelVectorUnsafe().setToFiltered();
-        }
+        hasAtLeastOneSelectedValue =
+            expressionEvaluator->select(state->getSelVectorUnsafe(), !state->isFlat());
     } while (!hasAtLeastOneSelectedValue);
     metrics->numOutputTuple.increase(state->getSelVector().getSelSize());
     return true;

--- a/src/processor/operator/order_by/top_k.cpp
+++ b/src/processor/operator/order_by/top_k.cpp
@@ -198,17 +198,18 @@ bool TopKBuffer::compareBoundaryValue(const std::vector<common::ValueVector*>& k
 }
 
 bool TopKBuffer::compareFlatKeys(idx_t vectorIdxToCompare, std::vector<ValueVector*> keyVectors) {
+    KU_ASSERT(!keyVectors.empty());
     auto selVector = std::make_shared<common::SelectionVector>(common::DEFAULT_VECTOR_CAPACITY);
     selVector->setToFiltered();
-    auto compareResult = compareFuncs[vectorIdxToCompare](*keyVectors[vectorIdxToCompare],
-        *boundaryVecs[vectorIdxToCompare], *selVector);
-    if (vectorIdxToCompare == keyVectors.size() - 1) {
-        return compareResult;
-    } else if (equalsFuncs[vectorIdxToCompare](*keyVectors[vectorIdxToCompare],
-                   *boundaryVecs[vectorIdxToCompare], *selVector)) {
+
+    if (vectorIdxToCompare < keyVectors.size() - 1 &&
+        equalsFuncs[vectorIdxToCompare](*keyVectors[vectorIdxToCompare],
+            *boundaryVecs[vectorIdxToCompare], *selVector)) {
         return compareFlatKeys(vectorIdxToCompare + 1, std::move(keyVectors));
     } else {
-        return false;
+        auto compareResult = compareFuncs[vectorIdxToCompare](*keyVectors[vectorIdxToCompare],
+            *boundaryVecs[vectorIdxToCompare], *selVector);
+        return compareResult;
     }
 }
 

--- a/src/processor/operator/order_by/top_k.cpp
+++ b/src/processor/operator/order_by/top_k.cpp
@@ -207,9 +207,8 @@ bool TopKBuffer::compareFlatKeys(idx_t vectorIdxToCompare, std::vector<ValueVect
             *boundaryVecs[vectorIdxToCompare], *selVector)) {
         return compareFlatKeys(vectorIdxToCompare + 1, std::move(keyVectors));
     } else {
-        auto compareResult = compareFuncs[vectorIdxToCompare](*keyVectors[vectorIdxToCompare],
+        return compareFuncs[vectorIdxToCompare](*keyVectors[vectorIdxToCompare],
             *boundaryVecs[vectorIdxToCompare], *selVector);
-        return compareResult;
     }
 }
 

--- a/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
@@ -38,17 +38,17 @@ uint64_t ParallelCSVReader::parseBlock(block_idx_t blockIdx, DataChunk& resultCh
     if (blockIdx == 0) {
         readBOM();
         if (option.hasHeader) {
-            uint64_t headerNumRows = readHeader();
-            errorHandler->setHeaderNumRows(headerNumRows);
+            const auto [numRowsRead, numErrors] = readHeader();
+            errorHandler->setHeaderNumRows(numRowsRead + numErrors);
         }
     }
     if (finishedBlock()) {
         return 0;
     }
     ParallelParsingDriver driver(resultChunk, this);
-    const auto numRowsParsed = parseCSV(driver);
-    increaseNumRowsInCurrentBlock(numRowsParsed);
-    return numRowsParsed;
+    const auto [numRowsRead, numErrors] = parseCSV(driver);
+    increaseNumRowsInCurrentBlock(numRowsRead, numErrors);
+    return numRowsRead;
 }
 
 void ParallelCSVReader::reportFinishedBlock() {
@@ -58,8 +58,8 @@ void ParallelCSVReader::reportFinishedBlock() {
 uint64_t ParallelCSVReader::continueBlock(DataChunk& resultChunk) {
     KU_ASSERT(hasMoreToRead());
     ParallelParsingDriver driver(resultChunk, this);
-    const auto numRowsParsed = parseCSV(driver);
-    increaseNumRowsInCurrentBlock(numRowsParsed);
+    const auto [numRowsParsed, numErrors] = parseCSV(driver);
+    increaseNumRowsInCurrentBlock(numRowsParsed, numErrors);
     return numRowsParsed;
 }
 

--- a/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
@@ -68,14 +68,14 @@ uint64_t SerialCSVReader::parseBlock(block_idx_t blockIdx, DataChunk& resultChun
     }
     currentBlockIdx = blockIdx;
     if (blockIdx == 0) {
-        uint64_t headerNumRows = handleFirstBlock();
-        errorHandler->setHeaderNumRows(headerNumRows);
+        const auto [numRowsRead, numErrors] = handleFirstBlock();
+        errorHandler->setHeaderNumRows(numRowsRead + numErrors);
     }
     SerialParsingDriver driver(resultChunk, this);
-    auto numRowsRead = parseCSV(driver);
+    const auto [numRowsRead, numErrors] = parseCSV(driver);
     errorHandler->reportFinishedBlock(blockIdx, numRowsRead);
     resultChunk.state->getSelVectorUnsafe().setSelSize(numRowsRead);
-    increaseNumRowsInCurrentBlock(numRowsRead);
+    increaseNumRowsInCurrentBlock(numRowsRead, numErrors);
     return numRowsRead;
 }
 

--- a/src/storage/store/column_chunk_data.cpp
+++ b/src/storage/store/column_chunk_data.cpp
@@ -689,6 +689,13 @@ void BoolChunkData::write(ColumnChunkData* srcChunk, offset_t srcOffsetInChunk,
     updateInMemoryStats(inMemoryStats, srcChunk, srcOffsetInChunk, numValuesToCopy);
 }
 
+NullMask NullChunkData::getNullMask() const {
+    return common::NullMask(
+        std::span(getData<uint64_t>(),
+            common::ceilDiv(capacity, common::NullMask::NUM_BITS_PER_NULL_ENTRY)),
+        !noNullsGuaranteedInMem());
+}
+
 void NullChunkData::setNull(offset_t pos, bool isNull) {
     setValue(isNull, pos);
     // TODO(Guodong): Better let NullChunkData also support `append` a

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -134,7 +134,7 @@ bool UncommittedPKInserter::processScanOutput(const Transaction* transaction,
         nodeIDVector.setValue(i, nodeID_t{startNodeOffset + i, tableID});
     }
     insertPK(transaction, nodeIDVector, scannedVector, pkIndex, isVisible);
-    startNodeOffset = scanResult.startRow + scanResult.numRows;
+    startNodeOffset += scanResult.numRows;
     return true;
 }
 

--- a/test/test_files/order_by/order_by.test
+++ b/test/test_files/order_by/order_by.test
@@ -12,6 +12,27 @@
 
 --
 
+-CASE OrderByWithLimitFlatKeys
+-STATEMENT CREATE REL TABLE knows(FROM person TO person)
+---- ok
+-STATEMENT UNWIND RANGE(1, 1000) AS i MATCH (p:person) WHERE p.id = i CREATE (p)-[:knows]->(p)
+---- ok
+-STATEMENT MATCH (p:person)-[:knows]->(p) RETURN COUNT(*)
+---- 1
+1000
+-STATEMENT MATCH (p:person)-[:knows]->(p) RETURN p.id ORDER BY p.id DESC, p.balance ASC LIMIT 10
+---- 10
+1000
+999
+998
+997
+996
+995
+994
+993
+992
+991
+
 -CASE OrderByLargeDatasetTest
 
 -LOG OrderByWithLimitTest


### PR DESCRIPTION
# Description

Some fixes for bugs found by https://github.com/kuzudb/kuzu/pull/4240. Tests to cover the fixes will be merged in the linked PR (I'll probably add some extra tests there as well).

Fixes:
- Check for null values in `CASE` expression selector (we should filter out NULL values)
- For `OnDiskGraph` scan if the filter is empty scan again instead of returning with an incorrect selection size
- For unary functions reset the result vector's null mask if the operand vector has no nulls
- Fix line number reporting for CSV errors to correctly account for skipped lines
- Fix `TopK::compareFlatKeys` for comparing multiple keys (before the comparison would always return false in this case).
- Fix node offsets for node table PK index commit (before the node offset committed was wrong for every committed vector after the 1st since it didn't correctly take into account the number of original rows in the table)
- Make list reverse function would if list size is greater than vector size

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).