### PR TITLE
Optimize embedding caching in vector index construction

### DIFF
--- a/extension/fts/test/test_files/error.test
+++ b/extension/fts/test/test_files/error.test
@@ -20,7 +20,7 @@ Binder exception: Index personIdx already exists in table person.
 
 -STATEMENT CALL CREATE_FTS_INDEX('knows', 'personIdx', ['fName'])
 ---- error
-Binder exception: Table knows is not a node table. Only a node table is supported for this function.
+Binder exception: knows is not of type NODE.
 
 -STATEMENT CALL CREATE_FTS_INDEX('person', 'personIdx1', ['fName1'])
 ---- error
@@ -48,7 +48,7 @@ Binder exception: Table person1 does not exist.
 
 -STATEMENT CALL QUERY_FTS_INDEX('knows', 'personIdx', 'alice') RETURN *
 ---- error
-Binder exception: Table knows is not a node table. Only a node table is supported for this function.
+Binder exception: knows is not of type NODE.
 
 -STATEMENT CALL QUERY_FTS_INDEX('movies', 'personIdx', 'alice') RETURN *
 ---- error
@@ -60,7 +60,7 @@ Binder exception: Table person1 does not exist.
 
 -STATEMENT CALL DROP_FTS_INDEX('knows', 'personIdx')
 ---- error
-Binder exception: Table knows is not a node table. Only a node table is supported for this function.
+Binder exception: knows is not of type NODE.
 
 -STATEMENT CALL DROP_FTS_INDEX('person', 'personIdx1')
 ---- error

