### PR TITLE
Fixes the `alias` issue of `struct_pack` function

### DIFF
--- a/src/binder/bind_expression/bind_comparison_expression.cpp
+++ b/src/binder/bind_expression/bind_comparison_expression.cpp
@@ -56,7 +56,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindComparisonExpression(
     if (function->bindFunc) {
         // Resolve exec and select function if necessary
         // Only used for decimal at the moment. See `bindDecimalCompare`.
-        function->bindFunc({childrenAfterCast, function, nullptr});
+        function->bindFunc({childrenAfterCast, function, nullptr,
+            std::vector<std::string>{} /* optionalParams */});
     }
     auto bindData = std::make_unique<FunctionBindData>(LogicalType(function->returnTypeID));
     auto uniqueExpressionName =

--- a/src/binder/bind_expression/bind_function_expression.cpp
+++ b/src/binder/bind_expression/bind_function_expression.cpp
@@ -52,7 +52,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindScalarFunctionExpression(
         children.push_back(expr);
     }
     return bindScalarFunctionExpression(children, functionName,
-        parsedExpression.constCast<ParsedFunctionExpression>().getOptionalParams());
+        parsedExpression.constCast<ParsedFunctionExpression>().getOptionalArguments());
 }
 
 static std::vector<LogicalType> getTypes(const expression_vector& exprs) {
@@ -65,7 +65,7 @@ static std::vector<LogicalType> getTypes(const expression_vector& exprs) {
 
 std::shared_ptr<Expression> ExpressionBinder::bindScalarFunctionExpression(
     const expression_vector& children, const std::string& functionName,
-    std::vector<std::string> optionalParams) {
+    std::vector<std::string> optionalArguments) {
     auto catalog = context->getCatalog();
     auto transaction = context->getTransaction();
     auto childrenTypes = getTypes(children);
@@ -85,7 +85,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindScalarFunctionExpression(
     expression_vector childrenAfterCast;
     std::unique_ptr<function::FunctionBindData> bindData;
     auto bindInput =
-        ScalarBindFuncInput{children, function.get(), context, std::move(optionalParams)};
+        ScalarBindFuncInput{children, function.get(), context, std::move(optionalArguments)};
     if (functionName == CastAnyFunction::name) {
         bindData = function->bindFunc(bindInput);
         if (bindData == nullptr) { // No need to cast.

--- a/src/function/struct/struct_pack_function.cpp
+++ b/src/function/struct/struct_pack_function.cpp
@@ -13,7 +13,7 @@ static std::unique_ptr<FunctionBindData> bindFunc(const ScalarBindFuncInput& inp
         if (argument->getDataType().getLogicalTypeID() == LogicalTypeID::ANY) {
             argument->cast(LogicalType::STRING());
         }
-        fields.emplace_back(input.optionalParams[i], argument->getDataType().copy());
+        fields.emplace_back(input.optionalArguments[i], argument->getDataType().copy());
     }
     const auto resultType = LogicalType::STRUCT(std::move(fields));
     return FunctionBindData::getSimpleBindData(input.arguments, resultType);

--- a/src/function/struct/struct_pack_function.cpp
+++ b/src/function/struct/struct_pack_function.cpp
@@ -8,11 +8,12 @@ namespace function {
 
 static std::unique_ptr<FunctionBindData> bindFunc(const ScalarBindFuncInput& input) {
     std::vector<StructField> fields;
-    for (auto& argument : input.arguments) {
+    for (auto i = 0u; i < input.arguments.size(); i++) {
+        auto& argument = input.arguments[i];
         if (argument->getDataType().getLogicalTypeID() == LogicalTypeID::ANY) {
             argument->cast(LogicalType::STRING());
         }
-        fields.emplace_back(argument->getAlias(), argument->getDataType().copy());
+        fields.emplace_back(input.optionalParams[i], argument->getDataType().copy());
     }
     const auto resultType = LogicalType::STRUCT(std::move(fields));
     return FunctionBindData::getSimpleBindData(input.arguments, resultType);

--- a/src/include/binder/expression_binder.h
+++ b/src/include/binder/expression_binder.h
@@ -71,7 +71,7 @@ public:
         const parser::ParsedExpression& parsedExpression, const std::string& functionName);
     std::shared_ptr<Expression> bindScalarFunctionExpression(const expression_vector& children,
         const std::string& functionName,
-        std::vector<std::string> optionalParams = std::vector<std::string>{});
+        std::vector<std::string> optionalArguments = std::vector<std::string>{});
     std::shared_ptr<Expression> bindRewriteFunctionExpression(const parser::ParsedExpression& expr);
     std::shared_ptr<Expression> bindAggregateFunctionExpression(
         const parser::ParsedExpression& parsedExpression, const std::string& functionName,

--- a/src/include/binder/expression_binder.h
+++ b/src/include/binder/expression_binder.h
@@ -70,7 +70,8 @@ public:
     std::shared_ptr<Expression> bindScalarFunctionExpression(
         const parser::ParsedExpression& parsedExpression, const std::string& functionName);
     std::shared_ptr<Expression> bindScalarFunctionExpression(const expression_vector& children,
-        const std::string& functionName);
+        const std::string& functionName,
+        std::vector<std::string> optionalParams = std::vector<std::string>{});
     std::shared_ptr<Expression> bindRewriteFunctionExpression(const parser::ParsedExpression& expr);
     std::shared_ptr<Expression> bindAggregateFunctionExpression(
         const parser::ParsedExpression& parsedExpression, const std::string& functionName,

--- a/src/include/function/function.h
+++ b/src/include/function/function.h
@@ -47,10 +47,12 @@ struct ScalarBindFuncInput {
     const binder::expression_vector& arguments;
     Function* definition;
     main::ClientContext* context;
+    std::vector<std::string> optionalParams;
 
     ScalarBindFuncInput(const binder::expression_vector& arguments, Function* definition,
-        main::ClientContext* context)
-        : arguments{arguments}, definition{definition}, context{context} {}
+        main::ClientContext* context, std::vector<std::string> optionalParams)
+        : arguments{arguments}, definition{definition}, context{context},
+          optionalParams{std::move(optionalParams)} {}
 };
 
 using scalar_bind_func =

--- a/src/include/function/function.h
+++ b/src/include/function/function.h
@@ -47,12 +47,12 @@ struct ScalarBindFuncInput {
     const binder::expression_vector& arguments;
     Function* definition;
     main::ClientContext* context;
-    std::vector<std::string> optionalParams;
+    std::vector<std::string> optionalArguments;
 
     ScalarBindFuncInput(const binder::expression_vector& arguments, Function* definition,
-        main::ClientContext* context, std::vector<std::string> optionalParams)
+        main::ClientContext* context, std::vector<std::string> optionalArguments)
         : arguments{arguments}, definition{definition}, context{context},
-          optionalParams{std::move(optionalParams)} {}
+          optionalArguments{std::move(optionalArguments)} {}
 };
 
 using scalar_bind_func =

--- a/src/include/parser/expression/parsed_function_expression.h
+++ b/src/include/parser/expression/parsed_function_expression.h
@@ -25,11 +25,11 @@ public:
           isDistinct{isDistinct}, functionName{std::move(functionName)} {}
 
     ParsedFunctionExpression(std::string alias, std::string rawName, parsed_expr_vector children,
-        std::string functionName, bool isDistinct, std::vector<std::string> optionalParams)
+        std::string functionName, bool isDistinct, std::vector<std::string> optionalArguments)
         : ParsedExpression{expressionType_, std::move(alias), std::move(rawName),
               std::move(children)},
           isDistinct{isDistinct}, functionName{std::move(functionName)},
-          optionalParams{std::move(optionalParams)} {}
+          optionalArguments{std::move(optionalArguments)} {}
 
     ParsedFunctionExpression(std::string functionName, bool isDistinct)
         : ParsedExpression{expressionType_}, isDistinct{isDistinct},
@@ -45,18 +45,18 @@ public:
     void addChild(std::unique_ptr<ParsedExpression> child) { children.push_back(std::move(child)); }
 
     void addOptionalParams(std::string name, std::unique_ptr<ParsedExpression> child) {
-        optionalParams.push_back(std::move(name));
+        optionalArguments.push_back(std::move(name));
         children.push_back(std::move(child));
     }
 
-    std::vector<std::string> getOptionalParams() const { return optionalParams; }
+    std::vector<std::string> getOptionalArguments() const { return optionalArguments; }
 
     static std::unique_ptr<ParsedFunctionExpression> deserialize(
         common::Deserializer& deserializer);
 
     std::unique_ptr<ParsedExpression> copy() const override {
         return std::make_unique<ParsedFunctionExpression>(alias, rawName, copyVector(children),
-            functionName, isDistinct, optionalParams);
+            functionName, isDistinct, optionalArguments);
     }
 
 private:
@@ -65,7 +65,9 @@ private:
 private:
     bool isDistinct;
     std::string functionName;
-    std::vector<std::string> optionalParams;
+    // In Kuzu, function arguments must be either all required or all optional - mixing required and
+    // optional parameters in the same function is not allowed.
+    std::vector<std::string> optionalArguments;
 };
 
 } // namespace parser

--- a/src/include/parser/expression/parsed_function_expression.h
+++ b/src/include/parser/expression/parsed_function_expression.h
@@ -25,10 +25,11 @@ public:
           isDistinct{isDistinct}, functionName{std::move(functionName)} {}
 
     ParsedFunctionExpression(std::string alias, std::string rawName, parsed_expr_vector children,
-        std::string functionName, bool isDistinct)
+        std::string functionName, bool isDistinct, std::vector<std::string> optionalParams)
         : ParsedExpression{expressionType_, std::move(alias), std::move(rawName),
               std::move(children)},
-          isDistinct{isDistinct}, functionName{std::move(functionName)} {}
+          isDistinct{isDistinct}, functionName{std::move(functionName)},
+          optionalParams{std::move(optionalParams)} {}
 
     ParsedFunctionExpression(std::string functionName, bool isDistinct)
         : ParsedExpression{expressionType_}, isDistinct{isDistinct},
@@ -55,7 +56,7 @@ public:
 
     std::unique_ptr<ParsedExpression> copy() const override {
         return std::make_unique<ParsedFunctionExpression>(alias, rawName, copyVector(children),
-            functionName, isDistinct);
+            functionName, isDistinct, optionalParams);
     }
 
 private:

