### PR TITLE
Fix extend cardinality

### DIFF
--- a/src/include/planner/join_order/cardinality_estimator.h
+++ b/src/include/planner/join_order/cardinality_estimator.h
@@ -32,7 +32,6 @@ public:
     void clearPerQueryGraphStats();
 
     cardinality_t estimateScanNode(const LogicalOperator& op) const;
-    cardinality_t estimateExtend(double extensionRate, const LogicalOperator& childOp) const;
     cardinality_t estimateHashJoin(const std::vector<binder::expression_pair>& joinConditions,
         const LogicalOperator& probeOp, const LogicalOperator& buildOp) const;
     cardinality_t estimateCrossProduct(const LogicalOperator& probeOp,
@@ -47,6 +46,7 @@ public:
 
     double getExtensionRate(const binder::RelExpression& rel,
         const binder::NodeExpression& boundNode, const transaction::Transaction* transaction) const;
+    cardinality_t multiply(double extensionRate, cardinality_t card) const;
 
 private:
     cardinality_t getNodeIDDom(const std::string& nodeIDName) const;

--- a/src/optimizer/cardinality_updater.cpp
+++ b/src/optimizer/cardinality_updater.cpp
@@ -82,7 +82,8 @@ void CardinalityUpdater::visitExtend(planner::LogicalOperator* op) {
     auto& extend = op->cast<planner::LogicalExtend&>();
     const auto extensionRate = cardinalityEstimator.getExtensionRate(*extend.getRel(),
         *extend.getBoundNode(), transaction);
-    extend.setCardinality(cardinalityEstimator.multiply(extensionRate, op->getChild(0)->getCardinality()));
+    extend.setCardinality(
+        cardinalityEstimator.multiply(extensionRate, op->getChild(0)->getCardinality()));
 }
 
 void CardinalityUpdater::visitHashJoin(planner::LogicalOperator* op) {

--- a/src/optimizer/cardinality_updater.cpp
+++ b/src/optimizer/cardinality_updater.cpp
@@ -82,7 +82,7 @@ void CardinalityUpdater::visitExtend(planner::LogicalOperator* op) {
     auto& extend = op->cast<planner::LogicalExtend&>();
     const auto extensionRate = cardinalityEstimator.getExtensionRate(*extend.getRel(),
         *extend.getBoundNode(), transaction);
-    extend.setCardinality(cardinalityEstimator.estimateExtend(extensionRate, *op->getChild(0)));
+    extend.setCardinality(cardinalityEstimator.multiply(extensionRate, op->getChild(0)->getCardinality()));
 }
 
 void CardinalityUpdater::visitHashJoin(planner::LogicalOperator* op) {

--- a/src/planner/join_order/cardinality_estimator.cpp
+++ b/src/planner/join_order/cardinality_estimator.cpp
@@ -91,9 +91,8 @@ uint64_t CardinalityEstimator::estimateAggregate(const LogicalAggregate& op) con
     return op.getKeys().empty() ? 1 : op.getChild(0)->getCardinality();
 }
 
-cardinality_t CardinalityEstimator::estimateExtend(double extensionRate,
-    const LogicalOperator& childOp) const {
-    return atLeastOne(extensionRate * childOp.getCardinality());
+cardinality_t CardinalityEstimator::multiply(double extensionRate, cardinality_t card) const {
+    return atLeastOne(extensionRate * card);
 }
 
 uint64_t CardinalityEstimator::estimateHashJoin(

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -216,7 +216,8 @@ void Planner::appendRecursiveExtendAsGDS(const std::shared_ptr<NodeExpression>& 
     pathPropertyProbe->computeFactorizedSchema();
     auto extensionRate =
         cardinalityEstimator.getExtensionRate(*rel, *boundNode, clientContext->getTransaction());
-    auto resultCard = cardinalityEstimator.multiply(extensionRate, plan.getLastOperator()->getCardinality());
+    auto resultCard =
+        cardinalityEstimator.multiply(extensionRate, plan.getLastOperator()->getCardinality());
     pathPropertyProbe->setCardinality(resultCard);
     probePlan.setLastOperator(pathPropertyProbe);
     probePlan.setCost(plan.getCardinality());

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -91,11 +91,10 @@ void Planner::appendNonRecursiveExtend(const std::shared_ptr<NodeExpression>& bo
     auto extend = make_shared<LogicalExtend>(boundNode, nbrNode, rel, direction, extendFromSource,
         properties_, plan.getLastOperator());
     extend->computeFactorizedSchema();
-    // Update cost & cardinality. Note that extend does not change cardinality.
+    // Update cost & cardinality. Note that extend does not change factorized cardinality.
     const auto extensionRate =
         cardinalityEstimator.getExtensionRate(*rel, *boundNode, clientContext->getTransaction());
-    extend->setCardinality(
-        cardinalityEstimator.estimateExtend(extensionRate, plan.getLastOperatorRef()));
+    extend->setCardinality(plan.getLastOperator()->getCardinality());
     plan.setCost(CostModel::computeExtendCost(plan));
     auto group = extend->getSchema()->getGroup(nbrNode->getInternalID());
     group->setMultiplier(extensionRate);
@@ -217,17 +216,17 @@ void Planner::appendRecursiveExtendAsGDS(const std::shared_ptr<NodeExpression>& 
     pathPropertyProbe->computeFactorizedSchema();
     auto extensionRate =
         cardinalityEstimator.getExtensionRate(*rel, *boundNode, clientContext->getTransaction());
-    pathPropertyProbe->setCardinality(
-        cardinalityEstimator.estimateExtend(extensionRate, plan.getLastOperatorRef()));
+    auto resultCard = cardinalityEstimator.multiply(extensionRate, plan.getLastOperator()->getCardinality());
+    pathPropertyProbe->setCardinality(resultCard);
     probePlan.setLastOperator(pathPropertyProbe);
     probePlan.setCost(plan.getCardinality());
 
     // Join with input node
     auto joinConditions = expression_vector{boundNode->getInternalID()};
     appendHashJoin(joinConditions, JoinType::INNER, probePlan, plan, plan);
-    // Hash join above should not change the cardinality of probe plan.
-    // plan.setCardinality(probePlan.getCardinality());
-    // KU_ASSERT(plan.getCardinality() == plan.getLastOperator()->getCardinality());
+    // Hash join above is joining input node with its properties. So 1-1 match is guaranteed and
+    // thus should not change cardinality.
+    plan.getLastOperator()->setCardinality(resultCard);
 }
 
 void Planner::appendRecursiveExtend(const std::shared_ptr<NodeExpression>& boundNode,
@@ -284,7 +283,7 @@ void Planner::appendRecursiveExtend(const std::shared_ptr<NodeExpression>& bound
     auto extensionRate =
         cardinalityEstimator.getExtensionRate(*rel, *boundNode, clientContext->getTransaction());
     pathPropertyProbe->setCardinality(
-        cardinalityEstimator.estimateExtend(extensionRate, plan.getLastOperatorRef()));
+        cardinalityEstimator.multiply(extensionRate, plan.getLastOperator()->getCardinality()));
     plan.setLastOperator(std::move(pathPropertyProbe));
     // Update cost
     plan.setCost(CostModel::computeRecursiveExtendCost(rel->getUpperBound(), extensionRate, plan));


### PR DESCRIPTION
# Description

Remove the code that updates extend cardinality in `appendExtend` as extend doesn't affect factorized cardinality (otherwise we double-count with the factorized group multiplier). This was causing the lsqb benchmark to fail.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).