### PR TITLE
Fix export database with official extension.

### DIFF
--- a/src/extension/loaded_extension.cpp
+++ b/src/extension/loaded_extension.cpp
@@ -8,7 +8,8 @@ namespace extension {
 std::string LoadedExtension::toCypher() {
     switch (source) {
     case ExtensionSource::OFFICIAL:
-        return common::stringFormat("INSTALL {};\nLOAD EXTENSION {};\n", extensionName);
+        return common::stringFormat("INSTALL {};\nLOAD EXTENSION {};\n", extensionName,
+            extensionName);
     case ExtensionSource::USER:
         return common::stringFormat("LOAD EXTENSION '{}';\n", fullPath);
     default:


### PR DESCRIPTION
Since we don't rebuild the official extensions for every dev build, we can't test the behaviour of  load official extension with export db. So we don't have a test case for such query.
closes #4959