### PR TITLE
Fix rust build threads in CI

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -324,7 +324,8 @@ jobs:
     needs: [rustfmt-check]
     runs-on: kuzu-self-hosted-testing
     env:
-      CARGO_BUILD_JOBS: 32
+      # CARGO_BUILD_JOBS is set using this in the Makefile
+      NUM_THREADS: 32
       CMAKE_BUILD_PARALLEL_LEVEL: 32
       CC: gcc
       CXX: g++

--- a/Makefile
+++ b/Makefile
@@ -172,11 +172,10 @@ ifeq ($(OS),Windows_NT)
 	set CARGO_BUILD_JOBS=$(NUM_THREADS)
 else
 	export CARGO_BUILD_JOBS=$(NUM_THREADS)
-endif
-	export CARGO_BUILD_JOBS=$(NUM_THREADS)
 	# Note that the number of test threads has a hard limit (unlike with ctest)
 	# since they are all run in the same process and most tests create a database
 	# (requiring mmapping 8TB of virtual memory). This quickly exhausts the process' virtual memory.
+endif
 	cd tools/rust_api && cargo test --profile=relwithdebinfo --locked --all-features -- --test-threads=12
 
 wasmtest:


### PR DESCRIPTION
Also fixed invalid lines in windows makefile (don't allow # comments and there was an export that shouldn't have been there)

The `CARGO_BUILD_JOBS` from the ci workflow was being overridden in the makefile using `NUM_THREADS`, which since it wasn't set, was defaulting to 1.