### PR TITLE
Statistics update optimization

### DIFF
--- a/src/include/common/vector/value_vector.h
+++ b/src/include/common/vector/value_vector.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <utility>
 
 #include "common/assert.h"
@@ -34,6 +35,25 @@ public:
 
     DELETE_COPY_AND_MOVE(ValueVector);
     ~ValueVector() = default;
+
+    template<typename T>
+    std::optional<T> firstNonNull() const {
+        sel_t selectedSize = state->getSelSize();
+        if (selectedSize == 0) {
+            return std::nullopt;
+        }
+        if (hasNoNullsGuarantee()) {
+            return getValue<T>(state->getSelVector()[0]);
+        } else {
+            for (size_t i = 0; i < selectedSize; i++) {
+                auto pos = state->getSelVector()[i];
+                if (!isNull(pos)) {
+                    return std::make_optional(getValue<T>(pos));
+                }
+            }
+        }
+        return std::nullopt;
+    }
 
     template<class Func>
     void forEachNonNull(Func&& func) const {

--- a/src/storage/store/column_chunk_stats.cpp
+++ b/src/storage/store/column_chunk_stats.cpp
@@ -27,7 +27,12 @@ void ColumnChunkStats::update(std::optional<StorageValue> newMin,
 }
 
 void ColumnChunkStats::update(StorageValue val, common::PhysicalTypeID dataType) {
-    update(val, val, dataType);
+    if (!min.has_value() || min->gt(val, dataType)) {
+        min = val;
+    }
+    if (!max.has_value() || val.gt(*max, dataType)) {
+        max = val;
+    }
 }
 
 void ColumnChunkStats::reset() {


### PR DESCRIPTION
As far as I can tell, the issue in #4936 (where speed is concerned; I still need to look into memory usage) is that it's hitting a particularly slow way of updating our statistics. Copying from CSV is significantly better, but was still slower than it could be.

I've optimized this particular part of the code by removing the repeated calls to the single-input `ColumnChunkStats::update` and replacing it with code that calculates the min/max of the vector and passing those to the ColumnChunkStats just once (I also inlined the single-input update to remove the unnecessary optionals).

~~I'm still a little concerned by how much time is spent updating statistics when copying relationship data (even after the optimization, \~86% of the time spent in `ChunkedNodeGroup::append` is spent in `ColumnChunkData::updateStats` (and `ChunkedNodeGroup::append` itself is 76% of the runtime of the copies). I'll try and look further into that to see if it's actually reasonable, but this is a significant improvement by itself.~~ *Update: Figured this out: https://github.com/kuzudb/kuzu/pull/4980#issuecomment-2694911770. Due to the partitioner selecting just one value from a vector at a time, and that the SelVector passed in is not the same as the one on the vector (which I think usually has the full vector selected), we end up doing vastly more work than necessary. Of course, optimising the update still will help.*

Copying the first 10000000 edges from the datagen-9.0-fb dataset:

| | Before | After |
| --- | --- | --- |
| Edges from CSV | 13s | 2.3s |
| Edges from Parquet | 70s | 1.8s |
| Edges from Pandas Dataframe (created from parquet in python) | 70s | 1.8s |