### PR TITLE
Optimize recompile times

### DIFF
--- a/scripts/headers.txt
+++ b/scripts/headers.txt
@@ -7,7 +7,6 @@ src/include/common/assert.h
 src/include/common/case_insensitive_map.h
 src/include/common/cast.h
 src/include/common/constants.h
-${BUILD_DIR}/src/include/common/system_config.h
 src/include/common/copier_config/csv_reader_config.h
 src/include/common/copier_config/file_scan_info.h
 src/include/common/copy_constructors.h
@@ -15,7 +14,6 @@ src/include/common/data_chunk/data_chunk.h
 src/include/common/data_chunk/data_chunk_state.h
 src/include/common/data_chunk/sel_vector.h
 src/include/common/enums/expression_type.h
-src/include/common/enums/extend_direction.h
 src/include/common/enums/path_semantic.h
 src/include/common/enums/statement_type.h
 src/include/common/exception/binder.h

--- a/src/binder/bind/bind_ddl.cpp
+++ b/src/binder/bind/bind_ddl.cpp
@@ -15,6 +15,7 @@
 #include "common/exception/binder.h"
 #include "common/exception/message.h"
 #include "common/string_format.h"
+#include "common/system_config.h"
 #include "common/types/types.h"
 #include "function/cast/functions/cast_from_string_functions.h"
 #include "main/client_context.h"

--- a/src/common/data_chunk/data_chunk_collection.cpp
+++ b/src/common/data_chunk/data_chunk_collection.cpp
@@ -1,5 +1,7 @@
 #include "common/data_chunk/data_chunk_collection.h"
 
