### PR TITLE
build: separate out test build and run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,9 +115,11 @@ alldebug:
 	)
 
 # Main tests
-test:
-	python3 dataset/ldbc-1/download_data.py
+test-build:
 	$(call run-cmake-relwithdebinfo, -DBUILD_TESTS=TRUE -DENABLE_BACKTRACES=TRUE)
+
+test: test-build
+	python3 dataset/ldbc-1/download_data.py
 	ctest --test-dir build/relwithdebinfo/test --output-on-failure -j ${TEST_JOBS}
 
 lcov:


### PR DESCRIPTION
# Description

Unless I missed it, I didn't see a way to just build the tests but not run all of them. Separating those out.

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).