### PR TITLE
Parallel Distinct SimpleAggregate

### DIFF
--- a/src/include/processor/operator/aggregate/base_aggregate.h
+++ b/src/include/processor/operator/aggregate/base_aggregate.h
@@ -3,25 +3,114 @@
 #include <mutex>
 
 #include "aggregate_input.h"
+#include "common/mpsc_queue.h"
 #include "function/aggregate_function.h"
 #include "processor/operator/sink.h"
+#include "processor/result/factorized_table.h"
+#include "processor/result/factorized_table_schema.h"
 
 namespace kuzu {
+namespace main {
+class ClientContext;
+}
 namespace processor {
+class AggregateHashTable;
+
+size_t getNumPartitionsForParallelism(main::ClientContext* context);
 
 class BaseAggregateSharedState {
+    friend class BaseAggregate;
+
+public:
+    template<typename Partition, typename Func>
+    void finalizePartitions(std::vector<Partition>& globalPartitions, Func finalizeFunc) {
+        for (auto& partition : globalPartitions) {
+            if (!partition.finalized && partition.mtx.try_lock()) {
+                if (partition.finalized) {
+                    // If there was a data race in the above && a thread may get through after
+                    // another thread has finalized this partition Ignore coverage since we can't
+                    // reliably test this data race
+                    // LCOV_EXCL_START
+                    partition.mtx.unlock();
+                    continue;
+                    // LCOV_EXCL_END
+                }
+                finalizeFunc(partition);
+                partition.finalized = true;
+                partition.mtx.unlock();
+            }
+        }
+    }
+
+    bool isReadyForFinalization() const { return readyForFinalization; }
+
 protected:
     explicit BaseAggregateSharedState(
-        const std::vector<function::AggregateFunction>& aggregateFunctions);
+        const std::vector<function::AggregateFunction>& aggregateFunctions, size_t numPartitions);
 
     virtual std::pair<uint64_t, uint64_t> getNextRangeToRead() = 0;
 
     ~BaseAggregateSharedState() = default;
 
+    void finalizeAggregateHashTable(const AggregateHashTable& localHashTable);
+
+    class HashTableQueue {
+    public:
+        HashTableQueue(storage::MemoryManager* memoryManager, FactorizedTableSchema tableSchema);
+
+        std::unique_ptr<HashTableQueue> copy() const {
+            return std::make_unique<HashTableQueue>(headBlock.load()->table.getMemoryManager(),
+                headBlock.load()->table.getTableSchema()->copy());
+        }
+        ~HashTableQueue();
+
+        void appendTuple(std::span<uint8_t> tuple);
+
+        void mergeInto(AggregateHashTable& hashTable);
+
+        bool empty() const {
+            auto headBlock = this->headBlock.load();
+            return (headBlock == nullptr || headBlock->numTuplesReserved == 0) &&
+                   queuedTuples.approxSize() == 0;
+        }
+
+        struct TupleBlock {
+            TupleBlock(storage::MemoryManager* memoryManager, FactorizedTableSchema tableSchema)
+                : numTuplesReserved{0}, numTuplesWritten{0},
+                  table{memoryManager, std::move(tableSchema)} {
+                // Start at a fixed capacity of one full block (so that concurrent writes are safe).
+                // If it is not filled, we resize it to the actual capacity before writing it to the
+                // hashTable
+                table.resize(table.getNumTuplesPerBlock());
+            }
+            // numTuplesReserved may be greater than the capacity of the factorizedTable
+            // if threads try to write to it while a new block is being allocated
+            // So it should not be relied on for anything other than reserving tuples
+            std::atomic<uint64_t> numTuplesReserved;
+            // Set after the tuple has been written to the block.
+            // Once numTuplesWritten == factorizedTable.getNumTuplesPerBlock() all writes have
+            // finished
+            std::atomic<uint64_t> numTuplesWritten;
+            FactorizedTable table;
+        };
+        common::MPSCQueue<TupleBlock*> queuedTuples;
+        // When queueing tuples, they are always added to the headBlock until the headBlock is full
+        // (numTuplesReserved >= factorizedTable.getNumTuplesPerBlock()), then pushed into the
+        // queuedTuples (at which point, the numTuplesReserved may not be equal to the
+        // numTuplesWritten)
+        std::atomic<TupleBlock*> headBlock;
+        uint64_t numTuplesPerBlock;
+    };
+
 protected:
     std::mutex mtx;
     uint64_t currentOffset;
     std::vector<function::AggregateFunction> aggregateFunctions;
+    std::atomic<size_t> numThreadsFinishedProducing;
+    std::atomic<size_t> numThreads;
+    common::MPSCQueue<std::unique_ptr<common::InMemOverflowBuffer>> overflow;
+    uint8_t shiftForPartitioning;
+    bool readyForFinalization;
 };
 
 class BaseAggregate : public Sink {
@@ -29,24 +118,30 @@ class BaseAggregate : public Sink {
 
 protected:
     BaseAggregate(std::unique_ptr<ResultSetDescriptor> resultSetDescriptor,
+        std::shared_ptr<BaseAggregateSharedState> sharedState,
         std::vector<function::AggregateFunction> aggregateFunctions,
         std::vector<AggregateInfo> aggInfos, std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
         : Sink{std::move(resultSetDescriptor), type_, std::move(child), id, std::move(printInfo)},
-          aggregateFunctions{std::move(aggregateFunctions)}, aggInfos{std::move(aggInfos)} {}
+          aggregateFunctions{std::move(aggregateFunctions)}, aggInfos{std::move(aggInfos)},
+          sharedState{std::move(sharedState)} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
-
-    void finalizeInternal(ExecutionContext* context) override = 0;
 
     std::unique_ptr<PhysicalOperator> copy() override = 0;
 
     bool containDistinctAggregate() const;
 
+    void finalizeInternal(ExecutionContext* /*context*/) override {
+        // Delegated to HashAggregateFinalize so it can be parallelized
+        sharedState->readyForFinalization = true;
+    }
+
 protected:
     std::vector<function::AggregateFunction> aggregateFunctions;
     std::vector<AggregateInfo> aggInfos;
     std::vector<AggregateInput> aggInputs;
+    std::shared_ptr<BaseAggregateSharedState> sharedState;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/aggregate/simple_aggregate.h
+++ b/src/include/processor/operator/aggregate/simple_aggregate.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <memory>
+
+#include "common/cast.h"
+#include "common/copy_constructors.h"
 #include "processor/operator/aggregate/aggregate_hash_table.h"
 #include "processor/operator/aggregate/base_aggregate.h"
 
@@ -8,15 +12,21 @@ namespace processor {
 
 // NOLINTNEXTLINE(cppcoreguidelines-virtual-class-destructor): This is a final class.
 class SimpleAggregateSharedState final : public BaseAggregateSharedState {
+    friend class SimpleAggregate;
+
 public:
-    explicit SimpleAggregateSharedState(
-        const std::vector<function::AggregateFunction>& aggregateFunctions);
+    explicit SimpleAggregateSharedState(main::ClientContext* clientContext,
+        const std::vector<function::AggregateFunction>& aggregateFunctions,
+        const std::vector<AggregateInfo>& aggInfos);
+
+    // The partitioningData objects need a stable pointer to this shared state
+    DELETE_COPY_AND_MOVE(SimpleAggregateSharedState);
 
     void combineAggregateStates(
         const std::vector<std::unique_ptr<function::AggregateState>>& localAggregateStates,
         storage::MemoryManager* memoryManager);
 
-    void finalizeAggregateStates();
+    void finalizeAggregateStates(storage::MemoryManager* memoryManager);
 
     std::pair<uint64_t, uint64_t> getNextRangeToRead() override;
 
@@ -24,7 +34,44 @@ public:
         return globalAggregateStates[idx].get();
     }
 
+    // Merges data from the queues into the distinct hash tables
+    // Can be run concurrently (but only after all data has been written into the queues)
+    void finalizePartitions(storage::MemoryManager* memoryManager,
+        const std::vector<AggregateInfo>& aggInfos);
+
+    bool isReadyForFinalization() const { return readyForFinalization; }
+
+protected:
+    struct Partition {
+        struct DistinctData {
+            std::unique_ptr<AggregateHashTable> hashTable;
+            std::unique_ptr<HashTableQueue> queue;
+            std::unique_ptr<function::AggregateState> state;
+        };
+        std::mutex mtx;
+        std::vector<DistinctData> distinctTables;
+        std::atomic<bool> finalized = false;
+    };
+
+    class SimpleAggregatePartitioningData : public AggregatePartitioningData {
+    public:
+        SimpleAggregatePartitioningData(SimpleAggregateSharedState* sharedState, size_t functionIdx)
+            : sharedState{sharedState}, functionIdx{functionIdx} {}
+
+        void appendTuples(const FactorizedTable& factorizedTable,
+            ft_col_offset_t hashOffset) override;
+        void appendDistinctTuple(size_t, std::span<uint8_t>, common::hash_t) override;
+        void appendOverflow(common::InMemOverflowBuffer&& overflowBuffer) override;
+
+    private:
+        SimpleAggregateSharedState* sharedState;
+        size_t functionIdx;
+    };
+
 private:
+    bool hasDistinct;
+    std::vector<Partition> globalPartitions;
+    std::vector<SimpleAggregatePartitioningData> partitioningData;
     std::vector<std::unique_ptr<function::AggregateState>> globalAggregateStates;
 };
 
@@ -52,44 +99,61 @@ public:
         std::vector<function::AggregateFunction> aggregateFunctions,
         std::vector<AggregateInfo> aggInfos, std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : BaseAggregate{std::move(resultSetDescriptor), std::move(aggregateFunctions),
-              std::move(aggInfos), std::move(child), id, std::move(printInfo)},
-          sharedState{std::move(sharedState)} {}
+        : BaseAggregate{std::move(resultSetDescriptor), std::move(sharedState),
+              std::move(aggregateFunctions), std::move(aggInfos), std::move(child), id,
+              std::move(printInfo)} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
     void executeInternal(ExecutionContext* context) override;
 
-    void finalizeInternal(ExecutionContext* /*context*/) override {
-        sharedState->finalizeAggregateStates();
-        if (metrics) {
-            metrics->numOutputTuple.incrementByOne();
-        }
-    }
-
     std::unique_ptr<PhysicalOperator> copy() override {
-        return make_unique<SimpleAggregate>(resultSetDescriptor->copy(), sharedState,
+        return make_unique<SimpleAggregate>(resultSetDescriptor->copy(),
+            std::reinterpret_pointer_cast<SimpleAggregateSharedState>(sharedState),
             copyVector(aggregateFunctions), copyVector(aggInfos), children[0]->copy(), id,
             printInfo->copy());
     }
 
-    // TODO(bmwinger): We can use the same type of partitioning to handle distinct simple aggregates
-    // It could even be the exact same pipeline, but it would perform better if we don't use the
-    // hash tables for anything but collecting the distinct values
-    // Maybe try and move the partitioning into BaseAggregate
-    bool isParallel() const final { return !containDistinctAggregate(); }
-
 private:
-    void computeDistinctAggregate(AggregateHashTable* distinctHT,
-        function::AggregateFunction* function, AggregateInput* input,
-        function::AggregateState* state, storage::MemoryManager* memoryManager);
     void computeAggregate(function::AggregateFunction* function, AggregateInput* input,
         function::AggregateState* state, storage::MemoryManager* memoryManager);
 
+    SimpleAggregateSharedState& getSharedState() {
+        return common::ku_dynamic_cast<SimpleAggregateSharedState&>(*sharedState.get());
+    }
+
+private:
+    std::vector<std::unique_ptr<function::AggregateState>> localAggregateStates;
+    std::vector<std::unique_ptr<PartitioningAggregateHashTable>> distinctHashTables;
+};
+
+class SimpleAggregateFinalize final : public Sink {
+public:
+    SimpleAggregateFinalize(std::unique_ptr<ResultSetDescriptor> resultSetDescriptor,
+        std::shared_ptr<SimpleAggregateSharedState> sharedState,
+        std::unique_ptr<PhysicalOperator> child, std::vector<AggregateInfo> aggInfos, uint32_t id,
+        std::unique_ptr<OPPrintInfo> printInfo)
+        : Sink{std::move(resultSetDescriptor), PhysicalOperatorType::AGGREGATE_FINALIZE,
+              std::move(child), id, std::move(printInfo)},
+          sharedState{std::move(sharedState)}, aggInfos{std::move(aggInfos)} {}
+
+    // Otherwise the runtime metrics for this operator are negative
+    // since it doesn't call children[0]->getNextTuple
+    bool isSource() const override { return true; }
+
+    void executeInternal(ExecutionContext* context) override;
+
+    void finalizeInternal(ExecutionContext* context) override;
+
+    std::unique_ptr<PhysicalOperator> copy() override {
+        return make_unique<SimpleAggregateFinalize>(resultSetDescriptor->copy(), sharedState,
+            children[0]->copy(), copyVector(aggInfos), id, printInfo->copy());
+    }
+
 private:
     std::shared_ptr<SimpleAggregateSharedState> sharedState;
-    std::vector<std::unique_ptr<function::AggregateState>> localAggregateStates;
-    std::vector<std::unique_ptr<AggregateHashTable>> distinctHashTables;
+    std::vector<AggregateInfo> aggInfos;
+    std::vector<std::unique_ptr<function::AggregateState>> globalAggregateStates;
 };
 
 } // namespace processor

--- a/src/processor/operator/aggregate/base_aggregate.cpp
+++ b/src/processor/operator/aggregate/base_aggregate.cpp
@@ -1,22 +1,25 @@
 #include "processor/operator/aggregate/base_aggregate.h"
 
+#include "main/client_context.h"
+#include "processor/operator/aggregate/aggregate_hash_table.h"
+
 using namespace kuzu::function;
 
 namespace kuzu {
 namespace processor {
 
-BaseAggregateSharedState::BaseAggregateSharedState(
-    const std::vector<AggregateFunction>& aggregateFunctions)
-    : currentOffset{0}, aggregateFunctions{copyVector(aggregateFunctions)} {}
-
-bool BaseAggregate::containDistinctAggregate() const {
-    for (auto& function : aggregateFunctions) {
-        if (function.isFunctionDistinct()) {
-            return true;
-        }
-    }
-    return false;
+size_t getNumPartitionsForParallelism(main::ClientContext* context) {
+    return context->getMaxNumThreadForExec();
 }
+
+BaseAggregateSharedState::BaseAggregateSharedState(
+    const std::vector<AggregateFunction>& aggregateFunctions, size_t numPartitions)
+    : currentOffset{0}, aggregateFunctions{copyVector(aggregateFunctions)}, numThreads{0},
+      // numPartitions - 1 since we want the bit width of the largest value that
+      // could be used to index the partitions
+      shiftForPartitioning{
+          static_cast<uint8_t>(sizeof(common::hash_t) * 8 - std::bit_width(numPartitions - 1))},
+      readyForFinalization{false} {}
 
 void BaseAggregate::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* /*context*/) {
     for (auto& info : aggInfos) {
@@ -32,6 +35,76 @@ void BaseAggregate::initLocalStateInternal(ResultSet* resultSet, ExecutionContex
         }
         aggInputs.push_back(std::move(aggregateInput));
     }
+}
+
+BaseAggregateSharedState::HashTableQueue::HashTableQueue(storage::MemoryManager* memoryManager,
+    FactorizedTableSchema tableSchema) {
+    headBlock = new TupleBlock(memoryManager, std::move(tableSchema));
+    numTuplesPerBlock = headBlock.load()->table.getNumTuplesPerBlock();
+}
+
+BaseAggregateSharedState::HashTableQueue::~HashTableQueue() {
+    delete headBlock.load();
+    TupleBlock* block = nullptr;
+    while (queuedTuples.pop(block)) {
+        delete block;
+    }
+}
+
+void BaseAggregateSharedState::HashTableQueue::appendTuple(std::span<uint8_t> tuple) {
+    while (true) {
+        auto* block = headBlock.load();
+        KU_ASSERT(tuple.size() == block->table.getTableSchema()->getNumBytesPerTuple());
+        auto posToWrite = block->numTuplesReserved++;
+        if (posToWrite < numTuplesPerBlock) {
+            memcpy(block->table.getTuple(posToWrite), tuple.data(), tuple.size());
+            block->numTuplesWritten++;
+            return;
+        } else {
+            // No more space in the block, allocate and replace it
+            auto* newBlock = new TupleBlock(block->table.getMemoryManager(),
+                block->table.getTableSchema()->copy());
+            if (headBlock.compare_exchange_strong(block, newBlock)) {
+                // TODO(bmwinger): if the queuedTuples has at least a certain size (benchmark to see
+                // if there's a benefit to waiting for multiple blocks) then cycle through the queue
+                // and flush any blocks which have been fully written
+                queuedTuples.push(block);
+            } else {
+                // If the block was replaced by another thread, discard the block we created and try
+                // again with the block allocated by the other thread
+                delete newBlock;
+            }
+        }
+    }
+}
+
+void BaseAggregateSharedState::HashTableQueue::mergeInto(AggregateHashTable& hashTable) {
+    std::vector<TupleBlock*> partitionsToMerge;
+    partitionsToMerge.reserve(queuedTuples.approxSize());
+    TupleBlock* partitionToMerge = nullptr;
+    // Over-estimate the total number of distinct groups using the total number of tuples
+    // after the per-thread pre-aggregation
+    // This will probably use more memory than necessary, but will greatly reduce the need
+    // to resize the hash table. It will only use memory proportional to what is already
+    // used by the queuedTuples already, and the hash slots are usually small in comparison
+    // to the full tuple data.
+    auto headBlock = this->headBlock.load();
+    KU_ASSERT(headBlock != nullptr);
+    hashTable.resizeHashTableIfNecessary(
+        queuedTuples.approxSize() * headBlock->table.getNumTuplesPerBlock() +
+        headBlock->numTuplesWritten);
+    while (queuedTuples.pop(partitionToMerge)) {
+        KU_ASSERT(
+            partitionToMerge->numTuplesWritten == partitionToMerge->table.getNumTuplesPerBlock());
+        hashTable.merge(std::move(partitionToMerge->table));
+        delete partitionToMerge;
+    }
+    if (headBlock->numTuplesWritten > 0) {
+        headBlock->table.resize(headBlock->numTuplesWritten);
+        hashTable.merge(std::move(headBlock->table));
+    }
+    delete headBlock;
+    this->headBlock = nullptr;
 }
 
 } // namespace processor

--- a/src/processor/operator/aggregate/simple_aggregate.cpp
+++ b/src/processor/operator/aggregate/simple_aggregate.cpp
@@ -1,7 +1,23 @@
 #include "processor/operator/aggregate/simple_aggregate.h"
 
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
 #include "binder/expression/expression_util.h"
+#include "common/data_chunk/data_chunk_state.h"
+#include "common/system_config.h"
+#include "common/types/types.h"
+#include "common/vector/value_vector.h"
+#include "function/aggregate_function.h"
+#include "main/client_context.h"
 #include "processor/execution_context.h"
+#include "processor/operator/aggregate/aggregate_hash_table.h"
+#include "processor/operator/aggregate/aggregate_input.h"
+#include "processor/operator/aggregate/base_aggregate.h"
+#include "processor/result/factorized_table.h"
+#include "processor/result/factorized_table_schema.h"
+#include "storage/buffer_manager/memory_manager.h"
 
 using namespace kuzu::common;
 using namespace kuzu::function;
@@ -16,11 +32,44 @@ std::string SimpleAggregatePrintInfo::toString() const {
     return result;
 }
 
-SimpleAggregateSharedState::SimpleAggregateSharedState(
-    const std::vector<AggregateFunction>& aggregateFunctions)
-    : BaseAggregateSharedState{aggregateFunctions} {
-    for (auto& aggregateFunction : this->aggregateFunctions) {
+static bool isAnyFunctionDistinct(const std::vector<AggregateFunction>& functions) {
+    return std::any_of(functions.begin(), functions.end(),
+        [&](auto& func) { return func.isDistinct; });
+}
+
+SimpleAggregateSharedState::SimpleAggregateSharedState(main::ClientContext* context,
+    const std::vector<AggregateFunction>& aggregateFunctions,
+    const std::vector<AggregateInfo>& aggInfos)
+    : BaseAggregateSharedState{aggregateFunctions,
+          // Only distinct functions need partitioning
+          getNumPartitionsForParallelism(context)},
+      hasDistinct{isAnyFunctionDistinct(aggregateFunctions)},
+      globalPartitions{hasDistinct ? getNumPartitionsForParallelism(context) : 0} {
+    for (size_t funcIdx = 0; funcIdx < this->aggregateFunctions.size(); funcIdx++) {
+        auto& aggregateFunction = this->aggregateFunctions[funcIdx];
         globalAggregateStates.push_back(aggregateFunction.createInitialNullAggregateState());
+        partitioningData.emplace_back(this, funcIdx);
+        if (aggregateFunction.isDistinct) {
+            const auto& distinctKeyType = aggInfos[funcIdx].distinctAggKeyType;
+            auto schema = AggregateHashTableUtils::getTableSchemaForKeys(std::vector<LogicalType>{},
+                aggInfos[funcIdx].distinctAggKeyType);
+            for (auto& partition : globalPartitions) {
+                std::vector<LogicalType> keyTypes(1);
+                keyTypes[0] = distinctKeyType.copy();
+                auto hashTable = std::make_unique<AggregateHashTable>(*context->getMemoryManager(),
+                    std::move(keyTypes), std::vector<LogicalType>{} /*payloadTypes*/,
+                    std::vector<AggregateFunction>{}, std::vector<LogicalType>{}, 0, schema.copy());
+                auto queue = std::make_unique<HashTableQueue>(context->getMemoryManager(),
+                    AggregateHashTableUtils::getTableSchemaForKeys(std::vector<LogicalType>{},
+                        aggInfos[funcIdx].distinctAggKeyType));
+                partition.distinctTables.emplace_back(Partition::DistinctData{std::move(hashTable),
+                    std::move(queue), aggregateFunction.createInitialNullAggregateState()});
+            }
+        } else {
+            for (auto& partition : globalPartitions) {
+                partition.distinctTables.emplace_back();
+            }
+        }
     }
 }
 
@@ -30,15 +79,28 @@ void SimpleAggregateSharedState::combineAggregateStates(
     KU_ASSERT(localAggregateStates.size() == globalAggregateStates.size());
     std::unique_lock lck{mtx};
     for (auto i = 0u; i < aggregateFunctions.size(); ++i) {
-        aggregateFunctions[i].combineState((uint8_t*)globalAggregateStates[i].get(),
-            (uint8_t*)localAggregateStates[i].get(), memoryManager);
+        // Distinct functions will be combined accross the partitions in
+        // finalizeAggregateStates
+        if (!aggregateFunctions[i].isDistinct) {
+            aggregateFunctions[i].combineState(
+                reinterpret_cast<uint8_t*>(globalAggregateStates[i].get()),
+                reinterpret_cast<uint8_t*>(localAggregateStates[i].get()), memoryManager);
+        }
     }
 }
 
-void SimpleAggregateSharedState::finalizeAggregateStates() {
+void SimpleAggregateSharedState::finalizeAggregateStates(storage::MemoryManager* memoryManager) {
     std::unique_lock lck{mtx};
     for (auto i = 0u; i < aggregateFunctions.size(); ++i) {
-        aggregateFunctions[i].finalizeState((uint8_t*)globalAggregateStates[i].get());
+        if (aggregateFunctions[i].isDistinct) {
+            for (auto& partition : globalPartitions) {
+                aggregateFunctions[i].combineState(reinterpret_cast<uint8_t*>(getAggregateState(i)),
+                    reinterpret_cast<uint8_t*>(partition.distinctTables[i].state.get()),
+                    memoryManager);
+            }
+        }
+        aggregateFunctions[i].finalizeState(
+            reinterpret_cast<uint8_t*>(globalAggregateStates[i].get()));
     }
 }
 
@@ -52,17 +114,86 @@ std::pair<uint64_t, uint64_t> SimpleAggregateSharedState::getNextRangeToRead() {
     return std::make_pair(startOffset, currentOffset);
 }
 
+void SimpleAggregateSharedState::SimpleAggregatePartitioningData::appendTuples(
+    const FactorizedTable& factorizedTable, ft_col_offset_t hashOffset) {
+    KU_ASSERT(sharedState->globalPartitions.size() > 0);
+    auto numBytesPerTuple = factorizedTable.getTableSchema()->getNumBytesPerTuple();
+    for (ft_tuple_idx_t tupleIdx = 0; tupleIdx < factorizedTable.getNumTuples(); tupleIdx++) {
+        auto tuple = factorizedTable.getTuple(tupleIdx);
+        auto hash = *reinterpret_cast<common::hash_t*>(tuple + hashOffset);
+        auto& partition =
+            sharedState->globalPartitions[(hash >> sharedState->shiftForPartitioning) %
+                                          sharedState->globalPartitions.size()];
+        partition.distinctTables[functionIdx].queue->appendTuple(
+            std::span(tuple, numBytesPerTuple));
+    }
+}
+
+// LCOV_EXCL_START
+void SimpleAggregateSharedState::SimpleAggregatePartitioningData::appendDistinctTuple(size_t,
+    std::span<uint8_t>, common::hash_t) {
+    KU_UNREACHABLE;
+}
+// LCOV_EXCL_END
+
+void SimpleAggregateSharedState::SimpleAggregatePartitioningData::appendOverflow(
+    common::InMemOverflowBuffer&& overflowBuffer) {
+    sharedState->overflow.push(
+        std::make_unique<common::InMemOverflowBuffer>(std::move(overflowBuffer)));
+}
+
+void SimpleAggregateSharedState::finalizePartitions(storage::MemoryManager* memoryManager,
+    const std::vector<AggregateInfo>& aggInfos) {
+    if (!hasDistinct) {
+        return;
+    }
+    BaseAggregateSharedState::finalizePartitions(globalPartitions, [&](auto& partition) {
+        for (size_t i = 0; i < partition.distinctTables.size(); i++) {
+            auto& [hashTable, queue, state] = partition.distinctTables[i];
+            if (queue) {
+                KU_ASSERT(hashTable);
+                queue->mergeInto(*hashTable);
+            }
+
+            ValueVector aggregateVector(aggInfos[i].distinctAggKeyType.copy(), memoryManager,
+                std::make_shared<DataChunkState>());
+            const auto& ft = hashTable->getFactorizedTable();
+            ft_tuple_idx_t startTupleIdx = 0;
+            ft_tuple_idx_t numTuplesToScan =
+                std::min(DEFAULT_VECTOR_CAPACITY, ft->getNumTuples() - startTupleIdx);
+            std::array<uint32_t, 1> colIdxToScan = {0};
+            std::array<ValueVector*, 1> vectors = {&aggregateVector};
+            while (numTuplesToScan > 0) {
+                ft->scan(vectors, startTupleIdx, numTuplesToScan, colIdxToScan);
+                aggregateFunctions[i].updateAllState((uint8_t*)state.get(), &aggregateVector,
+                    1 /*multiplicity*/, memoryManager);
+                startTupleIdx += numTuplesToScan;
+                numTuplesToScan =
+                    std::min(DEFAULT_VECTOR_CAPACITY, ft->getNumTuples() - startTupleIdx);
+            }
+            hashTable.reset();
+            queue.reset();
+        }
+    });
+}
+
 void SimpleAggregate::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     BaseAggregate::initLocalStateInternal(resultSet, context);
     for (auto i = 0u; i < aggregateFunctions.size(); ++i) {
         auto& func = aggregateFunctions[i];
         localAggregateStates.push_back(func.createInitialNullAggregateState());
-        std::unique_ptr<AggregateHashTable> distinctHT;
+        std::unique_ptr<PartitioningAggregateHashTable> distinctHT;
         if (func.isDistinct) {
             auto mm = context->clientContext->getMemoryManager();
-            distinctHT = AggregateHashTableUtils::createDistinctHashTable(*mm,
-                std::vector<LogicalType>{} /* empty group by keys */,
-                aggInfos[i].distinctAggKeyType);
+            std::vector<LogicalType> keyTypes;
+            keyTypes.push_back(aggInfos[i].distinctAggKeyType.copy());
+            distinctHT = std::make_unique<PartitioningAggregateHashTable>(
+                &getSharedState().partitioningData[i], *mm, std::move(keyTypes),
+                std::vector<LogicalType>{} /* empty payload*/,
+                std::vector<function::AggregateFunction>{},
+                std::vector<LogicalType>{} /*empty distinct keys*/,
+                AggregateHashTableUtils::getTableSchemaForKeys(std::vector<LogicalType>{},
+                    aggInfos[i].distinctAggKeyType));
         } else {
             distinctHT = nullptr;
         }
@@ -76,27 +207,22 @@ void SimpleAggregate::executeInternal(ExecutionContext* context) {
         for (auto i = 0u; i < aggregateFunctions.size(); i++) {
             auto aggregateFunction = &aggregateFunctions[i];
             if (aggregateFunction->isFunctionDistinct()) {
-                computeDistinctAggregate(distinctHashTables[i].get(), aggregateFunction,
-                    &aggInputs[i], localAggregateStates[i].get(), memoryManager);
+                // Just add distinct value to the hash table. We'll calculate the final hash table
+                // once it's been merged into the global state
+                distinctHashTables[i].get()->insertAggregateValueIfDistinctForGroupByKeys(
+                    std::vector<ValueVector*>{}, aggInputs[i].aggregateVector);
             } else {
                 computeAggregate(aggregateFunction, &aggInputs[i], localAggregateStates[i].get(),
                     memoryManager);
             }
         }
     }
-    sharedState->combineAggregateStates(localAggregateStates, memoryManager);
-}
-
-void SimpleAggregate::computeDistinctAggregate(AggregateHashTable* distinctHT,
-    function::AggregateFunction* function, AggregateInput* input, function::AggregateState* state,
-    storage::MemoryManager* memoryManager) {
-    auto multiplicity = 1; // Distinct aggregate should ignore multiplicity.
-    if (distinctHT->insertAggregateValueIfDistinctForGroupByKeys(std::vector<ValueVector*>{},
-            input->aggregateVector)) {
-        auto pos = input->aggregateVector->state->getSelVector()[0];
-        function->updatePosState((uint8_t*)state, input->aggregateVector, multiplicity, pos,
-            memoryManager);
+    if (getSharedState().hasDistinct) {
+        for (auto& hashTable : distinctHashTables) {
+            hashTable->mergeAll();
+        }
     }
+    getSharedState().combineAggregateStates(localAggregateStates, memoryManager);
 }
 
 void SimpleAggregate::computeAggregate(function::AggregateFunction* function, AggregateInput* input,
@@ -115,6 +241,18 @@ void SimpleAggregate::computeAggregate(function::AggregateFunction* function, Ag
         function->updateAllState((uint8_t*)state, input->aggregateVector, multiplicity,
             memoryManager);
     }
+}
+
+void SimpleAggregateFinalize::finalizeInternal(ExecutionContext* context) {
+    sharedState->finalizeAggregateStates(context->clientContext->getMemoryManager());
+    if (metrics) {
+        metrics->numOutputTuple.incrementByOne();
+    }
+}
+
+void SimpleAggregateFinalize::executeInternal(ExecutionContext* context) {
+    KU_ASSERT(sharedState->isReadyForFinalization());
+    sharedState->finalizePartitions(context->clientContext->getMemoryManager(), aggInfos);
 }
 
 } // namespace processor

--- a/test/test_files/agg/distinct_agg.test
+++ b/test/test_files/agg/distinct_agg.test
@@ -29,9 +29,9 @@
 5
 
 -LOG SimpleDistinctCollectINT64Test
--STATEMENT MATCH (p:person) RETURN collect(distinct p.age)
+-STATEMENT MATCH (p:person) RETURN list_sort(collect(distinct p.age), 'ASC')
 ---- 1
-[35,30,45,20,25,40,83]
+[20,25,30,35,40,45,83]
 
 -LOG HashDistinctCollectDoubleTest
 -STATEMENT MATCH (p:person) RETURN p.gender, collect(distinct p.isStudent)


### PR DESCRIPTION
Extends the same method used to parallelize the hash aggregate and distinct hash aggregate to the simple, non-grouped aggregates.

~~There is still a reasonable amount of work being done single-threaded since after doing the parallel build + finalize of the distinct hash table we have to then scan it to actually compute the function result and that's currently being done in the single-threaded finalize since it can't be started until the parallel finalization is complete.
It would be possible to add another operator which does that in parallel, which I think could yield up to another 2x improvement to the runtime (skipping this step dropped both of the below benchmarks to \~0.9s, so this single-threaded part is clearly a significant part of the total runtime). But I think that's best left for a different PR.~~
 (*Edit: this can actually be done in the current operator fairly easily, we just need to store a state for each partition and combine them in finalize instead*).

| Query | master | 1 thread | 128 threads |
| --- | --- | --- | --- |
| `MATCH (h:hits) RETURN COUNT(DISTINCT h.UserID);` | 20.5s | 18.6s | 0.77s |
| `MATCH (h:hits) RETURN COUNT(DISTINCT h.SearchPhrase);` | 16.6s | 15.9s | 0.85s |

~Probably needs a bit more cleanup so I'm opening as a draft for now.~ (Should be good now; I updated the benchmarks twice between what was mentioned above as well as a small optimization to make it use fixed-sized hash tables prior to partitioning like in the hash aggregate).