### PR TITLE
Skip inserting null keys into distinct hash tables

### DIFF
--- a/src/include/processor/operator/aggregate/aggregate_hash_table.h
+++ b/src/include/processor/operator/aggregate/aggregate_hash_table.h
@@ -64,21 +64,6 @@ public:
         const std::vector<common::LogicalType>& distinctAggKeyTypes, uint64_t numEntriesToAllocate,
         FactorizedTableSchema tableSchema);
 
-    void append(const std::vector<common::ValueVector*>& flatKeyVectors,
-        const std::vector<common::ValueVector*>& unFlatKeyVectors,
-        common::DataChunkState* leadingState, const std::vector<AggregateInput>& aggregateInputs,
-        uint64_t resultSetMultiplicity) {
-        append(flatKeyVectors, unFlatKeyVectors, std::vector<common::ValueVector*>(), leadingState,
-            aggregateInputs, resultSetMultiplicity);
-    }
-
-    //! update aggregate states for an input
-    uint64_t append(const std::vector<common::ValueVector*>& flatKeyVectors,
-        const std::vector<common::ValueVector*>& unFlatKeyVectors,
-        const std::vector<common::ValueVector*>& dependentKeyVectors,
-        common::DataChunkState* leadingState, const std::vector<AggregateInput>& aggregateInputs,
-        uint64_t resultSetMultiplicity);
-
     // Returns true if the value was distinct and was inserted
     // otherwise if the value already existed, returns false and the hash table is unchanged
     bool insertAggregateValueIfDistinctForGroupByKeys(
@@ -163,11 +148,6 @@ protected:
 
     void increaseHashSlotIdxes(uint64_t numNoMatches);
 
-    void updateDistinctAggState(const std::vector<common::ValueVector*>& flatKeyVectors,
-        const std::vector<common::ValueVector*>& unFlatKeyVectors,
-        function::AggregateFunction& aggregateFunction, common::ValueVector* aggregateVector,
-        uint64_t multiplicity, uint32_t colIdx, uint32_t aggStateOffset);
-
     void updateAggState(const std::vector<common::ValueVector*>& flatKeyVectors,
         const std::vector<common::ValueVector*>& unFlatKeyVectors,
         function::AggregateFunction& aggregateFunction, common::ValueVector* aggVector,
@@ -175,8 +155,7 @@ protected:
 
     void updateAggStates(const std::vector<common::ValueVector*>& flatKeyVectors,
         const std::vector<common::ValueVector*>& unFlatKeyVectors,
-        const std::vector<AggregateInput>& aggregateInputs, uint64_t resultSetMultiplicity,
-        bool updateDistinct);
+        const std::vector<AggregateInput>& aggregateInputs, uint64_t resultSetMultiplicity);
 
     void fillEntryWithInitialNullAggregateState(FactorizedTable& table, uint8_t* entry);
 

--- a/src/processor/operator/aggregate/aggregate_hash_table.cpp
+++ b/src/processor/operator/aggregate/aggregate_hash_table.cpp
@@ -46,19 +46,6 @@ AggregateHashTable::AggregateHashTable(MemoryManager& memoryManager,
     initializeTmpVectors();
 }
 
-uint64_t AggregateHashTable::append(const std::vector<ValueVector*>& flatKeyVectors,
-    const std::vector<ValueVector*>& unFlatKeyVectors,
-    const std::vector<ValueVector*>& dependentKeyVectors, DataChunkState* leadingState,
-    const std::vector<AggregateInput>& aggregateInputs, uint64_t resultSetMultiplicity) {
-    const auto numFlatTuples = leadingState->getSelVector().getSelSize();
-    resizeHashTableIfNecessary(numFlatTuples);
-    computeVectorHashes(flatKeyVectors, unFlatKeyVectors);
-    findHashSlots(flatKeyVectors, unFlatKeyVectors, dependentKeyVectors, leadingState);
-    updateAggStates(flatKeyVectors, unFlatKeyVectors, aggregateInputs, resultSetMultiplicity,
-        true /*updateDistinct*/);
-    return numFlatTuples;
-}
-
 bool AggregateHashTable::insertAggregateValueIfDistinctForGroupByKeys(
     const std::vector<ValueVector*>& groupByFlatKeyVectors, ValueVector* aggregateVector) {
     auto pos = aggregateVector->state->getSelVector()[0];
@@ -210,13 +197,9 @@ void AggregateHashTable::initializeFT(const std::vector<AggregateFunction>& aggF
     aggStateColOffsetInFT = numBytesForKeys + numBytesForDependentKeys;
 
     aggregateFunctions.reserve(aggFuncs.size());
-    updateAggFuncs.reserve(aggFuncs.size());
     for (auto i = 0u; i < aggFuncs.size(); i++) {
         auto& aggFunc = aggFuncs[i];
         aggregateFunctions.push_back(aggFunc.copy());
-        updateAggFuncs.push_back(aggFunc.isFunctionDistinct() ?
-                                     &AggregateHashTable::updateDistinctAggState :
-                                     &AggregateHashTable::updateAggState);
     }
     hashColIdxInFT = tableSchema.getNumColumns() - 1;
     hashColOffsetInFT = tableSchema.getColOffset(hashColIdxInFT);
@@ -588,27 +571,6 @@ void AggregateHashTable::findHashSlots(const FactorizedTable& srcTable, uint64_t
     }
 }
 
-void AggregateHashTable::updateDistinctAggState(const std::vector<ValueVector*>& flatKeyVectors,
-    const std::vector<ValueVector*>& /*unFlatKeyVectors*/, AggregateFunction& aggregateFunction,
-    ValueVector* aggregateVector, uint64_t /*multiplicity*/, uint32_t colIdx,
-    uint32_t aggStateOffset) {
-    auto distinctHT = distinctHashTables[colIdx].get();
-    KU_ASSERT(distinctHT != nullptr);
-    if (distinctHT->insertAggregateValueIfDistinctForGroupByKeys(flatKeyVectors, aggregateVector)) {
-        auto pos = aggregateVector->state->getSelVector()[0];
-        aggregateFunction.updatePosState(
-            hashSlotsToUpdateAggState[flatKeyVectors.empty() ?
-                                          0 :
-                                          flatKeyVectors[0]->state->getSelVector()[0]]
-                    ->entry +
-                aggStateOffset,
-            aggregateVector, 1 /* Distinct aggregate should ignore multiplicity
-                                      since they are known to be non-distinct. */
-            ,
-            pos, memoryManager);
-    }
-}
-
 void AggregateHashTable::updateAggState(const std::vector<ValueVector*>& flatKeyVectors,
     const std::vector<ValueVector*>& unFlatKeyVectors, AggregateFunction& aggregateFunction,
     ValueVector* aggVector, uint64_t multiplicity, uint32_t /*colIdx*/, uint32_t aggStateOffset) {
@@ -635,16 +597,15 @@ void AggregateHashTable::updateAggState(const std::vector<ValueVector*>& flatKey
 
 void AggregateHashTable::updateAggStates(const std::vector<ValueVector*>& flatKeyVectors,
     const std::vector<ValueVector*>& unFlatKeyVectors,
-    const std::vector<AggregateInput>& aggregateInputs, uint64_t resultSetMultiplicity,
-    bool updateDistinct) {
+    const std::vector<AggregateInput>& aggregateInputs, uint64_t resultSetMultiplicity) {
     auto aggregateStateOffset = aggStateColOffsetInFT;
     for (auto i = 0u; i < aggregateFunctions.size(); i++) {
-        if (!aggregateFunctions[i].isDistinct || updateDistinct) {
+        if (!aggregateFunctions[i].isDistinct) {
             auto multiplicity = resultSetMultiplicity;
             for (auto& dataChunk : aggregateInputs[i].multiplicityChunks) {
                 multiplicity *= dataChunk->state->getSelVector().getSelSize();
             }
-            updateAggFuncs[i](this, flatKeyVectors, unFlatKeyVectors, aggregateFunctions[i],
+            updateAggState(flatKeyVectors, unFlatKeyVectors, aggregateFunctions[i],
                 aggregateInputs[i].aggregateVector, multiplicity, i, aggregateStateOffset);
             aggregateStateOffset += aggregateFunctions[i].getAggregateStateSize();
         } else {
@@ -814,8 +775,7 @@ uint64_t PartitioningAggregateHashTable::append(const std::vector<ValueVector*>&
     findHashSlots(flatKeyVectors, unFlatKeyVectors, dependentKeyVectors, leadingState);
     // Don't update distinct states since they can't be merged into the global hash tables. Instead
     // we'll calculate them from scratch when merging.
-    updateAggStates(flatKeyVectors, unFlatKeyVectors, aggregateInputs, resultSetMultiplicity,
-        false /*updateDistinct*/);
+    updateAggStates(flatKeyVectors, unFlatKeyVectors, aggregateInputs, resultSetMultiplicity);
     return numFlatTuples;
 }
 

--- a/src/processor/operator/aggregate/simple_aggregate.cpp
+++ b/src/processor/operator/aggregate/simple_aggregate.cpp
@@ -94,10 +94,8 @@ void SimpleAggregate::computeDistinctAggregate(AggregateHashTable* distinctHT,
     if (distinctHT->insertAggregateValueIfDistinctForGroupByKeys(std::vector<ValueVector*>{},
             input->aggregateVector)) {
         auto pos = input->aggregateVector->state->getSelVector()[0];
-        if (!input->aggregateVector->isNull(pos)) {
-            function->updatePosState((uint8_t*)state, input->aggregateVector, multiplicity, pos,
-                memoryManager);
-        }
+        function->updatePosState((uint8_t*)state, input->aggregateVector, multiplicity, pos,
+            memoryManager);
     }
 }
 

--- a/test/test_files/agg/hash_ldbc.test
+++ b/test/test_files/agg/hash_ldbc.test
@@ -37,3 +37,14 @@ Internet Explorer|[ar,tk,uz]|32861
 Chrome|[ar,tk,uz]|30514
 Safari|[ar,tk,uz]|5410
 Opera|[ar,tk,uz]|3938
+
+-STATEMENT
+    MATCH (p:Post)
+    OPTIONAL MATCH (c:Comment)-[]->(p:Post)
+    RETURN p.browserUsed, list_sort(COLLECT(DISTINCT c.browserUsed), 'ASC');
+---- 5
+Firefox|[Chrome,Firefox,Internet Explorer,Opera,Safari]
+Internet Explorer|[Chrome,Firefox,Internet Explorer,Opera,Safari]
+Chrome|[Chrome,Firefox,Internet Explorer,Opera,Safari]
+Safari|[Chrome,Firefox,Internet Explorer,Opera,Safari]
+Opera|[Chrome,Firefox,Internet Explorer,Opera,Safari]

--- a/test/test_files/agg/hash_ldbc.test
+++ b/test/test_files/agg/hash_ldbc.test
@@ -28,3 +28,12 @@ Chrome|[uz,]|2501
 Firefox|[tk,]|2216
 Internet Explorer|[tk,]|1789
 Chrome|[tk,]|1710
+-STATEMENT MATCH (p:Post) RETURN p.browserUsed, list_sort(COLLECT(DISTINCT p.language), 'ASC'), COUNT(DISTINCT p.imageFile) as n ORDER BY n DESC;
+# The 3 distinct languages are easy to verify, but the distinct image files are just the results computed from a version we think are correct, and are just to give warning of nondeterministic behaviour or unexpected changes
+-CHECK_ORDER
+---- 5
+Firefox|[ar,tk,uz]|47533
+Internet Explorer|[ar,tk,uz]|32861
+Chrome|[ar,tk,uz]|30514
+Safari|[ar,tk,uz]|5410
+Opera|[ar,tk,uz]|3938


### PR DESCRIPTION
We always skip them when updating the aggregate state, so there's no point including them in the table at all.

There was a small regression introduced in #4881, which led to null values being included in the distinct output.