### PR TITLE
Refactor path backtrack

### DIFF
--- a/src/function/gds/output_writer.cpp
+++ b/src/function/gds/output_writer.cpp
@@ -65,11 +65,6 @@ static void addListEntry(ValueVector* vector, uint64_t length) {
     vector->setValue(0, entry);
 }
 
-static void setLength(ValueVector* vector, uint16_t length) {
-    KU_ASSERT(vector->dataType.getLogicalTypeID() == LogicalTypeID::UINT16);
-    vector->setValue<uint16_t>(0, length);
-}
-
 static ParentList* getTop(const std::vector<ParentList*>& path) {
     return path[path.size() - 1];
 }
@@ -82,63 +77,61 @@ void PathsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNo
         if (sourceNodeID == dstNodeID && info.lowerBound == 0) {
             // We still output a path from src to src if required path length is 0.
             // This case should only run for variable length joins.
-            setLength(lengthVector.get(), 0);
-            if (info.writePath) {
-                beginWritePath(0);
-            }
+            writePath({});
             fTable.append(vectors);
             // No need to check against limit number since this is the first output.
-            if (counter != nullptr) {
-                counter->increase(1);
-            }
+            updateCounterAndTerminate(counter);
         }
         return;
     }
-    setLength(lengthVector.get(), firstParent->getIter());
+    if (!info.hasNodeMask() && info.semantic == PathSemantic::WALK) {
+        dfsFast(firstParent, fTable, counter);
+        return;
+    }
+    dfsSlow(firstParent, fTable, counter);
+}
+
+void PathsOutputWriter::dfsFast(ParentList* firstParent, FactorizedTable& fTable, GDSOutputCounter* counter) {
     std::vector<ParentList*> curPath;
     curPath.push_back(firstParent);
     auto backtracking = false;
-    if (!info.hasNodeMask() && info.semantic == PathSemantic::WALK) {
-        // Fast path when there is no node predicate or semantic check
-        while (!curPath.empty()) {
-            if (context->interrupted()) {
-                throw InterruptException{};
-            }
-            auto top = curPath[curPath.size() - 1];
-            auto topNodeID = top->getNodeID();
-            if (top->getIter() == 1) {
-                writePath(curPath);
-                fTable.append(vectors);
-                if (counter != nullptr) {
-                    counter->increase(1);
-                    if (counter->exceedLimit()) {
-                        return;
-                    }
-                }
-                backtracking = true;
-            }
-            if (backtracking) {
-                auto next = getTop(curPath)->getNextPtr();
-                if (isNextViable(next, curPath)) {
-                    curPath[curPath.size() - 1] = next;
-                    if (curPath.size() == 1) {
-                        setLength(lengthVector.get(), curPath[0]->getIter());
-                    }
-                    backtracking = false;
-                } else {
-                    curPath.pop_back();
-                }
-            } else {
-                auto parent = bfsGraph.getParentListHead(topNodeID);
-                while (parent->getIter() != top->getIter() - 1) {
-                    parent = parent->getNextPtr();
-                }
-                curPath.push_back(parent);
-                backtracking = false;
-            }
+    while (!curPath.empty()) {
+        if (context->interrupted()) {
+            throw InterruptException{};
         }
-        return;
+        auto top = curPath[curPath.size() - 1];
+        auto topNodeID = top->getNodeID();
+        if (top->getIter() == 1) {
+            writePath(curPath);
+            fTable.append(vectors);
+            if (updateCounterAndTerminate(counter)) {
+                return;
+            }
+            backtracking = true;
+        }
+        if (backtracking) {
+            auto next = getTop(curPath)->getNextPtr();
+            if (isNextViable(next, curPath)) {
+                curPath[curPath.size() - 1] = next;
+                backtracking = false;
+            } else {
+                curPath.pop_back();
+            }
+        } else {
+            auto parent = bfsGraph.getParentListHead(topNodeID);
+            while (parent->getIter() != top->getIter() - 1) {
+                parent = parent->getNextPtr();
+            }
+            curPath.push_back(parent);
+            backtracking = false;
+        }
     }
+}
+
+void PathsOutputWriter::dfsSlow(kuzu::function::ParentList* firstParent, processor::FactorizedTable& fTable, processor::GDSOutputCounter* counter) {
+    std::vector<ParentList*> curPath;
+    curPath.push_back(firstParent);
+    auto backtracking = false;
     while (!curPath.empty()) {
         if (context->interrupted()) {
             throw InterruptException{};
@@ -146,11 +139,8 @@ void PathsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNo
         if (getTop(curPath)->getIter() == 1) {
             writePath(curPath);
             fTable.append(vectors);
-            if (counter != nullptr) {
-                counter->increase(1);
-                if (counter->exceedLimit()) {
-                    return;
-                }
+            if (updateCounterAndTerminate(counter)) {
+                return;
             }
             backtracking = true;
         }
@@ -168,9 +158,6 @@ void PathsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNo
                 }
                 // Next is a valid path element. Push into stack and switch to forward track.
                 curPath[curPath.size() - 1] = next;
-                if (curPath.size() == 1) {
-                    setLength(lengthVector.get(), curPath[0]->getIter());
-                }
                 backtracking = false;
                 break;
             }
@@ -195,7 +182,14 @@ void PathsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNo
             }
         }
     }
-    return;
+}
+
+bool PathsOutputWriter::updateCounterAndTerminate(GDSOutputCounter* counter) {
+    if (counter != nullptr) {
+        counter->increase(1);
+        return counter->exceedLimit();
+    }
+    return false;
 }
 
 ParentList* PathsOutputWriter::findFirstParent(offset_t dstOffset) const {
@@ -320,6 +314,11 @@ bool PathsOutputWriter::isReplaceTopAcyclic(const std::vector<ParentList*>& path
     return true;
 }
 
+static void setLength(ValueVector* vector, uint16_t length) {
+    KU_ASSERT(vector->dataType.getLogicalTypeID() == LogicalTypeID::UINT16);
+    vector->setValue<uint16_t>(0, length);
+}
+
 void PathsOutputWriter::beginWritePath(idx_t length) const {
     KU_ASSERT(info.writePath);
     addListEntry(pathNodeIDsVector.get(), length > 1 ? length - 1 : 0);
@@ -330,10 +329,14 @@ void PathsOutputWriter::beginWritePath(idx_t length) const {
 }
 
 void PathsOutputWriter::writePath(const std::vector<ParentList*>& path) const {
+    setLength(lengthVector.get(), path.size());
     if (!info.writePath) {
         return;
     }
     beginWritePath(path.size());
+    if (path.size() == 0) {
+        return;
+    }
     if (!info.flipPath) {
         // By default, write path in reverse direction because we append ParentList from dst to src.
         writePathBwd(path);

--- a/src/function/gds/output_writer.cpp
+++ b/src/function/gds/output_writer.cpp
@@ -91,7 +91,8 @@ void PathsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNo
     dfsSlow(firstParent, fTable, counter);
 }
 
-void PathsOutputWriter::dfsFast(ParentList* firstParent, FactorizedTable& fTable, GDSOutputCounter* counter) {
+void PathsOutputWriter::dfsFast(ParentList* firstParent, FactorizedTable& fTable,
+    GDSOutputCounter* counter) {
     std::vector<ParentList*> curPath;
     curPath.push_back(firstParent);
     auto backtracking = false;
@@ -128,7 +129,8 @@ void PathsOutputWriter::dfsFast(ParentList* firstParent, FactorizedTable& fTable
     }
 }
 
-void PathsOutputWriter::dfsSlow(kuzu::function::ParentList* firstParent, processor::FactorizedTable& fTable, processor::GDSOutputCounter* counter) {
+void PathsOutputWriter::dfsSlow(kuzu::function::ParentList* firstParent,
+    processor::FactorizedTable& fTable, processor::GDSOutputCounter* counter) {
     std::vector<ParentList*> curPath;
     curPath.push_back(firstParent);
     auto backtracking = false;

--- a/src/function/gds/variable_length_path.cpp
+++ b/src/function/gds/variable_length_path.cpp
@@ -61,8 +61,9 @@ struct VarLenJoinsEdgeCompute : public EdgeCompute {
             if (!parentPtrsBlock->hasSpace()) {
                 parentPtrsBlock = bfsGraph->addNewBlock();
             }
-            bfsGraph->addParent(frontierPair->getCurrentIter(), parentPtrsBlock,
-                nbrNode /* child */, boundNodeID /* parent */, edgeID, isFwd);
+            auto parent = parentPtrsBlock->reserveNext();
+            parent->store(frontierPair->getCurrentIter(), boundNodeID, edgeID, isFwd);
+            bfsGraph->addParent(parent, nbrNode.offset);
             activeNodes.push_back(nbrNode);
         });
         return activeNodes;

--- a/src/function/gds/weighted_shortest_paths.cpp
+++ b/src/function/gds/weighted_shortest_paths.cpp
@@ -99,7 +99,7 @@ template<typename T>
 class DestinationsOutputWriter : public RJOutputWriter {
 public:
     DestinationsOutputWriter(main::ClientContext* context,
-        processor::NodeOffsetMaskMap* outputNodeMask, common::nodeID_t sourceNodeID,
+        processor::NodeOffsetMaskMap* outputNodeMask, nodeID_t sourceNodeID,
         std::shared_ptr<Weights<T>> weights, const LogicalType& weightType)
         : RJOutputWriter{context, outputNodeMask, sourceNodeID}, weights{std::move(weights)} {
         weightVector = createVector(weightType, context->getMemoryManager());

--- a/src/include/function/gds/bfs_graph.h
+++ b/src/include/function/gds/bfs_graph.h
@@ -12,51 +12,39 @@ namespace function {
 // TODO(Xiyang): optimize if edgeID is not needed.
 class ParentList {
 public:
-    ParentList() = default;
-
-    void store(uint16_t iter_, common::nodeID_t nodeID, common::relID_t edgeID, bool isFwd) {
-        iter.store(iter_, std::memory_order_relaxed);
-        nodeOffset.store(nodeID.offset, std::memory_order_relaxed);
-        nodeTableID.store(nodeID.tableID, std::memory_order_relaxed);
-        edgeOffset.store(edgeID.offset, std::memory_order_relaxed);
-        edgeTableID.store(edgeID.tableID, std::memory_order_relaxed);
-        fwd_.store(isFwd, std::memory_order_relaxed);
+    void store(uint16_t iter_, common::nodeID_t nodeID_, common::relID_t edgeID_, bool isFwd_) {
+        iter = iter_;
+        nodeID = nodeID_;
+        edgeID = edgeID_;
+        isFwd = isFwd_;
     }
 
     void setNextPtr(ParentList* ptr) { next.store(ptr, std::memory_order_relaxed); }
 
     ParentList* getNextPtr() { return next.load(std::memory_order_relaxed); }
 
-    uint16_t getIter() { return iter.load(std::memory_order_relaxed); }
-
-    common::nodeID_t getNodeID() {
-        return {nodeOffset.load(std::memory_order_relaxed),
-            nodeTableID.load(std::memory_order_relaxed)};
+    uint16_t getIter() const { return iter; }
+    common::nodeID_t getNodeID() const {
+        return nodeID;
     }
-    common::relID_t getEdgeID() {
-        return {edgeOffset.load(std::memory_order_relaxed),
-            edgeTableID.load(std::memory_order_relaxed)};
+    common::relID_t getEdgeID() const {
+        return edgeID;
     }
-    bool isFwdEdge() { return fwd_.load(std::memory_order_relaxed); }
+    bool isFwdEdge() const { return isFwd; }
 
 private:
     // Iteration level
-    std::atomic<uint16_t> iter;
-    // Node information
-    std::atomic<common::offset_t> nodeOffset;
-    std::atomic<common::table_id_t> nodeTableID;
-    // Edge information
-    std::atomic<common::offset_t> edgeOffset;
-    std::atomic<common::table_id_t> edgeTableID;
-    // Edge direction
-    std::atomic<bool> fwd_;
+    uint16_t iter = UINT16_MAX;
+    common::nodeID_t nodeID;
+    common::relID_t edgeID;
+    bool isFwd = true;
     // Next pointer
     std::atomic<ParentList*> next;
 };
 
 class BFSGraph {
     friend class BFSGraphInitVertexCompute;
-    static constexpr uint64_t ALL_PATHS_BLOCK_SIZE = (std::uint64_t)1 << 19;
+    static constexpr uint64_t BFS_GRAPH_BLOCK_SIZE = (std::uint64_t)1 << 19;
     // Data type that is allocated to max num nodes per node table.
     using parent_entry_t = std::atomic<ParentList*>;
 
@@ -72,9 +60,9 @@ public:
     // of memory that Ti owns and writes to.
     ObjectBlock<ParentList>* addNewBlock() {
         std::unique_lock lck{mtx};
-        auto memBlock = mm->allocateBuffer(false /* don't init to 0 */, ALL_PATHS_BLOCK_SIZE);
+        auto memBlock = mm->allocateBuffer(false /* init to 0 */, BFS_GRAPH_BLOCK_SIZE);
         blocks.push_back(
-            std::make_unique<ObjectBlock<ParentList>>(std::move(memBlock), ALL_PATHS_BLOCK_SIZE));
+            std::make_unique<ObjectBlock<ParentList>>(std::move(memBlock), BFS_GRAPH_BLOCK_SIZE));
         return blocks[blocks.size() - 1].get();
     }
 
@@ -82,37 +70,22 @@ public:
         return parentArray.getData(nodeID.tableID)[nodeID.offset].load(std::memory_order_relaxed);
     }
     ParentList* getParentListHead(common::offset_t offset) {
-        KU_ASSERT(currParentPtrs.load(std::memory_order_relaxed) != nullptr);
-        return currParentPtrs.load(std::memory_order_relaxed)[offset].load(
-            std::memory_order_relaxed);
+        return currParentPtrs[offset].load(std::memory_order_relaxed);
     }
 
-    // Warning: Make sure hasSpace has returned true on parentPtrBlock already before calling this
-    // function.
-    void addParent(uint16_t iter, ObjectBlock<ParentList>* parentListBlock,
-        common::nodeID_t childNodeID, common::nodeID_t parentNodeID, common::relID_t edgeID,
-        bool isFwd) {
-        auto parentEdgePtr = parentListBlock->reserveNext();
-        parentEdgePtr->store(iter, parentNodeID, edgeID, isFwd);
-        auto curPtr = currParentPtrs.load(std::memory_order_relaxed);
-        KU_ASSERT(curPtr != nullptr);
+    void addParent(ParentList* parentPtr, common::offset_t childNodeOffset) {
         // Since by default the parentPtr of each node is nullptr, that's what we start with.
         ParentList* expected = nullptr;
-        while (!curPtr[childNodeID.offset].compare_exchange_strong(expected, parentEdgePtr))
+        while (!currParentPtrs[childNodeOffset].compare_exchange_strong(expected, parentPtr))
             ;
-        parentEdgePtr->setNextPtr(expected);
+        parentPtr->setNextPtr(expected);
     }
 
-    // For single shortest path, we do NOT add parent if a parent has already existed.
-    void tryAddSingleParent(uint16_t iter, ObjectBlock<ParentList>* parentListBlock,
-        common::nodeID_t childNodeID, common::nodeID_t parentNodeID, common::relID_t edgeID,
-        bool isFwd) {
-        auto parentEdgePtr = parentListBlock->reserveNext();
-        parentEdgePtr->store(iter, parentNodeID, edgeID, isFwd);
-        auto curPtr = currParentPtrs.load(std::memory_order_relaxed);
+    void tryAddSingleParent(ParentList* parentPtr, common::offset_t childNodeOffset,
+        ObjectBlock<ParentList>* parentListBlock) {
         ParentList* expected = nullptr;
-        if (curPtr[childNodeID.offset].compare_exchange_strong(expected, parentEdgePtr)) {
-            parentEdgePtr->setNextPtr(expected);
+        if (currParentPtrs[childNodeOffset].compare_exchange_strong(expected, parentPtr)) {
+            parentPtr->setNextPtr(expected);
         } else {
             // Do NOT add parent and revert reserved slot.
             parentListBlock->revertLast();
@@ -120,15 +93,14 @@ public:
     }
 
     void pinTableID(common::table_id_t tableID) {
-        KU_ASSERT(parentArray.contains(tableID));
-        currParentPtrs.store(parentArray.getData(tableID), std::memory_order_relaxed);
+        currParentPtrs = parentArray.getData(tableID);
     }
 
 private:
     std::mutex mtx;
     storage::MemoryManager* mm;
     ObjectArraysMap<parent_entry_t> parentArray;
-    std::atomic<parent_entry_t*> currParentPtrs;
+    parent_entry_t* currParentPtrs = nullptr;
     std::vector<std::unique_ptr<ObjectBlock<ParentList>>> blocks;
 };
 
@@ -143,10 +115,8 @@ public:
 
     void vertexCompute(common::offset_t startOffset, common::offset_t endOffset,
         common::table_id_t) override {
-        auto array = bfsGraph.currParentPtrs.load(std::memory_order_relaxed);
-        KU_ASSERT(array != nullptr);
         for (auto i = startOffset; i < endOffset; ++i) {
-            array[i].store(nullptr);
+            bfsGraph.currParentPtrs[i].store(nullptr);
         }
     }
 
@@ -157,6 +127,8 @@ public:
 private:
     BFSGraph& bfsGraph;
 };
+
+
 
 } // namespace function
 } // namespace kuzu

--- a/src/include/function/gds/bfs_graph.h
+++ b/src/include/function/gds/bfs_graph.h
@@ -24,12 +24,8 @@ public:
     ParentList* getNextPtr() { return next.load(std::memory_order_relaxed); }
 
     uint16_t getIter() const { return iter; }
-    common::nodeID_t getNodeID() const {
-        return nodeID;
-    }
-    common::relID_t getEdgeID() const {
-        return edgeID;
-    }
+    common::nodeID_t getNodeID() const { return nodeID; }
+    common::relID_t getEdgeID() const { return edgeID; }
     bool isFwdEdge() const { return isFwd; }
 
 private:
@@ -92,9 +88,7 @@ public:
         }
     }
 
-    void pinTableID(common::table_id_t tableID) {
-        currParentPtrs = parentArray.getData(tableID);
-    }
+    void pinTableID(common::table_id_t tableID) { currParentPtrs = parentArray.getData(tableID); }
 
 private:
     std::mutex mtx;
@@ -127,8 +121,6 @@ public:
 private:
     BFSGraph& bfsGraph;
 };
-
-
 
 } // namespace function
 } // namespace kuzu

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -320,7 +320,6 @@ public:
           pathLengths{std::move(pathLengths)} {}
 
     PathLengths* getPathLengths() const { return pathLengths.get(); }
-    std::shared_ptr<PathLengths> getPathLengthsShared() const { return pathLengths; }
 
     void initSource(common::nodeID_t source) override;
 

--- a/src/include/function/gds/output_writer.h
+++ b/src/include/function/gds/output_writer.h
@@ -78,11 +78,19 @@ public:
     void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID,
         processor::GDSOutputCounter* counter) override;
 
-private:
+protected:
+    // Fast path when there is no node predicate or semantic check
+    void dfsFast(ParentList* firstParent, processor::FactorizedTable& fTable,
+        processor::GDSOutputCounter* counter);
+    void dfsSlow(ParentList* firstParent, processor::FactorizedTable& fTable,
+        processor::GDSOutputCounter* counter);
+
+    bool updateCounterAndTerminate(processor::GDSOutputCounter* counter);
+
     ParentList* findFirstParent(common::offset_t dstOffset) const;
 
     bool checkPathNodeMask(ParentList* element) const;
-
+    // Check semantics
     bool checkAppendSemantic(const std::vector<ParentList*>& path, ParentList* candidate) const;
     bool checkReplaceTopSemantic(const std::vector<ParentList*>& path, ParentList* candidate) const;
     bool isAppendTrail(const std::vector<ParentList*>& path, ParentList* candidate) const;


### PR DESCRIPTION
# Description

- Remove unnecessary usage of std::atomic in BFSGraph
- Simplify `addParent` interface in `BFSGraph`, the construction of parent object can be done in each edge compute.
- Extract path backtracking logic in `PathOutputWriter` as private functions