### PR TITLE
Only merge distinct aggregate hash tables into the global queues when full

### DIFF
--- a/src/include/processor/operator/aggregate/aggregate_hash_table.h
+++ b/src/include/processor/operator/aggregate/aggregate_hash_table.h
@@ -312,7 +312,7 @@ public:
         common::DataChunkState* leadingState, const std::vector<AggregateInput>& aggregateInputs,
         uint64_t resultSetMultiplicity);
 
-    void mergeAll();
+    void mergeIfFull(uint64_t tuplesToAdd, bool mergeAll = false);
 
     bool insertAggregateValueIfDistinctForGroupByKeys(
         const std::vector<common::ValueVector*>& groupByKeyVectors,

--- a/src/include/processor/result/base_hash_table.h
+++ b/src/include/processor/result/base_hash_table.h
@@ -32,6 +32,7 @@ public:
         return factorizedTable->getTableSchema();
     }
     uint64_t getNumEntries() const { return factorizedTable->getNumTuples(); }
+    uint64_t getCapacity() const { return maxNumHashSlots; }
     const FactorizedTable* getFactorizedTable() const { return factorizedTable.get(); }
 
 protected:

--- a/src/processor/operator/aggregate/hash_aggregate.cpp
+++ b/src/processor/operator/aggregate/hash_aggregate.cpp
@@ -254,7 +254,7 @@ void HashAggregate::executeInternal(ExecutionContext* context) {
             break;
         }
     }
-    localState.aggregateHashTable->mergeAll();
+    localState.aggregateHashTable->mergeIfFull(0 /*tuplesToAdd*/, true /*mergeAll*/);
 }
 
 } // namespace processor

--- a/src/processor/operator/aggregate/simple_aggregate.cpp
+++ b/src/processor/operator/aggregate/simple_aggregate.cpp
@@ -219,7 +219,7 @@ void SimpleAggregate::executeInternal(ExecutionContext* context) {
     }
     if (getSharedState().hasDistinct) {
         for (auto& hashTable : distinctHashTables) {
-            hashTable->mergeAll();
+            hashTable->mergeIfFull(0 /*tuplesToAdd*/, true /*mergeAll*/);
         }
     }
     getSharedState().combineAggregateStates(localAggregateStates, memoryManager);


### PR DESCRIPTION
Instead of whenever their parent hash table is full. This improves performance when the distinct hash tables fill up significantly more quickly than their parents.

| Query | before | after |
| --- | --- | --- |
| `MATCH (h:hits) RETURN h.RegionID, COUNT(DISTINCT h.UserID) AS u ORDER BY u DESC LIMIT 10;` | 2.5s | 2.2s |
| `MATCH (h:hits) RETURN h.RegionID, SUM(h.AdvEngineID), COUNT(*) AS c, AVG(h.ResolutionWidth), COUNT(DISTINCT h.UserID) ORDER BY c DESC LIMIT 10;` | 2.7s | 2.3s |

In more extreme cases the difference would probably be larger.