### PR TITLE
Forward declare ExecutionContext in PhysicalOperator

### DIFF
--- a/src/function/table/hnsw/drop_hnsw_index.cpp
+++ b/src/function/table/hnsw/drop_hnsw_index.cpp
@@ -1,6 +1,7 @@
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "function/table/bind_data.h"
 #include "function/table/hnsw/hnsw_index_functions.h"
+#include "processor/execution_context.h"
 #include "storage/index/hnsw_index_utils.h"
 #include "storage/index/index_utils.h"
 

--- a/src/include/main/attached_database.h
+++ b/src/include/main/attached_database.h
@@ -4,15 +4,12 @@
 #include <string>
 
 #include "extension/catalog_extension.h"
+#include "transaction/transaction_manager.h"
 
 namespace kuzu {
 namespace storage {
 class StorageManager;
 } // namespace storage
-
-namespace transaction {
-class TransactionManager;
-} // namespace transaction
 
 namespace main {
 

--- a/src/include/processor/operator/aggregate/base_aggregate.h
+++ b/src/include/processor/operator/aggregate/base_aggregate.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "aggregate_input.h"
 #include "function/aggregate_function.h"
 #include "processor/operator/sink.h"

--- a/src/include/processor/operator/ddl/alter.h
+++ b/src/include/processor/operator/ddl/alter.h
@@ -42,12 +42,7 @@ public:
         : DDL{type_, outputPos, id, std::move(printInfo)}, info{std::move(info)},
           defaultValueEvaluator{std::move(defaultValueEvaluator)} {}
 
-    void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override {
-        DDL::initLocalStateInternal(resultSet, context);
-        if (defaultValueEvaluator) {
-            defaultValueEvaluator->init(*resultSet, context->clientContext);
-        }
-    }
+    void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
     void executeDDLInternal(ExecutionContext* context) override;
 

--- a/src/include/processor/operator/hash_join/hash_join_build.h
+++ b/src/include/processor/operator/hash_join/hash_join_build.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "binder/expression/expression.h"
 #include "join_hash_table.h"
 #include "processor/operator/physical_operator.h"
 #include "processor/operator/sink.h"

--- a/src/include/processor/operator/limit.h
+++ b/src/include/processor/operator/limit.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include "processor/operator/physical_operator.h"
 
 namespace kuzu {

--- a/src/include/processor/operator/order_by/order_by.h
+++ b/src/include/processor/operator/order_by/order_by.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "binder/expression/expression.h"
 #include "processor/operator/sink.h"
 #include "processor/result/result_set.h"
 #include "sort_state.h"

--- a/src/include/processor/operator/order_by/top_k.h
+++ b/src/include/processor/operator/order_by/top_k.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "binder/expression/expression.h"
 #include "processor/operator/sink.h"
 #include "sort_state.h"
 
@@ -177,10 +178,7 @@ public:
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
-    void initGlobalStateInternal(ExecutionContext* context) override {
-        sharedState->init(*info, context->clientContext->getMemoryManager(), skipNumber,
-            limitNumber);
-    }
+    void initGlobalStateInternal(ExecutionContext* context) override;
 
     void executeInternal(ExecutionContext* context) override;
 

--- a/src/include/processor/operator/persistent/batch_insert.h
+++ b/src/include/processor/operator/persistent/batch_insert.h
@@ -3,6 +3,7 @@
 #include <numeric>
 
 #include "processor/operator/sink.h"
+#include "processor/result/factorized_table.h"
 #include "storage/store/table.h"
 
 namespace kuzu {

--- a/src/include/processor/operator/physical_operator.h
+++ b/src/include/processor/operator/physical_operator.h
@@ -1,11 +1,16 @@
 #pragma once
 
 #include "planner/operator/operator_print_info.h"
-#include "processor/execution_context.h"
 #include "processor/result/result_set.h"
 
+namespace kuzu::common {
+class Profiler;
+class NumericMetric;
+class TimeMetric;
+} // namespace kuzu::common
 namespace kuzu {
 namespace processor {
+struct ExecutionContext;
 
 using physical_op_id = uint32_t;
 
@@ -68,6 +73,7 @@ enum class PhysicalOperatorType : uint8_t {
     USE_DATABASE,
 };
 
+class PhysicalOperator;
 class PhysicalOperatorUtils {
 public:
     static std::string operatorToString(const PhysicalOperator* physicalOp);
@@ -84,7 +90,6 @@ struct OperatorMetrics {
         : executionTime{executionTime}, numOutputTuple{numOutputTuple} {}
 };
 
-class PhysicalOperator;
 using physical_op_vector_t = std::vector<std::unique_ptr<PhysicalOperator>>;
 
 class PhysicalOperator {

--- a/src/include/processor/operator/profile.h
+++ b/src/include/processor/operator/profile.h
@@ -4,6 +4,7 @@
 
 namespace kuzu {
 namespace processor {
+class PhysicalPlan;
 
 struct ProfileInfo {
     PhysicalPlan* physicalPlan;

--- a/src/include/processor/operator/result_collector.h
+++ b/src/include/processor/operator/result_collector.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "binder/expression/expression.h"
 #include "common/enums/accumulate_type.h"
 #include "processor/operator/sink.h"
 #include "processor/result/factorized_table.h"

--- a/src/include/processor/operator/semi_masker.h
+++ b/src/include/processor/operator/semi_masker.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "common/enums/extend_direction.h"
 #include "common/mask.h"
 #include "processor/operator/physical_operator.h"

--- a/src/include/processor/operator/sink.h
+++ b/src/include/processor/operator/sink.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common/exception/internal.h"
+#include "common/metric.h"
 #include "processor/operator/physical_operator.h"
 #include "processor/result/result_set_descriptor.h"
 

--- a/src/include/processor/operator/skip.h
+++ b/src/include/processor/operator/skip.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include "processor/operator/filtering_operator.h"
 #include "processor/operator/physical_operator.h"
 

--- a/src/include/processor/operator/table_scan/union_all_scan.h
+++ b/src/include/processor/operator/table_scan/union_all_scan.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "binder/expression/expression.h"
 #include "processor/operator/physical_operator.h"
 #include "processor/result/factorized_table.h"
 

--- a/src/include/processor/operator/transaction.h
+++ b/src/include/processor/operator/transaction.h
@@ -4,6 +4,10 @@
 #include "transaction/transaction_action.h"
 
 namespace kuzu {
+namespace transaction {
+class TransactionContext;
+} // namespace transaction
+
 namespace processor {
 
 struct TransactionPrintInfo final : OPPrintInfo {

--- a/src/processor/map/create_result_collector.cpp
+++ b/src/processor/map/create_result_collector.cpp
@@ -1,3 +1,4 @@
+#include "main/client_context.h"
 #include "processor/operator/result_collector.h"
 #include "processor/plan_mapper.h"
 #include "processor/result/factorized_table_util.h"

--- a/src/processor/map/map_copy_to.cpp
+++ b/src/processor/map/map_copy_to.cpp
@@ -1,3 +1,4 @@
+#include "main/client_context.h"
 #include "planner/operator/persistent/logical_copy_to.h"
 #include "processor/operator/persistent/copy_to.h"
 #include "processor/plan_mapper.h"

--- a/src/processor/map/map_create_macro.cpp
+++ b/src/processor/map/map_create_macro.cpp
@@ -1,3 +1,4 @@
+#include "main/client_context.h"
 #include "planner/operator/logical_create_macro.h"
 #include "processor/operator/macro/create_macro.h"
 #include "processor/plan_mapper.h"

--- a/src/processor/map/map_explain.cpp
+++ b/src/processor/map/map_explain.cpp
@@ -1,4 +1,5 @@
 #include "common/profiler.h"
+#include "main/client_context.h"
 #include "main/plan_printer.h"
 #include "planner/operator/logical_explain.h"
 #include "processor/operator/profile.h"

--- a/src/processor/map/map_hash_join.cpp
+++ b/src/processor/map/map_hash_join.cpp
@@ -1,4 +1,5 @@
 #include "binder/expression/expression_util.h"
+#include "main/client_context.h"
 #include "planner/operator/logical_hash_join.h"
 #include "processor/operator/hash_join/hash_join_build.h"
 #include "processor/operator/hash_join/hash_join_probe.h"

--- a/src/processor/map/map_intersect.cpp
+++ b/src/processor/map/map_intersect.cpp
@@ -1,4 +1,5 @@
 #include "binder/expression/expression_util.h"
+#include "main/client_context.h"
 #include "planner/operator/logical_intersect.h"
 #include "processor/operator/intersect/intersect.h"
 #include "processor/operator/intersect/intersect_build.h"

--- a/src/processor/map/map_path_property_probe.cpp
+++ b/src/processor/map/map_path_property_probe.cpp
@@ -2,6 +2,7 @@
 #include "binder/expression/property_expression.h"
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "common/string_utils.h"
+#include "main/client_context.h"
 #include "planner/operator/extend/logical_recursive_extend.h"
 #include "planner/operator/logical_gds_call.h"
 #include "processor/operator/gds_call.h"

--- a/src/processor/map/map_simple.cpp
+++ b/src/processor/map/map_simple.cpp
@@ -1,5 +1,6 @@
 #include "common/exception/runtime.h"
 #include "common/file_system/virtual_file_system.h"
+#include "main/client_context.h"
 #include "planner/operator/simple/logical_attach_database.h"
 #include "planner/operator/simple/logical_detach_database.h"
 #include "planner/operator/simple/logical_export_db.h"

--- a/src/processor/operator/aggregate/hash_aggregate.cpp
+++ b/src/processor/operator/aggregate/hash_aggregate.cpp
@@ -8,6 +8,7 @@
 #include "common/constants.h"
 #include "common/types/types.h"
 #include "main/client_context.h"
+#include "processor/execution_context.h"
 #include "processor/operator/aggregate/aggregate_hash_table.h"
 #include "processor/result/factorized_table_schema.h"
 

--- a/src/processor/operator/aggregate/simple_aggregate.cpp
+++ b/src/processor/operator/aggregate/simple_aggregate.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/aggregate/simple_aggregate.h"
 
 #include "binder/expression/expression_util.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::common;
 using namespace kuzu::function;

--- a/src/processor/operator/cross_product.cpp
+++ b/src/processor/operator/cross_product.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/cross_product.h"
 
+#include "common/metric.h"
+
 namespace kuzu {
 namespace processor {
 

--- a/src/processor/operator/ddl/alter.cpp
+++ b/src/processor/operator/ddl/alter.cpp
@@ -6,6 +6,7 @@
 #include "catalog/catalog_entry/rel_table_catalog_entry.h"
 #include "common/enums/alter_type.h"
 #include "common/exception/binder.h"
+#include "processor/execution_context.h"
 #include "storage/storage_manager.h"
 #include "storage/store/table.h"
 
@@ -16,6 +17,13 @@ using namespace kuzu::transaction;
 
 namespace kuzu {
 namespace processor {
+
+void Alter::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
+    DDL::initLocalStateInternal(resultSet, context);
+    if (defaultValueEvaluator) {
+        defaultValueEvaluator->init(*resultSet, context->clientContext);
+    }
+}
 
 void Alter::executeDDLInternal(ExecutionContext* context) {
     auto clientContext = context->clientContext;

--- a/src/processor/operator/ddl/create_sequence.cpp
+++ b/src/processor/operator/ddl/create_sequence.cpp
@@ -2,6 +2,7 @@
 
 #include "catalog/catalog.h"
 #include "common/string_format.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;

--- a/src/processor/operator/ddl/create_table.cpp
+++ b/src/processor/operator/ddl/create_table.cpp
@@ -2,6 +2,7 @@
 
 #include "common/exception/binder.h"
 #include "common/string_format.h"
+#include "processor/execution_context.h"
 #include "storage/storage_manager.h"
 
 using namespace kuzu::catalog;

--- a/src/processor/operator/ddl/create_type.cpp
+++ b/src/processor/operator/ddl/create_type.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/ddl/create_type.h"
 
 #include "catalog/catalog.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;

--- a/src/processor/operator/ddl/ddl.cpp
+++ b/src/processor/operator/ddl/ddl.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/ddl/ddl.h"
 
+#include "common/metric.h"
+
 namespace kuzu {
 namespace processor {
 

--- a/src/processor/operator/ddl/drop.cpp
+++ b/src/processor/operator/ddl/drop.cpp
@@ -5,6 +5,7 @@
 #include "catalog/catalog_entry/rel_table_catalog_entry.h"
 #include "common/exception/binder.h"
 #include "common/string_format.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;

--- a/src/processor/operator/filter.cpp
+++ b/src/processor/operator/filter.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/filter.h"
 
+#include "processor/execution_context.h"
+
 using namespace kuzu::common;
 
 namespace kuzu {

--- a/src/processor/operator/flatten.cpp
+++ b/src/processor/operator/flatten.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/flatten.h"
 
+#include "common/metric.h"
+
 using namespace kuzu::common;
 
 namespace kuzu {

--- a/src/processor/operator/hash_join/hash_join_build.cpp
+++ b/src/processor/operator/hash_join/hash_join_build.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/hash_join/hash_join_build.h"
 
 #include "binder/expression/expression_util.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::common;
 using namespace kuzu::storage;

--- a/src/processor/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/operator/hash_join/hash_join_probe.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/hash_join/hash_join_probe.h"
 
 #include "binder/expression/expression_util.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::common;
 

--- a/src/processor/operator/index_lookup.cpp
+++ b/src/processor/operator/index_lookup.cpp
@@ -8,7 +8,6 @@
 #include "common/vector/value_vector.h"
 #include "storage/index/hash_index.h"
 #include "storage/store/node_table.h"
-#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::storage;

--- a/src/processor/operator/limit.cpp
+++ b/src/processor/operator/limit.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/limit.h"
 
+#include "common/metric.h"
+
 namespace kuzu {
 namespace processor {
 

--- a/src/processor/operator/macro/create_macro.cpp
+++ b/src/processor/operator/macro/create_macro.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/macro/create_macro.h"
 
 #include "common/string_format.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::common;
 
@@ -11,7 +12,7 @@ std::string CreateMacroPrintInfo::toString() const {
     return macroName;
 }
 
-bool CreateMacro::getNextTuplesInternal(kuzu::processor::ExecutionContext* context) {
+bool CreateMacro::getNextTuplesInternal(ExecutionContext* context) {
     if (hasExecuted) {
         return false;
     }

--- a/src/processor/operator/order_by/order_by.cpp
+++ b/src/processor/operator/order_by/order_by.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/order_by/order_by.h"
 
 #include "binder/expression/expression_util.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::common;
 

--- a/src/processor/operator/order_by/order_by_merge.cpp
+++ b/src/processor/operator/order_by/order_by_merge.cpp
@@ -3,6 +3,7 @@
 #include <thread>
 
 #include "common/constants.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::common;
 

--- a/src/processor/operator/order_by/order_by_scan.cpp
+++ b/src/processor/operator/order_by/order_by_scan.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/order_by/order_by_scan.h"
 
+#include "common/metric.h"
+
 using namespace kuzu::common;
 
 namespace kuzu {

--- a/src/processor/operator/order_by/top_k.cpp
+++ b/src/processor/operator/order_by/top_k.cpp
@@ -4,6 +4,7 @@
 #include "common/type_utils.h"
 #include "function/binary_function_executor.h"
 #include "function/comparison/comparison_functions.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::common;
 
@@ -264,6 +265,10 @@ void TopK::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* contex
     for (auto& dataPos : info->keysPos) {
         orderByVectors.push_back(resultSet->getValueVector(dataPos).get());
     }
+}
+
+void TopK::initGlobalStateInternal(ExecutionContext* context) {
+    sharedState->init(*info, context->clientContext->getMemoryManager(), skipNumber, limitNumber);
 }
 
 void TopK::executeInternal(ExecutionContext* context) {

--- a/src/processor/operator/persistent/copy_to.cpp
+++ b/src/processor/operator/persistent/copy_to.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/persistent/copy_to.h"
 
+#include "processor/execution_context.h"
+
 namespace kuzu {
 namespace processor {
 

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -4,6 +4,7 @@
 #include "common/exception/message.h"
 #include "common/string_format.h"
 #include "common/task_system/progress_bar.h"
+#include "processor/execution_context.h"
 #include "processor/result/factorized_table_util.h"
 #include "storage/storage_utils.h"
 #include "storage/store/column_chunk_data.h"

--- a/src/processor/operator/physical_operator.cpp
+++ b/src/processor/operator/physical_operator.cpp
@@ -3,6 +3,7 @@
 #include "common/exception/interrupt.h"
 #include "common/exception/runtime.h"
 #include "common/task_system/progress_bar.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::common;
 

--- a/src/processor/operator/profile.cpp
+++ b/src/processor/operator/profile.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/profile.h"
 
 #include "main/plan_printer.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::common;
 

--- a/src/processor/operator/projection.cpp
+++ b/src/processor/operator/projection.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/projection.h"
 
 #include "binder/expression/expression_util.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::evaluator;
 

--- a/src/processor/operator/recursive_extend/recursive_join.cpp
+++ b/src/processor/operator/recursive_extend/recursive_join.cpp
@@ -1,5 +1,6 @@
 #include "processor/operator/recursive_extend/recursive_join.h"
 
+#include "processor/execution_context.h"
 #include "processor/operator/recursive_extend/all_shortest_path_state.h"
 #include "processor/operator/recursive_extend/shortest_path_state.h"
 #include "processor/operator/recursive_extend/variable_length_state.h"

--- a/src/processor/operator/result_collector.cpp
+++ b/src/processor/operator/result_collector.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/result_collector.h"
 
 #include "binder/expression/expression_util.h"
+#include "processor/execution_context.h"
 #include "processor/processor_task.h"
 
 using namespace kuzu::common;

--- a/src/processor/operator/scan/offset_scan_node_table.cpp
+++ b/src/processor/operator/scan/offset_scan_node_table.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/scan/offset_scan_node_table.h"
 
+#include "processor/execution_context.h"
+
 using namespace kuzu::common;
 using namespace kuzu::storage;
 

--- a/src/processor/operator/scan/primary_key_scan_node_table.cpp
+++ b/src/processor/operator/scan/primary_key_scan_node_table.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/scan/primary_key_scan_node_table.h"
 
 #include "binder/expression/expression_util.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::common;
 using namespace kuzu::storage;

--- a/src/processor/operator/scan/scan_multi_rel_tables.cpp
+++ b/src/processor/operator/scan/scan_multi_rel_tables.cpp
@@ -1,5 +1,6 @@
 #include "processor/operator/scan/scan_multi_rel_tables.h"
 
+#include "processor/execution_context.h"
 #include "storage/local_storage/local_rel_table.h"
 #include "storage/local_storage/local_storage.h"
 

--- a/src/processor/operator/scan/scan_node_table.cpp
+++ b/src/processor/operator/scan/scan_node_table.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/scan/scan_node_table.h"
 
 #include "binder/expression/expression_util.h"
+#include "processor/execution_context.h"
 #include "storage/local_storage/local_node_table.h"
 #include "storage/local_storage/local_storage.h"
 

--- a/src/processor/operator/scan/scan_rel_table.cpp
+++ b/src/processor/operator/scan/scan_rel_table.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/scan/scan_rel_table.h"
 
 #include "binder/expression/expression_util.h"
+#include "processor/execution_context.h"
 #include "storage/local_storage/local_rel_table.h"
 #include "storage/local_storage/local_storage.h"
 

--- a/src/processor/operator/semi_masker.cpp
+++ b/src/processor/operator/semi_masker.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/semi_masker.h"
 
+#include "processor/execution_context.h"
+
 using namespace kuzu::common;
 using namespace kuzu::storage;
 

--- a/src/processor/operator/simple/attach_database.cpp
+++ b/src/processor/operator/simple/attach_database.cpp
@@ -5,9 +5,9 @@
 #include "main/attached_database.h"
 #include "main/database.h"
 #include "main/database_manager.h"
+#include "processor/execution_context.h"
 #include "storage/storage_extension.h"
 #include "storage/storage_manager.h"
-#include "transaction/transaction_manager.h"
 
 namespace kuzu {
 namespace processor {

--- a/src/processor/operator/simple/detach_database.cpp
+++ b/src/processor/operator/simple/detach_database.cpp
@@ -2,6 +2,7 @@
 
 #include "main/database.h"
 #include "main/database_manager.h"
+#include "processor/execution_context.h"
 
 namespace kuzu {
 namespace processor {
@@ -10,7 +11,7 @@ std::string DetatchDatabasePrintInfo::toString() const {
     return "Database: " + name;
 }
 
-void DetachDatabase::executeInternal(kuzu::processor::ExecutionContext* context) {
+void DetachDatabase::executeInternal(ExecutionContext* context) {
     auto dbManager = context->clientContext->getDatabaseManager();
     if (dbManager->hasAttachedDatabase(dbName) &&
         dbManager->getAttachedDatabase(dbName)->getDBType() == common::ATTACHED_KUZU_DB_TYPE) {

--- a/src/processor/operator/simple/export_db.cpp
+++ b/src/processor/operator/simple/export_db.cpp
@@ -13,6 +13,7 @@
 #include "common/string_utils.h"
 #include "extension/extension_manager.h"
 #include "function/scalar_macro_function.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::common;
 using namespace kuzu::transaction;

--- a/src/processor/operator/simple/import_db.cpp
+++ b/src/processor/operator/simple/import_db.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/simple/import_db.h"
 
+#include "processor/execution_context.h"
+
 using namespace kuzu::common;
 using namespace kuzu::transaction;
 using namespace kuzu::catalog;

--- a/src/processor/operator/simple/install_extension.cpp
+++ b/src/processor/operator/simple/install_extension.cpp
@@ -5,7 +5,7 @@
 #include "extension/extension.h"
 #include "extension/extension_installer.h"
 #include "httplib.h"
-#include "main/database.h"
+#include "processor/execution_context.h"
 
 namespace kuzu {
 namespace processor {
@@ -17,7 +17,7 @@ std::string InstallExtensionPrintInfo::toString() const {
     return "Install " + extensionName;
 }
 
-void InstallExtension::executeInternal(kuzu::processor::ExecutionContext* context) {
+void InstallExtension::executeInternal(ExecutionContext* context) {
     installExtension(context->clientContext);
 }
 

--- a/src/processor/operator/simple/load_extension.cpp
+++ b/src/processor/operator/simple/load_extension.cpp
@@ -1,7 +1,7 @@
 #include "processor/operator/simple/load_extension.h"
 
 #include "extension/extension_manager.h"
-#include "main/database.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::common;
 
@@ -14,7 +14,7 @@ std::string LoadExtensionPrintInfo::toString() const {
     return "Load " + extensionName;
 }
 
-void LoadExtension::executeInternal(kuzu::processor::ExecutionContext* context) {
+void LoadExtension::executeInternal(ExecutionContext* context) {
     context->clientContext->getExtensionManager()->loadExtension(path, context->clientContext);
 }
 

--- a/src/processor/operator/simple/simple.cpp
+++ b/src/processor/operator/simple/simple.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/simple/simple.h"
 
+#include "common/metric.h"
+
 namespace kuzu {
 namespace processor {
 

--- a/src/processor/operator/simple/use_database.cpp
+++ b/src/processor/operator/simple/use_database.cpp
@@ -1,11 +1,12 @@
 #include "processor/operator/simple/use_database.h"
 
 #include "main/database_manager.h"
+#include "processor/execution_context.h"
 
 namespace kuzu {
 namespace processor {
 
-void UseDatabase::executeInternal(kuzu::processor::ExecutionContext* context) {
+void UseDatabase::executeInternal(ExecutionContext* context) {
     auto dbManager = context->clientContext->getDatabaseManager();
     dbManager->setDefaultDatabase(dbName);
 }

--- a/src/processor/operator/skip.cpp
+++ b/src/processor/operator/skip.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/skip.h"
 
+#include "processor/execution_context.h"
+
 namespace kuzu {
 namespace processor {
 

--- a/src/processor/operator/standalone_call.cpp
+++ b/src/processor/operator/standalone_call.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/standalone_call.h"
 
 #include "common/cast.h"
+#include "processor/execution_context.h"
 
 namespace kuzu {
 namespace processor {

--- a/src/processor/operator/table_function_call.cpp
+++ b/src/processor/operator/table_function_call.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/table_function_call.h"
 
 #include "binder/expression/expression_util.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::common;
 

--- a/src/processor/operator/table_scan/union_all_scan.cpp
+++ b/src/processor/operator/table_scan/union_all_scan.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/table_scan/union_all_scan.h"
 
 #include "binder/expression/expression_util.h"
+#include "common/metric.h"
 
 using namespace kuzu::common;
 

--- a/src/processor/operator/transaction.cpp
+++ b/src/processor/operator/transaction.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/transaction.h"
 
 #include "common/exception/transaction_manager.h"
+#include "processor/execution_context.h"
 #include "transaction/transaction_context.h"
 #include "transaction/transaction_manager.h"
 

--- a/src/processor/operator/unwind.cpp
+++ b/src/processor/operator/unwind.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/unwind.h"
 
+#include "processor/execution_context.h"
+
 using namespace kuzu::common;
 
 namespace kuzu {

--- a/src/processor/processor_task.cpp
+++ b/src/processor/processor_task.cpp
@@ -1,6 +1,7 @@
 #include "processor/processor_task.h"
 
 #include "main/settings.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::common;
 


### PR DESCRIPTION
# Description

Including `"processor/execution_context.h"` in `PhysicalOperator` can lead to cyclic dependencies if not carefully managed. Instead, `ExecutionContext` can be forward-declared to avoid this issue.