### PR TITLE
Fix extension-only build 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,8 +353,10 @@ add_definitions(-DKUZU_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}")
 add_definitions(-DKUZU_CMAKE_VERSION="${CMAKE_PROJECT_VERSION}")
 add_definitions(-DKUZU_EXTENSION_VERSION="0.8.0")
 
-include_directories(${CMAKE_BINARY_DIR}/src/include)
-include_directories(src/include)
+include_directories(
+    src/include
+    ${CMAKE_BINARY_DIR}/src/include
+)
 
 add_subdirectory(src)
 if (${BUILD_TESTS} OR ${BUILD_EXTENSION_TESTS})

--- a/extension/delta/CMakeLists.txt
+++ b/extension/delta/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(DuckDB REQUIRED)
 
 include_directories(
         ${PROJECT_SOURCE_DIR}/src/include
+        ${CMAKE_BINARY_DIR}/src/include
         src/include
         ${PROJECT_SOURCE_DIR}/extension/duckdb/src/include
         ${PROJECT_SOURCE_DIR}/extension/httpfs/src/include

--- a/extension/duckdb/CMakeLists.txt
+++ b/extension/duckdb/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(DuckDB REQUIRED)
 
 include_directories(
         ${PROJECT_SOURCE_DIR}/src/include
+        ${CMAKE_BINARY_DIR}/src/include
         ${PROJECT_SOURCE_DIR}/extension/httpfs/src/include  # For S3 configuration
         src/include
         ${DuckDB_INCLUDE_DIRS})

--- a/extension/fts/CMakeLists.txt
+++ b/extension/fts/CMakeLists.txt
@@ -1,5 +1,6 @@
 include_directories(
         ${PROJECT_SOURCE_DIR}/src/include
+        ${CMAKE_BINARY_DIR}/src/include
         src/include
         third_party/snowball/libstemmer)
 

--- a/extension/httpfs/CMakeLists.txt
+++ b/extension/httpfs/CMakeLists.txt
@@ -14,6 +14,7 @@ add_compile_definitions(CPPHTTPLIB_OPENSSL_SUPPORT)
 
 include_directories(
         ${PROJECT_SOURCE_DIR}/src/include
+        ${CMAKE_BINARY_DIR}/src/include
         ${PROJECT_SOURCE_DIR}/third_party/httplib
         src/include)
 

--- a/extension/iceberg/CMakeLists.txt
+++ b/extension/iceberg/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(DuckDB REQUIRED)
 
 include_directories(
         ${PROJECT_SOURCE_DIR}/src/include
+        ${CMAKE_BINARY_DIR}/src/include
         src/include
         ${PROJECT_SOURCE_DIR}/extension/duckdb/src/include
         ${PROJECT_SOURCE_DIR}/extension/httpfs/src/include

--- a/extension/json/CMakeLists.txt
+++ b/extension/json/CMakeLists.txt
@@ -1,6 +1,7 @@
 include_directories(
         src/include
         ${PROJECT_SOURCE_DIR}/src/include
+        ${CMAKE_BINARY_DIR}/src/include
         third_party/yyjson/src
 )
 

--- a/extension/postgres/CMakeLists.txt
+++ b/extension/postgres/CMakeLists.txt
@@ -10,6 +10,7 @@ include_directories(
         src/include
         ${PROJECT_SOURCE_DIR}/extension/duckdb/src/include
         ${DuckDB_INCLUDE_DIRS}
+        ${CMAKE_BINARY_DIR}/src/include
         ${PROJECT_SOURCE_DIR}/src/include)
 
 add_subdirectory(src/connector)

--- a/extension/sqlite/CMakeLists.txt
+++ b/extension/sqlite/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(DuckDB REQUIRED)
 
 include_directories(
         ${PROJECT_SOURCE_DIR}/src/include
+        ${CMAKE_BINARY_DIR}/src/include
         src/include
         ${PROJECT_SOURCE_DIR}/extension/duckdb/src/include
         ${DuckDB_INCLUDE_DIRS})


### PR DESCRIPTION
# Description

Explicitlty add directory including generated headers (in `${CMAKE_BINARY_DIR}/src/include`) to include directories when building extensions.

[The extension compile seems to be working now](https://github.com/kuzudb/kuzu/actions/runs/13243693404/job/36964865145)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).