### PR TITLE
Bundle httpfs,delta extension in duckdb lib

### DIFF
--- a/extension/delta/src/connector/delta_connector.cpp
+++ b/extension/delta/src/connector/delta_connector.cpp
@@ -9,10 +9,6 @@ void DeltaConnector::connect(const std::string& /*dbPath*/, const std::string& /
     instance = std::make_unique<duckdb::DuckDB>(nullptr);
     connection = std::make_unique<duckdb::Connection>(*instance);
     // Install the Desired Extension on DuckDB
-    executeQuery("install delta;");
-    executeQuery("load delta;");
-    executeQuery("install httpfs;");
-    executeQuery("load httpfs;");
     initRemoteFSSecrets(context);
 }
 

--- a/extension/duckdb/src/connector/remote_duckdb_connector.cpp
+++ b/extension/duckdb/src/connector/remote_duckdb_connector.cpp
@@ -12,8 +12,6 @@ void HTTPDuckDBConnector::connect(const std::string& dbPath, const std::string& 
     // Creates an in-memory duckdb instance, then install httpfs and attach remote duckdb.
     instance = std::make_unique<duckdb::DuckDB>(nullptr);
     connection = std::make_unique<duckdb::Connection>(*instance);
-    executeQuery("install httpfs;");
-    executeQuery("load httpfs;");
     executeQuery(common::stringFormat("attach '{}' as {} (read_only);", dbPath, catalogName));
 }
 
@@ -22,8 +20,6 @@ void S3DuckDBConnector::connect(const std::string& dbPath, const std::string& ca
     // Creates an in-memory duckdb instance, then install httpfs and attach remote duckdb.
     instance = std::make_unique<duckdb::DuckDB>(nullptr);
     connection = std::make_unique<duckdb::Connection>(*instance);
-    executeQuery("install httpfs;");
-    executeQuery("load httpfs;");
     initRemoteFSSecrets(context);
     executeQuery(common::stringFormat("attach '{}' as {} (read_only);", dbPath, catalogName));
 }

--- a/extension/iceberg/src/connector/iceberg_connector.cpp
+++ b/extension/iceberg/src/connector/iceberg_connector.cpp
@@ -11,8 +11,6 @@ void IcebergConnector::connect(const std::string& /*dbPath*/, const std::string&
     // Install the Desired Extension on DuckDB
     executeQuery("install iceberg;");
     executeQuery("load iceberg;");
-    executeQuery("install httpfs;");
-    executeQuery("load httpfs;");
     initRemoteFSSecrets(context);
 }
 


### PR DESCRIPTION
This PR bundles the `httpfs`, `delta` extensions in duckdb library. So we don't have to call  `install` and `load` on `httpfs` and `delta` extensions in our extensions. This should significantly improves the loading time of our extensions.

@mewim Can you rebuild duckdb on our CI?  We have to add these two lines to `extension_config.cmake` @line 12:
```
duckdb_extension_load(delta)
duckdb_extension_load(httpfs)
```

