### PR TITLE
Fix timing in the final QueryResult for create fts/hnsw index

### DIFF
--- a/extension/fts/src/function/create_fts_index.cpp
+++ b/extension/fts/src/function/create_fts_index.cpp
@@ -226,7 +226,7 @@ std::string createFTSIndexQuery(ClientContext& context, const TableFuncBindData&
         ftsBindData->createFTSConfig.stopWordsTableInfo.stopWords);
     query += stringFormat("CALL _CREATE_FTS_INDEX('{}', '{}', {}, {});", tableName, indexName,
         properties, params);
-    query += stringFormat("RETURN 'Index {} has been created.';", ftsBindData->indexName);
+    query += stringFormat("RETURN 'Index {} has been created.' as result;", ftsBindData->indexName);
     return query;
 }
 

--- a/extension/fts/test/test_files/stopwords.test
+++ b/extension/fts/test/test_files/stopwords.test
@@ -53,6 +53,8 @@ alice|0.457137
 #-IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_fts/stopwords_export_test"
 -STATEMENT IMPORT DATABASE '${KUZU_EXPORT_DB_DIRECTORY}_fts/stopwords_export_test'
 ---- ok
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
+---- ok
 -INSERT_STATEMENT_BLOCK VALIDATE_CITY_STOPWORDS_IDX
 
 -CASE CustomizedStopWordsFile

--- a/extension/fts/test/test_files/stopwords.test
+++ b/extension/fts/test/test_files/stopwords.test
@@ -53,8 +53,6 @@ alice|0.457137
 #-IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_fts/stopwords_export_test"
 -STATEMENT IMPORT DATABASE '${KUZU_EXPORT_DB_DIRECTORY}_fts/stopwords_export_test'
 ---- ok
--STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
----- ok
 -INSERT_STATEMENT_BLOCK VALIDATE_CITY_STOPWORDS_IDX
 
 -CASE CustomizedStopWordsFile

--- a/src/function/table/hnsw/create_hnsw_index.cpp
+++ b/src/function/table/hnsw/create_hnsw_index.cpp
@@ -135,7 +135,7 @@ static std::string createHNSWIndexTables(main::ClientContext& context,
     query += stringFormat("CALL _CREATE_HNSW_INDEX('{}', '{}', '{}', {});", hnswBindData->indexName,
         hnswBindData->tableEntry->getName(),
         hnswBindData->tableEntry->getProperty(hnswBindData->propertyID).getName(), params);
-    query += stringFormat("RETURN 'Index {} has been created.';", hnswBindData->indexName);
+    query += stringFormat("RETURN 'Index {} has been created.' as result;", hnswBindData->indexName);
     if (requireNewTransaction) {
         query += "COMMIT;";
     }

--- a/src/function/table/hnsw/create_hnsw_index.cpp
+++ b/src/function/table/hnsw/create_hnsw_index.cpp
@@ -23,8 +23,8 @@ namespace function {
 CreateHNSWSharedState::CreateHNSWSharedState(const CreateHNSWIndexBindData& bindData)
     : TableFuncSharedState{bindData.maxOffset}, name{bindData.indexName},
       nodeTable{bindData.context->getStorageManager()
-              ->getTable(bindData.tableEntry->getTableID())
-              ->cast<storage::NodeTable>()},
+                    ->getTable(bindData.tableEntry->getTableID())
+                    ->cast<storage::NodeTable>()},
       numNodes{bindData.numNodes}, bindData{&bindData} {
     hnswIndex = std::make_unique<storage::InMemHNSWIndex>(bindData.context, nodeTable,
         bindData.tableEntry->getColumnID(bindData.propertyID), bindData.config.copy());

--- a/src/function/table/hnsw/create_hnsw_index.cpp
+++ b/src/function/table/hnsw/create_hnsw_index.cpp
@@ -23,8 +23,8 @@ namespace function {
 CreateHNSWSharedState::CreateHNSWSharedState(const CreateHNSWIndexBindData& bindData)
     : TableFuncSharedState{bindData.maxOffset}, name{bindData.indexName},
       nodeTable{bindData.context->getStorageManager()
-                    ->getTable(bindData.tableEntry->getTableID())
-                    ->cast<storage::NodeTable>()},
+              ->getTable(bindData.tableEntry->getTableID())
+              ->cast<storage::NodeTable>()},
       numNodes{bindData.numNodes}, bindData{&bindData} {
     hnswIndex = std::make_unique<storage::InMemHNSWIndex>(bindData.context, nodeTable,
         bindData.tableEntry->getColumnID(bindData.propertyID), bindData.config.copy());
@@ -135,7 +135,8 @@ static std::string createHNSWIndexTables(main::ClientContext& context,
     query += stringFormat("CALL _CREATE_HNSW_INDEX('{}', '{}', '{}', {});", hnswBindData->indexName,
         hnswBindData->tableEntry->getName(),
         hnswBindData->tableEntry->getProperty(hnswBindData->propertyID).getName(), params);
-    query += stringFormat("RETURN 'Index {} has been created.' as result;", hnswBindData->indexName);
+    query +=
+        stringFormat("RETURN 'Index {} has been created.' as result;", hnswBindData->indexName);
     if (requireNewTransaction) {
         query += "COMMIT;";
     }

--- a/src/include/main/query_summary.h
+++ b/src/include/main/query_summary.h
@@ -31,6 +31,9 @@ public:
      */
     KUZU_API double getExecutionTime() const;
 
+    void incrementCompilingTime(double increment);
+    void incrementExecutionTime(double increment);
+
     void setPreparedSummary(PreparedSummary preparedSummary_);
 
     /**

--- a/src/main/query_summary.cpp
+++ b/src/main/query_summary.cpp
@@ -15,6 +15,14 @@ double QuerySummary::getExecutionTime() const {
     return executionTime;
 }
 
+void QuerySummary::incrementCompilingTime(double increment) {
+    preparedSummary.compilingTime += increment;
+}
+
+void QuerySummary::incrementExecutionTime(double increment) {
+    executionTime += increment;
+}
+
 void QuerySummary::setPreparedSummary(PreparedSummary preparedSummary_) {
     preparedSummary = preparedSummary_;
 }


### PR DESCRIPTION
# Description

Create fts/hnsw index invokes the rewrite mechanism, thus a single query expands into multiple statements, but only the last statement's execution result is visible to users (others are internal and their execution results are indivisible to users unless there are errors encountered). This causes a gap between the execution/compiling time of the last statement and the actual one for the whole query.
To fix the gap, this PR collects compiling/execution time for all internal statements and aggregate them into the final query result, which is visible to users.