### PR TITLE
Fix remote filesystem glob

### DIFF
--- a/extension/httpfs/test/test_files/gcs_glob.test
+++ b/extension/httpfs/test/test_files/gcs_glob.test
@@ -1,0 +1,20 @@
+-DATASET CSV empty
+
+--
+
+-CASE GCSGlob
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/httpfs/build/libhttpfs.kuzu_extension"
+---- ok
+-STATEMENT create node table person (ID INt64, fName StRING, gender INT64, isStudent BoOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration interval, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT copy person from "gs://tinysnb/vPerson*.csv"(header=true);
+---- ok
+-STATEMENT match (p:person) return p.id;
+---- 7
+0
+2
+3
+5
+7
+9
+10


### PR DESCRIPTION
# Description

Re-enable glob for remote filesystems (s3/GCS). This was disabled previously to help validate file paths for delta/iceberg, but we can avoid disabling the glob if we have the httpfs extension loaded.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).