### PR TITLE
Allow COPY FROM in manual transactions

### DIFF
--- a/src/include/processor/operator/partitioner.h
+++ b/src/include/processor/operator/partitioner.h
@@ -29,7 +29,7 @@ struct PartitionerFunctions {
 struct PartitioningBuffer {
     std::vector<std::unique_ptr<storage::InMemChunkedNodeGroupCollection>> partitions;
 
-    void merge(std::unique_ptr<PartitioningBuffer> localPartitioningStates) const;
+    void merge(const PartitioningBuffer& localPartitioningState) const;
 };
 
 // NOTE: Currently, Partitioner is tightly coupled with RelBatchInsert. We should generalize it
@@ -64,7 +64,7 @@ struct PartitionerSharedState {
         RelBatchInsertProgressSharedState& progressSharedState);
 
     void resetState();
-    void merge(std::vector<std::unique_ptr<PartitioningBuffer>> localPartitioningStates);
+    void merge(const std::vector<std::unique_ptr<PartitioningBuffer>>& localPartitioningStates);
 
     // Must only be called once for any given parameters.
     // The data gets moved out of the shared state since some of it may be spilled to disk and will
@@ -181,12 +181,13 @@ public:
         common::idx_t numPartitioners);
 
 private:
+    void evaluateExpressions(uint64_t numRels) const;
     common::DataChunk constructDataChunk(
         const std::shared_ptr<common::DataChunkState>& state) const;
     // TODO: For now, RelBatchInsert will guarantee all data are inside one data chunk. Should be
     //  generalized to resultSet later if needed.
     void copyDataToPartitions(storage::MemoryManager& memoryManager,
-        common::partition_idx_t partitioningIdx, common::DataChunk chunkToCopyFrom) const;
+        common::partition_idx_t partitioningIdx, const common::DataChunk& chunkToCopyFrom) const;
 
 private:
     PartitionerDataInfo dataInfo;

--- a/src/include/processor/operator/persistent/node_batch_insert.h
+++ b/src/include/processor/operator/persistent/node_batch_insert.h
@@ -138,6 +138,7 @@ public:
         std::optional<IndexBuilder>& indexBuilder, storage::MemoryManager* mm) const;
 
 private:
+    void evaluateExpressions(uint64_t numTuples) const;
     void appendIncompleteNodeGroup(transaction::Transaction* transaction,
         std::unique_ptr<storage::ChunkedNodeGroup> localNodeGroup,
         std::optional<IndexBuilder>& indexBuilder, storage::MemoryManager* mm) const;

--- a/src/include/storage/local_storage/local_hash_index.h
+++ b/src/include/storage/local_storage/local_hash_index.h
@@ -118,17 +118,21 @@ public:
             [&](auto) { KU_UNREACHABLE; });
     }
 
