### PR TITLE
Remove count from evaluator local state

### DIFF
--- a/src/expression_evaluator/expression_evaluator.cpp
+++ b/src/expression_evaluator/expression_evaluator.cpp
@@ -1,4 +1,5 @@
 #include "expression_evaluator/expression_evaluator.h"
+
 #include "common/exception/runtime.h"
 
 using namespace kuzu::common;
@@ -38,7 +39,8 @@ void ExpressionEvaluator::resolveResultStateFromChildren(
 void ExpressionEvaluator::evaluate(common::sel_t) {
     // LCOV_EXCL_START
     throw RuntimeException(stringFormat("Cannot evaluate expression {} with count. This should "
-                                        "never happen.", expression->toString()));
+                                        "never happen.",
+        expression->toString()));
     // LCOV_EXCL_STOP
 }
 

--- a/src/expression_evaluator/expression_evaluator.cpp
+++ b/src/expression_evaluator/expression_evaluator.cpp
@@ -1,4 +1,5 @@
 #include "expression_evaluator/expression_evaluator.h"
+#include "common/exception/runtime.h"
 
 using namespace kuzu::common;
 
@@ -8,7 +9,6 @@ namespace evaluator {
 void ExpressionEvaluator::init(const processor::ResultSet& resultSet,
     main::ClientContext* clientContext) {
     localState.clientContext = clientContext;
-    localState.count = 1;
     for (auto& child : children) {
         child->init(resultSet, clientContext);
     }
@@ -33,6 +33,13 @@ void ExpressionEvaluator::resolveResultStateFromChildren(
     resultVector->setState(std::make_shared<DataChunkState>());
     resultVector->state->initOriginalAndSelectedSize(1);
     resultVector->state->setToFlat();
+}
+
+void ExpressionEvaluator::evaluate(common::sel_t) {
+    // LCOV_EXCL_START
+    throw RuntimeException(stringFormat("Cannot evaluate expression {} with count. This should "
+                                        "never happen.", expression->toString()));
+    // LCOV_EXCL_STOP
 }
 
 bool ExpressionEvaluator::select(common::SelectionVector& selVector,

--- a/src/expression_evaluator/function_evaluator.cpp
+++ b/src/expression_evaluator/function_evaluator.cpp
@@ -33,7 +33,8 @@ void FunctionExpressionEvaluator::evaluate() {
 }
 
 void FunctionExpressionEvaluator::evaluate(common::sel_t count) {
-    KU_ASSERT(expression->constCast<ScalarFunctionExpression>().getFunction().name == NextValFunction::name);
+    KU_ASSERT(expression->constCast<ScalarFunctionExpression>().getFunction().name ==
+              NextValFunction::name);
     for (auto& child : children) {
         child->evaluate(count);
     }

--- a/src/expression_evaluator/literal_evaluator.cpp
+++ b/src/expression_evaluator/literal_evaluator.cpp
@@ -9,15 +9,13 @@ using namespace kuzu::main;
 namespace kuzu {
 namespace evaluator {
 
-void LiteralExpressionEvaluator::evaluate() {
-    resultVector->setState(flatState);
-    auto cnt = localState.count;
-    for (auto i = 1ul; i < cnt; i++) {
+void LiteralExpressionEvaluator::evaluate() {}
+
+void LiteralExpressionEvaluator::evaluate(sel_t count) {
+    unFlatState->getSelVectorUnsafe().setSelSize(count);
+    resultVector->setState(unFlatState);
+    for (auto i = 1ul; i < count; i++) {
         resultVector->copyFromVectorData(i, resultVector.get(), 0);
-    }
-    if (cnt > 1) {
-        unflatState->getSelVectorUnsafe().setSelSize(cnt);
-        resultVector->state = unflatState;
     }
 }
 
@@ -32,7 +30,7 @@ void LiteralExpressionEvaluator::resolveResultVector(const processor::ResultSet&
     MemoryManager* memoryManager) {
     resultVector = std::make_shared<ValueVector>(value.getDataType().copy(), memoryManager);
     flatState = DataChunkState::getSingleValueDataChunkState();
-    unflatState = std::make_shared<DataChunkState>();
+    unFlatState = std::make_shared<DataChunkState>();
     resultVector->setState(flatState);
     if (value.isNull()) {
         resultVector->setNull(0 /* pos */, true);

--- a/src/include/expression_evaluator/expression_evaluator.h
+++ b/src/include/expression_evaluator/expression_evaluator.h
@@ -8,7 +8,6 @@ namespace evaluator {
 
 struct EvaluatorLocalState {
     main::ClientContext* clientContext = nullptr;
-    uint64_t count = 0;
 };
 
 enum class EvaluatorType : uint8_t {
@@ -50,12 +49,15 @@ public:
     virtual void init(const processor::ResultSet& resultSet, main::ClientContext* clientContext);
 
     virtual void evaluate() = 0;
+    // Evaluate and duplicate result for count times. This is a fast path we implemented for
+    // bulk-insert when evaluate default values. A default value should be
+    // - a constant (after folding); or
+    // - a nextVal() function for serial column
+    virtual void evaluate(common::sel_t count);
 
     bool select(common::SelectionVector& selVector, bool shouldSetSelVectorToFiltered);
 
     virtual std::unique_ptr<ExpressionEvaluator> copy() = 0;
-
-    EvaluatorLocalState& getLocalStateUnsafe() { return localState; }
 
     template<class TARGET>
     const TARGET& constCast() const {

--- a/src/include/expression_evaluator/function_evaluator.h
+++ b/src/include/expression_evaluator/function_evaluator.h
@@ -14,6 +14,7 @@ public:
         std::vector<std::unique_ptr<ExpressionEvaluator>> children);
 
     void evaluate() override;
+    void evaluate(common::sel_t count) override;
 
     bool selectInternal(common::SelectionVector& selVector) override;
 

--- a/src/include/expression_evaluator/lambda_evaluator.h
+++ b/src/include/expression_evaluator/lambda_evaluator.h
@@ -12,6 +12,7 @@ enum class ListLambdaType : uint8_t {
     LIST_REDUCE = 2,
     DEFAULT = 3
 };
+
 class LambdaParamEvaluator : public ExpressionEvaluator {
     static constexpr EvaluatorType type_ = EvaluatorType::LAMBDA_PARAM;
 

--- a/src/include/expression_evaluator/literal_evaluator.h
+++ b/src/include/expression_evaluator/literal_evaluator.h
@@ -16,6 +16,8 @@ public:
 
     void evaluate() override;
 
+    void evaluate(common::sel_t count) override;
+
     bool selectInternal(common::SelectionVector& selVector) override;
 
     std::unique_ptr<ExpressionEvaluator> copy() override {
@@ -29,7 +31,7 @@ protected:
 private:
     common::Value value;
     std::shared_ptr<common::DataChunkState> flatState;
-    std::shared_ptr<common::DataChunkState> unflatState;
+    std::shared_ptr<common::DataChunkState> unFlatState;
 };
 
 } // namespace evaluator

--- a/src/include/function/function.h
+++ b/src/include/function/function.h
@@ -14,6 +14,7 @@ namespace function {
 struct KUZU_API FunctionBindData {
     std::vector<common::LogicalType> paramTypes;
     common::LogicalType resultType;
+    // TODO: the following two fields should be moved to FunctionLocalState.
     main::ClientContext* clientContext;
     int64_t count;
 

--- a/src/processor/operator/partitioner.cpp
+++ b/src/processor/operator/partitioner.cpp
@@ -159,8 +159,7 @@ void Partitioner::evaluateExpressions(uint64_t numRels) const {
         auto evaluator = dataInfo.columnEvaluators[i].get();
         switch (dataInfo.evaluateTypes[i]) {
         case ColumnEvaluateType::DEFAULT: {
-            evaluator->getLocalStateUnsafe().count = numRels;
-            evaluator->evaluate();
+            evaluator->evaluate(numRels);
         } break;
         default: {
             evaluator->evaluate();

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -106,9 +106,7 @@ void NodeBatchInsert::evaluateExpressions(uint64_t numTuples) const {
     for (auto i = 0u; i < nodeInfo->evaluateTypes.size(); ++i) {
         switch (nodeInfo->evaluateTypes[i]) {
         case ColumnEvaluateType::DEFAULT: {
-            auto& defaultEvaluator = nodeInfo->columnEvaluators[i];
-            defaultEvaluator->getLocalStateUnsafe().count = numTuples;
-            defaultEvaluator->evaluate();
+            nodeInfo->columnEvaluators[i]->evaluate(numTuples);
         } break;
         case ColumnEvaluateType::CAST: {
             nodeInfo->columnEvaluators[i]->evaluate();

--- a/src/storage/store/column_chunk_data.cpp
+++ b/src/storage/store/column_chunk_data.cpp
@@ -471,8 +471,7 @@ void ColumnChunkData::populateWithDefaultVal(ExpressionEvaluator& defaultEvaluat
     while (numValuesAppended < numValuesToPopulate) {
         const auto numValuesToAppend =
             std::min(DEFAULT_VECTOR_CAPACITY, numValuesToPopulate - numValuesAppended);
-        defaultEvaluator.getLocalStateUnsafe().count = numValuesToAppend;
-        defaultEvaluator.evaluate();
+        defaultEvaluator.evaluate(numValuesToAppend);
         auto resultVector = defaultEvaluator.resultVector.get();
         KU_ASSERT(resultVector->state->getSelVector().getSelSize() == numValuesToAppend);
         append(resultVector, resultVector->state->getSelVector());


### PR DESCRIPTION
# Description

This PR removes count from evaluator local state. The previous way of directly modifying an evaluator local state is way too hack. This PR instead provides a new API `evaluate(count)` specifically for this case. `evaluate(count)` is used in the following 2 cases
- evaluate constant for `count` times as default value.
- evaluate nextVal() for `count` times as default value for `SERIAL` column.
So we only implement it for the above two types of evaluator.

In the long term, we still need to
- remove `EvaluatorLocalState`. This is already doable but since it touches too many files, I will refactor with a separate PR.
- introduce `functionLocalState` and move `count` out of `FunctionBindData`

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).