### PR TITLE
Clean update info during node group checkpoint

### DIFF
--- a/src/storage/store/node_group.cpp
+++ b/src/storage/store/node_group.cpp
@@ -445,6 +445,7 @@ std::unique_ptr<ChunkedNodeGroup> NodeGroup::checkpointInMemAndOnDisk(MemoryMana
         std::make_unique<ChunkedNodeGroup>(*chunkedGroups.getGroup(lock, 0), state.columnIDs);
     KU_ASSERT(checkpointedChunkedGroup->getResidencyState() == ResidencyState::ON_DISK);
     checkpointedChunkedGroup->resetNumRowsFromChunks();
+    checkpointedChunkedGroup->resetVersionAndUpdateInfo();
     return checkpointedChunkedGroup;
 }
 

--- a/src/storage/store/update_info.cpp
+++ b/src/storage/store/update_info.cpp
@@ -4,7 +4,6 @@
 
 #include "common/exception/runtime.h"
 #include "common/vector/value_vector.h"
-#include "storage/buffer_manager/memory_manager.h"
 #include "storage/storage_utils.h"
 #include "storage/store/column_chunk_data.h"
 #include "transaction/transaction.h"

--- a/test/storage/node_update_test.cpp
+++ b/test/storage/node_update_test.cpp
@@ -14,9 +14,10 @@ protected:
 };
 
 TEST_F(NodeUpdateTest, UpdateSameRow) {
-    ASSERT_TRUE(conn->query("CREATE NODE TABLE IF NOT EXISTS Product (item STRING, price INT64, "
-                            "PRIMARY KEY (item))")
-                    ->isSuccess());
+    ASSERT_TRUE(
+        conn->query("CREATE NODE TABLE IF NOT EXISTS Product (item STRING, price INT64, "
+                    "PRIMARY KEY (item))")
+            ->isSuccess());
     ASSERT_TRUE(conn->query("CREATE (n:Product {item: 'watch'}) SET n.price = 100")->isSuccess());
     ASSERT_TRUE(
         conn->query("MATCH (n:Product) WHERE n.item = 'watch' SET n.price = 200")->isSuccess());
@@ -25,6 +26,18 @@ TEST_F(NodeUpdateTest, UpdateSameRow) {
     const auto res = conn->query("MATCH (n:Product) RETURN n.price");
     ASSERT_TRUE(res->isSuccess() && res->hasNext());
     ASSERT_EQ(res->getNext()->getValue(0)->val.int64Val, 300);
+}
+
+TEST_F(NodeUpdateTest, UpdateSameRowRedundtanly) {
+    ASSERT_TRUE(
+        conn->query("CREATE NODE TABLE test (id SERIAL PRIMARY KEY, name STRING, prop STRING);")
+            ->isSuccess());
+    for (auto i = 0u; i < 100; i++) {
+        ASSERT_TRUE(
+            conn->query("MERGE (s:test {name: 'chunkFileNames'}) ON MATCH SET "
+                        "s.prop=lpad('sss', 1000000, 'x');")
+                ->isSuccess());
+    }
 }
 
 } // namespace testing

--- a/test/storage/node_update_test.cpp
+++ b/test/storage/node_update_test.cpp
@@ -14,10 +14,9 @@ protected:
 };
 
 TEST_F(NodeUpdateTest, UpdateSameRow) {
-    ASSERT_TRUE(
-        conn->query("CREATE NODE TABLE IF NOT EXISTS Product (item STRING, price INT64, "
-                    "PRIMARY KEY (item))")
-            ->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE NODE TABLE IF NOT EXISTS Product (item STRING, price INT64, "
+                            "PRIMARY KEY (item))")
+                    ->isSuccess());
     ASSERT_TRUE(conn->query("CREATE (n:Product {item: 'watch'}) SET n.price = 100")->isSuccess());
     ASSERT_TRUE(
         conn->query("MATCH (n:Product) WHERE n.item = 'watch' SET n.price = 200")->isSuccess());
@@ -33,10 +32,9 @@ TEST_F(NodeUpdateTest, UpdateSameRowRedundtanly) {
         conn->query("CREATE NODE TABLE test (id SERIAL PRIMARY KEY, name STRING, prop STRING);")
             ->isSuccess());
     for (auto i = 0u; i < 100; i++) {
-        ASSERT_TRUE(
-            conn->query("MERGE (s:test {name: 'chunkFileNames'}) ON MATCH SET "
-                        "s.prop=lpad('sss', 1000000, 'x');")
-                ->isSuccess());
+        ASSERT_TRUE(conn->query("MERGE (s:test {name: 'chunkFileNames'}) ON MATCH SET "
+                                "s.prop=lpad('sss', 1000000, 'x');")
+                        ->isSuccess());
     }
 }
 


### PR DESCRIPTION
# Description

Fix the clearing of versioned update info chain during checkpointing. This fixed the problem of accumulated updates leading to OOM due to that the update info are not cleared during checkpoint.