### PR TITLE
Fix nested agg binding exception

### DIFF
--- a/src/binder/bind/bind_projection_clause.cpp
+++ b/src/binder/bind/bind_projection_clause.cpp
@@ -1,12 +1,12 @@
 #include "binder/binder.h"
 #include "binder/expression/expression_util.h"
+#include "binder/expression/lambda_expression.h"
 #include "binder/expression_visitor.h"
 #include "binder/query/return_with_clause/bound_return_clause.h"
 #include "binder/query/return_with_clause/bound_with_clause.h"
 #include "common/exception/binder.h"
 #include "parser/expression/parsed_property_expression.h"
 #include "parser/query/return_with_clause/with_clause.h"
-#include "binder/expression/lambda_expression.h"
 
 using namespace kuzu::common;
 using namespace kuzu::parser;
@@ -136,10 +136,8 @@ public:
     expression_vector exprs;
 
 protected:
-    void visitAggFunctionExpr(std::shared_ptr<Expression> expr) override {
-        exprs.push_back(expr);
-    }
-    void visitChildren(const Expression &expr) override {
+    void visitAggFunctionExpr(std::shared_ptr<Expression> expr) override { exprs.push_back(expr); }
+    void visitChildren(const Expression& expr) override {
         switch (expr.expressionType) {
         case ExpressionType::CASE_ELSE: {
             visitCaseExprChildren(expr);

--- a/src/include/binder/expression_visitor.h
+++ b/src/include/binder/expression_visitor.h
@@ -42,7 +42,7 @@ protected:
     virtual void visitGraphExpr(std::shared_ptr<Expression>) {}
     virtual void visitLambdaExpr(std::shared_ptr<Expression>) {}
 
-    void visitChildren(const Expression& expr);
+    virtual void visitChildren(const Expression& expr);
     void visitCaseExprChildren(const Expression& expr);
 };
 
@@ -54,19 +54,6 @@ public:
 
 protected:
     void visitSubqueryExpr(std::shared_ptr<Expression> expr) override { exprs.push_back(expr); }
-
-private:
-    expression_vector exprs;
-};
-
-class AggregateExprCollector final : public ExpressionVisitor {
-public:
-    AggregateExprCollector() {}
-
-    expression_vector getAggregates() const { return exprs; }
-
-protected:
-    void visitAggFunctionExpr(std::shared_ptr<Expression> expr) override { exprs.push_back(expr); }
 
 private:
     expression_vector exprs;

--- a/test/test_files/agg/simple.test
+++ b/test/test_files/agg/simple.test
@@ -350,6 +350,9 @@ pure ascii characters
 -STATEMENT MATCH (a:person) WITH COUNT(*) AS x RETURN SUM(x);
 ---- 1
 8
+-STATEMENT WITH SUM(1) AS x WITH SUM(x) AS y RETURN SUM(y)
+---- 1
+1
 
 -LOG SumInt8Overflow
 -STATEMENT MATCH (a:person)-[s:studyAt]->(o:organisation) RETURN SUM(10 * s.level)


### PR DESCRIPTION
# Description

We will throw exception if an aggregate is nested more than 3 levels deep even though it can be executed.