### PR TITLE
Separate hash aggregate finalization into its own operator

### DIFF
--- a/src/include/processor/operator/physical_operator.h
+++ b/src/include/processor/operator/physical_operator.h
@@ -17,6 +17,7 @@ using physical_op_id = uint32_t;
 enum class PhysicalOperatorType : uint8_t {
     ALTER,
     AGGREGATE,
+    AGGREGATE_FINALIZE,
     AGGREGATE_SCAN,
     ATTACH_DATABASE,
     BATCH_INSERT,

--- a/src/processor/map/map_distinct.cpp
+++ b/src/processor/map/map_distinct.cpp
@@ -26,7 +26,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapDistinct(const LogicalOperator*
     }
     auto op = createDistinctHashAggregate(distinct->getKeys(), distinct->getPayloads(), inSchema,
         outSchema, std::move(prevOperator));
-    auto hashAggregate = op->getChild(0)->ptrCast<HashAggregate>();
+    auto hashAggregate = op->getChild(0)->getChild(0)->ptrCast<HashAggregate>();
     hashAggregate->getSharedState()->setLimitNumber(limitNum);
     auto printInfo = static_cast<const HashAggregatePrintInfo*>(hashAggregate->getPrintInfo());
     const_cast<HashAggregatePrintInfo*>(printInfo)->limitNum = limitNum;

--- a/src/processor/operator/physical_operator.cpp
+++ b/src/processor/operator/physical_operator.cpp
@@ -16,6 +16,8 @@ std::string PhysicalOperatorUtils::operatorTypeToString(PhysicalOperatorType ope
         return "ALTER";
     case PhysicalOperatorType::AGGREGATE:
         return "AGGREGATE";
+    case PhysicalOperatorType::AGGREGATE_FINALIZE:
+        return "AGGREGATE_FINALIZE";
     case PhysicalOperatorType::AGGREGATE_SCAN:
         return "AGGREGATE_SCAN";
     case PhysicalOperatorType::ATTACH_DATABASE:


### PR DESCRIPTION
This fixes the data race I mentioned in #4906. It's a little difficult to rigorously test since I was having a hard time reproducing it, but moving the finalization into a separate operator should guarantee that all threads running HashAggregate operator tasks finish before finalization starts.

I think this may fix the issue in #4903, but I'm not positive that it's the same issue.