### PR TITLE
gds: init scc computation using kosaraju's algorithm

### DIFF
--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -241,6 +241,7 @@ FunctionCollection* FunctionCollection::getFunctions() {
 
         // Algorithm functions
         ALGORITHM_FUNCTION(WeaklyConnectedComponentsFunction),
+        ALGORITHM_FUNCTION(StronglyConnectedComponentsFunction),
         ALGORITHM_FUNCTION(KCoreDecompositionFunction), ALGORITHM_FUNCTION(VarLenJoinsFunction),
         ALGORITHM_FUNCTION(AllSPDestinationsFunction), ALGORITHM_FUNCTION(AllSPPathsFunction),
         ALGORITHM_FUNCTION(SingleSPDestinationsFunction), ALGORITHM_FUNCTION(SingleSPPathsFunction),

--- a/src/function/gds/CMakeLists.txt
+++ b/src/function/gds/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(kuzu_function_algorithm
         single_shortest_paths.cpp
         variable_length_path.cpp
         weakly_connected_components.cpp
+        strongly_connected_components.cpp
         weighted_shortest_paths.cpp
         )
 

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -8,6 +8,7 @@
 #include "graph/graph.h"
 #include "graph/graph_entry.h"
 #include "main/settings.h"
+#include <iostream>
 
 using namespace kuzu::common;
 using namespace kuzu::function;
@@ -60,6 +61,7 @@ void GDSUtils::runFrontiersUntilConvergence(processor::ExecutionContext* context
     compState.edgeCompute->resetSingleThreadState();
     while (frontierPair->continueNextIter(maxIteration)) {
         frontierPair->beginNewIteration();
+        std::cout << "beginNewIteration: " << frontierPair->getCurrentIter() << std::endl;
         if (compState.outputNodeMask != nullptr && compState.outputNodeMask->enabled() &&
             compState.edgeCompute->terminate(*compState.outputNodeMask)) {
             break;

--- a/src/function/gds/strongly_connected_components.cpp
+++ b/src/function/gds/strongly_connected_components.cpp
@@ -1,0 +1,250 @@
+#include <iostream>
+#include <thread>
+#include <tuple>
+#include <vector>
+#include <format>
+
+#include "binder/binder.h"
+#include "binder/expression/expression_util.h"
+#include "common/types/types.h"
+#include "function/gds/auxiliary_state/gds_auxilary_state.h"
+#include "function/gds/gds_frontier.h"
+#include "function/gds/gds_function_collection.h"
+#include "function/gds/gds_object_manager.h"
+#include "function/gds/gds_utils.h"
+#include "function/gds/output_writer.h"
+#include "function/gds_function.h"
+#include "graph/graph.h"
+#include "processor/execution_context.h"
+#include "processor/result/factorized_table.h"
+
+using namespace std;
+using namespace kuzu::binder;
+using namespace kuzu::common;
+using namespace kuzu::processor;
+using namespace kuzu::storage;
+using namespace kuzu::graph;
+
+namespace kuzu {
+namespace function {
+
+offset_t NOT_ASSIGNED = std::numeric_limits<offset_t>::max();
+
+/// State for the SCC algorithm
+class SCCState {
+public:
+    SCCState(const table_id_map_t<offset_t>& numNodesMap, MemoryManager* mm) {
+        for (const auto& [tableID, numNodes] : numNodesMap) {
+            componentIDsMap.allocate(tableID, numNodes, mm);
+            visitsMap.allocate(tableID, numNodes, mm);
+            pinTable(tableID);
+            for (auto i = 0u; i < numNodes; ++i) {
+                visits[i].store(false, std::memory_order_relaxed);
+                componentIDs[i].store(NOT_ASSIGNED, std::memory_order_relaxed);
+            }
+        }
+    }
+
+    void pinTable(table_id_t tableID) { componentIDs = componentIDsMap.getData(tableID); 
+        visits = visitsMap.getData(tableID);}
+
+    bool updateVisit(common::offset_t offset, bool value) {
+        visits[offset].store(value, std::memory_order_relaxed);
+        return true;
+    }
+
+    bool getVisit(offset_t offset) {
+        return visits[offset].load(std::memory_order_relaxed);
+    }
+
+    bool updateComponentID(common::offset_t offset, offset_t value) {
+        componentIDs[offset].store(value, std::memory_order_relaxed);
+        return true;
+    }
+
+    offset_t getComponentID(offset_t offset) {
+        return componentIDs[offset].load(std::memory_order_relaxed);
+    }
+
+private:
+    // Pointers to current tableID's visits and componentIDs
+    std::atomic<bool>* visits = nullptr;
+    std::atomic<offset_t>* componentIDs = nullptr;
+    // State for visits and componentIDs
+    ObjectArraysMap<std::atomic<bool>> visitsMap;
+    ObjectArraysMap<std::atomic<offset_t>> componentIDsMap;
+};
+
+class SCCCompute {
+public:
+    SCCCompute(graph::Graph* graph, const table_id_map_t<offset_t>& numNodesMap,
+        SCCState& sccState)
+        : graph{graph}, sccState{sccState}, numNodesMap{numNodesMap} {};
+    ~SCCCompute() = default;
+
+    // Forward DFS
+    void visit_vertex(nodeID_t node, catalog::TableCatalogEntry* relEntry) {
+        if (sccState.getVisit(node.offset)) {
+            // Already visited
+            return;
+        };
+        sccState.updateVisit(node.offset, true);
+        auto scanState = graph->prepareRelScan(relEntry, "");
+        for (auto chunk : graph->scanFwd(node, *scanState)) {
+            chunk.forEach([&](auto nbrNodeID, auto) {
+                visit_vertex(nbrNodeID, relEntry);
+            });
+        }
+        queue.push_back(node);
+    }
+
+    // Backwards DFS
+    void assign_id(nodeID_t node, offset_t root, catalog::TableCatalogEntry* relEntry) {
+        if (sccState.getComponentID(node.offset) != NOT_ASSIGNED) {
+            // Already assigned
+            return;
+        };
+        sccState.updateComponentID(node.offset, root);
+        auto scanState = graph->prepareRelScan(relEntry, "");
+        for (auto chunk : graph->scanBwd(node, *scanState)) {
+            chunk.forEach([&](auto nbrNodeID, auto) {
+                assign_id(nbrNodeID, root, relEntry);
+            });
+        }
+    }
+
+    void compute() {
+        for (const auto& [tableID, numNodes] : numNodesMap) {
+            sccState.pinTable(tableID);
+            for (auto& [fromEntry, toEntry, relEntry] : graph->getRelFromToEntryInfos()) {
+                for (auto i = 0u; i < numNodes; ++i) {
+                    auto nodeID = nodeID_t{i, tableID};
+                    visit_vertex(nodeID, relEntry);
+                }
+                for (auto it = queue.rbegin(); it != queue.rend(); ++it) {
+                    auto node = *it;
+                    assign_id(node, node.offset, relEntry);
+                }
+            }
+        }
+    }
+
+private:
+    std::vector<nodeID_t> queue;
+    graph::Graph* graph;
+    SCCState& sccState;
+    const table_id_map_t<offset_t>& numNodesMap;
+};
+
+class SCCOutputWriter : public GDSOutputWriter {
+    public:
+        explicit SCCOutputWriter(main::ClientContext* context) : GDSOutputWriter{context} {
+            nodeIDVector = createVector(LogicalType::INTERNAL_ID(), context->getMemoryManager());
+            componentIDVector = createVector(LogicalType::UINT64(), context->getMemoryManager());
+        }
+    
+        std::unique_ptr<SCCOutputWriter> copy() const {
+            return std::make_unique<SCCOutputWriter>(context);
+        }
+    
+    public:
+        std::unique_ptr<ValueVector> nodeIDVector;
+        std::unique_ptr<ValueVector> componentIDVector;
+    };
+    
+class SCCVertexCompute : public VertexCompute {
+public:
+    SCCVertexCompute(storage::MemoryManager* mm, processor::GDSCallSharedState* sharedState,
+        std::unique_ptr<SCCOutputWriter> writer, SCCState& sccState)
+        : mm{mm}, sharedState{sharedState}, writer{std::move(writer)}, sccState{sccState} {
+        localFT = sharedState->claimLocalTable(mm);
+    }
+    ~SCCVertexCompute() override { sharedState->returnLocalTable(localFT); }
+
+    bool beginOnTable(common::table_id_t tableID) override {
+        sccState.pinTable(tableID);
+        return true;
+    }
+
+    void vertexCompute(common::offset_t startOffset, common::offset_t endOffset,
+        common::table_id_t tableID) override {
+        for (auto i = startOffset; i < endOffset; ++i) {
+            auto nodeID = nodeID_t{i, tableID};
+            writer->nodeIDVector->setValue<nodeID_t>(0, nodeID);
+            writer->componentIDVector->setValue<uint64_t>(0, sccState.getComponentID(i));
+            localFT->append(writer->vectors);
+        }
+    }
+
+    std::unique_ptr<VertexCompute> copy() override {
+        return std::make_unique<SCCVertexCompute>(mm, sharedState, writer->copy(), sccState);
+    }
+
+private:
+    storage::MemoryManager* mm;
+    processor::GDSCallSharedState* sharedState;
+    std::unique_ptr<SCCOutputWriter> writer;
+    SCCState& sccState;
+
+    processor::FactorizedTable* localFT;
+};
+    
+class StronglyConnectedComponent final : public GDSAlgorithm {
+    static constexpr char GROUP_ID_COLUMN_NAME[] = "group_id";
+    static constexpr uint8_t MAX_ITERATION = 100;
+
+public:
+    StronglyConnectedComponent() = default;
+    StronglyConnectedComponent(const StronglyConnectedComponent& other) : GDSAlgorithm{other} {}
+
+    std::vector<common::LogicalTypeID> getParameterTypeIDs() const override {
+        return std::vector<LogicalTypeID>{LogicalTypeID::ANY};
+    }
+
+    binder::expression_vector getResultColumns(
+        const function::GDSBindInput& bindInput) const override {
+        expression_vector columns;
+        auto& outputNode = bindData->getNodeOutput()->constCast<NodeExpression>();
+        columns.push_back(outputNode.getInternalID());
+        columns.push_back(
+            bindInput.binder->createVariable(GROUP_ID_COLUMN_NAME, LogicalType::INT64()));
+        return columns;
+    }
+
+    void bind(const GDSBindInput& input, main::ClientContext& context) override {
+        auto graphName = binder::ExpressionUtil::getLiteralValue<std::string>(*input.getParam(0));
+        auto graphEntry = bindGraphEntry(context, graphName);
+        auto nodeOutput = bindNodeOutput(input, graphEntry.nodeEntries);
+        bindData = std::make_unique<GDSBindData>(std::move(graphEntry), nodeOutput);
+    }
+
+    void exec(processor::ExecutionContext* context) override {
+        auto clientContext = context->clientContext;
+        auto graph = sharedState->graph.get();
+        auto numNodesMap = graph->getNumNodesMap(clientContext->getTransaction());
+        auto sccState = SCCState(numNodesMap, clientContext->getMemoryManager());
+        auto writer = std::make_unique<SCCOutputWriter>(clientContext);
+        auto vertexCompute = std::make_unique<SCCVertexCompute>(clientContext->getMemoryManager(),
+            sharedState.get(), std::move(writer), sccState);
+        auto edgeCompute = std::make_unique<SCCCompute>(graph, numNodesMap, sccState);
+        edgeCompute->compute();
+        GDSUtils::runVertexCompute(context, graph, *vertexCompute);
+        sharedState->mergeLocalTables();
+    }
+
+    std::unique_ptr<GDSAlgorithm> copy() const override {
+        return std::make_unique<StronglyConnectedComponent>(*this);
+    }
+};
+
+function_set StronglyConnectedComponentsFunction::getFunctionSet() {
+    function_set result;
+    auto algo = std::make_unique<StronglyConnectedComponent>();
+    auto function =
+        std::make_unique<GDSFunction>(name, algo->getParameterTypeIDs(), std::move(algo));
+    result.push_back(std::move(function));
+    return result;
+}
+
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/gds/gds_function_collection.h
+++ b/src/include/function/gds/gds_function_collection.h
@@ -11,6 +11,12 @@ struct WeaklyConnectedComponentsFunction {
     static function_set getFunctionSet();
 };
 
+struct StronglyConnectedComponentsFunction {
+    static constexpr const char* name = "STRONGLY_CONNECTED_COMPONENT";
+
+    static function_set getFunctionSet();
+};
+
 struct KCoreDecompositionFunction {
     static constexpr const char* name = "K_CORE_DECOMPOSITION";
 

--- a/test/test_files/function/gds/scc.test
+++ b/test/test_files/function/gds/scc.test
@@ -1,0 +1,84 @@
+-DATASET CSV empty
+
+--
+
+-CASE Scc1
+-STATEMENT CREATE NODE TABLE User(id INT64, name STRING PRIMARY KEY);
+---- ok
+-STATEMENT CREATE REL TABLE FRIEND(FROM User to User);
+---- ok
+-STATEMENT CREATE (alice:User {id: 0, name: 'Alice'}),
+            (bob:User {id: 1, name: 'Bob'}),
+            (charles:User {id: 2, name: 'Charles'}),
+            (doug:User {id: 3, name: 'Doug'}),
+            (eva:User {id: 4, name: 'Eva'}),
+            (fred:User {id: 5, name: 'Fred'}),
+            (greg:User {id: 6, name: 'Greg'}),
+            (alice)-[:FRIEND]->(bob),
+            (bob)-[:FRIEND]->(charles),
+            (charles)-[:FRIEND]->(alice),
+            (charles)-[:FRIEND]->(doug),
+            (greg)-[:FRIEND]->(eva),
+            (greg)-[:FRIEND]->(fred);
+---- ok
+-STATEMENT CALL create_project_graph('WCC', ['User'], ['FRIEND'])
+---- ok
+-STATEMENT CALL strongly_connected_component('WCC') RETURN node.name, group_id;
+---- 7
+Alice|0
+Bob|0
+Charles|0
+Doug|1
+Eva|6
+Fred|5
+Greg|4
+
+-CASE Scc12
+-STATEMENT CREATE NODE TABLE User(id INT64 PRIMARY KEY);
+---- ok
+-STATEMENT CREATE REL TABLE FRIEND(FROM User to User);
+---- ok
+-STATEMENT CREATE (u0:User {id: 0}),
+            (u1:User {id: 1}),
+            (u2:User {id: 2}),
+            (u3:User {id: 3}),
+            (u4:User {id: 4}),
+            (u5:User {id: 5}),
+            (u6:User {id: 6}),
+            (u7:User {id: 7}),
+            (u8:User {id: 8}),
+            (u9:User {id: 9}),
+            (u10:User {id: 10}),
+            (u0)-[:FRIEND]->(u1),
+            (u0)-[:FRIEND]->(u3),
+            (u1)-[:FRIEND]->(u2),
+            (u1)-[:FRIEND]->(u4),
+            (u2)-[:FRIEND]->(u0),
+            (u2)-[:FRIEND]->(u6),
+            (u3)-[:FRIEND]->(u2),
+            (u4)-[:FRIEND]->(u5),
+            (u4)-[:FRIEND]->(u6),
+            (u5)-[:FRIEND]->(u6),
+            (u5)-[:FRIEND]->(u7),
+            (u5)-[:FRIEND]->(u8),
+            (u5)-[:FRIEND]->(u9),
+            (u6)-[:FRIEND]->(u4),
+            (u7)-[:FRIEND]->(u9),
+            (u8)-[:FRIEND]->(u9),
+            (u9)-[:FRIEND]->(u8);
+---- ok
+-STATEMENT CALL create_project_graph('WCC', ['User'], ['FRIEND']);
+---- ok
+-STATEMENT CALL strongly_connected_component('WCC') RETURN node.id, group_id;
+---- 11
+0|7
+1|7
+2|7
+3|7
+4|4
+5|4
+6|4
+7|3
+8|1
+9|1
+10|0


### PR DESCRIPTION
# Description

Single-threaded implementation of SCC using [Kosaraju's_algorithm](https://en.wikipedia.org/wiki/Kosaraju's_algorithm). 

* Does not use `EdgeCompute`, but instead is directly called from `exec()`.
* Added couple of tests. Are the internals IDs assigned in a deterministic manner?

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).