### PR TITLE
Support ignore_errors option for copy from subquery

### DIFF
--- a/src/binder/bound_scan_source.cpp
+++ b/src/binder/bound_scan_source.cpp
@@ -18,5 +18,11 @@ bool BoundTableScanSource::getIgnoreErrorsOption() const {
     return info.bindData->getIgnoreErrorsOption();
 }
 
+bool BoundQueryScanSource::getIgnoreErrorsOption() const {
+    return info.options.contains(CopyConstants::IGNORE_ERRORS_OPTION_NAME) ?
+               info.options.at(CopyConstants::IGNORE_ERRORS_OPTION_NAME).getValue<bool>() :
+               CopyConstants::DEFAULT_IGNORE_ERRORS;
+}
+
 } // namespace binder
 } // namespace kuzu

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -150,7 +150,8 @@ public:
         const std::vector<std::string>& columnNames,
         const std::vector<common::LogicalType>& columnTypes);
     std::unique_ptr<BoundBaseScanSource> bindQueryScanSource(
-        const parser::BaseScanSource& scanSource, const std::vector<std::string>& columnNames,
+        const parser::BaseScanSource& scanSource, const parser::options_t& options,
+        const std::vector<std::string>& columnNames,
         const std::vector<common::LogicalType>& columnTypes);
     std::unique_ptr<BoundBaseScanSource> bindObjectScanSource(
         const parser::BaseScanSource& scanSource, const parser::options_t& options,

--- a/src/include/binder/bound_scan_source.h
+++ b/src/include/binder/bound_scan_source.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "binder/bound_statement.h"
+#include "binder/copy/bound_query_scan_info.h"
 #include "binder/copy/bound_table_scan_info.h"
 #include "common/enums/scan_source_type.h"
 
@@ -66,11 +67,15 @@ struct BoundQueryScanSource final : BoundBaseScanSource {
     // Use shared ptr to avoid copy BoundStatement.
     // We should consider implement a copy constructor though.
     std::shared_ptr<BoundStatement> statement;
+    BoundQueryScanSourceInfo info;
 
-    explicit BoundQueryScanSource(std::shared_ptr<BoundStatement> statement)
-        : BoundBaseScanSource{common::ScanSourceType::QUERY}, statement{std::move(statement)} {}
-    BoundQueryScanSource(const BoundQueryScanSource& other)
-        : BoundBaseScanSource{other}, statement{other.statement} {}
+    explicit BoundQueryScanSource(std::shared_ptr<BoundStatement> statement,
+        BoundQueryScanSourceInfo info)
+        : BoundBaseScanSource{common::ScanSourceType::QUERY}, statement{std::move(statement)},
+          info(std::move(info)) {}
+    BoundQueryScanSource(const BoundQueryScanSource& other) = default;
+
+    bool getIgnoreErrorsOption() const override;
 
     expression_vector getColumns() override {
         return statement->getStatementResult()->getColumns();

--- a/src/include/binder/copy/bound_query_scan_info.h
+++ b/src/include/binder/copy/bound_query_scan_info.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "common/case_insensitive_map.h"
+#include "common/types/value/value.h"
+namespace kuzu {
+namespace binder {
+
+struct BoundQueryScanSourceInfo {
+    common::case_insensitive_map_t<common::Value> options;
+
+    explicit BoundQueryScanSourceInfo(common::case_insensitive_map_t<common::Value> options)
+        : options{std::move(options)} {}
+};
+
+} // namespace binder
+} // namespace kuzu

--- a/test/test_files/exceptions/copy/ignore_invalid_row.test
+++ b/test/test_files/exceptions/copy/ignore_invalid_row.test
@@ -373,3 +373,20 @@ Conversion exception: Cast failed. Could not convert "1111111111111111111111111"
 -STATEMENT MATCH (m:movie) return COUNT(*);
 ---- 1
 20
+
+-CASE CopyFromSubqueryIgnoreErrors
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/vPerson.csv" (ignore_errors=true, AUTO_DETECT=false)
+---- ok
+-STATEMENT COPY person FROM (MATCH (p:person) RETURN CASE WHEN p.id % 2 = 0 THEN p.id ELSE p.id + 10 END, p.gender) (ignore_errors=true)
+---- 2
+2 tuples have been copied to the person table.
+3 warnings encountered during copy. Use 'CALL show_warnings() RETURN *' to view the actual warnings. Query ID: 6
+-STATEMENT MATCH (p:person) RETURN p.id
+---- 7
+0
+3
+4
+6
+7
+13
+17


### PR DESCRIPTION
# Description

Most of the work was already done, this PR just passes the parsing options to `BoundQueryScanSource` so that it can determine what the `ignore_errors` option should be set to.

Fixes https://github.com/kuzudb/kuzu/issues/4926

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).