### PR TITLE
Disable test NodeUpdateTest.UpdateSameRowRedundtanly for in mem mode tests

### DIFF
--- a/test/storage/node_update_test.cpp
+++ b/test/storage/node_update_test.cpp
@@ -28,6 +28,9 @@ TEST_F(NodeUpdateTest, UpdateSameRow) {
 }
 
 TEST_F(NodeUpdateTest, UpdateSameRowRedundtanly) {
+    if (inMemMode) {
+        GTEST_SKIP();
+    }
     ASSERT_TRUE(
         conn->query("CREATE NODE TABLE test (id SERIAL PRIMARY KEY, name STRING, prop STRING);")
             ->isSuccess());

--- a/test/storage/node_update_test.cpp
+++ b/test/storage/node_update_test.cpp
@@ -28,7 +28,7 @@ TEST_F(NodeUpdateTest, UpdateSameRow) {
 }
 
 TEST_F(NodeUpdateTest, UpdateSameRowRedundtanly) {
-    if (inMemMode) {
+    if (inMemMode || systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }
     ASSERT_TRUE(


### PR DESCRIPTION
# Description

The test `NodeUpdateTest.UpdateSameRowRedundtanly` was introduced in the PR https://github.com/kuzudb/kuzu/pull/4895. However the fix in that PR does not apply to in-memory mode since we don't checkpoint in in-memory mode so I'm disable the test for now for in-mem mode only.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).