### PR TITLE
Refactor gds framework

### DIFF
--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -263,8 +263,9 @@ void QueryFTSAlgorithm::exec(processor::ExecutionContext* executionContext) {
 
     node_id_map_t<ScoreInfo> scores;
     auto edgeCompute = std::make_unique<QFTSEdgeCompute>(scores, dfs);
+    auto auxiliaryState = std::make_unique<EmptyGDSAuxiliaryState>();
     auto compState = GDSComputeState(std::move(frontierPair), std::move(edgeCompute),
-        nullptr /* outputNodeMask */);
+        std::move(auxiliaryState), nullptr /* outputNodeMask */);
     GDSUtils::runFrontiersUntilConvergence(executionContext, compState, graph, ExtendDirection::FWD,
         1 /* maxIters */, QueryFTSAlgorithm::TERM_FREQUENCY_PROP_NAME);
 

--- a/src/function/gds/CMakeLists.txt
+++ b/src/function/gds/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(kuzu_function_algorithm
         all_shortest_paths.cpp
         gds.cpp
         gds_frontier.cpp
+        gds_state.cpp
         gds_task.cpp
         gds_utils.cpp
         k_core_decomposition.cpp

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -3,7 +3,6 @@
 #include "binder/binder.h"
 #include "common/exception/binder.h"
 #include "function/gds/gds_frontier.h"
-#include "function/gds/gds_utils.h"
 #include "processor/execution_context.h"
 
 using namespace kuzu::common;

--- a/src/function/gds/gds_frontier.cpp
+++ b/src/function/gds/gds_frontier.cpp
@@ -190,7 +190,7 @@ bool FrontierPair::isCurFrontierSparse() {
     return curSparseFrontier->enabled();
 }
 
-void SinglePathLengthsFrontierPair::initRJFromSource(nodeID_t source) {
+void SinglePathLengthsFrontierPair::initSource(nodeID_t source) {
     pathLengths->pinNextFrontierTableID(source.tableID);
     pathLengths->setActive(source);
     nextSparseFrontier->pinTableID(source.tableID);
@@ -198,7 +198,7 @@ void SinglePathLengthsFrontierPair::initRJFromSource(nodeID_t source) {
     hasActiveNodesForNextIter_.store(true);
 }
 
-void DoublePathLengthsFrontierPair::initRJFromSource(nodeID_t source) {
+void DoublePathLengthsFrontierPair::initSource(nodeID_t source) {
     nextDenseFrontier->ptrCast<PathLengths>()->pinNextFrontierTableID(source.tableID);
     nextDenseFrontier->ptrCast<PathLengths>()->setActive(source);
     nextSparseFrontier->pinTableID(source.tableID);

--- a/src/function/gds/gds_state.cpp
+++ b/src/function/gds/gds_state.cpp
@@ -1,0 +1,18 @@
+#include "function/gds/gds_state.h"
+
+namespace kuzu {
+namespace function {
+
+void GDSComputeState::initSource(common::nodeID_t sourceNodeID) const {
+    frontierPair->initSource(sourceNodeID);
+    auxiliaryState->initSource(sourceNodeID);
+}
+
+void GDSComputeState::beginFrontierCompute(common::table_id_t currTableID,
+    common::table_id_t nextTableID) const {
+    frontierPair->beginFrontierComputeBetweenTables(currTableID, nextTableID);
+    auxiliaryState->beginFrontierCompute(currTableID, nextTableID);
+}
+
+}
+}

--- a/src/function/gds/gds_state.cpp
+++ b/src/function/gds/gds_state.cpp
@@ -14,5 +14,5 @@ void GDSComputeState::beginFrontierCompute(common::table_id_t currTableID,
     auxiliaryState->beginFrontierCompute(currTableID, nextTableID);
 }
 
-}
-}
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/gds/auxiliary_state/gds_auxilary_state.h
+++ b/src/include/function/gds/auxiliary_state/gds_auxilary_state.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "common/cast.h"
+#include "common/types/types.h"
+
+namespace kuzu {
+namespace function {
+
+// Maintain algorithm specific data structures
+class GDSAuxiliaryState {
+public:
+    GDSAuxiliaryState() = default;
+    virtual ~GDSAuxiliaryState() = default;
+
+    // Initialize state for source node.
+    virtual void initSource(common::nodeID_t) {}
+    // Initialize state before extending from `fromTable` to `toTable`.
+    // Normally you want to pin data structures on `toTableID`.
+    virtual void beginFrontierCompute(common::table_id_t fromTableID,
+        common::table_id_t toTableID) = 0;
+
+    template<class TARGET>
+    TARGET* ptrCast() {
+        return common::ku_dynamic_cast<TARGET*>(this);
+    }
+};
+
+class EmptyGDSAuxiliaryState : public GDSAuxiliaryState {
+public:
+    EmptyGDSAuxiliaryState() = default;
+
+    void beginFrontierCompute(common::table_id_t, common::table_id_t) override {}
+};
+
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/gds/auxiliary_state/path_auxiliary_state.h
+++ b/src/include/function/gds/auxiliary_state/path_auxiliary_state.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "function/gds/bfs_graph.h"
+#include "gds_auxilary_state.h"
+
+namespace kuzu {
+namespace function {
+
+class PathAuxiliaryState : public GDSAuxiliaryState {
+public:
+    explicit PathAuxiliaryState(std::unique_ptr<BFSGraph> bfsGraph)
+        : bfsGraph{std::move(bfsGraph)} {}
+
+    void beginFrontierCompute(common::table_id_t, common::table_id_t toTableID) override {
+        bfsGraph->pinTableID(toTableID);
+    }
+
+private:
+    std::unique_ptr<BFSGraph> bfsGraph;
+};
+
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -260,7 +260,7 @@ public:
 
     void beginNewIteration();
 
-    virtual void initRJFromSource(common::nodeID_t source) = 0;
+    virtual void initSource(common::nodeID_t source) = 0;
 
     virtual void beginFrontierComputeBetweenTables(common::table_id_t curTableID,
         common::table_id_t nextTableID);
@@ -320,8 +320,9 @@ public:
           pathLengths{std::move(pathLengths)} {}
 
     PathLengths* getPathLengths() const { return pathLengths.get(); }
+    std::shared_ptr<PathLengths> getPathLengthsShared() const { return pathLengths; }
 
-    void initRJFromSource(common::nodeID_t source) override;
+    void initSource(common::nodeID_t source) override;
 
     void pinCurrFrontier(common::table_id_t tableID) override {
         FrontierPair::pinCurrFrontier(tableID);
@@ -344,7 +345,7 @@ public:
         std::shared_ptr<PathLengths> nextFrontier)
         : FrontierPair{curFrontier, nextFrontier} {}
 
-    void initRJFromSource(common::nodeID_t source) override;
+    void initSource(common::nodeID_t source) override;
 
     void pinCurrFrontier(common::table_id_t tableID) override {
         FrontierPair::pinCurrFrontier(tableID);

--- a/src/include/function/gds/gds_state.h
+++ b/src/include/function/gds/gds_state.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "gds_frontier.h"
+#include "auxiliary_state/gds_auxilary_state.h"
+
+namespace kuzu {
+namespace function {
+
+struct KUZU_API GDSComputeState {
+    std::unique_ptr<function::FrontierPair> frontierPair = nullptr;
+    std::unique_ptr<function::EdgeCompute> edgeCompute = nullptr;
+    std::unique_ptr<function::GDSAuxiliaryState> auxiliaryState = nullptr;
+
+    processor::NodeOffsetMaskMap* outputNodeMask = nullptr;
+
+    GDSComputeState(std::unique_ptr<function::FrontierPair> frontierPair,
+        std::unique_ptr<function::EdgeCompute> edgeCompute,
+        std::unique_ptr<function::GDSAuxiliaryState> auxiliaryState,
+        processor::NodeOffsetMaskMap* outputNodeMask)
+        : frontierPair{std::move(frontierPair)}, edgeCompute{std::move(edgeCompute)},
+          auxiliaryState{std::move(auxiliaryState)}, outputNodeMask{outputNodeMask} {}
+
+    void initSource(common::nodeID_t sourceNodeID) const;
+    // When performing computations on multi-label graphs, it is beneficial to fix a single
+    // node table of nodes in the current frontier and a single node table of nodes for the next
+    // frontier. That is because algorithms will perform extensions using a single relationship
+    // table at a time, and each relationship table R is between a single source node table S and
+    // a single destination node table T. Therefore, during execution the algorithm will need to
+    // check only the active S nodes in current frontier and update the active statuses of only the
+    // T nodes in the next frontier. The information that the algorithm is beginning and S-to-T
+    // extensions are be given to the data structures of the computation, e.g., FrontierPairs and
+    // RJOutputs, to possibly avoid them doing lookups of S and T-related data structures,
+    // e.g., maps, internally.
+    void beginFrontierCompute(common::table_id_t currTableID, common::table_id_t nextTableID) const;
+};
+
+}
+}

--- a/src/include/function/gds/gds_state.h
+++ b/src/include/function/gds/gds_state.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "gds_frontier.h"
 #include "auxiliary_state/gds_auxilary_state.h"
+#include "gds_frontier.h"
 
 namespace kuzu {
 namespace function {
@@ -34,5 +34,5 @@ struct KUZU_API GDSComputeState {
     void beginFrontierCompute(common::table_id_t currTableID, common::table_id_t nextTableID) const;
 };
 
-}
-}
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/gds/gds_utils.h
+++ b/src/include/function/gds/gds_utils.h
@@ -2,42 +2,10 @@
 
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "common/enums/extend_direction.h"
-#include "common/types/types.h"
+#include "gds_state.h"
 
 namespace kuzu {
-namespace processor {
-struct ExecutionContext;
-class NodeOffsetMaskMap;
-} // namespace processor
-
-namespace graph {
-class Graph;
-}
-
 namespace function {
-struct FrontierTaskSharedState;
-struct RJCompState;
-class VertexCompute;
-class EdgeCompute;
-class FrontierPair;
-class SparseFrontier;
-struct VertexComputeTaskSharedState;
-struct VertexComputeTaskInfo;
-
-struct KUZU_API GDSComputeState {
-    std::unique_ptr<function::FrontierPair> frontierPair;
-    std::unique_ptr<function::EdgeCompute> edgeCompute;
-
-    processor::NodeOffsetMaskMap* outputNodeMask = nullptr;
-
-    GDSComputeState(std::unique_ptr<function::FrontierPair> frontierPair,
-        std::unique_ptr<function::EdgeCompute> edgeCompute,
-        processor::NodeOffsetMaskMap* outputNodeMask);
-    virtual ~GDSComputeState();
-
-    virtual void beginFrontierComputeBetweenTables(common::table_id_t currTableID,
-        common::table_id_t nextTableID);
-};
 
 class KUZU_API GDSUtils {
 public:

--- a/src/include/processor/operator/gds_call.h
+++ b/src/include/processor/operator/gds_call.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "function/gds/gds.h"
-#include "function/gds/gds_utils.h"
 #include "gds_call_shared_state.h"
 #include "processor/operator/sink.h"
 


### PR DESCRIPTION
# Description

This PR removes `GDS/RJOutputs` and let OutputWriter to maintain whatever data structure it wants to output. I'm still debating if we should just remove `OutputWriter` and just move every logic into `VertexCompute`. 

Add `GDSAuxiliaryState`. Every iterative GDS algorithm requires a `FrontierPair`, some algorithm requires additional data structure, e.g. `WCC` requires `ComponentIDs`. `GDSAuxiliaryState ` maintains such information.