--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -225,6 +225,7 @@ FunctionCollection* FunctionCollection::getFunctions() {
         TABLE_FUNCTION(ShowOfficialExtensionsFunction), TABLE_FUNCTION(ShowIndexesFunction),
 
         // Standalone Table functions
+        STANDALONE_TABLE_FUNCTION(LocalCacheArrayColumnFunction),
         STANDALONE_TABLE_FUNCTION(ClearWarningsFunction),
         STANDALONE_TABLE_FUNCTION(CreateProjectedGraphFunction),
         STANDALONE_TABLE_FUNCTION(DropProjectedGraphFunction),

--- a/src/function/table/CMakeLists.txt
+++ b/src/function/table/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(kuzu_table_function
         bind_data.cpp
         bind_input.cpp
         bm_info.cpp
+        cache_column.cpp
         catalog_version.cpp
         clear_warnings.cpp
         create_project_graph.cpp

--- a/src/function/table/cache_column.cpp
+++ b/src/function/table/cache_column.cpp
@@ -1,0 +1,193 @@
+#include "binder/binder.h"
+#include "catalog/catalog.h"
+#include "catalog/catalog_entry/table_catalog_entry.h"
+#include "common/exception/binder.h"
+#include "function/table/bind_data.h"
+#include "function/table/table_function.h"
+#include "processor/execution_context.h"
+#include "storage/local_cached_column.h"
+#include "storage/storage_manager.h"
+#include "storage/store/list_chunk_data.h"
+#include "storage/store/node_table.h"
+#include "storage/store/table.h"
+#include "transaction/transaction.h"
+
+namespace kuzu::catalog {
+class TableCatalogEntry;
+}
+
+using namespace kuzu::common;
+
+namespace kuzu {
+namespace function {
+
+struct CacheArrayColumnBindData final : TableFuncBindData {
+    catalog::TableCatalogEntry* tableEntry;
+    property_id_t propertyID;
+
+    CacheArrayColumnBindData(catalog::TableCatalogEntry* tableEntry, property_id_t propertyID)
+        : tableEntry{tableEntry}, propertyID{propertyID} {}
+
+    std::unique_ptr<TableFuncBindData> copy() const override {
+        return std::make_unique<CacheArrayColumnBindData>(tableEntry, propertyID);
+    }
+};
+
+static void validateArrayColumnType(const catalog::TableCatalogEntry* entry,
+    property_id_t propertyID) {
+    auto& type = entry->getProperty(propertyID).getType();
+    if (type.getLogicalTypeID() != LogicalTypeID::ARRAY) {
+        throw BinderException{stringFormat("Column {} is not of the expected type {}.",
+            entry->getProperty(propertyID).getName(),
+            LogicalTypeUtils::toString(LogicalTypeID::ARRAY))};
+    }
+}
+
+static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
+    const TableFuncBindInput* input) {
+    const auto tableName = input->getLiteralVal<std::string>(0);
+    const auto columnName = input->getLiteralVal<std::string>(1);
+    binder::Binder::validateTableExistence(*context, tableName);
+    const auto tableEntry =
+        context->getCatalog()->getTableCatalogEntry(context->getTransaction(), tableName);
+    binder::Binder::validateNodeTableType(tableEntry);
+    binder::Binder::validateColumnExistence(tableEntry, columnName);
+    auto propertyID = tableEntry->getPropertyID(columnName);
+    validateArrayColumnType(tableEntry, propertyID);
+    return std::make_unique<CacheArrayColumnBindData>(tableEntry, propertyID);
+}
+
+struct CacheArrayColumnSharedState final : TableFuncSharedState {
+    explicit CacheArrayColumnSharedState(storage::NodeTable& table,
+        node_group_idx_t maxNodeGroupIdx, const CacheArrayColumnBindData& bindData)
+        : TableFuncSharedState{maxNodeGroupIdx, 1 /*maxMorselSize*/}, table{table} {
+        cachedColumn = std::make_unique<storage::CachedColumn>(bindData.tableEntry->getTableID(),
+            bindData.propertyID);
+        cachedColumn->columnChunks.resize(maxNodeGroupIdx + 1);
+    }
+
+    void merge(node_group_idx_t nodeGroupIdx,
+        std::unique_ptr<storage::ColumnChunkData> columnChunkData) {
+        std::unique_lock lck{mtx};
+        KU_ASSERT(cachedColumn->columnChunks.size() > nodeGroupIdx);
+        cachedColumn->columnChunks[nodeGroupIdx] = std::move(columnChunkData);
+        ++numNodeGroupsCached;
+    }
+
+    std::mutex mtx;
+    storage::NodeTable& table;
+    std::unique_ptr<storage::CachedColumn> cachedColumn;
+    std::atomic<node_group_idx_t> numNodeGroupsCached;
+};
+
+static std::unique_ptr<TableFuncSharedState> initSharedState(const TableFunctionInitInput& input) {
+    const auto bindData = input.bindData->constPtrCast<CacheArrayColumnBindData>();
+    auto& table = input.context.getStorageManager()
+                      ->getTable(bindData->tableEntry->getTableID())
+                      ->cast<storage::NodeTable>();
+    auto numCommitedNodeGroups = table.getNumCommittedNodeGroups();
+    return std::make_unique<CacheArrayColumnSharedState>(table,
+        numCommitedNodeGroups == 0 ? 0 : numCommitedNodeGroups, *bindData);
+}
+
+struct CacheArrayColumnLocalState final : TableFuncLocalState {
+    CacheArrayColumnLocalState(const main::ClientContext& context, table_id_t tableID,
+        column_id_t columnID)
+        : dataChunk{2, std::make_shared<DataChunkState>()} {
+        std::vector<column_id_t> columnIDs;
+        columnIDs.push_back(columnID);
+        auto& table = context.getStorageManager()->getTable(tableID)->cast<storage::NodeTable>();
+        std::vector<const storage::Column*> columns;
+        columns.push_back(&table.getColumn(columnID));
+        scanState =
+            std::make_unique<storage::NodeTableScanState>(table.getTableID(), columnIDs, columns);
+        dataChunk.insert(0, std::make_shared<ValueVector>(LogicalType::INTERNAL_ID()));
+        dataChunk.insert(1, std::make_shared<ValueVector>(columns[0]->getDataType().copy()));
+        scanState->nodeIDVector = &dataChunk.getValueVectorMutable(0);
+        scanState->outputVectors.push_back(&dataChunk.getValueVectorMutable(1));
+        scanState->outState = dataChunk.state.get();
+        scanState->rowIdxVector->state = dataChunk.state;
+        scanState->source = storage::TableScanSource::COMMITTED;
+    }
+
+    DataChunk dataChunk;
+    std::unique_ptr<storage::NodeTableScanState> scanState;
+};
+
+static std::unique_ptr<TableFuncLocalState> initLocalState(const TableFunctionInitInput& input,
+    TableFuncSharedState*, storage::MemoryManager*) {
+    const auto bindData = input.bindData->constPtrCast<CacheArrayColumnBindData>();
+    auto tableID = bindData->tableEntry->getTableID();
+    auto columnID = bindData->tableEntry->getColumnID(bindData->propertyID);
+    return std::make_unique<CacheArrayColumnLocalState>(input.context, tableID, columnID);
+}
+
+static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
+    auto& bindData = input.bindData->cast<CacheArrayColumnBindData>();
+    const auto sharedState = input.sharedState->ptrCast<CacheArrayColumnSharedState>();
+    auto localState = input.localState->ptrCast<CacheArrayColumnLocalState>();
+    const auto morsel = sharedState->getMorsel();
+    if (morsel.isInvalid()) {
+        return 0;
+    }
+    auto context = input.context->clientContext;
+    auto columnType = bindData.tableEntry->getProperty(bindData.propertyID).getType().copy();
+    auto& table = sharedState->table;
+    auto& scanState = *localState->scanState;
+    for (auto i = morsel.startOffset; i < morsel.endOffset; i++) {
+        scanState.nodeGroupIdx = i;
+        auto numRows = table.getNumTuplesInNodeGroup(i);
+        auto data = storage::ColumnChunkFactory::createColumnChunkData(*context->getMemoryManager(),
+            columnType.copy(), false /*enableCompression*/, numRows,
+            storage::ResidencyState::IN_MEMORY, true /*hasNullData*/, false /*initializeToZero*/);
+        if (columnType.getLogicalTypeID() == LogicalTypeID::ARRAY) {
+            auto arrayTypeInfo = columnType.getExtraTypeInfo()->constPtrCast<ArrayTypeInfo>();
+            data->cast<storage::ListChunkData>().getDataColumnChunk()->resize(
+                numRows * arrayTypeInfo->getNumElements());
+        }
+        table.initScanState(context->getTransaction(), *localState->scanState);
+        while (table.scan(context->getTransaction(), scanState)) {
+            data->append(scanState.outputVectors[0], scanState.outState->getSelVector());
+        }
+        sharedState->merge(i, std::move(data));
+    }
+    return morsel.endOffset - morsel.startOffset;
+}
+
+static double progressFunc(TableFuncSharedState* sharedState) {
+    const auto cacheColumnSharedState = sharedState->ptrCast<CacheArrayColumnSharedState>();
+    const auto numNodeGroupsCached = cacheColumnSharedState->numNodeGroupsCached.load();
+    if (cacheColumnSharedState->maxOffset == 0) {
+        return 1.0;
+    }
+    if (numNodeGroupsCached == 0) {
+        return 0.0;
+    }
+    return static_cast<double>(numNodeGroupsCached) / cacheColumnSharedState->maxOffset;
+}
+
+static void finalizeFunc(const processor::ExecutionContext* context,
+    TableFuncSharedState* sharedState) {
+    auto transaction = context->clientContext->getTransaction();
+    auto cacheColumnSharedState = sharedState->ptrCast<CacheArrayColumnSharedState>();
+    auto& localCacheManager = transaction->getLocalCacheManager();
+    localCacheManager.put(std::move(cacheColumnSharedState->cachedColumn));
+}
+
+function_set LocalCacheArrayColumnFunction::getFunctionSet() {
+    function_set functionSet;
+    std::vector inputTypes = {LogicalTypeID::STRING, LogicalTypeID::STRING};
+    auto func = std::make_unique<TableFunction>(name, inputTypes);
+    func->bindFunc = bindFunc;
+    func->initSharedStateFunc = initSharedState;
+    func->initLocalStateFunc = initLocalState;
+    func->tableFunc = tableFunc;
+    func->finalizeFunc = finalizeFunc;
+    func->canParallelFunc = [] { return true; };
+    func->progressFunc = progressFunc;
+    functionSet.push_back(std::move(func));
+    return functionSet;
+}
+
+} // namespace function
+} // namespace kuzu

