### PR TITLE
Enable spilling during finalization of CreateHNSWIndex

### DIFF
--- a/src/function/table/hnsw/create_hnsw_index.cpp
+++ b/src/function/table/hnsw/create_hnsw_index.cpp
@@ -23,8 +23,8 @@ namespace function {
 CreateHNSWSharedState::CreateHNSWSharedState(const CreateHNSWIndexBindData& bindData)
     : TableFuncSharedState{bindData.maxOffset}, name{bindData.indexName},
       nodeTable{bindData.context->getStorageManager()
-                    ->getTable(bindData.tableEntry->getTableID())
-                    ->cast<storage::NodeTable>()},
+              ->getTable(bindData.tableEntry->getTableID())
+              ->cast<storage::NodeTable>()},
       numNodes{bindData.numNodes}, bindData{&bindData} {
     hnswIndex = std::make_unique<storage::InMemHNSWIndex>(bindData.context, nodeTable,
         bindData.tableEntry->getColumnID(bindData.propertyID), bindData.config.copy());
@@ -101,7 +101,6 @@ static void finalizeFunc(const processor::ExecutionContext* context,
                 storage::HNSWIndexUtils::getLowerGraphTableName(bindData->indexName))
             ->getTableID();
     auto auxInfo = std::make_unique<catalog::HNSWIndexAuxInfo>(upperRelTableID, lowerRelTableID,
-
         index->getUpperEntryPoint(), index->getLowerEntryPoint(), bindData->config.copy());
     auto indexEntry = std::make_unique<catalog::IndexCatalogEntry>(
         catalog::HNSWIndexCatalogEntry::TYPE_NAME, bindData->tableEntry->getTableID(),

--- a/src/function/table/hnsw/create_hnsw_index.cpp
+++ b/src/function/table/hnsw/create_hnsw_index.cpp
@@ -23,8 +23,8 @@ namespace function {
 CreateHNSWSharedState::CreateHNSWSharedState(const CreateHNSWIndexBindData& bindData)
     : TableFuncSharedState{bindData.maxOffset}, name{bindData.indexName},
       nodeTable{bindData.context->getStorageManager()
-              ->getTable(bindData.tableEntry->getTableID())
-              ->cast<storage::NodeTable>()},
+                    ->getTable(bindData.tableEntry->getTableID())
+                    ->cast<storage::NodeTable>()},
       numNodes{bindData.numNodes}, bindData{&bindData} {
     hnswIndex = std::make_unique<storage::InMemHNSWIndex>(bindData.context, nodeTable,
         bindData.tableEntry->getColumnID(bindData.propertyID), bindData.config.copy());

--- a/src/storage/index/hnsw_graph.cpp
+++ b/src/storage/index/hnsw_graph.cpp
@@ -154,7 +154,7 @@ void InMemHNSWGraph::finalizeNodeGroup(MemoryManager& mm, common::node_group_idx
         KU_ASSERT(offset < numNodes);
         KU_UNUSED(offset);
     }
-
+    chunkedNodeGroup->setUnused(mm);
     partition.merge(std::move(chunkedNodeGroup));
 }
 

--- a/src/storage/index/hnsw_index.cpp
+++ b/src/storage/index/hnsw_index.cpp
@@ -257,6 +257,7 @@ void InMemHNSWIndex::shrink(transaction::Transaction* transaction) {
 // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const function.
 void InMemHNSWIndex::finalize(MemoryManager& mm,
     const HNSWIndexPartitionerSharedState& partitionerSharedState) {
+    embeddings.reset();
     upperLayer->finalize(mm, *partitionerSharedState.upperPartitionerSharedState);
     lowerLayer->finalize(mm, *partitionerSharedState.lowerPartitionerSharedState);
 }


### PR DESCRIPTION
# Description

Adding spilling support during CreateHNSWIndex finalization, which utilizes the same mechanism as `Partitioner` in COPY REL pipeline.

Also release embedding caching earlier to reduce peak memory usage.

With spilling, deep-1M can be indexed with 6 threads given 2GB bm size, compared to ~4GB without spilling.