### PR TITLE
Fix hash 256 function

### DIFF
--- a/src/function/utility/sha256.cpp
+++ b/src/function/utility/sha256.cpp
@@ -14,6 +14,9 @@ struct SHA256Operator {
         SHA256 hasher;
         hasher.addString(operand.getAsString());
         hasher.finishSHA256(reinterpret_cast<char*>(result.getDataUnsafe()));
+        if (!ku_string_t::isShortString(result.len)) {
+            memcpy(result.prefix, result.getData(), ku_string_t::PREFIX_LENGTH);
+        }
     }
 };
 

--- a/test/test_files/function/hash/sha256.test
+++ b/test/test_files/function/hash/sha256.test
@@ -1,4 +1,4 @@
--DATASET CSV empty
+-DATASET CSV tinysnb
 
 --
 
@@ -23,3 +23,17 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ---- error
 Binder exception: Cannot match a built-in function for given function SHA256. Supported inputs are
 (STRING) -> STRING
+
+-STATEMENT create (p:person {ID: 12, fName: sha256('Alice')})
+---- ok
+-STATEMENT match (p:person) optional match (p1:person {fName: sha256(p.fName)}) RETURN p.fName, p1.ID
+---- 9
+Alice|12
+Bob|
+Carol|
+Dan|
+Elizabeth|
+Farooq|
+Greg|
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|
+3bc51062973c458d5a6f2d8d64a023246354ad7e064b1e4e009ec8a0699a3043|


### PR DESCRIPTION
This PR fixes a bug reported by the user on our merge clause: 
https://colab.research.google.com/drive/1YR-gm8yfZ-jUgSuCkTSRGI6M1SyW428s#scrollTo=bb96aa53d7b90fc3

The root cause of the bug is that we don't properly set the prefix of the output strings in the hash256 function.