### PR TITLE
Fix match after fts query

### DIFF
--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -339,6 +339,7 @@ void QueryFTSAlgorithm::bind(const GDSBindInput& input, main::ClientContext& con
     auto graphEntry = graph::GraphEntry({termsEntry, docsEntry}, {appearsInEntry});
     bindData = std::make_unique<QueryFTSBindData>(std::move(graphEntry), nodeOutput,
         std::move(query), *ftsIndexEntry, QueryFTSConfig{input.optionalParams});
+    context.setUseInternalCatalogEntry(false /* useInternalCatalogEntry */);
 }
 
 function_set QueryFTSFunction::getFunctionSet() {

--- a/extension/fts/test/test_files/fts_small.test
+++ b/extension/fts/test/test_files/fts_small.test
@@ -75,6 +75,27 @@
 3|0|0.271133
 3|3|0.209476
 
+-STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx4', 'waterloo') with node.ID as ID, score as score MATCH (n) RETURN ID, score, label(n)
+---- 18
+0|0.192034|city_stopwords
+0|0.192034|city_stopwords
+0|0.192034|city_stopwords
+20|0.210752|city_stopwords
+20|0.210752|city_stopwords
+20|0.210752|city_stopwords
+0|0.192034|doc
+0|0.192034|doc
+0|0.192034|doc
+20|0.210752|doc
+20|0.210752|doc
+20|0.210752|doc
+0|0.192034|name_stopwords
+0|0.192034|name_stopwords
+0|0.192034|name_stopwords
+20|0.210752|name_stopwords
+20|0.210752|name_stopwords
+20|0.210752|name_stopwords
+
 -CASE FTSWithParams
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
 ---- ok


### PR DESCRIPTION
fixes #4930 
We should set `useInternalTable` to false after binding queryFTS.