### PR TITLE
Fix label predicate in recursive pattern

### DIFF
--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -393,7 +393,9 @@ std::shared_ptr<RelExpression> Binder::createRecursiveQueryRel(const parser::Rel
             auto dependOnNode = dependentVariableNames.contains(node->getUniqueName());
             auto dependOnRel = dependentVariableNames.contains(rel->getUniqueName());
             if (dependOnNode && dependOnRel) {
-                throw BinderException(stringFormat("Cannot evaluate {} because it depends on both {} and {}.", predicate->toString(), node->toString(), rel->toString()));
+                throw BinderException(
+                    stringFormat("Cannot evaluate {} because it depends on both {} and {}.",
+                        predicate->toString(), node->toString(), rel->toString()));
             } else if (dependOnNode) {
                 nodePredicate = expressionBinder.combineBooleanExpressions(ExpressionType::AND,
                     nodePredicate, predicate);
@@ -402,7 +404,10 @@ std::shared_ptr<RelExpression> Binder::createRecursiveQueryRel(const parser::Rel
                     relPredicate, predicate);
             } else {
                 if (!ExpressionUtil::isBoolLiteral(*predicate)) {
-                    throw BinderException(stringFormat("Cannot evaluate {} because it does not depend on {} or {}. Treating it as a node or relationship predicate is ambiguous." , predicate->toString(), node->toString(), rel->toString()));
+                    throw BinderException(stringFormat(
+                        "Cannot evaluate {} because it does not depend on {} or {}. Treating it as "
+                        "a node or relationship predicate is ambiguous.",
+                        predicate->toString(), node->toString(), rel->toString()));
                 }
                 // If predicate is true literal, we ignore.
                 // If predicate is false literal, we mark this recursive relationship as empty

--- a/src/binder/bind/bind_projection_clause.cpp
+++ b/src/binder/bind/bind_projection_clause.cpp
@@ -231,9 +231,9 @@ BoundProjectionBody Binder::bindProjectionBody(const parser::ProjectionBody& pro
                 tmpAliases.push_back(expr->hasAlias() ? expr->getAlias() : expr->toString());
             }
             addToScope(tmpAliases, projectionExprs);
-            expressionBinder.bindOrderByAfterAggregation = true;
+            expressionBinder.config.bindOrderByAfterAggregate = true;
             orderByExprs = bindOrderByExpressions(projectionBody.getOrderByExpressions());
-            expressionBinder.bindOrderByAfterAggregation = false;
+            expressionBinder.config.bindOrderByAfterAggregate = false;
         } else {
             addToScope(aliases, projectionExprs);
             orderByExprs = bindOrderByExpressions(projectionBody.getOrderByExpressions());

--- a/src/binder/bind_expression/bind_property_expression.cpp
+++ b/src/binder/bind_expression/bind_property_expression.cpp
@@ -74,11 +74,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindPropertyExpression(
     ExpressionUtil::validateDataType(*child,
         std::vector<LogicalTypeID>{LogicalTypeID::NODE, LogicalTypeID::REL, LogicalTypeID::STRUCT,
             LogicalTypeID::ANY});
-    if (bindOrderByAfterAggregation) {
-        // If a property is not in projection list but required in order by after aggregation,
-        // we need to bind it as struct extraction because node/rel must have been evaluated as
-        // struct during aggregate
-        // e.g. RETURN a, COUNT(*) ORDER BY a.ID
+    if (config.bindOrderByAfterAggregate) {
+        // See the declaration of this field for more information.
         return bindStructPropertyExpression(child, propertyName);
     }
     if (isNodeOrRelPattern(*child)) {

--- a/src/binder/expression/expression_util.cpp
+++ b/src/binder/expression/expression_util.cpp
@@ -162,6 +162,13 @@ bool ExpressionUtil::isNullLiteral(const Expression& expression) {
     return expression.constCast<LiteralExpression>().getValue().isNull();
 }
 
+bool ExpressionUtil::isBoolLiteral(const Expression& expression) {
+    if (expression.expressionType != ExpressionType::LITERAL) {
+        return false;
+    }
+    return expression.dataType == LogicalType::BOOL();
+}
+
 bool ExpressionUtil::isFalseLiteral(const Expression& expression) {
     if (expression.expressionType != ExpressionType::LITERAL) {
         return false;

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -27,7 +27,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindExpression(
     // An exception is order by binding, e.g. RETURN a, COUNT(*) ORDER BY COUNT(*)
     // the later COUNT(*) should reference the one in projection list. So we need to explicitly
     // check scope when binding order by list.
-    if (bindOrderByAfterAggregation && binder->scope.contains(parsedExpression.toString())) {
+    if (config.bindOrderByAfterAggregate && binder->scope.contains(parsedExpression.toString())) {
         return binder->scope.getExpression(parsedExpression.toString());
     }
     auto collector = ParsedParamExprCollector();

--- a/src/function/pattern/label_function.cpp
+++ b/src/function/pattern/label_function.cpp
@@ -74,27 +74,32 @@ std::shared_ptr<Expression> LabelFunction::rewriteFunc(const RewriteFunctionBind
         return expressionBinder->bindScalarFunctionExpression(children,
             StructExtractFunctions::name);
     }
+    auto disableLiteralRewrite = expressionBinder->getConfig().disableLabelFunctionLiteralRewrite;
     if (ExpressionUtil::isNodePattern(*argument)) {
         auto& node = argument->constCast<NodeExpression>();
-        if (node.isEmpty()) {
-            return expressionBinder->createLiteralExpression("");
-        }
-        if (!node.isMultiLabeled()) {
-            auto label =
-                node.getSingleEntry()->getLabel(context->getCatalog(), context->getTransaction());
-            return expressionBinder->createLiteralExpression(label);
+        if (!disableLiteralRewrite) {
+            if (node.isEmpty()) {
+                return expressionBinder->createLiteralExpression("");
+            }
+            if (!node.isMultiLabeled()) {
+                auto label =
+                    node.getSingleEntry()->getLabel(context->getCatalog(), context->getTransaction());
+                return expressionBinder->createLiteralExpression(label);
+            }
         }
         children.push_back(node.getInternalID());
         children.push_back(getLabelsAsLiteral(context, node.getEntries(), expressionBinder));
     } else if (ExpressionUtil::isRelPattern(*argument)) {
         auto& rel = argument->constCast<RelExpression>();
-        if (rel.isEmpty()) {
-            return expressionBinder->createLiteralExpression("");
-        }
-        if (!rel.isMultiLabeled()) {
-            auto label =
-                rel.getSingleEntry()->getLabel(context->getCatalog(), context->getTransaction());
-            return expressionBinder->createLiteralExpression(label);
+        if (!disableLiteralRewrite) {
+            if (rel.isEmpty()) {
+                return expressionBinder->createLiteralExpression("");
+            }
+            if (!rel.isMultiLabeled()) {
+                auto label =
+                    rel.getSingleEntry()->getLabel(context->getCatalog(), context->getTransaction());
+                return expressionBinder->createLiteralExpression(label);
+            }
         }
         children.push_back(rel.getInternalIDProperty());
         children.push_back(getLabelsAsLiteral(context, rel.getEntries(), expressionBinder));

--- a/src/function/pattern/label_function.cpp
+++ b/src/function/pattern/label_function.cpp
@@ -82,8 +82,8 @@ std::shared_ptr<Expression> LabelFunction::rewriteFunc(const RewriteFunctionBind
                 return expressionBinder->createLiteralExpression("");
             }
             if (!node.isMultiLabeled()) {
-                auto label =
-                    node.getSingleEntry()->getLabel(context->getCatalog(), context->getTransaction());
+                auto label = node.getSingleEntry()->getLabel(context->getCatalog(),
+                    context->getTransaction());
                 return expressionBinder->createLiteralExpression(label);
             }
         }
@@ -96,8 +96,8 @@ std::shared_ptr<Expression> LabelFunction::rewriteFunc(const RewriteFunctionBind
                 return expressionBinder->createLiteralExpression("");
             }
             if (!rel.isMultiLabeled()) {
-                auto label =
-                    rel.getSingleEntry()->getLabel(context->getCatalog(), context->getTransaction());
+                auto label = rel.getSingleEntry()->getLabel(context->getCatalog(),
+                    context->getTransaction());
                 return expressionBinder->createLiteralExpression(label);
             }
         }

--- a/src/include/binder/expression/expression_util.h
+++ b/src/include/binder/expression/expression_util.h
@@ -35,6 +35,7 @@ struct KUZU_API ExpressionUtil {
     static bool isRelPattern(const Expression& expression);
     static bool isRecursiveRelPattern(const Expression& expression);
     static bool isNullLiteral(const Expression& expression);
+    static bool isBoolLiteral(const Expression& expression);
     static bool isFalseLiteral(const Expression& expression);
     static bool isEmptyList(const Expression& expression);
 

--- a/src/planner/plan/append_filter.cpp
+++ b/src/planner/plan/append_filter.cpp
@@ -6,8 +6,7 @@ using namespace kuzu::binder;
 namespace kuzu {
 namespace planner {
 
-void Planner::appendFilters(const binder::expression_vector& predicates,
-    kuzu::planner::LogicalPlan& plan) {
+void Planner::appendFilters(const expression_vector& predicates, LogicalPlan& plan) {
     for (auto& predicate : predicates) {
         appendFilter(predicate, plan);
     }

--- a/test/test_files/issue/issue.test
+++ b/test/test_files/issue/issue.test
@@ -560,3 +560,14 @@ Binder exception: Table rel2 does not exist.
 [2,3]
 -STATEMENT COMMIT;
 ---- ok
+
+-CASE 4918
+-STATEMENT CREATE NODE TABLE V (id int PRIMARY KEY);
+---- ok
+-STATEMENT CREATE REL TABLE E (FROM V TO V, val STRING);
+---- ok
+-STATEMENT CREATE (:V {id: 1})-[:E {val: "foo"}]->(:V {id: 2});
+---- ok
+-STATEMENT MATCH (a)-[:E * (r,n | WHERE label(n) = "X")]->(b) RETURN *;
+---- 1
+{_ID: 0:0, _LABEL: V, id: 1}|{_ID: 0:1, _LABEL: V, id: 2}

--- a/test/test_files/recursive_join/multi_label.test
+++ b/test/test_files/recursive_join/multi_label.test
@@ -78,4 +78,4 @@
 [2,0,2,1]|[3:3,7:0,4:1]
 -STATEMENT MATCH p = (a)-[e*2..3 (r, n | WHERE n.ID + offset(id(r)) < 3)]->(b) RETURN p
 ---- error
-Binder exception: Cannot evaluate LESS_THAN(+(n.ID,OFFSET(r._ID)),3) in recursive pattern e.
+Binder exception: Cannot evaluate LESS_THAN(+(n.ID,OFFSET(r._ID)),3) because it depends on both n and r.


### PR DESCRIPTION
# Description

If a node is single labeled, we rewrite its label function as string literal. This however, should be applied to recursive pattern predicate because if path is of length <= 1, there is no intermediate node and thus the predicate should be a noop. If we try to evaluate, it may lead to empty result. e.g.
```
 [* (r, n | WHERE label(n)='dummy') ]
```

Fixes #4918

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).