+#include "common/system_config.h"
+
 namespace kuzu {
 namespace common {
 

--- a/src/common/data_chunk/data_chunk_state.cpp
+++ b/src/common/data_chunk/data_chunk_state.cpp
@@ -1,10 +1,13 @@
 #include "common/data_chunk/data_chunk_state.h"
 
 #include "common/data_chunk/sel_vector.h"
+#include "common/system_config.h"
 #include "common/types/types.h"
 
 namespace kuzu {
 namespace common {
+
+DataChunkState::DataChunkState() : DataChunkState(DEFAULT_VECTOR_CAPACITY) {}
 
 std::shared_ptr<DataChunkState> DataChunkState::getSingleValueDataChunkState() {
     auto state = std::make_shared<DataChunkState>(1);

--- a/src/common/data_chunk/sel_vector.cpp
+++ b/src/common/data_chunk/sel_vector.cpp
@@ -1,5 +1,6 @@
 #include "common/data_chunk/sel_vector.h"
 
+#include <array>
 #include <numeric>
 
 #include "common/system_config.h"

--- a/src/common/data_chunk/sel_vector.cpp
+++ b/src/common/data_chunk/sel_vector.cpp
@@ -2,17 +2,32 @@
 
 #include <numeric>
 
+#include "common/system_config.h"
 #include "common/types/types.h"
 
 namespace kuzu {
 namespace common {
 
 // NOLINTNEXTLINE(cert-err58-cpp): always evaluated at compile time, and even not it would not throw
-const std::array<sel_t, DEFAULT_VECTOR_CAPACITY> SelectionVector::INCREMENTAL_SELECTED_POS =
+static const std::array<sel_t, DEFAULT_VECTOR_CAPACITY> INCREMENTAL_SELECTED_POS =
     []() constexpr noexcept {
         std::array<sel_t, DEFAULT_VECTOR_CAPACITY> selectedPos{};
         std::iota(selectedPos.begin(), selectedPos.end(), 0);
         return selectedPos;
     }();
+
+SelectionVector::SelectionVector() : SelectionVector{DEFAULT_VECTOR_CAPACITY} {}
+
+void SelectionVector::setToUnfiltered() {
+    selectedPositions = const_cast<sel_t*>(INCREMENTAL_SELECTED_POS.data());
+    state = State::STATIC;
+}
+void SelectionVector::setToUnfiltered(sel_t size) {
+    KU_ASSERT(size <= capacity);
+    selectedPositions = const_cast<sel_t*>(INCREMENTAL_SELECTED_POS.data());
+    selectedSize = size;
+    state = State::STATIC;
+}
+
 } // namespace common
 } // namespace kuzu

--- a/src/common/enums/extend_direction_util.cpp
+++ b/src/common/enums/extend_direction_util.cpp
@@ -3,10 +3,6 @@
 #include "common/exception/runtime.h"
 #include "common/string_utils.h"
 
-#define BOTH_REL_STORAGE 0
-#define FWD_REL_STORAGE 1
-#define BWD_REL_STORAGE 2
-
 namespace kuzu {
 namespace common {
 

--- a/src/common/serializer/buffered_file.cpp
+++ b/src/common/serializer/buffered_file.cpp
@@ -5,9 +5,12 @@
 #include "common/assert.h"
 #include "common/exception/runtime.h"
 #include "common/file_system/file_info.h"
+#include "common/system_config.h"
 
 namespace kuzu {
 namespace common {
+
+static constexpr uint64_t BUFFER_SIZE = KUZU_PAGE_SIZE;
 
 BufferedFileWriter::~BufferedFileWriter() {
     flush();

--- a/src/common/vector/auxiliary_buffer.cpp
+++ b/src/common/vector/auxiliary_buffer.cpp
@@ -3,6 +3,7 @@
 #include <numeric>
 
 #include "common/constants.h"
+#include "common/system_config.h"
 #include "common/vector/value_vector.h"
 
 namespace kuzu {

--- a/src/expression_evaluator/lambda_evaluator.cpp
+++ b/src/expression_evaluator/lambda_evaluator.cpp
@@ -3,6 +3,7 @@
 #include "binder/expression/lambda_expression.h"
 #include "binder/expression/scalar_function_expression.h"
 #include "common/exception/runtime.h"
+#include "common/system_config.h"
 #include "expression_evaluator/expression_evaluator_visitor.h"
 #include "function/list/vector_list_functions.h"
 #include "parser/expression/parsed_lambda_expression.h"

--- a/src/function/export/export_parquet_function.cpp
+++ b/src/function/export/export_parquet_function.cpp
@@ -1,5 +1,6 @@
 #include "common/exception/runtime.h"
 #include "common/string_utils.h"
+#include "common/system_config.h"
 #include "function/export/export_function.h"
 #include "main/client_context.h"
 #include "parquet_types.h"

--- a/src/function/gds/gds_frontier.cpp
+++ b/src/function/gds/gds_frontier.cpp
@@ -98,6 +98,8 @@ PathLengths::PathLengths(const common::table_id_map_t<common::offset_t>& numNode
     }
 }
 
+PathLengths::~PathLengths() = default;
+
 void PathLengths::pinCurFrontierTableID(common::table_id_t tableID) {
     curFrontier.store(getMaskData(tableID), std::memory_order_relaxed);
 }

--- a/src/function/gds/gds_frontier.cpp
+++ b/src/function/gds/gds_frontier.cpp
@@ -2,6 +2,7 @@
 
 #include "function/gds/gds_utils.h"
 #include "processor/execution_context.h"
+#include "storage/buffer_manager/memory_manager.h"
 
 using namespace kuzu::common;
 
@@ -113,6 +114,11 @@ std::shared_ptr<PathLengths> PathLengths::getFrontier(processor::ExecutionContex
     auto vc = std::make_unique<PathLengthsInitVertexCompute>(*pathLengths, initialValue);
     GDSUtils::runVertexCompute(context, graph, *vc);
     return pathLengths;
+}
+
+PathLengths::frontier_entry_t* PathLengths::getMaskData(common::table_id_t tableID) {
+    KU_ASSERT(masks.contains(tableID));
+    return reinterpret_cast<frontier_entry_t*>(masks.at(tableID)->getData());
 }
 
 bool PathLengthsInitVertexCompute::beginOnTable(common::table_id_t tableID) {

--- a/src/function/table/table_function.cpp
+++ b/src/function/table/table_function.cpp
@@ -2,6 +2,7 @@
 
 #include "binder/query/reading_clause/bound_table_function_call.h"
 #include "common/exception/binder.h"
+#include "common/system_config.h"
 #include "function/table/bind_data.h"
 #include "planner/operator/logical_table_function_call.h"
 #include "planner/planner.h"

--- a/src/function/vector_hash_functions.cpp
+++ b/src/function/vector_hash_functions.cpp
@@ -1,5 +1,6 @@
 #include "function/hash/vector_hash_functions.h"
 
+#include "common/system_config.h"
 #include "common/type_utils.h"
 #include "function/hash/hash_functions.h"
 #include "function/scalar_function.h"

--- a/src/graph/CMakeLists.txt
+++ b/src/graph/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(kuzu_graph
         OBJECT
+        graph.cpp
         graph_entry.cpp
         on_disk_graph.cpp)
 

--- a/src/graph/graph.cpp
+++ b/src/graph/graph.cpp
@@ -1,0 +1,19 @@
+#include "graph/graph.h"
+
+#include "common/system_config.h"
+
+namespace kuzu::graph {
+NbrScanState::Chunk::Chunk(std::span<const common::nodeID_t> nbrNodes,
+    std::span<const common::relID_t> edges, common::SelectionVector& selVector,
+    const common::ValueVector* propertyVector)
+    : nbrNodes{nbrNodes}, edges{edges}, selVector{selVector}, propertyVector{propertyVector} {
+    KU_ASSERT(nbrNodes.size() == common::DEFAULT_VECTOR_CAPACITY);
+    KU_ASSERT(edges.size() == common::DEFAULT_VECTOR_CAPACITY);
+}
+
+VertexScanState::Chunk::Chunk(std::span<const common::nodeID_t> nodeIDs,
+    std::span<const std::shared_ptr<common::ValueVector>> propertyVectors)
+    : nodeIDs{nodeIDs}, propertyVectors{propertyVectors} {
+    KU_ASSERT(nodeIDs.size() <= common::DEFAULT_VECTOR_CAPACITY);
+}
+} // namespace kuzu::graph

--- a/src/include/common/data_chunk/data_chunk_state.h
+++ b/src/include/common/data_chunk/data_chunk_state.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "common/data_chunk/sel_vector.h"
-#include "common/system_config.h"
 
 namespace kuzu {
 namespace common {
@@ -14,7 +13,7 @@ enum class FStateType : uint8_t {
 
 class KUZU_API DataChunkState {
 public:
-    DataChunkState() : DataChunkState(DEFAULT_VECTOR_CAPACITY) {}
+    DataChunkState();
     explicit DataChunkState(sel_t capacity) : fStateType{FStateType::UNFLAT} {
         selVector = std::make_shared<SelectionVector>(capacity);
     }

--- a/src/include/common/data_chunk/sel_vector.h
+++ b/src/include/common/data_chunk/sel_vector.h
@@ -2,7 +2,6 @@
 
 #include <string.h>
 
-#include <array>
 #include <memory>
 
 #include "common/types/types.h"

--- a/src/include/common/data_chunk/sel_vector.h
+++ b/src/include/common/data_chunk/sel_vector.h
@@ -5,7 +5,6 @@
 #include <array>
 #include <memory>
 
-#include "common/system_config.h"
 #include "common/types/types.h"
 #include <span>
 
@@ -13,7 +12,6 @@ namespace kuzu {
 namespace common {
 
 class SelectionVector {
-    KUZU_API static const std::array<sel_t, DEFAULT_VECTOR_CAPACITY> INCREMENTAL_SELECTED_POS;
 
     // In DYNAMIC mode, selectedPositions points to a mutable buffer that can be modified through
     // getMutableBuffer In STATIC mode, selectedPositions points to the beginning of
@@ -34,20 +32,12 @@ public:
         setToUnfiltered();
     }
 
-    SelectionVector() : SelectionVector{DEFAULT_VECTOR_CAPACITY} {}
+    SelectionVector();
 
     bool isUnfiltered() const { return state == State::STATIC && selectedPositions[0] == 0; }
 
-    void setToUnfiltered() {
-        selectedPositions = const_cast<sel_t*>(INCREMENTAL_SELECTED_POS.data());
-        state = State::STATIC;
-    }
-    void setToUnfiltered(sel_t size) {
-        KU_ASSERT(size <= capacity);
-        selectedPositions = const_cast<sel_t*>(INCREMENTAL_SELECTED_POS.data());
-        selectedSize = size;
-        state = State::STATIC;
-    }
+    void setToUnfiltered();
+    void setToUnfiltered(sel_t size);
     void setRange(sel_t startPos, sel_t size) {
         KU_ASSERT(startPos + size <= capacity);
         selectedPositions = selectedPositionsBuffer.get();

--- a/src/include/common/serializer/buffered_file.h
+++ b/src/include/common/serializer/buffered_file.h
@@ -4,7 +4,6 @@
 
 #include "common/serializer/reader.h"
 #include "common/serializer/writer.h"
-#include "common/system_config.h"
 
 namespace kuzu {
 namespace common {
@@ -36,7 +35,6 @@ protected:
     std::unique_ptr<uint8_t[]> buffer;
     uint64_t fileOffset, bufferOffset;
     FileInfo& fileInfo;
-    static constexpr uint64_t BUFFER_SIZE = KUZU_PAGE_SIZE;
 };
 
 class BufferedFileReader final : public Reader {
@@ -48,8 +46,6 @@ public:
     bool finished() override;
 
 private:
-    static constexpr uint64_t BUFFER_SIZE = KUZU_PAGE_SIZE;
-
     std::unique_ptr<uint8_t[]> buffer;
     uint64_t fileOffset, bufferOffset;
     std::unique_ptr<FileInfo> fileInfo;

--- a/src/include/common/vector/value_vector.h
+++ b/src/include/common/vector/value_vector.h
@@ -48,18 +48,7 @@ public:
         }
     }
 
-    uint32_t countNonNull() const {
-        if (hasNoNullsGuarantee()) {
-            return state->getSelVector().getSelSize();
-        } else if (state->getSelVector().isUnfiltered() &&
-                   state->getSelVector().getSelSize() == DEFAULT_VECTOR_CAPACITY) {
-            return DEFAULT_VECTOR_CAPACITY - nullMask.countNulls();
-        } else {
-            uint32_t count = 0;
-            forEachNonNull([&](auto) { count++; });
-            return count;
-        }
-    }
+    uint32_t countNonNull() const;
 
     void setState(const std::shared_ptr<DataChunkState>& state_);
 
@@ -167,11 +156,11 @@ public:
 struct KUZU_API BlobVector {
     static void addBlob(ValueVector* vector, uint32_t pos, const char* data, uint32_t length) {
         StringVector::addString(vector, pos, data, length);
-    }
+    } // namespace common
     static void addBlob(ValueVector* vector, uint32_t pos, const uint8_t* data, uint64_t length) {
         StringVector::addString(vector, pos, reinterpret_cast<const char*>(data), length);
     }
-};
+}; // namespace kuzu
 
 // ListVector is used for both LIST and ARRAY physical type
 class KUZU_API ListVector {

--- a/src/include/expression_evaluator/case_evaluator.h
+++ b/src/include/expression_evaluator/case_evaluator.h
@@ -3,6 +3,7 @@
 #include <bitset>
 
 #include "binder/expression/expression.h"
+#include "common/system_config.h"
 #include "expression_evaluator.h"
 
 namespace kuzu {

--- a/src/include/function/gds/bfs_graph.h
+++ b/src/include/function/gds/bfs_graph.h
@@ -2,9 +2,11 @@
 
 #include "compute.h"
 #include "gds_object_manager.h"
-#include "storage/buffer_manager/memory_manager.h"
 
 namespace kuzu {
+namespace storage {
+class MemoryManager;
+}
 namespace function {
 
 // TODO(Xiyang): optimize if edgeID is not needed.

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -4,10 +4,12 @@
 #include <mutex>
 
 #include "compute.h"
-#include "storage/buffer_manager/memory_manager.h"
 #include <span>
 
 namespace kuzu {
+namespace storage {
+class MemoryManager;
+}
 
 namespace processor {
 struct ExecutionContext;
@@ -208,10 +210,7 @@ private:
         return retVal;
     }
 
-    frontier_entry_t* getMaskData(common::table_id_t tableID) {
-        KU_ASSERT(masks.contains(tableID));
-        return reinterpret_cast<frontier_entry_t*>(masks.at(tableID)->getData());
-    }
+    frontier_entry_t* getMaskData(common::table_id_t tableID);
 
 private:
     common::table_id_map_t<std::unique_ptr<storage::MemoryBuffer>> masks;

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -164,6 +164,7 @@ public:
 
     PathLengths(const common::table_id_map_t<common::offset_t>& numNodesMap,
         storage::MemoryManager* mm);
+    ~PathLengths() override;
 
     uint16_t getMaskValueFromCurFrontier(common::offset_t offset) {
         return getCurFrontier()[offset].load(std::memory_order_relaxed);

--- a/src/include/graph/graph.h
+++ b/src/include/graph/graph.h
@@ -96,7 +96,7 @@ public:
         }
 
     private:
-        Chunk(std::span<const common::nodeID_t> nodeIDs,
+        KUZU_API Chunk(std::span<const common::nodeID_t> nodeIDs,
             std::span<const std::shared_ptr<common::ValueVector>> propertyVectors);
 
     private:

--- a/src/include/graph/graph.h
+++ b/src/include/graph/graph.h
@@ -57,12 +57,7 @@ public:
 
     private:
         Chunk(std::span<const common::nodeID_t> nbrNodes, std::span<const common::relID_t> edges,
-            common::SelectionVector& selVector, const common::ValueVector* propertyVector)
-            : nbrNodes{nbrNodes}, edges{edges}, selVector{selVector},
-              propertyVector{propertyVector} {
-            KU_ASSERT(nbrNodes.size() == common::DEFAULT_VECTOR_CAPACITY);
-            KU_ASSERT(edges.size() == common::DEFAULT_VECTOR_CAPACITY);
-        }
+            common::SelectionVector& selVector, const common::ValueVector* propertyVector);
 
     private:
         std::span<const common::nodeID_t> nbrNodes;
@@ -102,10 +97,7 @@ public:
 
     private:
         Chunk(std::span<const common::nodeID_t> nodeIDs,
-            std::span<const std::shared_ptr<common::ValueVector>> propertyVectors)
-            : nodeIDs{nodeIDs}, propertyVectors{propertyVectors} {
-            KU_ASSERT(nodeIDs.size() <= common::DEFAULT_VECTOR_CAPACITY);
-        }
+            std::span<const std::shared_ptr<common::ValueVector>> propertyVectors);
 
     private:
         std::span<const common::nodeID_t> nodeIDs;

--- a/src/include/processor/operator/aggregate/aggregate_hash_table.h
+++ b/src/include/processor/operator/aggregate/aggregate_hash_table.h
@@ -10,9 +10,11 @@
 #include "processor/result/base_hash_table.h"
 #include "processor/result/factorized_table.h"
 #include "processor/result/factorized_table_schema.h"
-#include "storage/buffer_manager/memory_manager.h"
 
 namespace kuzu {
+namespace storage {
+class MemoryManager;
+}
 namespace processor {
 
 struct HashSlot {

--- a/src/include/processor/operator/filtering_operator.h
+++ b/src/include/processor/operator/filtering_operator.h
@@ -11,10 +11,7 @@ namespace processor {
 
 class SelVectorOverWriter {
 public:
-    explicit SelVectorOverWriter() {
-        currentSelVector =
-            std::make_shared<common::SelectionVector>(common::DEFAULT_VECTOR_CAPACITY);
-    }
+    SelVectorOverWriter();
     virtual ~SelVectorOverWriter() = default;
 
 protected:

--- a/src/include/processor/operator/gds_call_shared_state.h
+++ b/src/include/processor/operator/gds_call_shared_state.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mutex>
 #include <stack>
 
 #include "common/mask.h"

--- a/src/include/processor/operator/hash_join/hash_join_build.h
+++ b/src/include/processor/operator/hash_join/hash_join_build.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "binder/expression/expression.h"
 #include "join_hash_table.h"
 #include "processor/operator/physical_operator.h"

--- a/src/include/processor/operator/hash_join/join_hash_table.h
+++ b/src/include/processor/operator/hash_join/join_hash_table.h
@@ -2,9 +2,11 @@
 
 #include "processor/result/base_hash_table.h"
 #include "processor/result/factorized_table.h"
-#include "storage/buffer_manager/memory_manager.h"
 
 namespace kuzu {
+namespace storage {
+class MemoryManager;
+}
 namespace processor {
 
 class JoinHashTable : public BaseHashTable {

--- a/src/include/processor/operator/order_by/key_block_merger.h
+++ b/src/include/processor/operator/order_by/key_block_merger.h
@@ -27,9 +27,6 @@ struct StrKeyColInfo {
 };
 
 class MergedKeyBlocks {
-private:
-    static constexpr uint64_t DATA_BLOCK_SIZE = common::TEMP_PAGE_SIZE;
-
 public:
     MergedKeyBlocks(uint32_t numBytesPerTuple, uint64_t numTuples,
         storage::MemoryManager* memoryManager);

--- a/src/include/processor/operator/order_by/key_block_merger.h
+++ b/src/include/processor/operator/order_by/key_block_merger.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mutex>
 #include <queue>
 
 #include "processor/operator/order_by/order_by_key_encoder.h"

--- a/src/include/processor/operator/order_by/order_by_key_encoder.h
+++ b/src/include/processor/operator/order_by/order_by_key_encoder.h
@@ -41,9 +41,6 @@ namespace processor {
 using encode_function_t = std::function<void(const uint8_t*, uint8_t*, bool)>;
 
 class OrderByKeyEncoder {
-private:
-    static constexpr uint64_t DATA_BLOCK_SIZE = common::TEMP_PAGE_SIZE;
-
 public:
     OrderByKeyEncoder(const OrderByDataInfo& orderByDataInfo, storage::MemoryManager* memoryManager,
         uint8_t ftIdx, uint32_t numTuplesPerBlockInFT, uint32_t numBytesPerTuple);

--- a/src/include/processor/operator/order_by/radix_sort.h
+++ b/src/include/processor/operator/order_by/radix_sort.h
@@ -24,18 +24,9 @@ public:
 // seen so far. If there are tie tuples, it will compare the overflow ptr of strings. For subsequent
 // columns, the algorithm only calls radixSort on tie tuples.
 class RadixSort {
-private:
-    static constexpr uint16_t COUNTING_ARRAY_SIZE = 256;
-    static constexpr uint64_t DATA_BLOCK_SIZE = common::TEMP_PAGE_SIZE;
-
 public:
     RadixSort(storage::MemoryManager* memoryManager, FactorizedTable& factorizedTable,
-        OrderByKeyEncoder& orderByKeyEncoder, std::vector<StrKeyColInfo> strKeyColsInfo)
-        : tmpSortingResultBlock{std::make_unique<DataBlock>(memoryManager, DATA_BLOCK_SIZE)},
-          tmpTuplePtrSortingBlock{std::make_unique<DataBlock>(memoryManager, DATA_BLOCK_SIZE)},
-          factorizedTable{factorizedTable}, strKeyColsInfo{std::move(strKeyColsInfo)},
-          numBytesPerTuple{orderByKeyEncoder.getNumBytesPerTuple()},
-          numBytesToRadixSort{numBytesPerTuple - 8} {}
+        OrderByKeyEncoder& orderByKeyEncoder, std::vector<StrKeyColInfo> strKeyColsInfo);
 
     void sortSingleKeyBlock(const DataBlock& keyBlock);
 

--- a/src/include/processor/operator/order_by/top_k.h
+++ b/src/include/processor/operator/order_by/top_k.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "binder/expression/expression.h"
 #include "processor/operator/sink.h"
 #include "sort_state.h"

--- a/src/include/processor/operator/persistent/reader/parquet/column_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/column_reader.h
@@ -2,6 +2,7 @@
 
 #include <bitset>
 
+#include "common/system_config.h"
 #include "common/types/types.h"
 #include "common/vector/value_vector.h"
 #include "parquet_dbp_decoder.h"

--- a/src/include/processor/operator/persistent/writer/parquet/parquet_writer.h
+++ b/src/include/processor/operator/persistent/writer/parquet/parquet_writer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "common/data_chunk/data_chunk.h"
 #include "common/file_system/file_info.h"
 #include "common/types/types.h"

--- a/src/include/processor/operator/result_collector.h
+++ b/src/include/processor/operator/result_collector.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "binder/expression/expression.h"
 #include "common/enums/accumulate_type.h"
 #include "processor/operator/sink.h"

--- a/src/include/processor/operator/table_scan/union_all_scan.h
+++ b/src/include/processor/operator/table_scan/union_all_scan.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "binder/expression/expression.h"
 #include "processor/operator/physical_operator.h"
 #include "processor/result/factorized_table.h"

--- a/src/include/processor/result/base_hash_table.h
+++ b/src/include/processor/result/base_hash_table.h
@@ -3,13 +3,16 @@
 #include <functional>
 
 #include "common/copy_constructors.h"
+#include "common/system_config.h"
 #include "common/types/types.h"
 #include "common/vector/value_vector.h"
 #include "processor/result/factorized_table.h"
 #include "processor/result/factorized_table_schema.h"
-#include "storage/buffer_manager/memory_manager.h"
 
 namespace kuzu {
+namespace storage {
+class MemoryManager;
+}
 namespace processor {
 
 using compare_function_t = std::function<bool(common::ValueVector*, uint32_t, const uint8_t*)>;

--- a/src/include/processor/result/factorized_table.h
+++ b/src/include/processor/result/factorized_table.h
@@ -7,9 +7,11 @@
 #include "common/types/value/value.h"
 #include "common/vector/value_vector.h"
 #include "factorized_table_schema.h"
-#include "storage/buffer_manager/memory_manager.h"
 
 namespace kuzu {
+namespace storage {
+class MemoryManager;
+}
 namespace processor {
 
 struct BlockAppendingInfo {
@@ -24,18 +26,14 @@ struct BlockAppendingInfo {
 // released when this struct goes out of scope.
 class DataBlock {
 public:
-    DataBlock(storage::MemoryManager* mm, uint64_t size) : numTuples{0}, freeSize{size} {
-        block = mm->allocateBuffer(true /* initializeToZero */, size);
-    }
+    DataBlock(storage::MemoryManager* mm, uint64_t size);
+    ~DataBlock();
 
-    uint8_t* getData() const { return block->getBuffer().data(); }
-    std::span<uint8_t> getSizedData() const { return block->getBuffer(); }
-    uint8_t* getWritableData() const { return block->getBuffer().last(freeSize).data(); }
-    void resetNumTuplesAndFreeSize() {
-        freeSize = block->getBuffer().size();
-        numTuples = 0;
-    }
-    void resetToZero() { memset(block->getBuffer().data(), 0, block->getBuffer().size()); }
+    uint8_t* getData() const;
+    std::span<uint8_t> getSizedData() const;
+    uint8_t* getWritableData() const;
+    void resetNumTuplesAndFreeSize();
+    void resetToZero();
 
     static void copyTuples(DataBlock* blockToCopyFrom, ft_tuple_idx_t tupleIdxToCopyFrom,
         DataBlock* blockToCopyInto, ft_tuple_idx_t tupleIdxToCopyTo, uint32_t numTuplesToCopy,

--- a/src/include/storage/storage_utils.h
+++ b/src/include/storage/storage_utils.h
@@ -6,6 +6,7 @@
 #include "common/constants.h"
 #include "common/file_system/virtual_file_system.h"
 #include "common/null_mask.h"
+#include "common/system_config.h"
 #include "common/types/types.h"
 #include "main/client_context.h"
 #include "main/db_config.h"

--- a/src/include/storage/store/dictionary_column.h
+++ b/src/include/storage/store/dictionary_column.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "dictionary_chunk.h"
-#include "storage/buffer_manager/memory_manager.h"
 #include "storage/store/column.h"
 
 namespace kuzu {

--- a/src/include/storage/store/in_mem_chunked_node_group_collection.h
+++ b/src/include/storage/store/in_mem_chunked_node_group_collection.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "storage/buffer_manager/memory_manager.h"
 #include "storage/store/chunked_node_group.h"
 
 namespace kuzu {

--- a/src/include/storage/store/in_memory_exception_chunk.h
+++ b/src/include/storage/store/in_memory_exception_chunk.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "storage/buffer_manager/memory_manager.h"
 #include "storage/compression/float_compression.h"
 #include "storage/store/column_reader_writer.h"
 

--- a/src/include/storage/store/list_column.h
+++ b/src/include/storage/store/list_column.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "column.h"
-#include "storage/buffer_manager/memory_manager.h"
 
 // List is a nested data type which is stored as three chunks:
 // 1. Offset column (type: INT64). Using offset to partition the data column into multiple lists.

--- a/src/include/storage/store/null_column.h
+++ b/src/include/storage/store/null_column.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "storage/buffer_manager/memory_manager.h"
 #include "storage/storage_utils.h"
 #include "storage/store/column.h"
 

--- a/src/include/storage/store/struct_column.h
+++ b/src/include/storage/store/struct_column.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "storage/buffer_manager/memory_manager.h"
 #include "storage/store/column.h"
 
 namespace kuzu {

--- a/src/include/storage/store/struct_column.h
+++ b/src/include/storage/store/struct_column.h
@@ -5,6 +5,7 @@
 
 namespace kuzu {
 namespace storage {
+class MemoryManager;
 
 class StructColumn final : public Column {
 public:

--- a/src/include/storage/store/version_info.h
+++ b/src/include/storage/store/version_info.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <array>
-
-#include "common/copy_constructors.h"
 #include "common/data_chunk/sel_vector.h"
 #include "common/types/types.h"
 

--- a/src/include/storage/store/version_info.h
+++ b/src/include/storage/store/version_info.h
@@ -13,77 +13,13 @@ class Transaction;
 
 namespace storage {
 
-struct VectorVersionInfo {
-    enum class InsertionStatus : uint8_t { NO_INSERTED, CHECK_VERSION, ALWAYS_INSERTED };
-    // TODO(Guodong): ALWAYS_INSERTED is not added for now, but it may be useful as an optimization
-    // to mark the vector data after checkpoint is all deleted.
-    enum class DeletionStatus : uint8_t { NO_DELETED, CHECK_VERSION };
-
-    // TODO: Keep an additional same insertion/deletion field as an optimization to avoid the need
-    // of `array` if all are inserted/deleted in the same transaction.
-    // Also, avoid allocate `array` when status are NO_INSERTED and NO_DELETED.
-    // We can even consider separating the insertion and deletion into two separate Vectors.
-    std::unique_ptr<std::array<common::transaction_t, common::DEFAULT_VECTOR_CAPACITY>>
-        insertedVersions;
-    std::unique_ptr<std::array<common::transaction_t, common::DEFAULT_VECTOR_CAPACITY>>
-        deletedVersions;
-    // If all values in the Vector are inserted/deleted in the same transaction, we can use this to
-    // aovid the allocation of `array`.
-    common::transaction_t sameInsertionVersion;
-    common::transaction_t sameDeletionVersion;
-    InsertionStatus insertionStatus;
-    DeletionStatus deletionStatus;
-
-    VectorVersionInfo()
-        : sameInsertionVersion{common::INVALID_TRANSACTION},
-          sameDeletionVersion{common::INVALID_TRANSACTION},
-          insertionStatus{InsertionStatus::NO_INSERTED},
-          deletionStatus{DeletionStatus::NO_DELETED} {}
-    DELETE_COPY_DEFAULT_MOVE(VectorVersionInfo);
-
-    void append(common::transaction_t transactionID, common::row_idx_t startRow,
-        common::row_idx_t numRows);
-    bool delete_(common::transaction_t transactionID, common::row_idx_t rowIdx);
-    void setInsertCommitTS(common::transaction_t commitTS, common::row_idx_t startRow,
-        common::row_idx_t numRows);
-    void setDeleteCommitTS(common::transaction_t commitTS, common::row_idx_t startRow,
-        common::row_idx_t numRows);
-
-    void getSelVectorForScan(common::transaction_t startTS, common::transaction_t transactionID,
-        common::SelectionVector& selVector, common::row_idx_t startRow, common::row_idx_t numRows,
-        common::sel_t startOutputPos) const;
-
-    void rollbackInsertions(common::row_idx_t startRowInVector, common::row_idx_t numRows);
-    void rollbackDeletions(common::row_idx_t startRowInVector, common::row_idx_t numRows);
-
-    bool hasDeletions(const transaction::Transaction* transaction) const;
-
-    // Given startTS and transactionID, if the row is deleted to the transaction, return true.
-    bool isDeleted(common::transaction_t startTS, common::transaction_t transactionID,
-        common::row_idx_t rowIdx) const;
-    // Given startTS and transactionID, if the row is readable to the transaction, return true.
-    bool isInserted(common::transaction_t startTS, common::transaction_t transactionID,
-        common::row_idx_t rowIdx) const;
-
-    common::row_idx_t getNumDeletions(common::transaction_t startTS,
-        common::transaction_t transactionID, common::row_idx_t startRow,
-        common::length_t numRows) const;
-
-    void serialize(common::Serializer& serializer) const;
-    static std::unique_ptr<VectorVersionInfo> deSerialize(common::Deserializer& deSer);
-
-private:
-    void initInsertionVersionArray();
-    void initDeletionVersionArray();
-
-    bool isSameInsertionVersion() const;
-    bool isSameDeletionVersion() const;
-};
-
 class ChunkedNodeGroup;
+struct VectorVersionInfo;
+
 class VersionInfo {
 public:
-    VersionInfo() {}
+    VersionInfo();
+    ~VersionInfo();
 
     void append(common::transaction_t transactionID, common::row_idx_t startRow,
         common::row_idx_t numRows);
@@ -105,10 +41,7 @@ public:
 
     bool hasDeletions(const transaction::Transaction* transaction) const;
 
-    // Return nullptr when vectorIdx is out of range or when the vector is not created.
-    VectorVersionInfo* getVectorVersionInfo(common::idx_t vectorIdx) const;
     common::idx_t getNumVectors() const { return vectorsInfo.size(); }
-    VectorVersionInfo& getOrCreateVersionInfo(common::idx_t vectorIdx);
 
     void commitInsert(common::row_idx_t startRow, common::row_idx_t numRows,
         common::transaction_t commitTS);
@@ -121,6 +54,10 @@ public:
     static std::unique_ptr<VersionInfo> deserialize(common::Deserializer& deSer);
 
 private:
+    // Return nullptr when vectorIdx is out of range or when the vector is not created.
+    VectorVersionInfo* getVectorVersionInfo(common::idx_t vectorIdx) const;
+    VectorVersionInfo& getOrCreateVersionInfo(common::idx_t vectorIdx);
+
     std::vector<std::unique_ptr<VectorVersionInfo>> vectorsInfo;
 };
 

--- a/src/processor/map/map_accumulate.cpp
+++ b/src/processor/map/map_accumulate.cpp
@@ -1,3 +1,4 @@
+#include "common/system_config.h"
 #include "planner/operator/logical_accumulate.h"
 #include "processor/operator/result_collector.h"
 #include "processor/plan_mapper.h"

--- a/src/processor/map/map_cross_product.cpp
+++ b/src/processor/map/map_cross_product.cpp
@@ -1,3 +1,4 @@
+#include "common/system_config.h"
 #include "planner/operator/logical_cross_product.h"
 #include "processor/operator/cross_product.h"
 #include "processor/plan_mapper.h"

--- a/src/processor/map/map_explain.cpp
+++ b/src/processor/map/map_explain.cpp
@@ -1,4 +1,5 @@
 #include "common/profiler.h"
+#include "common/system_config.h"
 #include "main/client_context.h"
 #include "main/plan_printer.h"
 #include "planner/operator/logical_explain.h"

--- a/src/processor/map/map_expressions_scan.cpp
+++ b/src/processor/map/map_expressions_scan.cpp
@@ -1,3 +1,4 @@
+#include "common/system_config.h"
 #include "planner/operator/logical_accumulate.h"
 #include "planner/operator/scan/logical_expressions_scan.h"
 #include "processor/operator/result_collector.h"

--- a/src/processor/map/map_union.cpp
+++ b/src/processor/map/map_union.cpp
@@ -1,3 +1,4 @@
+#include "common/system_config.h"
 #include "planner/operator/logical_union.h"
 #include "processor/operator/table_scan/union_all_scan.h"
 #include "processor/plan_mapper.h"

--- a/src/processor/operator/filtering_operator.cpp
+++ b/src/processor/operator/filtering_operator.cpp
@@ -3,11 +3,16 @@
 #include <cstring>
 
 #include "common/data_chunk/data_chunk_state.h"
+#include "common/system_config.h"
 
 using namespace kuzu::common;
 
 namespace kuzu {
 namespace processor {
+
+SelVectorOverWriter::SelVectorOverWriter() {
+    currentSelVector = std::make_shared<common::SelectionVector>(common::DEFAULT_VECTOR_CAPACITY);
+}
 
 void SelVectorOverWriter::restoreSelVector(DataChunkState& dataChunkState) const {
     if (prevSelVector != nullptr) {

--- a/src/processor/operator/gds_call_shared_state.cpp
+++ b/src/processor/operator/gds_call_shared_state.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/gds_call_shared_state.h"
 
+#include <mutex>
+
 using namespace kuzu::common;
 
 namespace kuzu {

--- a/src/processor/operator/order_by/key_block_merger.cpp
+++ b/src/processor/operator/order_by/key_block_merger.cpp
@@ -1,11 +1,15 @@
 #include "processor/operator/order_by/key_block_merger.h"
 
+#include "common/system_config.h"
+
 using namespace kuzu::common;
 using namespace kuzu::processor;
 using namespace kuzu::storage;
 
 namespace kuzu {
 namespace processor {
+
+static constexpr uint64_t DATA_BLOCK_SIZE = common::TEMP_PAGE_SIZE;
 
 MergedKeyBlocks::MergedKeyBlocks(uint32_t numBytesPerTuple, uint64_t numTuples,
     MemoryManager* memoryManager)

--- a/src/processor/operator/order_by/order_by_key_encoder.cpp
+++ b/src/processor/operator/order_by/order_by_key_encoder.cpp
@@ -13,6 +13,7 @@ using namespace kuzu::storage;
 
 namespace kuzu {
 namespace processor {
+static constexpr uint64_t DATA_BLOCK_SIZE = common::TEMP_PAGE_SIZE;
 
 OrderByKeyEncoder::OrderByKeyEncoder(const OrderByDataInfo& orderByDataInfo,
     MemoryManager* memoryManager, uint8_t ftIdx, uint32_t numTuplesPerBlockInFT,

--- a/src/processor/operator/order_by/radix_sort.cpp
+++ b/src/processor/operator/order_by/radix_sort.cpp
@@ -2,12 +2,24 @@
 
 #include <algorithm>
 
+#include "common/system_config.h"
 #include "function/comparison/comparison_functions.h"
 
 using namespace kuzu::common;
 
 namespace kuzu {
 namespace processor {
+
+static constexpr uint16_t COUNTING_ARRAY_SIZE = 256;
+static constexpr uint64_t DATA_BLOCK_SIZE = common::TEMP_PAGE_SIZE;
+
+RadixSort::RadixSort(storage::MemoryManager* memoryManager, FactorizedTable& factorizedTable,
+    OrderByKeyEncoder& orderByKeyEncoder, std::vector<StrKeyColInfo> strKeyColsInfo)
+    : tmpSortingResultBlock{std::make_unique<DataBlock>(memoryManager, DATA_BLOCK_SIZE)},
+      tmpTuplePtrSortingBlock{std::make_unique<DataBlock>(memoryManager, DATA_BLOCK_SIZE)},
+      factorizedTable{factorizedTable}, strKeyColsInfo{std::move(strKeyColsInfo)},
+      numBytesPerTuple{orderByKeyEncoder.getNumBytesPerTuple()},
+      numBytesToRadixSort{numBytesPerTuple - 8} {}
 
 void RadixSort::sortSingleKeyBlock(const DataBlock& keyBlock) {
     auto numBytesSorted = 0ul;

--- a/src/processor/operator/order_by/sort_state.cpp
+++ b/src/processor/operator/order_by/sort_state.cpp
@@ -1,6 +1,9 @@
 #include "processor/operator/order_by/sort_state.h"
 
+#include <mutex>
+
 #include "common/constants.h"
+#include "common/system_config.h"
 
 using namespace kuzu::common;
 

--- a/src/processor/operator/order_by/top_k.cpp
+++ b/src/processor/operator/order_by/top_k.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/order_by/top_k.h"
 
 #include "binder/expression/expression_util.h"
+#include "common/system_config.h"
 #include "common/type_utils.h"
 #include "function/binary_function_executor.h"
 #include "function/comparison/comparison_functions.h"

--- a/src/processor/operator/persistent/reader/csv/driver.cpp
+++ b/src/processor/operator/persistent/reader/csv/driver.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/persistent/reader/csv/driver.h"
 
 #include "common/string_format.h"
+#include "common/system_config.h"
 #include "function/cast/functions/cast_from_string_functions.h"
 #include "processor/operator/persistent/reader/csv/parallel_csv_reader.h"
 #include "processor/operator/persistent/reader/csv/serial_csv_reader.h"

--- a/src/processor/operator/persistent/writer/parquet/parquet_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/parquet_writer.cpp
@@ -3,6 +3,7 @@
 #include "common/data_chunk/data_chunk.h"
 #include "common/exception/runtime.h"
 #include "common/file_system/virtual_file_system.h"
+#include "common/system_config.h"
 #include "main/client_context.h"
 #include "protocol/TCompactProtocol.h"
 

--- a/src/processor/operator/recursive_extend/frontier_scanner.cpp
+++ b/src/processor/operator/recursive_extend/frontier_scanner.cpp
@@ -1,5 +1,6 @@
 #include "processor/operator/recursive_extend/frontier_scanner.h"
 
+#include "common/system_config.h"
 #include "processor/operator/recursive_extend/recursive_join.h"
 
 using namespace kuzu::common;

--- a/src/processor/operator/table_scan/union_all_scan.cpp
+++ b/src/processor/operator/table_scan/union_all_scan.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/table_scan/union_all_scan.h"
 
+#include <mutex>
+
 #include "binder/expression/expression_util.h"
 #include "common/metric.h"
 

--- a/src/processor/operator/unwind.cpp
+++ b/src/processor/operator/unwind.cpp
@@ -1,5 +1,6 @@
 #include "processor/operator/unwind.h"
 
+#include "common/system_config.h"
 #include "processor/execution_context.h"
 
 using namespace kuzu::common;

--- a/src/storage/store/version_info.cpp
+++ b/src/storage/store/version_info.cpp
@@ -11,6 +11,73 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace storage {
 
+struct VectorVersionInfo {
+    enum class InsertionStatus : uint8_t { NO_INSERTED, CHECK_VERSION, ALWAYS_INSERTED };
+    // TODO(Guodong): ALWAYS_INSERTED is not added for now, but it may be useful as an optimization
+    // to mark the vector data after checkpoint is all deleted.
+    enum class DeletionStatus : uint8_t { NO_DELETED, CHECK_VERSION };
+
+    // TODO: Keep an additional same insertion/deletion field as an optimization to avoid the need
+    // of `array` if all are inserted/deleted in the same transaction.
+    // Also, avoid allocate `array` when status are NO_INSERTED and NO_DELETED.
+    // We can even consider separating the insertion and deletion into two separate Vectors.
+    std::unique_ptr<std::array<common::transaction_t, common::DEFAULT_VECTOR_CAPACITY>>
+        insertedVersions;
+    std::unique_ptr<std::array<common::transaction_t, common::DEFAULT_VECTOR_CAPACITY>>
+        deletedVersions;
+    // If all values in the Vector are inserted/deleted in the same transaction, we can use this to
+    // aovid the allocation of `array`.
+    common::transaction_t sameInsertionVersion;
+    common::transaction_t sameDeletionVersion;
+    InsertionStatus insertionStatus;
+    DeletionStatus deletionStatus;
+
+    VectorVersionInfo()
+        : sameInsertionVersion{common::INVALID_TRANSACTION},
+          sameDeletionVersion{common::INVALID_TRANSACTION},
+          insertionStatus{InsertionStatus::NO_INSERTED},
+          deletionStatus{DeletionStatus::NO_DELETED} {}
+    DELETE_COPY_DEFAULT_MOVE(VectorVersionInfo);
+
+    void append(common::transaction_t transactionID, common::row_idx_t startRow,
+        common::row_idx_t numRows);
+    bool delete_(common::transaction_t transactionID, common::row_idx_t rowIdx);
+    void setInsertCommitTS(common::transaction_t commitTS, common::row_idx_t startRow,
+        common::row_idx_t numRows);
+    void setDeleteCommitTS(common::transaction_t commitTS, common::row_idx_t startRow,
+        common::row_idx_t numRows);
+
+    void getSelVectorForScan(common::transaction_t startTS, common::transaction_t transactionID,
+        common::SelectionVector& selVector, common::row_idx_t startRow, common::row_idx_t numRows,
+        common::sel_t startOutputPos) const;
+
+    void rollbackInsertions(common::row_idx_t startRowInVector, common::row_idx_t numRows);
+    void rollbackDeletions(common::row_idx_t startRowInVector, common::row_idx_t numRows);
+
+    bool hasDeletions(const transaction::Transaction* transaction) const;
+
+    // Given startTS and transactionID, if the row is deleted to the transaction, return true.
+    bool isDeleted(common::transaction_t startTS, common::transaction_t transactionID,
+        common::row_idx_t rowIdx) const;
+    // Given startTS and transactionID, if the row is readable to the transaction, return true.
+    bool isInserted(common::transaction_t startTS, common::transaction_t transactionID,
+        common::row_idx_t rowIdx) const;
+
+    common::row_idx_t getNumDeletions(common::transaction_t startTS,
+        common::transaction_t transactionID, common::row_idx_t startRow,
+        common::length_t numRows) const;
+
+    void serialize(common::Serializer& serializer) const;
+    static std::unique_ptr<VectorVersionInfo> deSerialize(common::Deserializer& deSer);
+
+private:
+    void initInsertionVersionArray();
+    void initDeletionVersionArray();
+
+    bool isSameInsertionVersion() const;
+    bool isSameDeletionVersion() const;
+};
+
 void VectorVersionInfo::append(const transaction_t transactionID, const row_idx_t startRow,
     const row_idx_t numRows) {
     insertionStatus = InsertionStatus::CHECK_VERSION;
@@ -351,6 +418,9 @@ VectorVersionInfo* VersionInfo::getVectorVersionInfo(idx_t vectorIdx) const {
     }
     return vectorsInfo[vectorIdx].get();
 }
+
+VersionInfo::VersionInfo() = default;
+VersionInfo::~VersionInfo() = default;
 
 void VersionInfo::append(transaction_t transactionID, const row_idx_t startRow,
     const row_idx_t numRows) {

--- a/test/copy/multi_copy_test.cpp
+++ b/test/copy/multi_copy_test.cpp
@@ -4,9 +4,9 @@
 #include <fstream>
 #include <random>
 
-#include "common/constants.h"
 #include "common/file_system/local_file_system.h"
 #include "common/string_format.h"
+#include "common/system_config.h"
 #include "graph_test/graph_test.h"
 
 namespace kuzu {

--- a/test/main/system_config_test.cpp
+++ b/test/main/system_config_test.cpp
@@ -1,4 +1,5 @@
 #include "common/exception/buffer_manager.h"
+#include "common/system_config.h"
 #include "main_test_helper/main_test_helper.h"
 
 using namespace kuzu::common;

--- a/test/storage/node_insertion_deletion_test.cpp
+++ b/test/storage/node_insertion_deletion_test.cpp
@@ -1,4 +1,5 @@
 #include "common/constants.h"
+#include "common/system_config.h"
 #include "graph_test/graph_test.h"
 
 using namespace kuzu::common;

--- a/test/test_runner/test_parser.cpp
+++ b/test/test_runner/test_parser.cpp
@@ -1,5 +1,6 @@
 #include "test_runner/test_parser.h"
 
+#include "common/system_config.h"
 #include "test_runner/test_group.h"
 
 #if defined(_WIN32)

--- a/tools/python_api/src_cpp/pyarrow/pyarrow_scan.cpp
+++ b/tools/python_api/src_cpp/pyarrow/pyarrow_scan.cpp
@@ -3,6 +3,7 @@
 #include "binder/binder.h"
 #include "cached_import/py_cached_import.h"
 #include "common/arrow/arrow_converter.h"
+#include "common/system_config.h"
 #include "function/cast/functions/numeric_limits.h"
 #include "function/table/bind_input.h"
 #include "processor/execution_context.h"


### PR DESCRIPTION
# Description

Follow up to https://github.com/kuzudb/kuzu/pull/4850

Reorganize includes, move stuff from header to cpp files, add forward declares to optimize recompile when system config changes. 

The main changes are:
- Remove the need to include `system_config.h` from headers, especially ones that are included everywhere such as `value_vector.h`, `sel_vector.h`, and `data_chunk_state.h`
- If the need for the constants in the headers are less simple to remove (e.g. needing a system config constant to define an member array size), try to forward-declare those classes so that the headers don't need to be included

This reduces the number of recompile steps to about 220 from 570:
![image](https://github.com/user-attachments/assets/23df6e67-ab63-4ca7-86c5-4cc0e3cb05c0)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).