### PR TITLE
Improve label pruning

### DIFF
--- a/src/binder/query/query_graph_label_analyzer.cpp
+++ b/src/binder/query/query_graph_label_analyzer.cpp
@@ -68,7 +68,7 @@ void QueryGraphLabelAnalyzer::pruneNode(const QueryGraph& graph, NodeExpression&
             }
         }
         if (candidates.empty()) { // No need to prune.
-            return;
+            continue;
         }
         std::vector<TableCatalogEntry*> prunedEntries;
         for (auto entry : node.getEntries()) {

--- a/test/test_files/tck/match/match3.test
+++ b/test/test_files/tck/match/match3.test
@@ -89,8 +89,10 @@
 -STATEMENT CREATE REL TABLE T(FROM A TO Foo);
 ---- ok
 -STATEMENT CREATE (a)-[:T]->(b1), (a)-[:T]->(b2)
----- error
-Binder exception: Create node b1 with multiple node labels is not supported.
+---- ok
+-STATEMENT MATCH (a)-[:T]->(b) RETURN COUNT(*);
+---- 1
+2
 
 # Matching nodes with many labels
 #-CASE Scenario7


### PR DESCRIPTION
# Description

When we try to prune node label on a query graph with more than one edge, if the first edge pruning fails (i.e. has nothing to prune), we will stop the process instead of proceeding to the next edge.

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).