### PR TITLE
Break when error in the middle of multi statements

### DIFF
--- a/extension/fts/test/test_files/stopwords.test
+++ b/extension/fts/test/test_files/stopwords.test
@@ -49,7 +49,11 @@ alice|0.457137
 -STATEMENT EXPORT DATABASE '${KUZU_EXPORT_DB_DIRECTORY}_fts/stopwords_export_test'
 ---- ok
 -RELOADDB
+# TODO(Ziyi): Fix import database here. RELOADDB is not the correct way to test export/import. The query result is incorrect after import.
+#-IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_fts/stopwords_export_test"
 -STATEMENT IMPORT DATABASE '${KUZU_EXPORT_DB_DIRECTORY}_fts/stopwords_export_test'
+---- ok
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
 ---- ok
 -INSERT_STATEMENT_BLOCK VALIDATE_CITY_STOPWORDS_IDX
 

--- a/extension/fts/test/test_files/stopwords.test
+++ b/extension/fts/test/test_files/stopwords.test
@@ -53,8 +53,6 @@ alice|0.457137
 #-IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_fts/stopwords_export_test"
 -STATEMENT IMPORT DATABASE '${KUZU_EXPORT_DB_DIRECTORY}_fts/stopwords_export_test'
 ---- ok
--STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
----- ok
 -INSERT_STATEMENT_BLOCK VALIDATE_CITY_STOPWORDS_IDX
 
 -CASE CustomizedStopWordsFile

--- a/src/function/table/hnsw/create_hnsw_index.cpp
+++ b/src/function/table/hnsw/create_hnsw_index.cpp
@@ -132,7 +132,8 @@ static std::string createHNSWIndexTables(main::ClientContext& context,
     query += stringFormat("CALL _CREATE_HNSW_INDEX('{}', '{}', '{}', {});", hnswBindData->indexName,
         hnswBindData->tableEntry->getName(),
         hnswBindData->tableEntry->getProperty(hnswBindData->propertyID).getName(), params);
-    query += stringFormat("RETURN 'Index {} has been created.';", hnswBindData->indexName);
+    query +=
+        stringFormat("RETURN 'Index {} has been created.';", hnswBindData->indexName);
     return query;
 }
 

--- a/src/function/table/hnsw/create_hnsw_index.cpp
+++ b/src/function/table/hnsw/create_hnsw_index.cpp
@@ -132,8 +132,7 @@ static std::string createHNSWIndexTables(main::ClientContext& context,
     query += stringFormat("CALL _CREATE_HNSW_INDEX('{}', '{}', '{}', {});", hnswBindData->indexName,
         hnswBindData->tableEntry->getName(),
         hnswBindData->tableEntry->getProperty(hnswBindData->propertyID).getName(), params);
-    query +=
-        stringFormat("RETURN 'Index {} has been created.';", hnswBindData->indexName);
+    query += stringFormat("RETURN 'Index {} has been created.';", hnswBindData->indexName);
     return query;
 }
 

--- a/test/test_files/exceptions/exception.test
+++ b/test/test_files/exceptions/exception.test
@@ -69,3 +69,20 @@ Overflow exception: Value 100000000 * 1000000000000 is not within UINT64 range.
 -STATEMENT RETURN cast(1000000000000, "UINT64") * cast(100000000, "UINT64");
 ---- error
 Overflow exception: Value 100000000 * 1000000000000 is not within UINT64 range.
+
+-CASE MultiStatements
+-STATEMENT create node table test(id serial primary key); create node table test(id int64 primary key); match (a) return a;
+---- ok
+---- error
+Binder exception: test already exists in catalog.
+-STATEMENT CALL show_tables() RETURN *;
+---- 1
+0|test|NODE|local(kuzu)|
+
+-CASE MultiStatementsWithTransaction
+-STATEMENT BEGIN TRANSACTION; create node table test(id serial primary key); create node table test(id int64 primary key); match (a) return a; COMMIT;
+---- ok
+---- error
+Binder exception: test already exists in catalog.
+-STATEMENT CALL show_tables() RETURN *;
+---- 0

--- a/tools/shell/test/test_shell_control_search.py
+++ b/tools/shell/test/test_shell_control_search.py
@@ -2,6 +2,7 @@ import os
 
 import pexpect
 import pytest
+
 from conftest import ShellTest
 from test_helper import KEY_ACTION, deleteIfExists
 
@@ -167,7 +168,8 @@ def test_ctrl_e(test) -> None:
     test.send_finished_statement('RETURN ;\r')
     assert (
         test.shell_process.expect_exact(
-            ['Error: Parser exception: Invalid input <RETURN >:', pexpect.EOF],
+            ['Error: Parser exception: Invalid input <RETURN ;>: expected rule oC_RegularQuery (line: 1, offset: 7)',
+             pexpect.EOF],
         )
         == 0
     )

--- a/tools/shell/test/test_shell_esc_search.py
+++ b/tools/shell/test/test_shell_esc_search.py
@@ -1,6 +1,6 @@
 import pexpect
 import pytest
-from conftest import ShellTest
+
 from test_helper import KEY_ACTION
 
 
@@ -67,7 +67,8 @@ def test_accept_move_end(test, esc) -> None:
     test.send_finished_statement('RETURN ;\r')
     assert (
         test.shell_process.expect_exact(
-            ['Error: Parser exception: Invalid input <RETURN >:', pexpect.EOF],
+            ['Error: Parser exception: Invalid input <RETURN ;>: expected rule oC_RegularQuery (line: 1, offset: 7)',
+             pexpect.EOF],
         )
         == 0
     )


### PR DESCRIPTION
# Description

This fixes the behaviour for execution of multiple statements in a single query. When there is an error with a statement in the middle of the query, we should error and break the execution.

Also changed how shell collects query results. Previously shell manually splits a query by ";" into multiple statements, however, I don't think this is safe in the first place, it also is not consistent with the behaviour of executing a single query with multiple statements through API.