--- a/src/function/table/hnsw/create_hnsw_index.cpp
+++ b/src/function/table/hnsw/create_hnsw_index.cpp
@@ -24,8 +24,8 @@ namespace function {
 CreateInMemHNSWSharedState::CreateInMemHNSWSharedState(const CreateHNSWIndexBindData& bindData)
     : TableFuncSharedState{bindData.maxOffset}, name{bindData.indexName},
       nodeTable{bindData.context->getStorageManager()
-              ->getTable(bindData.tableEntry->getTableID())
-              ->cast<storage::NodeTable>()},
+                    ->getTable(bindData.tableEntry->getTableID())
+                    ->cast<storage::NodeTable>()},
       numNodes{bindData.numNodes}, bindData{&bindData} {
     hnswIndex = std::make_shared<storage::InMemHNSWIndex>(bindData.context, nodeTable,
         bindData.tableEntry->getColumnID(bindData.propertyID), bindData.config.copy());

--- a/src/function/table/hnsw/create_hnsw_index.cpp
+++ b/src/function/table/hnsw/create_hnsw_index.cpp
@@ -24,8 +24,8 @@ namespace function {
 CreateInMemHNSWSharedState::CreateInMemHNSWSharedState(const CreateHNSWIndexBindData& bindData)
     : TableFuncSharedState{bindData.maxOffset}, name{bindData.indexName},
       nodeTable{bindData.context->getStorageManager()
-                    ->getTable(bindData.tableEntry->getTableID())
-                    ->cast<storage::NodeTable>()},
+              ->getTable(bindData.tableEntry->getTableID())
+              ->cast<storage::NodeTable>()},
       numNodes{bindData.numNodes}, bindData{&bindData} {
     hnswIndex = std::make_shared<storage::InMemHNSWIndex>(bindData.context, nodeTable,
         bindData.tableEntry->getColumnID(bindData.propertyID), bindData.config.copy());
@@ -96,41 +96,40 @@ static std::unique_ptr<processor::PhysicalOperator> getPhysicalPlan(
                                     ->getBindData()
                                     ->constPtrCast<CreateHNSWIndexBindData>();
     auto createHNSWCallOp = TableFunction::getPhysicalPlan(clientContext, planMapper, logicalOp);
-    auto createHNSWTableFuncCall = createHNSWCallOp->ptrCast<processor::TableFunctionCall>();
-    KU_ASSERT(createHNSWTableFuncCall->getOperatorType() ==
+    KU_ASSERT(createHNSWCallOp->getOperatorType() ==
               processor::PhysicalOperatorType::TABLE_FUNCTION_CALL);
-    auto createHNSWFuncSharedState =
-        createHNSWTableFuncCall->getSharedState()->funcState->ptrCast<CreateInMemHNSWSharedState>();
-    auto indexName = createHNSWFuncSharedState->name;
+    auto createFuncCall = createHNSWCallOp->ptrCast<processor::TableFunctionCall>();
+    auto createFuncSharedState =
+        createFuncCall->getSharedState()->funcState->ptrCast<CreateInMemHNSWSharedState>();
+    auto indexName = createFuncSharedState->name;
     // Append a dummy sink to end the first pipeline
-    auto createHNSWDummySink = std::make_unique<processor::DummySink>(
+    auto createDummySink = std::make_unique<processor::DummySink>(
         std::make_unique<processor::ResultSetDescriptor>(logicalOp->getSchema()),
         std::move(createHNSWCallOp), planMapper->getOperatorID(), std::make_unique<OPPrintInfo>());
     // Append _FinalizeHNSWIndex table function.
-    auto finalizeHNSWTableFuncEntry = clientContext->getCatalog()->getFunctionEntry(
+    auto finalizeFuncEntry = clientContext->getCatalog()->getFunctionEntry(
         clientContext->getTransaction(), InternalFinalizeHNSWIndexFunction::name);
     auto func = BuiltInFunctionsUtils::matchFunction(InternalFinalizeHNSWIndexFunction::name,
-        finalizeHNSWTableFuncEntry->ptrCast<catalog::FunctionCatalogEntry>())
-                    ->constPtrCast<TableFunction>()
-                    ->copy();
+        finalizeFuncEntry->ptrCast<catalog::FunctionCatalogEntry>())
+                    ->constPtrCast<TableFunction>();
     auto info = processor::TableFunctionCallInfo();
     info.function = *func;
     info.bindData = std::make_unique<TableFuncBindData>();
-    auto finalizeHNSWCallSharedState = std::make_shared<processor::TableFunctionCallSharedState>();
-    TableFunctionInitInput finalizeHNSWTableFuncInitInput{info.bindData.get(), 0 /* queryID */,
+    auto finalizeSharedState = std::make_shared<processor::TableFunctionCallSharedState>();
+    TableFunctionInitInput finalizeFuncInitInput{info.bindData.get(), 0 /* queryID */,
         *clientContext};
-    finalizeHNSWCallSharedState->funcState =
-        info.function.initSharedStateFunc(finalizeHNSWTableFuncInitInput);
-    auto finalizeHNSWFuncSharedState =
-        finalizeHNSWCallSharedState->funcState->ptrCast<FinalizeHNSWSharedState>();
-    finalizeHNSWFuncSharedState->hnswIndex = createHNSWFuncSharedState->hnswIndex;
-    finalizeHNSWFuncSharedState->maxOffset =
+    finalizeSharedState->funcState = info.function.initSharedStateFunc(finalizeFuncInitInput);
+    auto finalizeFuncSharedState =
+        finalizeSharedState->funcState->ptrCast<FinalizeHNSWSharedState>();
+    finalizeFuncSharedState->hnswIndex = createFuncSharedState->hnswIndex;
+    finalizeFuncSharedState->maxOffset =
         (logicalCallBoundData->numNodes + StorageConfig::NODE_GROUP_SIZE - 1) /
         StorageConfig::NODE_GROUP_SIZE;
-    finalizeHNSWFuncSharedState->bindData = logicalCallBoundData->copy();
+    finalizeFuncSharedState->maxMorselSize = 1;
+    finalizeFuncSharedState->bindData = logicalCallBoundData->copy();
     auto finalizeCallOp = std::make_unique<processor::TableFunctionCall>(std::move(info),
-        finalizeHNSWCallSharedState, planMapper->getOperatorID(), std::make_unique<OPPrintInfo>());
-    finalizeCallOp->addChild(std::move(createHNSWDummySink));
+        finalizeSharedState, planMapper->getOperatorID(), std::make_unique<OPPrintInfo>());
+    finalizeCallOp->addChild(std::move(createDummySink));
     // Append a dummy sink to the end of the second pipeline
     auto finalizeHNSWDummySink = std::make_unique<processor::DummySink>(
         std::make_unique<processor::ResultSetDescriptor>(logicalOp->getSchema()),
@@ -151,13 +150,13 @@ static std::unique_ptr<processor::PhysicalOperator> getPhysicalPlan(
     auto lowerRelTable =
         storageManager->getTable(lowerRelTableEntry->getTableID())->ptrCast<storage::RelTable>();
     // Initialize partitioner shared state.
-    const auto partitionerSharedState = finalizeHNSWFuncSharedState->partitionerSharedState;
+    const auto partitionerSharedState = finalizeFuncSharedState->partitionerSharedState;
     partitionerSharedState->setTables(nodeTable, upperRelTable);
     logical_type_vec_t callColumnTypes;
     callColumnTypes.push_back(LogicalType::INTERNAL_ID());
     callColumnTypes.push_back(LogicalType::INTERNAL_ID());
     callColumnTypes.push_back(LogicalType::INTERNAL_ID());
-    finalizeHNSWFuncSharedState->partitionerSharedState->initialize(callColumnTypes, clientContext);
+    finalizeFuncSharedState->partitionerSharedState->initialize(callColumnTypes, clientContext);
     // Initialize fTable for BatchInsert.
     auto fTable = processor::FactorizedTableUtils::getSingleStringColumnFTable(
         clientContext->getMemoryManager());
@@ -214,17 +213,6 @@ function_set InternalCreateHNSWIndexFunction::getFunctionSet() {
 static std::unique_ptr<TableFuncBindData> finalizeHNSWBindFunc(main::ClientContext*,
     const TableFuncBindInput*) {
     return std::make_unique<TableFuncBindData>();
-}
-
-TableFuncMorsel FinalizeHNSWSharedState::getMorsel() {
-    std::unique_lock lck{mtx};
-    KU_ASSERT(curOffset <= maxOffset);
-    if (curOffset == maxOffset) {
-        return TableFuncMorsel::createInvalidMorsel();
-    }
-    const auto numNodeGroups = std::min(static_cast<uint64_t>(1), maxOffset - curOffset);
-    curOffset += numNodeGroups;
-    return {curOffset - numNodeGroups, curOffset};
 }
 
 static std::unique_ptr<TableFuncSharedState> initFinalizeHNSWSharedState(
@@ -302,6 +290,7 @@ function_set InternalFinalizeHNSWIndexFunction::getFunctionSet() {
 
 static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     const TableFuncBindInput* input) {
+    storage::IndexUtils::validateAutoTransaction(*context, CreateHNSWIndexFunction::name);
     return createInMemHNSWBindFunc(context, input);
 }
 
@@ -309,33 +298,28 @@ static std::string rewriteCreateHNSWQuery(main::ClientContext& context,
     const TableFuncBindData& bindData) {
     context.setUseInternalCatalogEntry(true /* useInternalCatalogEntry */);
     const auto hnswBindData = bindData.constPtrCast<CreateHNSWIndexBindData>();
-    std::string query = "";
-    auto requireNewTransaction = !context.getTransactionContext()->hasActiveTransaction();
-    if (requireNewTransaction) {
-        query += "BEGIN TRANSACTION;";
-    }
+    std::string query = "BEGIN TRANSACTION;";
+    auto indexName = hnswBindData->indexName;
+    auto tableName = hnswBindData->tableEntry->getName();
     query += stringFormat("CREATE REL TABLE {} (FROM {} TO {});",
-        storage::HNSWIndexUtils::getUpperGraphTableName(hnswBindData->indexName),
-        hnswBindData->tableEntry->getName(), hnswBindData->tableEntry->getName());
+        storage::HNSWIndexUtils::getUpperGraphTableName(indexName), tableName, tableName);
     query += stringFormat("CREATE REL TABLE {} (FROM {} TO {});",
-        storage::HNSWIndexUtils::getLowerGraphTableName(hnswBindData->indexName),
-        hnswBindData->tableEntry->getName(), hnswBindData->tableEntry->getName());
+        storage::HNSWIndexUtils::getLowerGraphTableName(indexName), tableName, tableName);
     std::string params;
-    params += stringFormat("mu := {}, ", hnswBindData->config.mu);
-    params += stringFormat("ml := {}, ", hnswBindData->config.ml);
-    params += stringFormat("efc := {}, ", hnswBindData->config.efc);
+    auto& config = hnswBindData->config;
+    params += stringFormat("mu := {}, ", config.mu);
+    params += stringFormat("ml := {}, ", config.ml);
+    params += stringFormat("efc := {}, ", config.efc);
     params += stringFormat("distFunc := '{}', ",
-        storage::HNSWIndexConfig::distFuncToString(hnswBindData->config.distFunc));
-    params += stringFormat("alpha := {}, ", hnswBindData->config.alpha);
-    params += stringFormat("pu := {}", hnswBindData->config.pu);
-    query += stringFormat("CALL _CREATE_HNSW_INDEX('{}', '{}', '{}', {});", hnswBindData->indexName,
-        hnswBindData->tableEntry->getName(),
-        hnswBindData->tableEntry->getProperty(hnswBindData->propertyID).getName(), params);
-    query +=
-        stringFormat("RETURN 'Index {} has been created.' as result;", hnswBindData->indexName);
-    if (requireNewTransaction) {
-        query += "COMMIT;";
-    }
+        storage::HNSWIndexConfig::distFuncToString(config.distFunc));
+    params += stringFormat("alpha := {}, ", config.alpha);
+    params += stringFormat("pu := {}", config.pu);
+    auto columnName = hnswBindData->tableEntry->getProperty(hnswBindData->propertyID).getName();
+    query += stringFormat("CALL _CACHE_ARRAY_COLUMN_LOCALLY('{}', '{}');", tableName, columnName);
+    query += stringFormat("CALL _CREATE_HNSW_INDEX('{}', '{}', '{}', {});", indexName, tableName,
+        columnName, params);
+    query += stringFormat("RETURN 'Index {} has been created.' as result;", indexName);
+    query += "COMMIT;";
     return query;
 }
 

--- a/src/function/table/table_function.cpp
+++ b/src/function/table/table_function.cpp
@@ -13,13 +13,23 @@
 namespace kuzu {
 namespace function {
 
+TableFuncSharedState::TableFuncSharedState()
+    : maxOffset{0}, curOffset{0}, maxMorselSize{common::DEFAULT_VECTOR_CAPACITY} {}
+
+TableFuncSharedState::TableFuncSharedState(common::offset_t maxOffset)
+    : maxOffset{maxOffset}, curOffset{0}, maxMorselSize{common::DEFAULT_VECTOR_CAPACITY} {}
+
+TableFuncSharedState::TableFuncSharedState(common::offset_t maxOffset,
+    common::offset_t maxMorselSize)
+    : maxOffset{maxOffset}, curOffset{0}, maxMorselSize{maxMorselSize} {}
+
 TableFuncMorsel TableFuncSharedState::getMorsel() {
     std::lock_guard lck{mtx};
     KU_ASSERT(curOffset <= maxOffset);
     if (curOffset == maxOffset) {
         return TableFuncMorsel::createInvalidMorsel();
     }
-    const auto numValuesToOutput = std::min(common::DEFAULT_VECTOR_CAPACITY, maxOffset - curOffset);
+    const auto numValuesToOutput = std::min(maxMorselSize, maxOffset - curOffset);
     curOffset += numValuesToOutput;
     return {curOffset - numValuesToOutput, curOffset};
 }

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -286,6 +286,12 @@ public:
         const BoundProjectionBody& boundProjectionBody);
     static bool isOrderByKeyTypeSupported(const common::LogicalType& dataType);
 
+    static void validateTableExistence(const main::ClientContext& context,
+        const std::string& tableName);
+    static void validateNodeTableType(const catalog::TableCatalogEntry* entry);
+    static void validateColumnExistence(const catalog::TableCatalogEntry* entry,
+        const std::string& columnName);
+
     void validateNoIndexOnProperty(const std::string& tableName,
         const std::string& propertyName) const;
     /*** helpers ***/

--- a/src/include/function/table/hnsw/hnsw_index_functions.h
+++ b/src/include/function/table/hnsw/hnsw_index_functions.h
@@ -59,8 +59,6 @@ struct FinalizeHNSWSharedState final : TableFuncSharedState {
     explicit FinalizeHNSWSharedState(storage::MemoryManager& mm) {
         partitionerSharedState = std::make_shared<storage::HNSWIndexPartitionerSharedState>(mm);
     }
-
-    TableFuncMorsel getMorsel() override;
 };
 
 struct BoundQueryHNSWIndexInput {

--- a/src/include/function/table/table_function.h
+++ b/src/include/function/table/table_function.h
@@ -56,11 +56,12 @@ struct TableFuncMorsel {
 struct KUZU_API TableFuncSharedState {
     common::offset_t maxOffset;
     common::offset_t curOffset;
+    common::offset_t maxMorselSize;
     std::mutex mtx;
 
-    explicit TableFuncSharedState() : maxOffset{0}, curOffset{0} {}
-    explicit TableFuncSharedState(common::offset_t maxOffset)
-        : maxOffset{maxOffset}, curOffset{0} {}
+    explicit TableFuncSharedState();
+    explicit TableFuncSharedState(common::offset_t maxOffset);
+    TableFuncSharedState(common::offset_t maxOffset, common::offset_t maxMorselSize);
     virtual ~TableFuncSharedState() = default;
 
     virtual TableFuncMorsel getMorsel();
@@ -285,6 +286,14 @@ struct ShowOfficialExtensionsFunction final {
 
 struct ShowIndexesFunction final {
     static constexpr const char* name = "SHOW_INDEXES";
+
+    static function_set getFunctionSet();
+};
+
+// Cache a table column to the transaction local cache.
+// Note this is only used for internal purpose, and only supports node tables for now.
+struct LocalCacheArrayColumnFunction final {
+    static constexpr const char* name = "_CACHE_ARRAY_COLUMN_LOCALLY";
 
     static function_set getFunctionSet();
 };

--- a/src/include/storage/index/hnsw_graph.h
+++ b/src/include/storage/index/hnsw_graph.h
@@ -2,6 +2,7 @@
 
 #include "processor/operator/partitioner.h"
 #include "storage/index/hnsw_config.h"
+#include "storage/local_cached_column.h"
 #include "storage/store/column_chunk_data.h"
 
 namespace kuzu {
@@ -20,26 +21,19 @@ public:
     const EmbeddingTypeInfo& getTypeInfo() const { return typeInfo; }
     common::length_t getDimension() const { return typeInfo.dimension; }
 
-    virtual void initialize(main::ClientContext*, NodeTable&, common::column_id_t) {
-        // DO NOTHING.
-    }
-
 protected:
     EmbeddingTypeInfo typeInfo;
 };
 
 class InMemEmbeddings final : public EmbeddingColumn {
 public:
-    InMemEmbeddings(MemoryManager& mm, EmbeddingTypeInfo typeInfo, common::offset_t numNodes,
-        const common::LogicalType& columnType);
+    InMemEmbeddings(transaction::Transaction* transaction, EmbeddingTypeInfo typeInfo,
+        common::table_id_t tableID, common::column_id_t columnID);
 
     float* getEmbedding(common::offset_t offset) const;
 
-    void initialize(main::ClientContext* context, NodeTable& table,
-        common::column_id_t columnID) override;
-
 private:
-    std::unique_ptr<ColumnChunkData> data;
+    CachedColumn* data;
 };
 
 struct NodeTableScanState;

--- a/src/include/storage/index/hnsw_index.h
+++ b/src/include/storage/index/hnsw_index.h
@@ -128,13 +128,8 @@ private:
 
 class InMemHNSWIndex final : public HNSWIndex {
 public:
-    InMemHNSWIndex(main::ClientContext* context, NodeTable& table, common::column_id_t columnID,
-        HNSWIndexConfig config);
-
-    // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const.
-    void initialize(main::ClientContext* context, NodeTable& table, common::column_id_t columnID) {
-        embeddings->initialize(context, table, columnID);
-    }
+    InMemHNSWIndex(const main::ClientContext* context, NodeTable& table,
+        common::column_id_t columnID, HNSWIndexConfig config);
 
     common::offset_t getUpperEntryPoint() const override { return upperLayer->getEntryPoint(); }
     common::offset_t getLowerEntryPoint() const override { return lowerLayer->getEntryPoint(); }

--- a/src/include/storage/local_cached_column.h
+++ b/src/include/storage/local_cached_column.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "storage/store/column_chunk_data.h"
+#include "transaction/transaction.h"
+
+namespace kuzu {
+namespace storage {
+
+class CachedColumn final : public transaction::LocalCacheObject {
+public:
+    static std::string getKey(common::table_id_t tableID, common::property_id_t propertyID) {
+        return common::stringFormat("{}-{}", tableID, propertyID);
+    }
+    explicit CachedColumn(common::table_id_t tableID, common::property_id_t propertyID)
+        : LocalCacheObject{getKey(tableID, propertyID)}, columnChunks{} {}
+
+    std::vector<std::unique_ptr<ColumnChunkData>> columnChunks;
+};
+
+} // namespace storage
+} // namespace kuzu

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -356,8 +356,8 @@ std::unique_ptr<QueryResult> ClientContext::queryNoLock(std::string_view query,
         if (statement->isInternal()) {
             // The result of internal statements should be invisible to end users. Skip chaining the
             // result of internal statements to the final result to end users.
-            internalCompilingTime = currentQuerySummary->getCompilingTime();
-            internalExecutionTime = currentQuerySummary->getExecutionTime();
+            internalCompilingTime += currentQuerySummary->getCompilingTime();
+            internalExecutionTime += currentQuerySummary->getExecutionTime();
             continue;
         }
         currentQuerySummary->incrementCompilingTime(internalCompilingTime);

--- a/src/storage/index/hnsw_index_utils.cpp
+++ b/src/storage/index/hnsw_index_utils.cpp
@@ -1,5 +1,6 @@
 #include "storage/index/hnsw_index_utils.h"
 
+#include "binder/binder.h"
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "common/exception/binder.h"
 #include "common/types/types.h"
@@ -34,6 +35,7 @@ static void l2SquareDistance(const float* left, const float* right, common::leng
 
 void HNSWIndexUtils::validateColumnType(const catalog::TableCatalogEntry& tableEntry,
     const std::string& columnName) {
+    binder::Binder::validateColumnExistence(&tableEntry, columnName);
     auto& type = tableEntry.getProperty(columnName).getType();
     validateColumnType(type);
 }

--- a/src/storage/index/index_utils.cpp
+++ b/src/storage/index/index_utils.cpp
@@ -4,6 +4,7 @@
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "common/exception/binder.h"
 #include "main/client_context.h"
+#include <binder/binder.h>
 
 namespace kuzu {
 namespace storage {
@@ -33,27 +34,12 @@ static void validateIndexExistence(const main::ClientContext& context,
     }
 }
 
-static void validateTableExistence(const main::ClientContext& context,
-    const std::string& tableName) {
-    if (!context.getCatalog()->containsTable(context.getTransaction(), tableName)) {
-        throw common::BinderException{common::stringFormat("Table {} does not exist.", tableName)};
-    }
-}
-
-static void validateNodeTable(const catalog::TableCatalogEntry* tableEntry) {
-    if (tableEntry->getTableType() != common::TableType::NODE) {
-        throw common::BinderException(common::stringFormat(
-            "Table {} is not a node table. Only a node table is supported for this function.",
-            tableEntry->getName()));
-    }
-}
-
 catalog::NodeTableCatalogEntry* IndexUtils::bindTable(const main::ClientContext& context,
     const std::string& tableName, const std::string& indexName, IndexOperation indexOperation) {
-    validateTableExistence(context, tableName);
+    binder::Binder::validateTableExistence(context, tableName);
     const auto tableEntry =
         context.getCatalog()->getTableCatalogEntry(context.getTransaction(), tableName);
-    validateNodeTable(tableEntry);
+    binder::Binder::validateNodeTableType(tableEntry);
     validateIndexExistence(context, tableEntry, indexName, indexOperation);
     return tableEntry->ptrCast<catalog::NodeTableCatalogEntry>();
 }

--- a/src/storage/store/column_chunk_data.cpp
+++ b/src/storage/store/column_chunk_data.cpp
@@ -442,7 +442,6 @@ void ColumnChunkData::resize(uint64_t newCapacity) {
         auto bufferSize = getBufferSize();
         auto resizedBufferData = resizedBuffer->getBuffer().data();
         memcpy(resizedBufferData, buffer->getBuffer().data(), bufferSize);
-        memset(resizedBufferData + bufferSize, 0, numBytesAfterResize - bufferSize);
         buffer = std::move(resizedBuffer);
     }
     if (nullData) {

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -15,6 +15,16 @@ using namespace kuzu::catalog;
 namespace kuzu {
 namespace transaction {
 
+bool LocalCacheManager::put(std::unique_ptr<LocalCacheObject> object) {
+    std::unique_lock lck{mtx};
+    auto key = object->getKey();
+    if (cachedObjects.contains(key)) {
+        return false;
+    }
+    cachedObjects[object->getKey()] = std::move(object);
+    return true;
+}
+
 Transaction::Transaction(main::ClientContext& clientContext, TransactionType transactionType,
     common::transaction_t transactionID, common::transaction_t startTS)
     : type{transactionType}, ID{transactionID}, startTS{startTS},

--- a/test/test_files/function/call/call.test
+++ b/test/test_files/function/call/call.test
@@ -393,3 +393,15 @@ Binder exception: The number of variables in the yield clause exceeds the number
 -STATEMENT CALL catalog_version() return *;
 ---- 1
 10
+
+-CASE CacheArrayColumn
+-STATEMENT CREATE NODE TABLE testArray(id INT64 PRIMARY KEY, arr INT64[8]);
+---- ok
+-STATEMENT CALL _CACHE_ARRAY_COLUMN_LOCALLY('testArray', 'i');
+---- error
+Binder exception: Column i does not exist in table testArray.
+-STATEMENT CALL _CACHE_ARRAY_COLUMN_LOCALLY('testArray', 'id');
+---- error
+Binder exception: Column id is not of the expected type ARRAY.
+-STATEMENT CALL _CACHE_ARRAY_COLUMN_LOCALLY('testArray', 'arr');
+---- ok

--- a/test/test_files/function/hnsw/error.test
+++ b/test/test_files/function/hnsw/error.test
@@ -5,6 +5,12 @@
 -CASE Error
 -STATEMENT CREATE NODE TABLE test(id int64 primary key, vec double[90]);
 ---- ok
+-STATEMENT CALL CREATE_HNSW_INDEX('e_hnsw_index', 'test2', 'vec');
+---- error
+Binder exception: Table test2 does not exist.
+-STATEMENT CALL CREATE_HNSW_INDEX('e_hnsw_index', 'test', 'vec2');
+---- error
+Binder exception: Column vec2 does not exist in table test.
 -STATEMENT CALL CREATE_HNSW_INDEX('e_hnsw_index', 'test', 'vec');
 ---- error
 Binder exception: HNSW_INDEX only supports FLOAT ARRAY columns.

--- a/test/test_files/transaction/hnsw.test
+++ b/test/test_files/transaction/hnsw.test
@@ -30,15 +30,16 @@
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
 -STATEMENT CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec', distFunc := 'l2');
----- ok
--STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
--CHECK_ORDER
----- 3
-333
-444
-133
--STATEMENT COMMIT;
----- ok
+---- error
+Binder exception: CREATE_HNSW_INDEX is only supported in auto transaction mode.
+# -STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
+# -CHECK_ORDER
+# ---- 3
+# 333
+# 444
+# 133
+# -STATEMENT COMMIT;
+# ---- ok
 
 -CASE DropHNSWComit
 -STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
@@ -64,22 +65,23 @@
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
 -STATEMENT CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec', distFunc := 'l2');
----- ok
--STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
--CHECK_ORDER
----- 3
-333
-444
-133
--STATEMENT COMMIT;
----- ok
--RELOADDB
--STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
--CHECK_ORDER
----- 3
-333
-444
-133
+---- error
+Binder exception: CREATE_HNSW_INDEX is only supported in auto transaction mode.
+# -STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
+# -CHECK_ORDER
+# ---- 3
+# 333
+# 444
+# 133
+# -STATEMENT COMMIT;
+# ---- ok
+# -RELOADDB
+# -STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
+# -CHECK_ORDER
+# ---- 3
+# 333
+# 444
+# 133
 
 -CASE DropHNSWComitRecovery
 -STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
@@ -108,17 +110,18 @@
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
 -STATEMENT CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec', distFunc := 'l2');
----- ok
--STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
--CHECK_ORDER
----- 3
-333
-444
-133
--STATEMENT ROLLBACK;
----- ok
--STATEMENT CALL SHOW_INDEXES() RETURN *;
----- 0
+---- error
+Binder exception: CREATE_HNSW_INDEX is only supported in auto transaction mode.
+# -STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
+# -CHECK_ORDER
+# ---- 3
+# 333
+# 444
+# 133
+# -STATEMENT ROLLBACK;
+# ---- ok
+# -STATEMENT CALL SHOW_INDEXES() RETURN *;
+# ---- 0
 
 -CASE DropHNSWRollback
 -STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
@@ -145,20 +148,21 @@ embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_HNSW_INDEX('e_hnsw_index', '
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
 -STATEMENT CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec', distFunc := 'l2');
----- ok
--STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
--CHECK_ORDER
----- 3
-333
-444
-133
--STATEMENT ROLLBACK;
----- ok
--STATEMENT CALL SHOW_INDEXES() RETURN *;
----- 0
--RELOADDB
--STATEMENT CALL SHOW_INDEXES() RETURN *;
----- 0
+---- error
+Binder exception: CREATE_HNSW_INDEX is only supported in auto transaction mode.
+# -STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
+# -CHECK_ORDER
+# ---- 3
+# 333
+# 444
+# 133
+# -STATEMENT ROLLBACK;
+# ---- ok
+# -STATEMENT CALL SHOW_INDEXES() RETURN *;
+# ---- 0
+# -RELOADDB
+# -STATEMENT CALL SHOW_INDEXES() RETURN *;
+# ---- 0
 
 -CASE DropHNSWRollbackRecovery
 -STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));


### PR DESCRIPTION
# Description

Pre-resize data chunk for the cached embeddings. Also parallel the scan of embedding column.
This can greatly reduce cache initialization time.

On a dataset of 1M vectors with 96 dimension extracted from Yandex DEEP (https://big-ann-benchmarks.com/neurips21.html), the index building time can be reduced from 95.7s to 80.9s on a Mac Studio (M1 Max chip, 64GB RAM).

Note that this PR introduces a framework for transaction local object caching.
`CREATE_HNSW_INDEX` makes use of this mechanism to fetch cached column populated with `_TRANSACTION_LOCAL_CACHE_COLUMN()`.