--- a/src/include/parser/expression/parsed_function_expression.h
+++ b/src/include/parser/expression/parsed_function_expression.h
@@ -43,6 +43,13 @@ public:
 
     void addChild(std::unique_ptr<ParsedExpression> child) { children.push_back(std::move(child)); }
 
+    void addOptionalParams(std::string name, std::unique_ptr<ParsedExpression> child) {
+        optionalParams.push_back(std::move(name));
+        children.push_back(std::move(child));
+    }
+
+    std::vector<std::string> getOptionalParams() const { return optionalParams; }
+
     static std::unique_ptr<ParsedFunctionExpression> deserialize(
         common::Deserializer& deserializer);
 
@@ -57,6 +64,7 @@ private:
 private:
     bool isDistinct;
     std::string functionName;
+    std::vector<std::string> optionalParams;
 };
 
 } // namespace parser

--- a/src/parser/transform/transform_expression.cpp
+++ b/src/parser/transform/transform_expression.cpp
@@ -445,14 +445,13 @@ std::unique_ptr<ParsedExpression> Transformer::transformStructLiteral(
         std::make_unique<ParsedFunctionExpression>(StructPackFunctions::name, ctx.getText());
     for (auto& structField : ctx.kU_StructField()) {
         auto structExpr = transformExpression(*structField->oC_Expression());
-        std::string alias;
+        std::string paramName;
         if (structField->oC_SymbolicName()) {
-            alias = transformSymbolicName(*structField->oC_SymbolicName());
+            paramName = transformSymbolicName(*structField->oC_SymbolicName());
         } else {
-            alias = transformStringLiteral(*structField->StringLiteral());
+            paramName = transformStringLiteral(*structField->StringLiteral());
         }
-        structExpr->setAlias(alias);
-        structPack->addChild(std::move(structExpr));
+        structPack->addOptionalParams(std::move(paramName), std::move(structExpr));
     }
     return structPack;
 }

