### PR TITLE
Make extension statements readonly

### DIFF
--- a/extension/fts/test/CMakeLists.txt
+++ b/extension/fts/test/CMakeLists.txt
@@ -1,3 +1,4 @@
 if (${BUILD_EXTENSION_TESTS})
     add_kuzu_test(fts_prepare_test prepare_test.cpp)
+    add_kuzu_test(fts_read_only_test read_only_test.cpp)
 endif ()

--- a/extension/fts/test/prepare_test.cpp
+++ b/extension/fts/test/prepare_test.cpp
@@ -14,16 +14,16 @@ TEST_F(ApiTest, PrepareFTSTest) {
     ASSERT_TRUE(
         conn->query("CALL CREATE_FTS_INDEX('person', 'personIdx', ['fName'])")->isSuccess());
     auto prepared =
-        conn->prepare("CALL QUERY_FTS_INDEX('person', 'personIdx', $q) RETURN _node.ID, score;");
+        conn->prepare("CALL QUERY_FTS_INDEX('person', 'personIdx', $q) RETURN node.ID, score;");
     auto preparedResult = TestHelper::convertResultToString(
         *conn->execute(prepared.get(), std::make_pair(std::string("q"), std::string("alice"))));
     auto nonPreparedResult = TestHelper::convertResultToString(*conn->query(
-        "CALL QUERY_FTS_INDEX('person', 'personIdx', 'alice') RETURN _node.ID, score;"));
+        "CALL QUERY_FTS_INDEX('person', 'personIdx', 'alice') RETURN node.ID, score;"));
     sortAndCheckTestResults(preparedResult, nonPreparedResult);
 
     // The query parameter has to be a literal/parameter expression.
     prepared = conn->prepare("MATCH (d:person) CALL QUERY_FTS_INDEX('person', 'personIdx', "
-                             "d.fName) RETURN _node.ID, score;");
+                             "d.fName) RETURN node.ID, score;");
     auto result = conn->execute(prepared.get());
     ASSERT_FALSE(result->isSuccess());
     ASSERT_EQ(result->getErrorMessage(),
@@ -31,7 +31,7 @@ TEST_F(ApiTest, PrepareFTSTest) {
 
     // User must have to give a value when executing the QUERY_FTS_INDEX.
     prepared =
-        conn->prepare("CALL QUERY_FTS_INDEX('person', 'personIdx', $1) RETURN _node.ID, score;");
+        conn->prepare("CALL QUERY_FTS_INDEX('person', 'personIdx', $1) RETURN node.ID, score;");
     result = conn->execute(prepared.get());
     ASSERT_FALSE(result->isSuccess());
     ASSERT_EQ(result->getErrorMessage(),
@@ -39,7 +39,7 @@ TEST_F(ApiTest, PrepareFTSTest) {
 
     // Table name can't be a parameter expression.
     prepared =
-        conn->prepare("CALL QUERY_FTS_INDEX($3, 'personIdx', 'alice') RETURN _node.ID, score;");
+        conn->prepare("CALL QUERY_FTS_INDEX($3, 'personIdx', 'alice') RETURN node.ID, score;");
     result = conn->execute(prepared.get(), std::make_pair(std::string("3"), std::string("person")));
     ASSERT_FALSE(result->isSuccess());
     ASSERT_EQ(result->getErrorMessage(),

--- a/extension/fts/test/read_only_test.cpp
+++ b/extension/fts/test/read_only_test.cpp
@@ -1,0 +1,32 @@
+#include "main_test_helper/main_test_helper.h"
+
+using namespace kuzu::common;
+
+namespace kuzu {
+namespace testing {
+
+TEST_F(ApiTest, ReadOnlyDBTest) {
+    createDBAndConn();
+    ASSERT_TRUE(conn
+            ->query(common::stringFormat("LOAD EXTENSION '{}'",
+                TestHelper::appendKuzuRootPath("extension/fts/build/libfts.kuzu_extension")))
+            ->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE NODE TABLE doc (NAME STRING, PRIMARY KEY(NAME))")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (d:doc {NAME: 'alice'})")->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (d:doc {NAME: 'bob'})")->isSuccess());
+    ASSERT_TRUE(conn->query("CALL CREATE_FTS_INDEX('doc', 'docIdx', ['NAME'])")->isSuccess());
+    systemConfig->readOnly = true;
+    createDBAndConn();
+    ASSERT_TRUE(conn
+            ->query(common::stringFormat("LOAD EXTENSION '{}'",
+                TestHelper::appendKuzuRootPath("extension/fts/build/libfts.kuzu_extension")))
+            ->isSuccess());
+    ASSERT_STREQ("Connection exception: Cannot execute write operations in a read-only database!",
+        conn->query("CALL CREATE_FTS_INDEX('doc', 'docIdx1', ['NAME'])")->toString().c_str());
+    ASSERT_TRUE(
+        conn->query("CALL QUERY_FTS_INDEX('doc', 'docIdx', 'alice') RETURN node.NAME, score")
+            ->isSuccess());
+}
+
+} // namespace testing
+} // namespace kuzu

--- a/extension/fts/test/read_only_test.cpp
+++ b/extension/fts/test/read_only_test.cpp
@@ -7,20 +7,20 @@ namespace testing {
 
 TEST_F(ApiTest, ReadOnlyDBTest) {
     createDBAndConn();
-    ASSERT_TRUE(conn
-            ->query(common::stringFormat("LOAD EXTENSION '{}'",
-                TestHelper::appendKuzuRootPath("extension/fts/build/libfts.kuzu_extension")))
-            ->isSuccess());
+    ASSERT_TRUE(conn->query(common::stringFormat("LOAD EXTENSION '{}'",
+                                TestHelper::appendKuzuRootPath(
+                                    "extension/fts/build/libfts.kuzu_extension")))
+                    ->isSuccess());
     ASSERT_TRUE(conn->query("CREATE NODE TABLE doc (NAME STRING, PRIMARY KEY(NAME))")->isSuccess());
     ASSERT_TRUE(conn->query("CREATE (d:doc {NAME: 'alice'})")->isSuccess());
     ASSERT_TRUE(conn->query("CREATE (d:doc {NAME: 'bob'})")->isSuccess());
     ASSERT_TRUE(conn->query("CALL CREATE_FTS_INDEX('doc', 'docIdx', ['NAME'])")->isSuccess());
     systemConfig->readOnly = true;
     createDBAndConn();
-    ASSERT_TRUE(conn
-            ->query(common::stringFormat("LOAD EXTENSION '{}'",
-                TestHelper::appendKuzuRootPath("extension/fts/build/libfts.kuzu_extension")))
-            ->isSuccess());
+    ASSERT_TRUE(conn->query(common::stringFormat("LOAD EXTENSION '{}'",
+                                TestHelper::appendKuzuRootPath(
+                                    "extension/fts/build/libfts.kuzu_extension")))
+                    ->isSuccess());
     ASSERT_STREQ("Connection exception: Cannot execute write operations in a read-only database!",
         conn->query("CALL CREATE_FTS_INDEX('doc', 'docIdx1', ['NAME'])")->toString().c_str());
     ASSERT_TRUE(

--- a/src/include/parser/visitor/statement_read_write_analyzer.h
+++ b/src/include/parser/visitor/statement_read_write_analyzer.h
@@ -21,7 +21,7 @@ private:
     void visitStandaloneCall(const Statement& /*statement*/) override { readOnly = true; }
     void visitStandaloneCallFunction(const Statement& /*statement*/) override { readOnly = false; }
     void visitCreateMacro(const Statement& /*statement*/) override { readOnly = false; }
-    void visitExtension(const Statement& /*statement*/) override { readOnly = false; }
+    void visitExtension(const Statement& /*statement*/) override { readOnly = true; }
 
     void visitReadingClause(const ReadingClause* readingClause) override;
     void visitWithClause(const WithClause* withClause) override;

--- a/src/parser/visitor/standalone_call_rewriter.cpp
+++ b/src/parser/visitor/standalone_call_rewriter.cpp
@@ -2,8 +2,6 @@
 
 #include "binder/binder.h"
 #include "binder/bound_standalone_call_function.h"
-#include "common/exception/connection.h"
-#include "main/database.h"
 #include "parser/standalone_call_function.h"
 
 namespace kuzu {

--- a/src/parser/visitor/standalone_call_rewriter.cpp
+++ b/src/parser/visitor/standalone_call_rewriter.cpp
@@ -2,6 +2,8 @@
 
 #include "binder/binder.h"
 #include "binder/bound_standalone_call_function.h"
+#include "common/exception/connection.h"
+#include "main/database.h"
 #include "parser/standalone_call_function.h"
 
 namespace kuzu {
@@ -27,7 +29,7 @@ void StandaloneCallRewriter::visitStandaloneCallFunction(const Statement& statem
                 rewriteQuery = func->rewriteFunc(*context, *boundStandaloneCall.getBindData());
             }
         },
-        false /*readOnlyStatement*/, false /*isTransactionStatement*/,
+        true /*readOnlyStatement*/, false /*isTransactionStatement*/,
         main::ClientContext::TransactionHelper::TransactionCommitAction::COMMIT_IF_NEW);
 }
 


### PR DESCRIPTION
This PR makes extension statements read-only, so users can load extension in read-only database.
Fixes #4867 