### PR TITLE
Fix export/import database

### DIFF
--- a/src/binder/bind/bind_export_database.cpp
+++ b/src/binder/bind/bind_export_database.cpp
@@ -34,7 +34,7 @@ static std::vector<ExportedTableData> getExportInfo(const Catalog& catalog,
 }
 
 FileTypeInfo getFileType(case_insensitive_map_t<Value>& options) {
-    auto fileTypeInfo = FileTypeInfo{FileType::CSV, "CSV"};
+    auto fileTypeInfo = FileTypeInfo{FileType::PARQUET, "PARQUET"};
     if (options.contains("FORMAT")) {
         auto value = options.at("FORMAT");
         if (value.getDataType().getLogicalTypeID() != LogicalTypeID::STRING) {
@@ -49,7 +49,7 @@ FileTypeInfo getFileType(case_insensitive_map_t<Value>& options) {
 }
 
 static void bindExportNodeTableDataQuery(const TableCatalogEntry& entry, std::string& exportQuery) {
-    exportQuery = stringFormat("match (a:{}) return a.*", entry.getName());
+    exportQuery = stringFormat("match (a:`{}`) return a.*", entry.getName());
 }
 
 static void bindExportRelTableDataQuery(const TableCatalogEntry& entry, std::string& exportQuery,
@@ -59,7 +59,7 @@ static void bindExportRelTableDataQuery(const TableCatalogEntry& entry, std::str
                               ->constCast<NodeTableCatalogEntry>();
     auto& dstTableEntry = catalog.getTableCatalogEntry(transaction, relTableEntry->getDstTableID())
                               ->constCast<NodeTableCatalogEntry>();
-    exportQuery = stringFormat("match (a:{})-[r:{}]->(b:{}) return a.{},b.{},r.*;",
+    exportQuery = stringFormat("match (a:`{}`)-[r:`{}`]->(b:`{}`) return a.{},b.{},r.*;",
         srcTableEntry.getName(), relTableEntry->getName(), dstTableEntry.getName(),
         srcTableEntry.getPrimaryKeyName(), dstTableEntry.getPrimaryKeyName());
 }

--- a/src/binder/bind/bind_import_database.cpp
+++ b/src/binder/bind/bind_import_database.cpp
@@ -91,8 +91,9 @@ std::unique_ptr<BoundStatement> Binder::bindImportDatabaseClause(const Statement
             if (fileTypeInfo.fileType == FileType::CSV) {
                 auto csvConfig = CSVReaderConfig::construct(
                     bindParsingOptions(copyFromStatement.getParsingOptions()));
-                query = stringFormat("COPY `{}` {} FROM \"{}\" {};", copyFromStatement.getTableName(),
-                    columnNames, copyFilePath, csvConfig.option.toCypher());
+                query =
+                    stringFormat("COPY `{}` {} FROM \"{}\" {};", copyFromStatement.getTableName(),
+                        columnNames, copyFilePath, csvConfig.option.toCypher());
             } else {
                 query = stringFormat("COPY `{}` {} FROM \"{}\";", copyFromStatement.getTableName(),
                     columnNames, copyFilePath);

--- a/src/binder/bind/bind_import_database.cpp
+++ b/src/binder/bind/bind_import_database.cpp
@@ -91,10 +91,10 @@ std::unique_ptr<BoundStatement> Binder::bindImportDatabaseClause(const Statement
             if (fileTypeInfo.fileType == FileType::CSV) {
                 auto csvConfig = CSVReaderConfig::construct(
                     bindParsingOptions(copyFromStatement.getParsingOptions()));
-                query = stringFormat("COPY {} {} FROM \"{}\" {};", copyFromStatement.getTableName(),
+                query = stringFormat("COPY `{}` {} FROM \"{}\" {};", copyFromStatement.getTableName(),
                     columnNames, copyFilePath, csvConfig.option.toCypher());
             } else {
-                query = stringFormat("COPY {} {} FROM \"{}\";", copyFromStatement.getTableName(),
+                query = stringFormat("COPY `{}` {} FROM \"{}\";", copyFromStatement.getTableName(),
                     columnNames, copyFilePath);
             }
             finalQueryStatements += query;

--- a/src/catalog/catalog_entry/node_table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/node_table_catalog_entry.cpp
@@ -51,7 +51,7 @@ std::unique_ptr<NodeTableCatalogEntry> NodeTableCatalogEntry::deserialize(
 }
 
 std::string NodeTableCatalogEntry::toCypher(main::ClientContext* /*clientContext*/) const {
-    return common::stringFormat("CREATE NODE TABLE {} ({} PRIMARY KEY({}));", getName(),
+    return common::stringFormat("CREATE NODE TABLE `{}` ({} PRIMARY KEY({}));", getName(),
         propertyCollection.toCypher(), primaryKeyName);
 }
 

--- a/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
@@ -100,7 +100,7 @@ std::string RelGroupCatalogEntry::toCypher(ClientContext* context) const {
     auto catalog = context->getCatalog();
     auto transaction = context->getTransaction();
     std::stringstream ss;
-    ss << stringFormat("CREATE REL TABLE {} (", getName());
+    ss << stringFormat("CREATE REL TABLE `{}` (", getName());
     KU_ASSERT(!relTableIDs.empty());
     ss << getFromToStr(relTableIDs[0], catalog, transaction);
     for (auto i = 1u; i < relTableIDs.size(); ++i) {

--- a/src/catalog/catalog_entry/rel_table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_table_catalog_entry.cpp
@@ -130,7 +130,7 @@ std::string RelTableCatalogEntry::toCypher(main::ClientContext* clientContext) c
     auto srcTableName = catalog->getTableCatalogEntry(transaction, srcTableID)->getName();
     auto dstTableName = catalog->getTableCatalogEntry(transaction, dstTableID)->getName();
     std::string tableInfo =
-        stringFormat("CREATE REL TABLE {} (FROM {} TO {}, ", getName(), srcTableName, dstTableName);
+        stringFormat("CREATE REL TABLE `{}` (FROM {} TO {}, ", getName(), srcTableName, dstTableName);
     ss << tableInfo << propertiesToCypher() << getMultiplicityStr() << ");";
     return ss.str();
 }

--- a/src/catalog/catalog_entry/rel_table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_table_catalog_entry.cpp
@@ -129,8 +129,8 @@ std::string RelTableCatalogEntry::toCypher(main::ClientContext* clientContext) c
     auto transaction = clientContext->getTransaction();
     auto srcTableName = catalog->getTableCatalogEntry(transaction, srcTableID)->getName();
     auto dstTableName = catalog->getTableCatalogEntry(transaction, dstTableID)->getName();
-    std::string tableInfo =
-        stringFormat("CREATE REL TABLE `{}` (FROM {} TO {}, ", getName(), srcTableName, dstTableName);
+    std::string tableInfo = stringFormat("CREATE REL TABLE `{}` (FROM {} TO {}, ", getName(),
+        srcTableName, dstTableName);
     ss << tableInfo << propertiesToCypher() << getMultiplicityStr() << ");";
     return ss.str();
 }

--- a/src/function/cast/cast_array.cpp
+++ b/src/function/cast/cast_array.cpp
@@ -19,7 +19,7 @@ bool CastArrayHelper::checkCompatibleNestedTypes(LogicalTypeID sourceTypeID,
     } break;
     case LogicalTypeID::MAP:
     case LogicalTypeID::STRUCT: {
-        if (sourceTypeID == targetTypeID) {
+        if (sourceTypeID == targetTypeID || targetTypeID == LogicalTypeID::UNION) {
             return true;
         }
     } break;

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -55,7 +55,7 @@ static void resolveNestedVector(std::shared_ptr<ValueVector> inputVector, ValueV
             inputType = &inputVector->dataType;
             resultType = &resultVector->dataType;
         } else if (inputType->getLogicalTypeID() == LogicalTypeID::STRUCT &&
-                   resultType->getLogicalTypeID() == LogicalTypeID::STRUCT) {
+                   resultType->getPhysicalType() == PhysicalTypeID::STRUCT) {
             // Check if struct type can be cast
             auto errorMsg = stringFormat("Unsupported casting function from {} to {}.",
                 inputType->toString(), resultType->toString());
@@ -845,6 +845,9 @@ std::unique_ptr<ScalarFunction> CastFunction::bindCastFunction(const std::string
     case LogicalTypeID::ARRAY:
     case LogicalTypeID::MAP:
     case LogicalTypeID::STRUCT: {
+        return bindCastBetweenNested<EXECUTOR>(functionName, sourceType, targetType);
+    }
+    case LogicalTypeID::UNION: {
         return bindCastBetweenNested<EXECUTOR>(functionName, sourceType, targetType);
     }
     default: {

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -844,9 +844,7 @@ std::unique_ptr<ScalarFunction> CastFunction::bindCastFunction(const std::string
     case LogicalTypeID::LIST:
     case LogicalTypeID::ARRAY:
     case LogicalTypeID::MAP:
-    case LogicalTypeID::STRUCT: {
-        return bindCastBetweenNested<EXECUTOR>(functionName, sourceType, targetType);
-    }
+    case LogicalTypeID::STRUCT:
     case LogicalTypeID::UNION: {
         return bindCastBetweenNested<EXECUTOR>(functionName, sourceType, targetType);
     }

--- a/src/processor/operator/simple/export_db.cpp
+++ b/src/processor/operator/simple/export_db.cpp
@@ -70,10 +70,10 @@ static void writeCopyStatement(stringstream& ss, const TableCatalogEntry* entry,
         columns += i == numProperties - 1 ? "" : ",";
     }
     if (columns.empty()) {
-        ss << stringFormat("COPY {} FROM \"{}\" {};\n", entry->getName(), fileName,
+        ss << stringFormat("COPY `{}` FROM \"{}\" {};\n", entry->getName(), fileName,
             csvConfig.option.toCypher());
     } else {
-        ss << stringFormat("COPY {} ({}) FROM \"{}\" {};\n", entry->getName(), columns, fileName,
+        ss << stringFormat("COPY `{}` ({}) FROM \"{}\" {};\n", entry->getName(), columns, fileName,
             csvConfig.option.toCypher());
     }
 }

--- a/test/test_files/copy/export_import_db.test
+++ b/test/test_files/copy/export_import_db.test
@@ -86,7 +86,7 @@ Binder exception: The type of format option must be a string.
 ---- error
 Binder exception: Only export to csv can have options.
 
--STATEMENT Export Database "${KUZU_EXPORT_DB_DIRECTORY}_case4/demo-db4" (header=true)
+-STATEMENT Export Database "${KUZU_EXPORT_DB_DIRECTORY}_case4/demo-db4" (format="CSV", header=true)
 ---- ok
 
 -IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_case4/demo-db5"
@@ -246,3 +246,19 @@ Binder exception: No file found that matches the pattern: ${KUZU_EXPORT_DB_DIREC
 Alice|1
 Bob|1
 Farooq|1
+
+-CASE ExportDBWithSpecialTableName
+-SKIP_WASM
+-SKIP_IN_MEM
+-STATEMENT CREATE NODE TABLE `0_idx_person` (ID SERIAL, PRIMARY KEY(ID))
+---- ok
+-STATEMENT CREATE NODE TABLE person (ID SERIAL, PRIMARY KEY(ID))
+---- ok
+-STATEMENT CREATE REL TABLE `0_idx_knows` (FROM `0_idx_person` TO  `0_idx_person`)
+---- ok
+-STATEMENT CREATE REL TABLE `0_idx_knows_group` (FROM `0_idx_person` TO  `0_idx_person`, FROM person TO `0_idx_person`)
+---- ok
+-STATEMENT EXPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/special_char" (format="csv");
+---- ok
+-STATEMENT IMPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/special_char";
+---- ok


### PR DESCRIPTION
Changes default export format from `csv` to `parquet`    Fixes #4889 
Fixes export database with special characteres in table name   Fixes #4858 