### PR TITLE
Update Kùzu to Kuzu for consistency with SEO discoverability

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,9 +1,9 @@
-We are developing Kùzu in a publicly open GitHub repo and encourage everyone
-to comment and discuss topics related to Kùzu. However, we ask everyone to be
-very respectful and polite in discussions and avoid any hurtful language in any form.
-Kùzu is being developed in Canada, a land that is proud in their high standards
+Kuzu is being developed publicly by Kùzu Inc., under an MIT license in this GitHub repo. We encourage everyone
+to open issues and discuss topics only related to Kuzu. We also kindly ask everyone to be
+respectful, polite and avoid any hurtful language in any form.
+Kùzu Inc. is a startup based in Canada 🇨🇦, a land that is proud of their high standards
 for politeness and where a person you bumped into on the road will likely
-apologize to you even if it was your fault: so please be
-kind and respectful to everyone.
+apologize to you even if it was your fault: so, again, we ask you to please be
+kind and respectful to everyone on this GitHub.
 If you prefer not to discuss something through open issues and discussions,
 you can always reach us through [email](mailto:contact@kuzudb.com).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Welcome to Kùzu! We are excited that you are interested in contributing to Kùzu.
+Welcome! We are excited that you are interested in contributing to Kuzu.
 Before submitting your contribution though, please make sure to take a moment and read through the following guidelines.
 
 Join our project's [Discord community](https://discord.gg/VtX2gw9Rug) for real-time communication with the core team and other contributors.
@@ -24,4 +24,4 @@ Whether or not you state this explicitly, by submitting any copyrighted material
 * Avoid large pull requests - they are much less likely to be merged as they are incredibly hard to review.
 * We reserve full and final discretion over whether or not we will merge a pull request. Adhering to these guidelines is not a complete guarantee that your pull request will be merged.
 
-Thank you for your contribution to Kùzu! We're grateful for your time and effort, and we look forward to working with you.
+Thank you for your contribution to Kuzu! We're grateful for your time and effort, and we look forward to working with you.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p>
 
 # Kùzu
-Kùzu is an embedded graph database built for query speed and scalability. Kùzu is optimized for handling complex analytical workloads 
+Kuzu is an embedded graph database built for query speed and scalability. Kuzu is optimized for handling complex analytical workloads 
 on very large databases and provides a set of retrieval features, such as a full text search and vector indices. Our core feature set includes:
 
 - Flexible Property Graph Data Model and Cypher query language
@@ -28,7 +28,7 @@ on very large databases and provides a set of retrieval features, such as a full
 - Serializable ACID transactions
 - Wasm (WebAssembly) bindings for fast, secure execution in the browser
 
-Kùzu is being developed by [Kùzu Inc.](https://kuzudb.com/) and 
+Kuzu is being developed by [Kùzu Inc.](https://kuzudb.com/) and 
 is available under a permissible license. So try it out and help us make it better! We welcome your feedback and feature requests.
 
 ## Installation
@@ -54,13 +54,13 @@ Refer to our [Getting Started](https://docs.kuzudb.com/get-started/) page for yo
 You can build from source using the instructions provided in the [developer guide](https://docs.kuzudb.com/developer-guide).
 
 ## Contributing
-We welcome contributions to Kùzu. If you are interested in contributing to Kùzu, please read our [Contributing Guide](CONTRIBUTING.md).
+We welcome contributions to Kuzu. If you are interested in contributing to Kuzu, please read our [Contributing Guide](CONTRIBUTING.md).
 
 ## License
-By contributing to Kùzu, you agree that your contributions will be licensed under the [MIT License](LICENSE).
+By contributing to Kuzu, you agree that your contributions will be licensed under the [MIT License](LICENSE).
 
 ## Support 
-We provide professional support for using Kùzu, ensuring timely responses and flexible coverage. Please visit [here](https://kuzudb.com/#support) 
+We provide professional support for using Kuzu, ensuring timely responses and flexible coverage. Please visit [here](https://kuzudb.com/#support) 
 for more information.
 
 ## Contact


### PR DESCRIPTION
# Description

Based on an internal discussion, we are now referencing the database name as Kuzu in our docs, blogs and other communication for ease of typing and better discoverability by search engines. The company name is still, officially, Kùzu Inc. and it's kept that way in this README as well as the main title.

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).