### PR TITLE
Sparse in-mem HNSW graph

### DIFF
--- a/src/include/storage/index/hnsw_config.h
+++ b/src/include/storage/index/hnsw_config.h
@@ -11,7 +11,7 @@ enum class DistFuncType : uint8_t { Cosine = 0, L2 = 1, L2_SQUARE = 2, DotProduc
 // Max degree of the upper graph.
 struct Mu {
     static constexpr const char* NAME = "mu";
-    static constexpr common::LogicalTypeID TYPE = common::LogicalTypeID::INT64;
+    static constexpr auto TYPE = common::LogicalTypeID::INT64;
     static constexpr int64_t DEFAULT_VALUE = 30;
 
     static void validate(int64_t value);
@@ -20,7 +20,7 @@ struct Mu {
 // Max degree of the lower graph.
 struct Ml {
     static constexpr const char* NAME = "ml";
-    static constexpr common::LogicalTypeID TYPE = common::LogicalTypeID::INT64;
+    static constexpr auto TYPE = common::LogicalTypeID::INT64;
     static constexpr int64_t DEFAULT_VALUE = 60;
 
     static void validate(int64_t value);
@@ -29,7 +29,7 @@ struct Ml {
 // Percentage of nodes in the upper layer.
 struct Pu {
     static constexpr const char* NAME = "pu";
-    static constexpr common::LogicalTypeID TYPE = common::LogicalTypeID::DOUBLE;
+    static constexpr auto TYPE = common::LogicalTypeID::DOUBLE;
     static constexpr double DEFAULT_VALUE = 0.05;
 
     static void validate(double value);
@@ -37,15 +37,15 @@ struct Pu {
 
 struct DistFunc {
     static constexpr const char* NAME = "distfunc";
-    static constexpr common::LogicalTypeID TYPE = common::LogicalTypeID::STRING;
-    static constexpr DistFuncType DEFAULT_VALUE = DistFuncType::Cosine;
+    static constexpr auto TYPE = common::LogicalTypeID::STRING;
+    static constexpr auto DEFAULT_VALUE = DistFuncType::Cosine;
 
     static void validate(const std::string& distFuncName);
 };
 
 struct Alpha {
     static constexpr const char* NAME = "alpha";
-    static constexpr common::LogicalTypeID TYPE = common::LogicalTypeID::DOUBLE;
+    static constexpr auto TYPE = common::LogicalTypeID::DOUBLE;
     static constexpr double DEFAULT_VALUE = 1.1;
 
     static void validate(double value);
@@ -53,7 +53,7 @@ struct Alpha {
 
 struct Efc {
     static constexpr const char* NAME = "efc";
-    static constexpr common::LogicalTypeID TYPE = common::LogicalTypeID::INT64;
+    static constexpr auto TYPE = common::LogicalTypeID::INT64;
     static constexpr int64_t DEFAULT_VALUE = 200;
 
     static void validate(int64_t value);
@@ -61,7 +61,7 @@ struct Efc {
 
 struct Efs {
     static constexpr const char* NAME = "efs";
-    static constexpr common::LogicalTypeID TYPE = common::LogicalTypeID::INT64;
+    static constexpr auto TYPE = common::LogicalTypeID::INT64;
     static constexpr int64_t DEFAULT_VALUE = 200;
 
     static void validate(int64_t value);

--- a/src/include/storage/index/hnsw_graph.h
+++ b/src/include/storage/index/hnsw_graph.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include "common/uniq_lock.h"
 #include "processor/operator/partitioner.h"
 #include "storage/index/hnsw_config.h"
 #include "storage/store/column_chunk_data.h"
 
 namespace kuzu {
 namespace storage {
-
 struct EmbeddingTypeInfo {
     common::LogicalType elementType;
     common::length_t dimension;
@@ -87,8 +87,133 @@ public:
     using shrink_func_t =
         std::function<void(transaction::Transaction*, common::offset_t, common::length_t)>;
 
-    InMemHNSWGraph(MemoryManager* mm, common::offset_t numNodes, common::length_t maxDegree)
-        : numNodes{numNodes}, maxDegree{maxDegree} {
+    InMemHNSWGraph(common::offset_t numNodes, common::length_t maxDegree)
+        : numNodes{numNodes}, maxDegree{maxDegree} {}
+    virtual ~InMemHNSWGraph() = default;
+
+    virtual common::offset_vec_t getNeighbors(transaction::Transaction* transaction,
+        common::offset_t nodeOffset) = 0;
+    virtual common::offset_vec_t getNeighbors(transaction::Transaction* transaction,
+        common::offset_t nodeOffset, common::length_t numNbrs) = 0;
+
+    common::length_t getMaxDegree() const { return maxDegree; }
+
+    virtual uint16_t getNumRels(common::offset_t nodeOffset) = 0;
+    // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const function.
+    virtual void setNumRels(common::offset_t nodeOffset, uint16_t length) = 0;
+    // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const function.
+    virtual uint16_t incrementNumRels(common::offset_t nodeOffset) = 0;
+    // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const function.
+    virtual void setDstNode(common::offset_t nodeOffset, common::offset_t offsetInCSRList,
+        common::offset_t dstNode) = 0;
+
+    void finalize(MemoryManager& mm,
+        const processor::PartitionerSharedState& partitionerSharedState);
+
+private:
+    void finalizeNodeGroup(MemoryManager& mm, common::node_group_idx_t nodeGroupIdx,
+        common::table_id_t srcNodeTableID, common::table_id_t dstNodeTableID,
+        common::table_id_t relTableID, InMemChunkedNodeGroupCollection& partition);
+
+    virtual common::offset_t getDstNode(common::offset_t nodeOffset,
+        common::offset_t offsetInCSRList) = 0;
+
+protected:
+    common::offset_t numNodes;
+    // Max allowed degree of a node in the graph before shrinking.
+    common::length_t maxDegree;
+
+    std::vector<common::length_t> numRelsPerNodeGroup;
+};
+
+class SparseInMemHNSWGraph final : public InMemHNSWGraph {
+public:
+    SparseInMemHNSWGraph(common::offset_t numNodes, common::length_t maxDegree);
+
+    common::offset_vec_t getNeighbors(transaction::Transaction*,
+        common::offset_t nodeOffset) override;
+    common::offset_vec_t getNeighbors(transaction::Transaction* transaction,
+        common::offset_t nodeOffset, common::length_t numNbrs) override;
+
+    uint16_t getNumRels(common::offset_t nodeOffset) override {
+        auto& partition = getPartition(nodeOffset);
+        auto lock = partition.lock();
+        return partition.getNumRels(lock, nodeOffset);
+    }
+    void setNumRels(common::offset_t nodeOffset, uint16_t length) override {
+        auto& partition = getPartition(nodeOffset);
+        auto lock = partition.lock();
+        partition.setNumRels(lock, nodeOffset, length);
+    }
+    uint16_t incrementNumRels(common::offset_t nodeOffset) override {
+        auto& partition = getPartition(nodeOffset);
+        auto lock = partition.lock();
+        return partition.incrementNumRels(lock, nodeOffset);
+    }
+    void setDstNode(common::offset_t nodeOffset, common::offset_t offsetInCSRList,
+        common::offset_t dstNode) override;
+    common::offset_t getDstNode(common::offset_t nodeOffset,
+        common::offset_t offsetInCSRList) override {
+        auto& partition = getPartition(nodeOffset);
+        auto lock = partition.lock();
+        return partition.getDstNode(lock, nodeOffset, offsetInCSRList);
+    }
+
+private:
+    static constexpr uint64_t PARTITION_SIZE = common::StorageConfig::NODE_GROUP_SIZE;
+    struct Partition {
+        common::UniqLock lock() const { return common::UniqLock{mtx}; }
+        common::offset_vec_t getNeighbors([[maybe_unused]] const common::UniqLock& lock,
+            common::offset_t nodeOffset) const {
+            KU_ASSERT(lock.isLocked());
+            return neighbors.contains(nodeOffset) ? neighbors.at(nodeOffset) :
+                                                    common::offset_vec_t{};
+        }
+        common::offset_vec_t& getNeighbors([[maybe_unused]] const common::UniqLock& lock,
+            common::offset_t nodeOffset) {
+            KU_ASSERT(lock.isLocked());
+            return neighbors.contains(nodeOffset) ? neighbors.at(nodeOffset) :
+                                                    neighbors[nodeOffset];
+        }
+        common::offset_t getDstNode([[maybe_unused]] const common::UniqLock& lock,
+            common::offset_t nodeOffset, common::offset_t offsetInCSRList) const {
+            KU_ASSERT(lock.isLocked());
+            return neighbors.contains(nodeOffset) &&
+                           neighbors.at(nodeOffset).size() > offsetInCSRList ?
+                       neighbors.at(nodeOffset)[offsetInCSRList] :
+                       common::INVALID_OFFSET;
+        }
+        uint16_t getNumRels([[maybe_unused]] const common::UniqLock& lock,
+            common::offset_t nodeOffset) const {
+            KU_ASSERT(lock.isLocked());
+            return neighbors.contains(nodeOffset) ? neighbors.at(nodeOffset).size() : 0;
+        }
+        void setNumRels([[maybe_unused]] const common::UniqLock& lock, common::offset_t nodeOffset,
+            uint16_t length) {
+            KU_ASSERT(lock.isLocked());
+            if (neighbors.contains(nodeOffset) && neighbors.at(nodeOffset).size() > length) {
+                neighbors.at(nodeOffset).resize(length);
+            }
+        }
+        uint16_t incrementNumRels([[maybe_unused]] const common::UniqLock& lock,
+            common::offset_t nodeOffset);
+
+    private:
+        mutable std::mutex mtx;
+        std::unordered_map<common::offset_t, common::offset_vec_t> neighbors;
+    };
+
+    Partition& getPartition(common::offset_t nodeOffset);
+    const Partition& getPartition(common::offset_t nodeOffset) const;
+
+private:
+    std::vector<std::unique_ptr<Partition>> partitions;
+};
+
+class DenseInMemHNSWGraph final : public InMemHNSWGraph {
+public:
+    DenseInMemHNSWGraph(MemoryManager* mm, common::offset_t numNodes, common::length_t maxDegree)
+        : InMemHNSWGraph{numNodes, maxDegree} {
         csrLengthBuffer = mm->allocateBuffer(true, numNodes * sizeof(std::atomic<uint16_t>));
         csrLengths = reinterpret_cast<std::atomic<uint16_t>*>(csrLengthBuffer->getData());
         dstNodesBuffer =
@@ -98,52 +223,42 @@ public:
     }
 
     common::offset_vec_t getNeighbors(transaction::Transaction* transaction,
-        common::offset_t nodeOffset) const;
+        common::offset_t nodeOffset) override;
     common::offset_vec_t getNeighbors(transaction::Transaction* transaction,
-        common::offset_t nodeOffset, common::length_t numNbrs) const;
+        common::offset_t nodeOffset, common::length_t numNbrs) override;
 
-    common::length_t getMaxDegree() const { return maxDegree; }
-
-    uint16_t getCSRLength(common::offset_t nodeOffset) const {
+    uint16_t getNumRels(common::offset_t nodeOffset) override {
         return csrLengths[nodeOffset].load(std::memory_order_relaxed);
     }
     // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const function.
-    void setCSRLength(common::offset_t nodeOffset, uint16_t length) {
+    void setNumRels(common::offset_t nodeOffset, uint16_t length) override {
         csrLengths[nodeOffset].store(length, std::memory_order_relaxed);
     }
     // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const function.
-    uint16_t incrementCSRLength(common::offset_t nodeOffset) {
+    uint16_t incrementNumRels(common::offset_t nodeOffset) override {
         return csrLengths[nodeOffset].fetch_add(1, std::memory_order_relaxed);
     }
     // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const function.
-    void setDstNode(common::offset_t csrOffset, common::offset_t dstNode) {
+    void setDstNode(common::offset_t nodeOffset, common::offset_t offsetInCSRList,
+        common::offset_t dstNode) override {
+        auto csrOffset = nodeOffset * maxDegree + offsetInCSRList;
         dstNodes[csrOffset].store(dstNode, std::memory_order_relaxed);
     }
-
-    void finalize(MemoryManager& mm,
-        const processor::PartitionerSharedState& partitionerSharedState);
 
 private:
     void resetCSRLengthAndDstNodes();
 
-    void finalizeNodeGroup(MemoryManager& mm, common::node_group_idx_t nodeGroupIdx,
-        common::table_id_t srcNodeTableID, common::table_id_t dstNodeTableID,
-        common::table_id_t relTableID, InMemChunkedNodeGroupCollection& partition) const;
-
-    common::offset_t getDstNode(common::offset_t csrOffset) const {
+    common::offset_t getDstNode(common::offset_t nodeOffset,
+        common::offset_t offsetInCSRList) override {
+        auto csrOffset = nodeOffset * maxDegree + offsetInCSRList;
         return dstNodes[csrOffset].load(std::memory_order_relaxed);
     }
 
 private:
-    common::offset_t numNodes;
     std::unique_ptr<MemoryBuffer> csrLengthBuffer;
     std::unique_ptr<MemoryBuffer> dstNodesBuffer;
     std::atomic<uint16_t>* csrLengths;
     std::atomic<common::offset_t>* dstNodes;
-    // Max allowed degree of a node in the graph before shrinking.
-    common::length_t maxDegree;
-
-    std::vector<common::length_t> numRelsPerNodeGroup;
 };
 
 } // namespace storage

--- a/src/include/storage/index/hnsw_index.h
+++ b/src/include/storage/index/hnsw_index.h
@@ -103,7 +103,9 @@ struct InMemHNSWLayerInfo {
 
 class InMemHNSWLayer {
 public:
-    explicit InMemHNSWLayer(MemoryManager* mm, InMemHNSWLayerInfo info);
+    enum class LayerLevel { UPPER = 0, LOWER = 1 };
+
+    explicit InMemHNSWLayer(MemoryManager* mm, InMemHNSWLayerInfo info, LayerLevel level);
     void setEntryPoint(common::offset_t offset) { entryPoint.store(offset); }
     common::offset_t getEntryPoint() const { return entryPoint.load(); }
 


### PR DESCRIPTION
# Description

Introduce `SparseInMemHNSWGraph`, which is more space-efficient, as the upper layer for `InMemHNSWIndex` during index construction.