### PR TITLE
Try to mitigate data race in the HashAggregate

### DIFF
--- a/src/processor/operator/aggregate/hash_aggregate.cpp
+++ b/src/processor/operator/aggregate/hash_aggregate.cpp
@@ -91,6 +91,7 @@ HashAggregateInfo::HashAggregateInfo(const HashAggregateInfo& other)
 void HashAggregateLocalState::init(HashAggregateSharedState* sharedState, ResultSet& resultSet,
     main::ClientContext* context, std::vector<function::AggregateFunction>& aggregateFunctions,
     std::vector<common::LogicalType> types) {
+    sharedState->registerThread();
     auto& info = sharedState->getAggregateInfo();
     std::vector<LogicalType> keyDataTypes;
     for (auto& pos : info.flatKeysPos) {
@@ -111,8 +112,6 @@ void HashAggregateLocalState::init(HashAggregateSharedState* sharedState, Result
     }
     leadingState = unFlatKeyVectors.empty() ? flatKeyVectors[0]->state.get() :
                                               unFlatKeyVectors[0]->state.get();
-
-    sharedState->registerThread();
 
     aggregateHashTable = std::make_unique<PartitioningAggregateHashTable>(sharedState,
         *context->getMemoryManager(), std::move(keyDataTypes), std::move(payloadDataTypes),


### PR DESCRIPTION
There's a test that has occasionally been failing in CI (e.g. https://github.com/kuzudb/kuzu/commit/afd089b62b2d02d919a8e0b56990bed8e71af3ec), it's happening very infrequently and I've narrowed down the issue to a data race in the HashAggregate operator.

We're tracking the number of threads running the hash aggregate so that we can wait to do the parallel finalization until all threads have finished However it's possible for threads to finish before other threads have started, leading the remaining threads to start finalization early. This tries to mitigate that by registering the thread as soon as possible (not that it's skipping a lot of work, but this might improve things slightly), however to truly fix it the finalization should be moved into a separate operator so we can guarantee that all data is partitioned before starting the parallel finalization.

There's probably a similar issue in the IndexBuilder, it's just that the IndexBuilder doesn't have a multithreaded finalization stage, and the thread tracking is just to determine if a thread should continue working on the global queues after its finished processing its local data.