### PR TITLE
Refactor semi mask

### DIFF
--- a/src/include/common/mask.h
+++ b/src/include/common/mask.h
@@ -43,8 +43,7 @@ private:
 class Roaring32BitmapSemiMask : public RoaringBitmapSemiMask {
 public:
     explicit Roaring32BitmapSemiMask(common::offset_t maxOffset)
-        : RoaringBitmapSemiMask(maxOffset), roaring(std::make_shared<roaring::Roaring>()) {
-    }
+        : RoaringBitmapSemiMask(maxOffset), roaring(std::make_shared<roaring::Roaring>()) {}
 
     void mask(common::offset_t nodeOffset) override { roaring->add(nodeOffset); }
     void maskRange(common::offset_t startNodeOffset, common::offset_t endNodeOffset) override {
@@ -78,8 +77,7 @@ public:
 class Roaring64BitmapSemiMask : public RoaringBitmapSemiMask {
 public:
     explicit Roaring64BitmapSemiMask(common::offset_t maxOffset)
-        : RoaringBitmapSemiMask(maxOffset),
-          roaring(std::make_shared<roaring::Roaring64Map>()) {}
+        : RoaringBitmapSemiMask(maxOffset), roaring(std::make_shared<roaring::Roaring64Map>()) {}
 
     void mask(common::offset_t nodeOffset) override { roaring->add(nodeOffset); }
     void maskRange(common::offset_t startNodeOffset, common::offset_t endNodeOffset) override {

--- a/src/include/processor/operator/gds_call.h
+++ b/src/include/processor/operator/gds_call.h
@@ -46,10 +46,6 @@ public:
 
     void executeInternal(ExecutionContext* executionContext) override;
 
-    void setNodeProperty(common::node_id_map_t<uint64_t>* nodeProp) {
-        sharedState->nodeProp = nodeProp;
-    }
-
     std::unique_ptr<PhysicalOperator> copy() override {
         return std::make_unique<GDSCall>(resultSetDescriptor->copy(), gds->copy(), sharedState, id,
             printInfo->copy());

--- a/src/include/processor/operator/gds_call_shared_state.h
+++ b/src/include/processor/operator/gds_call_shared_state.h
@@ -32,7 +32,6 @@ public:
         return result;
     }
 
-
     bool containsTableID(common::table_id_t tableID) const { return maskMap.contains(tableID); }
     common::semi_mask_t* getOffsetMask(common::table_id_t tableID) const {
         KU_ASSERT(containsTableID(tableID));

--- a/src/include/processor/operator/recursive_extend/recursive_join.h
+++ b/src/include/processor/operator/recursive_extend/recursive_join.h
@@ -14,10 +14,10 @@ namespace processor {
 class OffsetScanNodeTable;
 
 struct RecursiveJoinSharedState {
-    std::vector<std::unique_ptr<common::RoaringBitmapSemiMask>> semiMasks;
+    common::table_id_map_t<std::unique_ptr<common::semi_mask_t>> semiMasks;
 
     explicit RecursiveJoinSharedState(
-        std::vector<std::unique_ptr<common::RoaringBitmapSemiMask>> semiMasks)
+        common::table_id_map_t<std::unique_ptr<common::semi_mask_t>> semiMasks)
         : semiMasks{std::move(semiMasks)} {}
 };
 
@@ -116,7 +116,7 @@ public:
           info{std::move(info)}, sharedState{std::move(sharedState)},
           recursiveRoot{std::move(recursiveRoot)}, recursiveSource{nullptr} {}
 
-    std::vector<common::RoaringBitmapSemiMask*> getSemiMask() const;
+    common::table_id_map_t<common::semi_mask_t*> getSemiMasks() const;
 
     void initLocalStateInternal(ResultSet* resultSet_, ExecutionContext* context) final;
 

--- a/src/include/processor/operator/scan/scan_node_table.h
+++ b/src/include/processor/operator/scan/scan_node_table.h
@@ -16,7 +16,7 @@ struct ScanNodeTableProgressSharedState {
 
 class ScanNodeTableSharedState {
 public:
-    explicit ScanNodeTableSharedState(std::unique_ptr<common::RoaringBitmapSemiMask> semiMask)
+    explicit ScanNodeTableSharedState(std::unique_ptr<common::semi_mask_t> semiMask)
         : table{nullptr}, currentCommittedGroupIdx{common::INVALID_NODE_GROUP_IDX},
           currentUnCommittedGroupIdx{common::INVALID_NODE_GROUP_IDX}, numCommittedNodeGroups{0},
           numUnCommittedNodeGroups{0}, semiMask{std::move(semiMask)} {};
@@ -27,7 +27,7 @@ public:
     void nextMorsel(storage::NodeTableScanState& scanState,
         ScanNodeTableProgressSharedState& progressSharedState);
 
-    common::RoaringBitmapSemiMask* getSemiMask() const { return semiMask.get(); }
+    common::semi_mask_t* getSemiMask() const { return semiMask.get(); }
 
 private:
     std::mutex mtx;
@@ -36,7 +36,7 @@ private:
     common::node_group_idx_t currentUnCommittedGroupIdx;
     common::node_group_idx_t numCommittedNodeGroups;
     common::node_group_idx_t numUnCommittedNodeGroups;
-    std::unique_ptr<common::RoaringBitmapSemiMask> semiMask;
+    std::unique_ptr<common::semi_mask_t> semiMask;
 };
 
 struct ScanNodeTableInfo {
@@ -52,7 +52,7 @@ struct ScanNodeTableInfo {
           columnPredicates{std::move(columnPredicates)} {}
     EXPLICIT_COPY_DEFAULT_MOVE(ScanNodeTableInfo);
 
-    void initScanState(common::RoaringBitmapSemiMask* semiMask);
+    void initScanState(common::semi_mask_t* semiMask);
 
 private:
     ScanNodeTableInfo(const ScanNodeTableInfo& other)
@@ -96,7 +96,7 @@ public:
         KU_ASSERT(this->nodeInfos.size() == this->sharedStates.size());
     }
 
-    std::vector<common::RoaringBitmapSemiMask*> getSemiMasks() const;
+    common::table_id_map_t<common::semi_mask_t*> getSemiMasks() const;
 
     bool isSource() const override { return true; }
 

--- a/src/include/processor/operator/semi_masker.h
+++ b/src/include/processor/operator/semi_masker.h
@@ -24,7 +24,8 @@ struct SemiMaskerLocalState {
 
 class SemiMaskerSharedState {
 public:
-    explicit SemiMaskerSharedState(common::table_id_map_t<std::vector<common::semi_mask_t*>> masksPerTable)
+    explicit SemiMaskerSharedState(
+        common::table_id_map_t<std::vector<common::semi_mask_t*>> masksPerTable)
         : masksPerTable{std::move(masksPerTable)} {}
 
     SemiMaskerLocalState* appendLocalState();

--- a/src/include/processor/operator/semi_masker.h
+++ b/src/include/processor/operator/semi_masker.h
@@ -11,11 +11,9 @@ namespace processor {
 
 class BaseSemiMasker;
 
-using mask_vector = std::vector<common::RoaringBitmapSemiMask*>;
-
 struct SemiMaskerLocalState {
-    common::table_id_map_t<std::unique_ptr<common::RoaringBitmapSemiMask>> localMasksPerTable;
-    common::RoaringBitmapSemiMask* singleTableRef = nullptr;
+    common::table_id_map_t<std::unique_ptr<common::semi_mask_t>> localMasksPerTable;
+    common::semi_mask_t* singleTableRef = nullptr;
 
     void maskSingleTable(common::offset_t offset) const { singleTableRef->mask(offset); }
     void maskMultiTable(common::nodeID_t nodeID) const {
@@ -26,7 +24,7 @@ struct SemiMaskerLocalState {
 
 class SemiMaskerSharedState {
 public:
-    explicit SemiMaskerSharedState(common::table_id_map_t<mask_vector> masksPerTable)
+    explicit SemiMaskerSharedState(common::table_id_map_t<std::vector<common::semi_mask_t*>> masksPerTable)
         : masksPerTable{std::move(masksPerTable)} {}
 
     SemiMaskerLocalState* appendLocalState();
@@ -34,7 +32,7 @@ public:
     void mergeToGlobal();
 
 private:
-    common::table_id_map_t<mask_vector> masksPerTable;
+    common::table_id_map_t<std::vector<common::semi_mask_t*>> masksPerTable;
     std::vector<std::shared_ptr<SemiMaskerLocalState>> localInfos;
     std::mutex mtx;
 };

--- a/src/include/storage/store/table.h
+++ b/src/include/storage/store/table.h
@@ -24,7 +24,7 @@ struct TableScanState {
     std::vector<common::ValueVector*> outputVectors;
     common::DataChunkState* outState;
     std::vector<common::column_id_t> columnIDs;
-    common::RoaringBitmapSemiMask* semiMask;
+    common::semi_mask_t* semiMask;
     bool randomLookup = false;
 
     // Only used when scan from persistent data.

--- a/src/processor/map/map_gds.cpp
+++ b/src/processor/map/map_gds.cpp
@@ -21,7 +21,7 @@ static std::unique_ptr<NodeOffsetMaskMap> getNodeOffsetMaskMap(const main::Clien
     auto map = std::make_unique<NodeOffsetMaskMap>();
     for (auto tableID : tableIDs) {
         auto nodeTable = storageManager->getTable(tableID)->ptrCast<NodeTable>();
-        map->addMask(tableID, RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(tableID,
+        map->addMask(tableID, RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(
                                   nodeTable->getNumTotalRows(context->getTransaction())));
     }
     return map;

--- a/src/processor/map/map_recursive_extend.cpp
+++ b/src/processor/map/map_recursive_extend.cpp
@@ -13,12 +13,12 @@ namespace processor {
 
 static std::shared_ptr<RecursiveJoinSharedState> createSharedState(const NodeExpression& nbrNode,
     const main::ClientContext& context) {
-    std::vector<std::unique_ptr<RoaringBitmapSemiMask>> semiMasks;
+    common::table_id_map_t<std::unique_ptr<semi_mask_t>> semiMasks;
     for (auto entry : nbrNode.getEntries()) {
         auto tableID = entry->getTableID();
         auto table = context.getStorageManager()->getTable(tableID)->ptrCast<storage::NodeTable>();
-        semiMasks.push_back(RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(tableID,
-            table->getNumTotalRows(context.getTransaction())));
+        auto semiMask = RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(table->getNumTotalRows(context.getTransaction()));
+        semiMasks.emplace(tableID, std::move(semiMask));
     }
     return std::make_shared<RecursiveJoinSharedState>(std::move(semiMasks));
 }

--- a/src/processor/map/map_recursive_extend.cpp
+++ b/src/processor/map/map_recursive_extend.cpp
@@ -17,7 +17,8 @@ static std::shared_ptr<RecursiveJoinSharedState> createSharedState(const NodeExp
     for (auto entry : nbrNode.getEntries()) {
         auto tableID = entry->getTableID();
         auto table = context.getStorageManager()->getTable(tableID)->ptrCast<storage::NodeTable>();
-        auto semiMask = RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(table->getNumTotalRows(context.getTransaction()));
+        auto semiMask = RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(
+            table->getNumTotalRows(context.getTransaction()));
         semiMasks.emplace(tableID, std::move(semiMask));
     }
     return std::make_shared<RecursiveJoinSharedState>(std::move(semiMasks));

--- a/src/processor/map/map_scan_node_table.cpp
+++ b/src/processor/map/map_scan_node_table.cpp
@@ -44,7 +44,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapScanNodeTable(
     std::vector<std::shared_ptr<ScanNodeTableSharedState>> sharedStates;
     for (auto& tableID : tableIDs) {
         auto table = storageManager->getTable(tableID)->ptrCast<storage::NodeTable>();
-        auto semiMask = RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(table->getNumTotalRows(transaction));
+        auto semiMask = RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(
+            table->getNumTotalRows(transaction));
         sharedStates.push_back(std::make_shared<ScanNodeTableSharedState>(std::move(semiMask)));
     }
     auto alias = scan.getNodeID()->cast<PropertyExpression>().getRawVariableName();

--- a/src/processor/map/map_scan_node_table.cpp
+++ b/src/processor/map/map_scan_node_table.cpp
@@ -44,8 +44,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapScanNodeTable(
     std::vector<std::shared_ptr<ScanNodeTableSharedState>> sharedStates;
     for (auto& tableID : tableIDs) {
         auto table = storageManager->getTable(tableID)->ptrCast<storage::NodeTable>();
-        auto semiMask = RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(tableID,
-            table->getNumTotalRows(transaction));
+        auto semiMask = RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(table->getNumTotalRows(transaction));
         sharedStates.push_back(std::make_shared<ScanNodeTableSharedState>(std::move(semiMask)));
     }
     auto alias = scan.getNodeID()->cast<PropertyExpression>().getRawVariableName();

--- a/src/processor/map/map_semi_masker.cpp
+++ b/src/processor/map/map_semi_masker.cpp
@@ -11,7 +11,8 @@ using namespace kuzu::planner;
 namespace kuzu {
 namespace processor {
 
-static void initMask(table_id_map_t<std::vector<semi_mask_t*>>& masksPerTable, const table_id_map_t<semi_mask_t*>& maskPerTable) {
+static void initMask(table_id_map_t<std::vector<semi_mask_t*>>& masksPerTable,
+    const table_id_map_t<semi_mask_t*>& maskPerTable) {
     for (auto& [tableID, mask] : maskPerTable) {
         mask->enable();
         KU_ASSERT(maskPerTable.contains(tableID));

--- a/src/processor/map/map_semi_masker.cpp
+++ b/src/processor/map/map_semi_masker.cpp
@@ -11,10 +11,10 @@ using namespace kuzu::planner;
 namespace kuzu {
 namespace processor {
 
-static void initMask(table_id_map_t<mask_vector>& masksPerTable, mask_vector masks) {
-    for (auto& mask : masks) {
-        auto tableID = mask->getTableID();
+static void initMask(table_id_map_t<std::vector<semi_mask_t*>>& masksPerTable, const table_id_map_t<semi_mask_t*>& maskPerTable) {
+    for (auto& [tableID, mask] : maskPerTable) {
         mask->enable();
+        KU_ASSERT(maskPerTable.contains(tableID));
         masksPerTable.at(tableID).emplace_back(mask);
     }
 }
@@ -25,9 +25,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapSemiMasker(
     const auto inSchema = semiMasker.getChild(0)->getSchema();
     auto prevOperator = mapOperator(logicalOperator->getChild(0).get());
     const auto tableIDs = semiMasker.getNodeTableIDs();
-    table_id_map_t<mask_vector> masksPerTable;
+    table_id_map_t<std::vector<semi_mask_t*>> masksPerTable;
     for (auto tableID : tableIDs) {
-        masksPerTable.insert({tableID, std::vector<RoaringBitmapSemiMask*>{}});
+        masksPerTable.insert({tableID, std::vector<semi_mask_t*>{}});
     }
     std::vector<std::string> operatorNames;
     for (auto& op : semiMasker.getTargetOperators()) {
@@ -42,7 +42,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapSemiMasker(
         case PhysicalOperatorType::RECURSIVE_JOIN: {
             KU_ASSERT(semiMasker.getTargetType() == SemiMaskTargetType::RECURSIVE_JOIN_TARGET_NODE);
             auto& recursiveJoin = physicalOp->constCast<RecursiveJoin>();
-            initMask(masksPerTable, recursiveJoin.getSemiMask());
+            initMask(masksPerTable, recursiveJoin.getSemiMasks());
         } break;
         case PhysicalOperatorType::GDS_CALL: {
             auto sharedState = physicalOp->ptrCast<GDSCall>()->getSharedState();

--- a/src/processor/operator/scan/scan_node_table.cpp
+++ b/src/processor/operator/scan/scan_node_table.cpp
@@ -63,7 +63,7 @@ void ScanNodeTableSharedState::nextMorsel(NodeTableScanState& scanState,
     scanState.source = TableScanSource::NONE;
 }
 
-void ScanNodeTableInfo::initScanState(RoaringBitmapSemiMask* semiMask) {
+void ScanNodeTableInfo::initScanState(semi_mask_t* semiMask) {
     std::vector<const Column*> columns;
     columns.reserve(columnIDs.size());
     for (const auto columnID : columnIDs) {
@@ -78,12 +78,13 @@ void ScanNodeTableInfo::initScanState(RoaringBitmapSemiMask* semiMask) {
     localScanState->semiMask = semiMask;
 }
 
-std::vector<RoaringBitmapSemiMask*> ScanNodeTable::getSemiMasks() const {
-    std::vector<RoaringBitmapSemiMask*> maskVector;
-    for (auto& sharedState : sharedStates) {
-        maskVector.push_back(sharedState->getSemiMask());
+table_id_map_t<semi_mask_t*> ScanNodeTable::getSemiMasks() const {
+    table_id_map_t<semi_mask_t*> result;
+    KU_ASSERT(nodeInfos.size() == sharedStates.size());
+    for (auto i = 0u; i < sharedStates.size(); ++i) {
+        result.insert({nodeInfos[i].table->getTableID(), sharedStates[i]->getSemiMask()});
     }
-    return maskVector;
+    return result;
 }
 
 void ScanNodeTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {

--- a/src/processor/operator/semi_masker.cpp
+++ b/src/processor/operator/semi_masker.cpp
@@ -13,7 +13,8 @@ SemiMaskerLocalState* SemiMaskerSharedState::appendLocalState() {
     bool isSingle = masksPerTable.size() == 1;
     for (const auto& [tableID, vector] : masksPerTable) {
         auto& mask = vector.front();
-        auto newOne = common::RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(mask->getMaxOffset());
+        auto newOne =
+            common::RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(mask->getMaxOffset());
         if (isSingle) {
             localInfo->singleTableRef = newOne.get();
         }

--- a/src/processor/operator/semi_masker.cpp
+++ b/src/processor/operator/semi_masker.cpp
@@ -13,8 +13,7 @@ SemiMaskerLocalState* SemiMaskerSharedState::appendLocalState() {
     bool isSingle = masksPerTable.size() == 1;
     for (const auto& [tableID, vector] : masksPerTable) {
         auto& mask = vector.front();
-        auto newOne = common::RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(
-            mask->getTableID(), mask->getMaxOffset());
+        auto newOne = common::RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(mask->getMaxOffset());
         if (isSingle) {
             localInfo->singleTableRef = newOne.get();
         }

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -86,8 +86,7 @@ struct RollbackPKDeleter final : PKColumnScanHelper {
     RollbackPKDeleter(row_idx_t startNodeOffset, row_idx_t numRows, table_id_t tableID,
         PrimaryKeyIndex* pkIndex)
         : PKColumnScanHelper(pkIndex, tableID),
-          semiMask(RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(tableID,
-              startNodeOffset + numRows)) {
+          semiMask(RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(startNodeOffset + numRows)) {
         semiMask->maskRange(startNodeOffset, startNodeOffset + numRows);
         semiMask->enable();
     }
@@ -98,7 +97,7 @@ struct RollbackPKDeleter final : PKColumnScanHelper {
     bool processScanOutput(const Transaction* transaction, NodeGroupScanResult scanResult,
         const ValueVector& scannedVector) override;
 
-    std::unique_ptr<RoaringBitmapSemiMask> semiMask;
+    std::unique_ptr<semi_mask_t> semiMask;
 };
 
 void insertPK(const Transaction* transaction, const ValueVector& nodeIDVector,

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -86,7 +86,8 @@ struct RollbackPKDeleter final : PKColumnScanHelper {
     RollbackPKDeleter(row_idx_t startNodeOffset, row_idx_t numRows, table_id_t tableID,
         PrimaryKeyIndex* pkIndex)
         : PKColumnScanHelper(pkIndex, tableID),
-          semiMask(RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(startNodeOffset + numRows)) {
+          semiMask(
+              RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(startNodeOffset + numRows)) {
         semiMask->maskRange(startNodeOffset, startNodeOffset + numRows);
         semiMask->enable();
     }


### PR DESCRIPTION
# Description

Remove tableID field from semi mask. Also make operator generate `table_id_map_t<SemiMask>` instead of `vector<SemiMask>` which is easier to read.