--- a/src/parser/transform/transform_expression.cpp
+++ b/src/parser/transform/transform_expression.cpp
@@ -493,7 +493,15 @@ std::unique_ptr<ParsedExpression> Transformer::transformFunctionInvocation(
         }
     } else {
         for (auto& functionParameter : ctx.kU_FunctionParameter()) {
-            expression->addChild(transformFunctionParameterExpression(*functionParameter));
+            auto parsedFunctionParameter = transformFunctionParameterExpression(*functionParameter);
+            if (functionParameter->oC_SymbolicName()) {
+                // Optional parameter
+                expression->addOptionalParams(
+                    transformSymbolicName(*functionParameter->oC_SymbolicName()),
+                    std::move(parsedFunctionParameter));
+            } else {
+                expression->addChild(std::move(parsedFunctionParameter));
+            }
         }
     }
     return expression;

--- a/test/test_files/agg/simple.test
+++ b/test/test_files/agg/simple.test
@@ -354,6 +354,10 @@ pure ascii characters
 ---- 1
 1
 
+-STATEMENT with count(5) as x return count({y: x});
+---- 1
+1
+
 -LOG SumInt8Overflow
 -STATEMENT MATCH (a:person)-[s:studyAt]->(o:organisation) RETURN SUM(10 * s.level)
 ---- 1

