### PR TITLE
Fix `skipWhiteSpace()` function

### DIFF
--- a/src/function/cast_from_string_functions.cpp
+++ b/src/function/cast_from_string_functions.cpp
@@ -4,7 +4,6 @@
 #include "common/string_format.h"
 #include "common/types/blob.h"
 #include "function/list/functions/list_unique_function.h"
-#include "utf8proc.h"
 #include "utf8proc_wrapper.h"
 
 using namespace kuzu::common;

--- a/src/function/cast_from_string_functions.cpp
+++ b/src/function/cast_from_string_functions.cpp
@@ -4,6 +4,7 @@
 #include "common/string_format.h"
 #include "common/types/blob.h"
 #include "function/list/functions/list_unique_function.h"
+#include "utf8proc.h"
 #include "utf8proc_wrapper.h"
 
 using namespace kuzu::common;
@@ -172,7 +173,16 @@ void CastStringHelper::cast(const char* input, uint64_t len, ku_uuid_t& result,
 
 // ---------------------- cast String to nested types ------------------------------ //
 static void skipWhitespace(const char*& input, const char* end) {
-    while (input < end && isspace(*input)) {
+    while (input < end) {
+        if (*input & 0x80) {
+            // We only skip ASCII white spaces there.
+            break;
+        } else {
+            KU_ASSERT(*input >= -1);
+            if (!isspace(*input)) {
+                break;
+            }
+        }
         input++;
     }
 }


### PR DESCRIPTION
`skipWhiteSpace()` doesn't handle UTF8, which causes assertion failure on windows build.