-    common::offset_t lookup(const common::ValueVector& keyVector, visible_func isVisible) {
-        KU_ASSERT(keyVector.state->getSelVector().getSelSize() == 1);
+    common::offset_t lookup(const common::ValueVector& keyVector, common::sel_t pos,
+        visible_func isVisible) {
         common::offset_t result = common::INVALID_OFFSET;
         common::TypeUtils::visit(
             keyDataTypeID,
-            [&]<common::IndexHashable T>(T) {
-                const auto pos = keyVector.state->getSelVector().getSelectedPositions()[0];
-                result = lookup(keyVector.getValue<T>(pos), isVisible);
-            },
+            [&]<common::IndexHashable T>(
+                T) { result = lookup(keyVector.getValue<T>(pos), isVisible); },
             [](auto) { KU_UNREACHABLE; });
         return result;
+    }
+
+    common::offset_t lookup(const common::ValueVector& keyVector, visible_func isVisible) {
+        KU_ASSERT(keyVector.state->getSelVector().getSelSize() == 1);
+        auto pos = keyVector.state->getSelVector().getSelectedPositions()[0];
+        return lookup(keyVector, pos, isVisible);
     }
 
     common::offset_t lookup(const common::ku_string_t key, visible_func isVisible) {

--- a/src/include/storage/local_storage/local_node_table.h
+++ b/src/include/storage/local_storage/local_node_table.h
@@ -42,7 +42,7 @@ public:
     NodeGroupCollection& getNodeGroups() { return nodeGroups; }
 
     bool lookupPK(const transaction::Transaction* transaction, const common::ValueVector* keyVector,
-        common::offset_t& result) const;
+        common::sel_t pos, common::offset_t& result) const;
 
     TableStats getStats() const { return nodeGroups.getStats(); }
 

--- a/src/include/storage/store/rel_table.h
+++ b/src/include/storage/store/rel_table.h
@@ -169,8 +169,7 @@ public:
     }
     common::column_id_t getNumColumns() const {
         KU_ASSERT(directedRelData.size() >= 1);
-        RUNTIME_CHECK(for (const auto& relData
-                           : directedRelData) {
+        RUNTIME_CHECK(for (const auto& relData : directedRelData) {
             KU_ASSERT(relData->getNumColumns() == directedRelData[0]->getNumColumns());
         });
         return directedRelData[0]->getNumColumns();
@@ -211,8 +210,6 @@ private:
         const row_idx_vec_t& rowIndices, common::column_id_t skippedColumn);
 
     void updateRelOffsets(const LocalRelTable& localRelTable);
-    void updateNodeOffsets(const transaction::Transaction* transaction,
-        LocalRelTable& localRelTable) const;
 
     static common::offset_t getCommittedOffset(common::offset_t uncommittedOffset,
         common::offset_t maxCommittedOffset);

--- a/src/include/storage/store/rel_table.h
+++ b/src/include/storage/store/rel_table.h
@@ -169,7 +169,8 @@ public:
     }
     common::column_id_t getNumColumns() const {
         KU_ASSERT(directedRelData.size() >= 1);
-        RUNTIME_CHECK(for (const auto& relData : directedRelData) {
+        RUNTIME_CHECK(for (const auto& relData
+                           : directedRelData) {
             KU_ASSERT(relData->getNumColumns() == directedRelData[0]->getNumColumns());
         });
         return directedRelData[0]->getNumColumns();

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -425,11 +425,6 @@ void ClientContext::validateTransaction(const PreparedStatement& preparedStateme
     if (!canExecuteWriteQuery() && !preparedStatement.isReadOnly()) {
         throw ConnectionException("Cannot execute write operations in a read-only database!");
     }
-    // TODO(Guodong): Remove this check after we support COPY FROM in manual transactions.
-    if (preparedStatement.getStatementType() == StatementType::COPY_FROM &&
-        !transactionContext->isAutoTransaction()) {
-        throw ConnectionException("COPY FROM is only supported in auto transaction mode.");
-    }
     if (preparedStatement.parsedStatement->requireTransaction() &&
         transactionContext->hasActiveTransaction()) {
         KU_ASSERT(!transactionContext->isAutoTransaction());

--- a/src/processor/operator/partitioner.cpp
+++ b/src/processor/operator/partitioner.cpp
@@ -151,7 +151,7 @@ void Partitioner::executeInternal(ExecutionContext* context) {
                 chunkToCopyFrom);
         }
     }
-    sharedState->merge(std::move(localState->partitioningBuffers));
+    sharedState->merge(localState->partitioningBuffers);
 }
 
 void Partitioner::evaluateExpressions(uint64_t numRels) const {

--- a/src/processor/operator/partitioner.cpp
+++ b/src/processor/operator/partitioner.cpp
@@ -67,7 +67,7 @@ void PartitionerSharedState::merge(
     std::unique_lock xLck{mtx};
     KU_ASSERT(partitioningBuffers.size() == localPartitioningStates.size());
     for (auto partitioningIdx = 0u; partitioningIdx < partitioningBuffers.size();
-        partitioningIdx++) {
+         partitioningIdx++) {
         partitioningBuffers[partitioningIdx]->merge(*localPartitioningStates[partitioningIdx]);
     }
 }

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -6,6 +6,7 @@
 #include "common/task_system/progress_bar.h"
 #include "processor/execution_context.h"
 #include "processor/result/factorized_table_util.h"
+#include "storage/local_storage/local_storage.h"
 #include "storage/storage_utils.h"
 #include "storage/store/column_chunk_data.h"
 #include "storage/store/rel_table.h"
@@ -47,7 +48,7 @@ void RelBatchInsert::initLocalStateInternal(ResultSet* /*resultSet_*/, Execution
     }
 }
 
-void RelBatchInsert::initGlobalStateInternal(ExecutionContext* /* context */) {
+void RelBatchInsert::initGlobalStateInternal(ExecutionContext*) {
     progressSharedState = std::make_shared<RelBatchInsertProgressSharedState>();
     progressSharedState->partitionsDone = 0;
     progressSharedState->partitionsTotal =

--- a/src/storage/local_storage/local_node_table.cpp
+++ b/src/storage/local_storage/local_node_table.cpp
@@ -125,8 +125,8 @@ void LocalNodeTable::clear() {
 }
 
 bool LocalNodeTable::lookupPK(const Transaction* transaction, const ValueVector* keyVector,
-    offset_t& result) const {
-    result = hashIndex->lookup(*keyVector,
+    sel_t pos, offset_t& result) const {
+    result = hashIndex->lookup(*keyVector, pos,
         [&](offset_t offset) { return isVisible(transaction, offset); });
     return result != INVALID_OFFSET;
 }

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -472,7 +472,6 @@ DataChunk NodeTable::constructDataChunkForPKColumn() const {
 void NodeTable::commit(Transaction* transaction, TableCatalogEntry* tableEntry,
     LocalTable* localTable) {
     auto startNodeOffset = nodeGroups->getNumTotalRows();
-    transaction->setMaxCommittedNodeOffset(tableID, startNodeOffset);
     auto& localNodeTable = localTable->cast<LocalNodeTable>();
 
     std::vector<column_id_t> columnIDsToCommit;
@@ -489,7 +488,7 @@ void NodeTable::commit(Transaction* transaction, TableCatalogEntry* tableEntry,
     // 2. Set deleted flag for tuples that are deleted in local storage.
     row_idx_t numLocalRows = 0u;
     for (auto localNodeGroupIdx = 0u; localNodeGroupIdx < localNodeTable.getNumNodeGroups();
-        localNodeGroupIdx++) {
+         localNodeGroupIdx++) {
         const auto localNodeGroup = localNodeTable.getNodeGroup(localNodeGroupIdx);
         if (localNodeGroup->hasDeletions(transaction)) {
             // TODO(Guodong): Assume local storage is small here. Should optimize the loop away by

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -489,7 +489,7 @@ void NodeTable::commit(Transaction* transaction, TableCatalogEntry* tableEntry,
     // 2. Set deleted flag for tuples that are deleted in local storage.
     row_idx_t numLocalRows = 0u;
     for (auto localNodeGroupIdx = 0u; localNodeGroupIdx < localNodeTable.getNumNodeGroups();
-         localNodeGroupIdx++) {
+        localNodeGroupIdx++) {
         const auto localNodeGroup = localNodeTable.getNodeGroup(localNodeGroupIdx);
         if (localNodeGroup->hasDeletions(transaction)) {
             // TODO(Guodong): Assume local storage is small here. Should optimize the loop away by
@@ -612,8 +612,8 @@ bool NodeTable::lookupPK(const Transaction* transaction, ValueVector* keyVector,
     if (transaction->getLocalStorage()) {
         const auto localTable = transaction->getLocalStorage()->getLocalTable(tableID,
             LocalStorage::NotExistAction::RETURN_NULL);
-        if (localTable &&
-            localTable->cast<LocalNodeTable>().lookupPK(transaction, keyVector, result)) {
+        if (localTable && localTable->cast<LocalNodeTable>().lookupPK(transaction, keyVector,
+                              vectorPos, result)) {
             return true;
         }
     }

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -415,7 +415,6 @@ void RelTable::commit(Transaction* transaction, TableCatalogEntry* tableEntry,
     }
     // Update relID in local storage.
     updateRelOffsets(localRelTable);
-    updateNodeOffsets(transaction, localRelTable);
     // For both forward and backward directions, re-org local storage into compact CSR node groups.
     auto& localNodeGroup = localRelTable.getLocalNodeGroup();
     // Scan from local node group and write to WAL.
@@ -465,51 +464,6 @@ void RelTable::updateRelOffsets(const LocalRelTable& localRelTable) {
             const auto committedRelOffset = getCommittedOffset(localRelOffset, maxCommittedOffset);
             internalIDData[rowIdx] = committedRelOffset;
             internalIDData.setTableID(tableID);
-        }
-    }
-}
-
-static void updateIndexNodeOffsets(const Transaction* transaction,
-    DirectedCSRIndex::index_t& localRelIndex, table_id_t nodeTableID) {
-    for (auto& [offset, rowIndices] : localRelIndex) {
-        if (transaction->isUnCommitted(nodeTableID, offset)) {
-            const auto committedOffset =
-                transaction->getCommittedOffsetFromUncommitted(nodeTableID, offset);
-            auto kvPair = localRelIndex.extract(offset);
-            kvPair.key() = committedOffset;
-            localRelIndex.insert(std::move(kvPair));
-        }
-    }
-}
-
-void RelTable::updateNodeOffsets(const Transaction* transaction,
-    LocalRelTable& localRelTable) const {
-    std::unordered_map<column_id_t, table_id_t> columnsToUpdate;
-    if (transaction->hasNewlyInsertedNodes(fromNodeTableID)) {
-        columnsToUpdate[LOCAL_BOUND_NODE_ID_COLUMN_ID] = fromNodeTableID;
-        updateIndexNodeOffsets(transaction, localRelTable.getCSRIndex(RelDataDirection::FWD),
-            fromNodeTableID);
-    }
-    if (transaction->hasNewlyInsertedNodes(toNodeTableID)) {
-        columnsToUpdate[LOCAL_NBR_NODE_ID_COLUMN_ID] = toNodeTableID;
-        updateIndexNodeOffsets(transaction, localRelTable.getCSRIndex(RelDataDirection::FWD),
-            toNodeTableID);
-    }
-    auto& localNodeGroup = localRelTable.getLocalNodeGroup();
-    for (auto i = 0u; i < localNodeGroup.getNumChunkedGroups(); i++) {
-        const auto chunkedGroup = localNodeGroup.getChunkedNodeGroup(i);
-        KU_ASSERT(chunkedGroup);
-        for (auto& [columnID, maxCommittedOffset] : columnsToUpdate) {
-            auto& nodeIDData =
-                chunkedGroup->getColumnChunk(columnID).getData().cast<InternalIDChunkData>();
-            for (auto rowIdx = 0u; rowIdx < nodeIDData.getNumValues(); rowIdx++) {
-                const auto localOffset = nodeIDData[rowIdx];
-                if (transaction->isUnCommitted(columnsToUpdate.at(columnID), localOffset)) {
-                    const auto committedOffset = transaction->getCommittedOffsetFromUncommitted(
-                        columnsToUpdate.at(columnID), localOffset);
-                    nodeIDData[rowIdx] = committedOffset;
-                }
-            }
         }
     }
 }

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -148,15 +148,13 @@ void RelTable::initScanState(Transaction* transaction, TableScanState& scanState
     const auto boundNodeID = relScanState.nodeIDVector->getValue<nodeID_t>(
         relScanState.nodeIDVector->state->getSelVector()[0]);
     NodeGroup* nodeGroup = nullptr;
-    if (!transaction->isUnCommitted(boundNodeID.tableID, boundNodeID.offset)) {
-        // Check if the node group idx is same as previous scan.
-        const auto nodeGroupIdx = StorageUtils::getNodeGroupIdx(boundNodeID.offset);
-        if (relScanState.nodeGroupIdx != nodeGroupIdx) {
-            // We need to re-initialize the node group scan state.
-            nodeGroup = getDirectedTableData(relScanState.direction)->getNodeGroup(nodeGroupIdx);
-        } else {
-            nodeGroup = relScanState.nodeGroup;
-        }
+    // Check if the node group idx is same as previous scan.
+    const auto nodeGroupIdx = StorageUtils::getNodeGroupIdx(boundNodeID.offset);
+    if (relScanState.nodeGroupIdx != nodeGroupIdx) {
+        // We need to re-initialize the node group scan state.
+        nodeGroup = getDirectedTableData(relScanState.direction)->getNodeGroup(nodeGroupIdx);
+    } else {
+        nodeGroup = relScanState.nodeGroup;
     }
     scanState.initState(transaction, nodeGroup);
 }

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -207,16 +207,14 @@ Transaction::~Transaction() = default;
 
 Transaction::Transaction(TransactionType transactionType, common::transaction_t ID,
     common::transaction_t startTS,
-    std::unordered_map<common::table_id_t, common::offset_t> minUncommittedNodeOffsets,
-    std::unordered_map<common::table_id_t, common::offset_t> maxCommittedNodeOffsets)
+    std::unordered_map<common::table_id_t, common::offset_t> minUncommittedNodeOffsets)
     : type{transactionType}, ID{ID}, startTS{startTS}, commitTS{common::INVALID_TRANSACTION},
       currentTS{INT64_MAX}, clientContext{nullptr}, undoBuffer{nullptr}, forceCheckpoint{false},
-      hasCatalogChanges{false}, minUncommittedNodeOffsets{std::move(minUncommittedNodeOffsets)},
-      maxCommittedNodeOffsets{std::move(maxCommittedNodeOffsets)} {}
+      hasCatalogChanges{false}, minUncommittedNodeOffsets{std::move(minUncommittedNodeOffsets)} {}
 
 Transaction Transaction::getDummyTransactionFromExistingOne(const Transaction& other) {
     return Transaction(TransactionType::DUMMY, DUMMY_TRANSACTION_ID, DUMMY_START_TIMESTAMP,
-        other.minUncommittedNodeOffsets, other.maxCommittedNodeOffsets);
+        other.minUncommittedNodeOffsets);
 }
 
 Transaction DUMMY_TRANSACTION = Transaction(TransactionType::DUMMY);

--- a/test/test_files/transaction/copy/copy_node.test
+++ b/test/test_files/transaction/copy/copy_node.test
@@ -15,17 +15,7 @@ Copy exception: Found duplicated primary key value \w+, which violates the uniqu
 ---- 1
 36.95.74.186
 
--CASE CopyNodeManualTransactionCheck
--STATEMENT BEGIN TRANSACTION;
----- ok
--STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
----- ok
--STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv"
----- error
-Connection exception: COPY FROM is only supported in auto transaction mode.
-
--CASE CopyNodeCommit
--SKIP
+-CASE CreateTableCopyNodeCommit
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
@@ -45,8 +35,19 @@ Connection exception: COPY FROM is only supported in auto transaction mode.
 35
 45
 
--CASE CopyNodeCommitRecovery
--SKIP
+-CASE CreateTableCopyNodeRollback
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv"
+---- ok
+-STATEMENT ROLLBACK;
+---- ok
+-STATEMENT CALL show_tables() RETURN *;
+---- 0
+
+-CASE CreateTableCopyNodeCommitRecovery
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
@@ -66,6 +67,21 @@ Connection exception: COPY FROM is only supported in auto transaction mode.
 30
 35
 45
+
+-CASE CreateTableCopyNodeRollbackRecovery
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv"
+---- ok
+-STATEMENT ROLLBACK;
+---- ok
+-STATEMENT CALL show_tables() RETURN *;
+---- 0
+-RELOADDB
+-STATEMENT CALL show_tables() RETURN *;
+---- 0
 
 -CASE CopyNodeRollbackDueToError
 -STATEMENT CREATE NODE TABLE person (ID INT64, name STRING, PRIMARY KEY (ID));
@@ -233,3 +249,190 @@ Copy exception: Found duplicated primary key value 0, which violates the uniquen
 -STATEMENT MATCH (p:person) return count(*);
 ---- 1
 0
+
+-CASE InsertAndCopyCommit
+-STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT CREATE (p:person {ID: 100000});
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv";
+---- ok
+-STATEMENT MATCH (p:person) RETURN COUNT(*);
+---- 1
+6
+-STATEMENT COMMIT;
+---- ok
+-STATEMENT MATCH (p:person) RETURN p.ID;
+---- 6
+0
+2
+3
+5
+7
+100000
+
+-CASE InsertAndCopyRollback
+-STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT CREATE (p:person {ID: 100000});
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv";
+---- ok
+-STATEMENT MATCH (p:person) RETURN COUNT(*);
+---- 1
+6
+-STATEMENT ROLLBACK;
+---- ok
+-STATEMENT MATCH (p:person) RETURN COUNT(*);
+---- 1
+0
+
+-CASE InsertAndCopyCommitRecovery
+-STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT CREATE (p:person {ID: 100000});
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv";
+---- ok
+-STATEMENT MATCH (p:person) RETURN COUNT(*);
+---- 1
+6
+-STATEMENT COMMIT;
+---- ok
+-STATEMENT MATCH (p:person) RETURN p.ID;
+---- 6
+0
+2
+3
+5
+7
+100000
+-RELOADDB
+-STATEMENT MATCH (p:person) RETURN p.ID;
+---- 6
+0
+2
+3
+5
+7
+100000
+
+-CASE InsertAndCopyRollbackRecovery
+-STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT CREATE (p:person {ID: 100000});
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv";
+---- ok
+-STATEMENT MATCH (p:person) RETURN COUNT(*);
+---- 1
+6
+-STATEMENT ROLLBACK;
+---- ok
+-STATEMENT MATCH (p:person) RETURN COUNT(*);
+---- 1
+0
+-RELOADDB
+-STATEMENT MATCH (p:person) RETURN COUNT(*);
+---- 1
+0
+
+-CASE CopyAndDeleteCommit
+-STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv";
+---- ok
+-STATEMENT MATCH (p:person) WHERE p.fname='Bob' DELETE p;
+---- ok
+-STATEMENT MATCH (p:person) RETURN p.ID;
+---- 4
+0
+3
+5
+7
+-STATEMENT COMMIT;
+---- ok
+-STATEMENT MATCH (p:person) RETURN p.ID;
+---- 4
+0
+3
+5
+7
+
+-CASE CopyAndDeleteRollback
+-STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv";
+---- ok
+-STATEMENT MATCH (p:person) WHERE p.fname='Bob' DELETE p;
+---- ok
+-STATEMENT MATCH (p:person) RETURN p.ID;
+---- 4
+0
+3
+5
+7
+-STATEMENT ROLLBACK;
+---- ok
+-STATEMENT MATCH (p:person) RETURN p.ID;
+---- 0
+
+-CASE CopyAndDeleteCommitRecovery
+-STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv";
+---- ok
+-STATEMENT MATCH (p:person) WHERE p.fname='Bob' DELETE p;
+---- ok
+-STATEMENT MATCH (p:person) RETURN p.ID;
+---- 4
+0
+3
+5
+7
+-STATEMENT COMMIT;
+---- ok
+-RELOADDB
+-STATEMENT MATCH (p:person) RETURN p.ID;
+---- 4
+0
+3
+5
+7
+
+-CASE CopyAndDeleteRollbackRecovery
+-STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv";
+---- ok
+-STATEMENT MATCH (p:person) WHERE p.fname='Bob' DELETE p;
+---- ok
+-STATEMENT MATCH (p:person) RETURN p.ID;
+---- 4
+0
+3
+5
+7
+-STATEMENT ROLLBACK;
+---- ok
+-STATEMENT MATCH (p:person) RETURN p.ID;
+---- 0
+-RELOADDB
+-STATEMENT MATCH (p:person) RETURN p.ID;
+---- 0

--- a/test/test_files/transaction/copy/copy_rel.test
+++ b/test/test_files/transaction/copy/copy_rel.test
@@ -2,12 +2,11 @@
 --
 
 -CASE CopyRelCommit
--SKIP
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
 ---- ok
--STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv" 
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv"
 ---- ok
 -STATEMENT create rel table knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, comments STRING[], summary STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[])), notes UNION(firstmet DATE, type INT16, comment STRING), someMap MAP(STRING, STRING), MANY_MANY);
 ---- ok
@@ -28,12 +27,11 @@
 1950-05-14
 
 -CASE CopyRelCommitRecovery
--SKIP
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
 ---- ok
--STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv" 
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv"
 ---- ok
 -STATEMENT create rel table knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, comments STRING[], summary STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[])), notes UNION(firstmet DATE, type INT16, comment STRING), someMap MAP(STRING, STRING), MANY_MANY);
 ---- ok
@@ -146,3 +144,252 @@
 2021-06-30
 2021-06-30
 2021-06-30
+
+-CASE CopyNodeAndRelCommit
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv"
+---- ok
+-STATEMENT CREATE REL TABLE knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, comments STRING[], summary STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[])), notes UNION(firstmet DATE, type INT16, comment STRING), someMap MAP(STRING, STRING), MANY_MANY);
+---- ok
+-STATEMENT MATCH (p1:person) MATCH (p2:person) WHERE p1.fname='Bob' AND p2.fname='Alice' CREATE (p1)-[e:knows]->(p2);
+---- ok
+-STATEMENT COPY knows FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv"
+---- ok
+-STATEMENT MATCH (:person)-[e:knows]->(:person) RETURN COUNT(e);
+---- 1
+7
+-STATEMENT COMMIT
+---- ok
+-STATEMENT MATCH (:person)-[e:knows]->(:person) return e.date;
+---- 7
+
+2021-06-30
+2021-06-30
+2021-06-30
+2021-06-30
+1950-05-14
+1950-05-14
+
+-CASE CopyNodeAndRelRollback
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv"
+---- ok
+-STATEMENT create rel table knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, comments STRING[], summary STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[])), notes UNION(firstmet DATE, type INT16, comment STRING), someMap MAP(STRING, STRING), MANY_MANY);
+---- ok
+-STATEMENT MATCH (p1:person) MATCH (p2:person) WHERE p1.fname='Bob' AND p2.fname='Alice' CREATE (p1)-[e:knows]->(p2);
+---- ok
+-STATEMENT COPY knows FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv"
+---- ok
+-STATEMENT MATCH (:person)-[e:knows]->(:person) RETURN COUNT(e);
+---- 1
+7
+-STATEMENT ROLLBACK
+---- ok
+-STATEMENT CALL show_tables() RETURN COUNT(*);
+---- 1
+0
+
+-CASE CopyNodeAndRelCommitRecovery
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv"
+---- ok
+-STATEMENT create rel table knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, comments STRING[], summary STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[])), notes UNION(firstmet DATE, type INT16, comment STRING), someMap MAP(STRING, STRING), MANY_MANY);
+---- ok
+-STATEMENT MATCH (p1:person) MATCH (p2:person) WHERE p1.fname='Bob' AND p2.fname='Alice' CREATE (p1)-[e:knows]->(p2);
+---- ok
+-STATEMENT COPY knows FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv"
+---- ok
+-STATEMENT MATCH (:person)-[e:knows]->(:person) RETURN COUNT(e);
+---- 1
+7
+-STATEMENT COMMIT
+---- ok
+-STATEMENT MATCH (:person)-[e:knows]->(:person) return e.date;
+---- 7
+
+2021-06-30
+2021-06-30
+2021-06-30
+2021-06-30
+1950-05-14
+1950-05-14
+-RELOADDB
+-STATEMENT MATCH (:person)-[e:knows]->(:person) return e.date;
+---- 7
+
+2021-06-30
+2021-06-30
+2021-06-30
+2021-06-30
+1950-05-14
+1950-05-14
+
+-CASE CopyNodeAndRelRollbackRecovery
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv"
+---- ok
+-STATEMENT create rel table knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, comments STRING[], summary STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[])), notes UNION(firstmet DATE, type INT16, comment STRING), someMap MAP(STRING, STRING), MANY_MANY);
+---- ok
+-STATEMENT MATCH (p1:person) MATCH (p2:person) WHERE p1.fname='Bob' AND p2.fname='Alice' CREATE (p1)-[e:knows]->(p2);
+---- ok
+-STATEMENT COPY knows FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv"
+---- ok
+-STATEMENT MATCH (:person)-[e:knows]->(:person) RETURN COUNT(e);
+---- 1
+7
+-STATEMENT ROLLBACK
+---- ok
+-STATEMENT CALL show_tables() RETURN COUNT(*);
+---- 1
+0
+-RELOADDB
+-STATEMENT CALL show_tables() RETURN COUNT(*);
+---- 1
+0
+
+-CASE CreateNodeAndCopyRelCommit
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT CREATE (p:person {id: 0, fname: 'Alice'});
+---- ok
+-STATEMENT CREATE (p:person {id: 2, fname: 'Bob'});
+---- ok
+-STATEMENT CREATE (p:person {id: 3, fname: 'Carol'});
+---- ok
+-STATEMENT CREATE (p:person {id: 5, fname: 'Dan'});
+---- ok
+-STATEMENT CREATE (p:person {id: 7, fname: 'Elizabeth'});
+---- ok
+-STATEMENT create rel table knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, comments STRING[], summary STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[])), notes UNION(firstmet DATE, type INT16, comment STRING), someMap MAP(STRING, STRING), MANY_MANY);
+---- ok
+-STATEMENT COPY knows FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv"
+---- ok
+-STATEMENT MATCH (:person)-[e:knows]->(:person) RETURN COUNT(e);
+---- 1
+6
+-STATEMENT COMMIT
+---- ok
+-STATEMENT MATCH (:person)-[e:knows]->(:person) return e.date;
+---- 6
+2021-06-30
+2021-06-30
+2021-06-30
+2021-06-30
+1950-05-14
+1950-05-14
+
+-CASE CreateNodeAndCopyRelCommitRecovery
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT CREATE (p:person {id: 0, fname: 'Alice'});
+---- ok
+-STATEMENT CREATE (p:person {id: 2, fname: 'Bob'});
+---- ok
+-STATEMENT CREATE (p:person {id: 3, fname: 'Carol'});
+---- ok
+-STATEMENT CREATE (p:person {id: 5, fname: 'Dan'});
+---- ok
+-STATEMENT CREATE (p:person {id: 7, fname: 'Elizabeth'});
+---- ok
+-STATEMENT create rel table knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, comments STRING[], summary STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[])), notes UNION(firstmet DATE, type INT16, comment STRING), someMap MAP(STRING, STRING), MANY_MANY);
+---- ok
+-STATEMENT COPY knows FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv"
+---- ok
+-STATEMENT MATCH (:person)-[e:knows]->(:person) RETURN COUNT(e);
+---- 1
+6
+-STATEMENT COMMIT
+---- ok
+-STATEMENT MATCH (:person)-[e:knows]->(:person) return e.date;
+---- 6
+2021-06-30
+2021-06-30
+2021-06-30
+2021-06-30
+1950-05-14
+1950-05-14
+-RELOADDB
+-STATEMENT MATCH (:person)-[e:knows]->(:person) return e.date;
+---- 6
+2021-06-30
+2021-06-30
+2021-06-30
+2021-06-30
+1950-05-14
+1950-05-14
+
+-CASE CreateNodeAndCopyRelRollback
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT CREATE (p:person {id: 0, fname: 'Alice'});
+---- ok
+-STATEMENT CREATE (p:person {id: 2, fname: 'Bob'});
+---- ok
+-STATEMENT CREATE (p:person {id: 3, fname: 'Carol'});
+---- ok
+-STATEMENT CREATE (p:person {id: 5, fname: 'Dan'});
+---- ok
+-STATEMENT CREATE (p:person {id: 7, fname: 'Elizabeth'});
+---- ok
+-STATEMENT create rel table knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, comments STRING[], summary STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[])), notes UNION(firstmet DATE, type INT16, comment STRING), someMap MAP(STRING, STRING), MANY_MANY);
+---- ok
+-STATEMENT COPY knows FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv"
+---- ok
+-STATEMENT MATCH (:person)-[e:knows]->(:person) RETURN COUNT(e);
+---- 1
+6
+-STATEMENT ROLLBACK
+---- ok
+-STATEMENT CALL show_tables() RETURN COUNT(*);
+---- 1
+0
+
+-CASE CreateNodeAndCopyRelRollbackRecovery
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT CREATE (p:person {id: 0, fname: 'Alice'});
+---- ok
+-STATEMENT CREATE (p:person {id: 2, fname: 'Bob'});
+---- ok
+-STATEMENT CREATE (p:person {id: 3, fname: 'Carol'});
+---- ok
+-STATEMENT CREATE (p:person {id: 5, fname: 'Dan'});
+---- ok
+-STATEMENT CREATE (p:person {id: 7, fname: 'Elizabeth'});
+---- ok
+-STATEMENT create rel table knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, comments STRING[], summary STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[])), notes UNION(firstmet DATE, type INT16, comment STRING), someMap MAP(STRING, STRING), MANY_MANY);
+---- ok
+-STATEMENT COPY knows FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv"
+---- ok
+-STATEMENT MATCH (:person)-[e:knows]->(:person) RETURN COUNT(e);
+---- 1
+6
+-STATEMENT ROLLBACK
+---- ok
+-STATEMENT CALL show_tables() RETURN COUNT(*);
+---- 1
+0
+-RELOADDB
+-STATEMENT CALL show_tables() RETURN COUNT(*);
+---- 1
+0


### PR DESCRIPTION
# Description

We had a strong constraint that a `COPY FROM` statement cannot run in manual transactions. However after #4420, we can allow this. This PR removes this restriction now.

This paves the way to make create vector/fts index running in a single transaction.