--- a/test/test_files/function/struct.test
+++ b/test/test_files/function/struct.test
@@ -87,3 +87,8 @@ C
 [date,meetTime,validInterval,comments,summary,notes,someMap,location,times,data]
 [date,meetTime,validInterval,comments,summary,notes,someMap,location,times,data]
 [date,meetTime,validInterval,comments,summary,notes,someMap,location,times,data]
+
+-LOG StructPackWithOptionalParam
+-STATEMENT RETURN STRUCT_PACK(x:=2,y:=3);
+---- 1
+{x: 2, y: 3}

--- a/test/test_files/tck/expressions/boolean/Boolean1.test
+++ b/test/test_files/tck/expressions/boolean/Boolean1.test
@@ -204,7 +204,7 @@ Binder exception: Expression LIST_CREATION() has data type INT64[] but expected 
 
 -STATEMENT RETURN {x: []} AND true;
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(LIST_CREATION()) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN false AND 123;
 ---- error
@@ -236,7 +236,7 @@ Binder exception: Expression LIST_CREATION() has data type INT64[] but expected 
 
 -STATEMENT RETURN false AND {x: []};
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(LIST_CREATION()) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN 123 AND 'foo';
 ---- error
@@ -256,4 +256,4 @@ Binder exception: Expression LIST_CREATION(True) has data type BOOL[] but expect
 
 -STATEMENT RETURN {x: []} AND [123];
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(LIST_CREATION()) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.

--- a/test/test_files/tck/expressions/boolean/Boolean2.test
+++ b/test/test_files/tck/expressions/boolean/Boolean2.test
@@ -202,7 +202,7 @@ Binder exception: Expression LIST_CREATION() has data type INT64[] but expected 
 
 -STATEMENT RETURN {x: []} OR true;
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(LIST_CREATION()) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN false OR 123;
 ---- error
@@ -234,7 +234,7 @@ Binder exception: Expression LIST_CREATION() has data type INT64[] but expected 
 
 -STATEMENT RETURN false OR {x: []};
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(LIST_CREATION()) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN 123 OR 'foo';
 ---- error
@@ -254,4 +254,4 @@ Binder exception: Expression LIST_CREATION(True) has data type BOOL[] but expect
 
 -STATEMENT RETURN {x: []} OR [123];
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(LIST_CREATION()) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.

--- a/test/test_files/tck/expressions/boolean/Boolean3.test
+++ b/test/test_files/tck/expressions/boolean/Boolean3.test
@@ -201,7 +201,7 @@ Binder exception: Expression LIST_CREATION() has data type INT64[] but expected 
 
 -STATEMENT RETURN {x: []} XOR true;
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(LIST_CREATION()) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN false XOR 123;
 ---- error
@@ -233,7 +233,7 @@ Binder exception: Expression LIST_CREATION() has data type INT64[] but expected 
 
 -STATEMENT RETURN false XOR {x: []};
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(LIST_CREATION()) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN 123 XOR 'foo';
 ---- error
@@ -253,4 +253,4 @@ Binder exception: Expression LIST_CREATION(True) has data type BOOL[] but expect
 
 -STATEMENT RETURN {x: []} XOR [123];
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(LIST_CREATION()) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.


### PR DESCRIPTION
We used to set the `alias` of `struct-pack` function parameters as their field names.
E.g. `{'x': y}` => We set the alias of `y` as x
This causes a bug in nested aggregation:
```
with count(5) as x return count({y: x});
```

This PR fixes it by introducing the optionalParams field in the functionExpression