### PR TITLE
Add projected graph node filter

### DIFF
--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -247,8 +247,8 @@ void QueryFTSAlgorithm::exec(processor::ExecutionContext* executionContext) {
     // for each term-doc pair. The reason why we store the term frequency and document frequency
     // is that: we need the `len` property from the docs table which is only available during the
     // vertex compute.
-    auto currentFrontier = getPathLengthsFrontier(executionContext, PathLengths::UNVISITED);
-    auto nextFrontier = getPathLengthsFrontier(executionContext, PathLengths::UNVISITED);
+    auto currentFrontier = PathLengths::getUnvisitedFrontier(executionContext, graph);
+    auto nextFrontier = PathLengths::getUnvisitedFrontier(executionContext, graph);
     auto frontierPair =
         std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier, nextFrontier);
     auto termsTableID = termsEntry.getTableID();

--- a/extension/fts/src/include/function/query_fts_bind_data.h
+++ b/extension/fts/src/include/function/query_fts_bind_data.h
@@ -35,8 +35,6 @@ struct QueryFTSBindData final : function::GDSBindData {
         : GDSBindData{other}, query{other.query}, entry{other.entry},
           optionalParams{other.optionalParams}, outputTableID{other.outputTableID} {}
 
-    bool hasNodeInput() const override { return false; }
-
     std::vector<std::string> getTerms(main::ClientContext& context) const;
 
     QueryFTSConfig getConfig() const { return optionalParams.getConfig(); }

--- a/src/function/gds/asp_destinations.cpp
+++ b/src/function/gds/asp_destinations.cpp
@@ -185,7 +185,7 @@ public:
 private:
     RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
-        auto frontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
+        auto frontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
         auto numNodesMap = sharedState->graph->getNumNodesMap(clientContext->getTransaction());
         auto mm = clientContext->getMemoryManager();
         auto multiplicities = std::make_shared<Multiplicities>(numNodesMap, mm);

--- a/src/function/gds/asp_paths.cpp
+++ b/src/function/gds/asp_paths.cpp
@@ -79,7 +79,7 @@ public:
 private:
     RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
-        auto frontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
+        auto frontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
         auto bfsGraph = getBFSGraph(context);
         auto rjBindData = bindData->ptrCast<RJBindData>();
         auto writerInfo = rjBindData->getPathWriterInfo();

--- a/src/function/gds/awsp_paths.cpp
+++ b/src/function/gds/awsp_paths.cpp
@@ -142,8 +142,8 @@ private:
         nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
         auto numNodes = sharedState->graph->getNumNodesMap(clientContext->getTransaction());
-        auto curFrontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
-        auto nextFrontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
+        auto curFrontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
+        auto nextFrontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
         auto frontierPair =
             std::make_unique<DoublePathLengthsFrontierPair>(curFrontier, nextFrontier);
         auto bfsGraph = getBFSGraph(context);

--- a/src/function/gds/degrees.h
+++ b/src/function/gds/degrees.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "function/gds/compute.h"
 #include "function/gds/gds_frontier.h"
 #include "function/gds/gds_object_manager.h"
@@ -62,13 +64,13 @@ struct DegreeEdgeCompute : public EdgeCompute {
 
 struct DegreesUtils {
     static void computeDegree(processor::ExecutionContext* context, graph::Graph* graph,
-        Degrees* degrees, ExtendDirection direction) {
-        auto currentFrontier = PathLengths::getFrontier(context, graph, PathLengths::UNVISITED);
-        auto nextFrontier = PathLengths::getFrontier(context, graph, 0);
+        processor::NodeOffsetMaskMap* nodeOffsetMaskMap, Degrees* degrees,
+        ExtendDirection direction) {
+        auto currentFrontier = PathLengths::getUnvisitedFrontier(context, graph);
+        auto nextFrontier = PathLengths::getVisitedFrontier(context, graph, nodeOffsetMaskMap);
         auto frontierPair =
             std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier, nextFrontier);
-        frontierPair->setActiveNodesForNextIter();
-        frontierPair->getNextSparseFrontier().disable();
+        frontierPair->initGDS();
         auto ec = std::make_unique<DegreeEdgeCompute>(degrees);
         auto auxiliaryState = std::make_unique<EmptyGDSAuxiliaryState>();
         auto computeState = GDSComputeState(std::move(frontierPair), std::move(ec),

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -2,8 +2,7 @@
 
 #include "binder/binder.h"
 #include "common/exception/binder.h"
-#include "function/gds/gds_frontier.h"
-#include "processor/execution_context.h"
+#include "main/client_context.h"
 
 using namespace kuzu::common;
 using namespace kuzu::binder;
@@ -31,11 +30,6 @@ std::shared_ptr<Expression> GDSAlgorithm::bindNodeOutput(const GDSBindInput& bin
     auto node = bindInput.binder->createQueryNode(nodeColumnName, nodeEntries);
     bindInput.binder->addToScope(nodeColumnName, node);
     return node;
-}
-
-std::shared_ptr<PathLengths> GDSAlgorithm::getPathLengthsFrontier(
-    processor::ExecutionContext* context, uint16_t initialVal) {
-    return PathLengths::getFrontier(context, sharedState->graph.get(), initialVal);
 }
 
 std::string GDSAlgorithm::bindColumnName(const parser::YieldVariable& yieldVariable,

--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -21,7 +21,7 @@ void FrontierTask::run() {
     FrontierMorsel morsel;
     auto numActiveNodes = 0u;
     auto graph = info.graph;
-    auto scanState = graph->prepareRelScan(info.relEntry, info.propertyToScan);
+    auto scanState = graph->prepareRelScan(info.relEntry, info.nbrEntry, info.propertyToScan);
     auto localEc = info.edgeCompute.copy();
     SparseFrontier localFrontier;
     localFrontier.pinTableID(info.nbrEntry->getTableID());
@@ -67,7 +67,7 @@ void FrontierTask::run() {
 void FrontierTask::runSparse() {
     auto numActiveNodes = 0u;
     auto graph = info.graph;
-    auto scanState = graph->prepareRelScan(info.relEntry, info.propertyToScan);
+    auto scanState = graph->prepareRelScan(info.relEntry, info.nbrEntry, info.propertyToScan);
     auto localEc = info.edgeCompute.copy();
     SparseFrontier localFrontier;
     localFrontier.pinTableID(info.nbrEntry->getTableID());

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -24,18 +24,18 @@ static uint64_t getNumThreads(processor::ExecutionContext& context) {
 
 static void scheduleFrontierTask(catalog::TableCatalogEntry* fromEntry,
     catalog::TableCatalogEntry* toEntry, catalog::TableCatalogEntry* relEntry, graph::Graph* graph,
-    ExtendDirection extendDirection, GDSComputeState& gdsComputeState,
+    ExtendDirection extendDirection, GDSComputeState& computeState,
     processor::ExecutionContext* context, const std::string& propertyToScan) {
     auto clientContext = context->clientContext;
     auto transaction = clientContext->getTransaction();
     auto info = FrontierTaskInfo(fromEntry, toEntry, relEntry, graph, extendDirection,
-        *gdsComputeState.edgeCompute, propertyToScan);
+        *computeState.edgeCompute, propertyToScan);
     auto numThreads = getNumThreads(*context);
     auto sharedState =
-        std::make_shared<FrontierTaskSharedState>(numThreads, *gdsComputeState.frontierPair);
+        std::make_shared<FrontierTaskSharedState>(numThreads, *computeState.frontierPair);
     auto task = std::make_shared<FrontierTask>(numThreads, info, sharedState);
 
-    if (gdsComputeState.frontierPair->isCurFrontierSparse()) {
+    if (computeState.frontierPair->isCurFrontierSparse()) {
         task->runSparse();
         return;
     }

--- a/src/function/gds/gds_vertex_compute.h
+++ b/src/function/gds/gds_vertex_compute.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "function/gds/compute.h"
+
+namespace kuzu {
+namespace function {
+
+class GDSVertexCompute : public VertexCompute {
+public:
+    explicit GDSVertexCompute(processor::NodeOffsetMaskMap* nodeMask) : nodeMask{nodeMask} {}
+
+    bool beginOnTable(common::table_id_t tableID) override {
+        if (nodeMask != nullptr) {
+            nodeMask->pin(tableID);
+        }
+        beginOnTableInternal(tableID);
+        return true;
+    }
+
+protected:
+    bool skip(common::offset_t offset) {
+        if (nodeMask != nullptr) {
+            return !nodeMask->valid(offset);
+        }
+        return false;
+    }
+
+    virtual void beginOnTableInternal(common::table_id_t tableID) = 0;
+
+protected:
+    processor::NodeOffsetMaskMap* nodeMask;
+};
+
+class GDSResultVertexCompute : public GDSVertexCompute {
+public:
+    GDSResultVertexCompute(storage::MemoryManager* mm, processor::GDSCallSharedState* sharedState)
+        : GDSVertexCompute{sharedState->getGraphNodeMaskMap()}, sharedState{sharedState}, mm{mm} {
+        localFT = sharedState->claimLocalTable(mm);
+    }
+    ~GDSResultVertexCompute() override { sharedState->returnLocalTable(localFT); }
+
+protected:
+    processor::GDSCallSharedState* sharedState;
+    storage::MemoryManager* mm;
+    processor::FactorizedTable* localFT;
+};
+
+} // namespace function
+} // namespace kuzu

--- a/src/function/gds/page_rank.cpp
+++ b/src/function/gds/page_rank.cpp
@@ -336,8 +336,8 @@ public:
                 std::make_unique<PageRankAuxiliaryState>(degrees, *pCurrent, *pNext);
             GDSUtils::runFrontiersUntilConvergence(context, computeState, graph,
                 ExtendDirection::BWD, computeState.frontierPair->getCurrentIter() + 1);
-            auto pNextUpdateVC =
-                PNextUpdateVertexCompute(config.dampingFactor, pNextUpdateConstant, *pNext, sharedState->getGraphNodeMaskMap());
+            auto pNextUpdateVC = PNextUpdateVertexCompute(config.dampingFactor, pNextUpdateConstant,
+                *pNext, sharedState->getGraphNodeMaskMap());
             GDSUtils::runVertexCompute(context, graph, pNextUpdateVC);
             std::atomic<double> diff;
             diff.store(0);

--- a/src/function/gds/ssp_destinations.cpp
+++ b/src/function/gds/ssp_destinations.cpp
@@ -98,7 +98,7 @@ public:
 private:
     RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
-        auto frontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
+        auto frontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
         auto outputWriter = std::make_unique<SSPDestinationsOutputWriter>(clientContext,
             sharedState->getOutputNodeMaskMap(), sourceNodeID, frontier);
         auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(frontier);

--- a/src/function/gds/ssp_paths.cpp
+++ b/src/function/gds/ssp_paths.cpp
@@ -70,7 +70,7 @@ public:
 private:
     RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
-        auto frontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
+        auto frontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
         auto bfsGraph = getBFSGraph(context);
         auto rjBindData = bindData->ptrCast<RJBindData>();
         auto writerInfo = rjBindData->getPathWriterInfo();

--- a/src/function/gds/strongly_connected_components_kosaraju.cpp
+++ b/src/function/gds/strongly_connected_components_kosaraju.cpp
@@ -67,8 +67,7 @@ public:
     void compute(const offset_t tableID, const offset_t numNodes) {
         auto nbrTables = graph->getForwardNbrTableInfos(tableID);
         auto nbrInfo = nbrTables[0];
-        auto relEntry = nbrInfo.relEntry;
-        auto scanState = graph->prepareRelScan(relEntry, "");
+        auto scanState = graph->prepareRelScan(nbrInfo.relEntry, nbrInfo.nodeEntry, "");
         vector<offset_t> toProcess;
         vector<offset_t> dfsStack;
         for (auto i = 0u; i < numNodes; ++i) {

--- a/src/function/gds/variable_length_path.cpp
+++ b/src/function/gds/variable_length_path.cpp
@@ -106,15 +106,15 @@ public:
 private:
     RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
-        auto frontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
+        auto frontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
         auto bfsGraph = getBFSGraph(context);
         auto rjBindData = bindData->ptrCast<RJBindData>();
         auto writerInfo = rjBindData->getPathWriterInfo();
         writerInfo.pathNodeMask = sharedState->getPathNodeMaskMap();
         auto outputWriter = std::make_unique<VarLenPathsOutputWriter>(clientContext,
             sharedState->getOutputNodeMaskMap(), sourceNodeID, writerInfo, *bfsGraph);
-        auto currentFrontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
-        auto nextFrontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
+        auto currentFrontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
+        auto nextFrontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
         auto frontierPair =
             std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier, nextFrontier);
         auto edgeCompute =

--- a/src/function/gds/wsp_destinations.cpp
+++ b/src/function/gds/wsp_destinations.cpp
@@ -151,8 +151,8 @@ private:
         nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
         auto numNodes = sharedState->graph->getNumNodesMap(clientContext->getTransaction());
-        auto curFrontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
-        auto nextFrontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
+        auto curFrontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
+        auto nextFrontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
         auto frontierPair =
             std::make_unique<DoublePathLengthsFrontierPair>(curFrontier, nextFrontier);
         auto rjBindData = bindData->ptrCast<RJBindData>();

--- a/src/function/gds/wsp_paths.cpp
+++ b/src/function/gds/wsp_paths.cpp
@@ -120,8 +120,8 @@ private:
         nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
         auto numNodes = sharedState->graph->getNumNodesMap(clientContext->getTransaction());
-        auto curFrontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
-        auto nextFrontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
+        auto curFrontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
+        auto nextFrontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
         auto frontierPair =
             std::make_unique<DoublePathLengthsFrontierPair>(curFrontier, nextFrontier);
         auto bfsGraph = getBFSGraph(context);

--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -15,6 +15,7 @@
 #include "main/client_context.h"
 #include "planner/operator/schema.h"
 #include "processor/expression_mapper.h"
+#include "processor/operator/gds_call_shared_state.h"
 #include "storage/local_storage/local_rel_table.h"
 #include "storage/local_storage/local_storage.h"
 #include "storage/storage_manager.h"
@@ -160,6 +161,9 @@ table_id_map_t<offset_t> OnDiskGraph::getNumNodesMap(transaction::Transaction* t
 }
 
 offset_t OnDiskGraph::getNumNodes(transaction::Transaction* transaction) const {
+    if (nodeOffsetMaskMap != nullptr) {
+        return nodeOffsetMaskMap->getNumMaskedNode();
+    }
     offset_t numNodes = 0u;
     for (auto id : getNodeTableIDs()) {
         numNodes += getNumNodes(transaction, id);
@@ -177,10 +181,17 @@ std::vector<NbrTableInfo> OnDiskGraph::getForwardNbrTableInfos(table_id_t srcNod
     return nodeIDToNbrTableInfos.at(srcNodeTableID);
 }
 
-std::unique_ptr<NbrScanState> OnDiskGraph::prepareRelScan(TableCatalogEntry* tableEntry,
-    const std::string& property) {
-    auto& info = graphEntry.getRelInfo(tableEntry->getTableID());
-    return std::make_unique<OnDiskGraphNbrScanState>(context, tableEntry, info.predicate, property);
+// TODO(Xiyang): since now we need to provide nbr info at prepare stage. It no longer make sense to
+// have scanFwd&scanBwd. The direction has already been decided in this function.
+std::unique_ptr<NbrScanState> OnDiskGraph::prepareRelScan(TableCatalogEntry* relEntry,
+    catalog::TableCatalogEntry* nbrNodeEntry, const std::string& property) {
+    auto& info = graphEntry.getRelInfo(relEntry->getTableID());
+    auto state =
+        std::make_unique<OnDiskGraphNbrScanState>(context, relEntry, info.predicate, property);
+    if (nodeOffsetMaskMap != nullptr) {
+        state->nbrNodeMask = nodeOffsetMaskMap->getOffsetMask(nbrNodeEntry->getTableID());
+    }
+    return state;
 }
 
 std::unique_ptr<NbrScanState> OnDiskGraph::prepareRelLookup(TableCatalogEntry* tableEntry) const {
@@ -217,7 +228,8 @@ std::unique_ptr<VertexScanState> OnDiskGraph::prepareVertexScan(TableCatalogEntr
     return std::make_unique<OnDiskGraphVertexScanState>(*context, tableEntry, propertiesToScan);
 }
 
-bool OnDiskGraphNbrScanState::InnerIterator::next(evaluator::ExpressionEvaluator* predicate) {
+bool OnDiskGraphNbrScanState::InnerIterator::next(evaluator::ExpressionEvaluator* predicate,
+    semi_mask_t* nbrNodeMask_) {
     bool hasAtLeastOneSelectedValue = false;
     do {
         restoreSelVector(*tableScanState->outState);
@@ -225,12 +237,22 @@ bool OnDiskGraphNbrScanState::InnerIterator::next(evaluator::ExpressionEvaluator
             return false;
         }
         saveSelVector(*tableScanState->outState);
+        hasAtLeastOneSelectedValue = tableScanState->outState->getSelVector().getSelSize() > 0;
         if (predicate != nullptr) {
-            hasAtLeastOneSelectedValue =
-                predicate->select(tableScanState->outState->getSelVectorUnsafe(),
-                    !tableScanState->outState->isFlat());
-        } else {
-            hasAtLeastOneSelectedValue = tableScanState->outState->getSelVector().getSelSize() > 0;
+            hasAtLeastOneSelectedValue = predicate->select(tableScanState->outState->getSelVectorUnsafe(),
+                !tableScanState->outState->isFlat());
+        }
+        if (nbrNodeMask_ != nullptr) {
+            auto selectedSize = 0u;
+            auto buffer = tableScanState->outState->getSelVectorUnsafe().getMutableBuffer();
+            for (auto i = 0u; i < tableScanState->outState->getSelSize(); ++i) {
+                auto pos = tableScanState->outState->getSelVector()[i];
+                buffer[selectedSize] = pos;
+                auto nbrNodeID = tableScanState->outputVectors[0]->getValue<nodeID_t>(pos);
+                selectedSize += nbrNodeMask_->isMasked(nbrNodeID.offset);
+            }
+            tableScanState->outState->getSelVectorUnsafe().setToFiltered(selectedSize);
+            hasAtLeastOneSelectedValue = selectedSize > 0;
         }
     } while (!hasAtLeastOneSelectedValue);
     return true;
@@ -253,7 +275,7 @@ void OnDiskGraphNbrScanState::startScan(RelDataDirection direction) {
 
 bool OnDiskGraphNbrScanState::next() {
     KU_ASSERT(currentIter != nullptr);
-    if (currentIter->next(relPredicateEvaluator.get())) {
+    if (currentIter->next(relPredicateEvaluator.get(), nbrNodeMask)) {
         return true;
     }
     return false;

--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -239,8 +239,9 @@ bool OnDiskGraphNbrScanState::InnerIterator::next(evaluator::ExpressionEvaluator
         saveSelVector(*tableScanState->outState);
         hasAtLeastOneSelectedValue = tableScanState->outState->getSelVector().getSelSize() > 0;
         if (predicate != nullptr) {
-            hasAtLeastOneSelectedValue = predicate->select(tableScanState->outState->getSelVectorUnsafe(),
-                !tableScanState->outState->isFlat());
+            hasAtLeastOneSelectedValue =
+                predicate->select(tableScanState->outState->getSelVectorUnsafe(),
+                    !tableScanState->outState->isFlat());
         }
         if (nbrNodeMask_ != nullptr) {
             auto selectedSize = 0u;

--- a/src/include/common/mask.h
+++ b/src/include/common/mask.h
@@ -109,8 +109,7 @@ public:
 };
 
 struct RoaringBitmapSemiMaskUtil {
-    static std::unique_ptr<RoaringBitmapSemiMask> createRoaringBitmapSemiMask(
-        common::offset_t maxOffset) {
+    static std::unique_ptr<RoaringBitmapSemiMask> createMask(common::offset_t maxOffset) {
         if (maxOffset > std::numeric_limits<uint32_t>::max()) {
             return std::make_unique<Roaring64BitmapSemiMask>(maxOffset);
         } else {

--- a/src/include/function/gds/gds.h
+++ b/src/include/function/gds/gds.h
@@ -121,9 +121,6 @@ protected:
     std::shared_ptr<binder::Expression> bindNodeOutput(const GDSBindInput& bindInput,
         const std::vector<catalog::TableCatalogEntry*>& nodeEntries);
 
-    std::shared_ptr<PathLengths> getPathLengthsFrontier(processor::ExecutionContext* context,
-        uint16_t initialVal);
-
     static std::string bindColumnName(const parser::YieldVariable& yieldVariable,
         std::string expressionName);
 

--- a/src/include/graph/graph.h
+++ b/src/include/graph/graph.h
@@ -200,8 +200,8 @@ public:
         common::table_id_t srcNodeTableID) = 0;
 
     // Prepares scan on the specified relationship table (works for backwards and forwards scans)
-    virtual std::unique_ptr<NbrScanState> prepareRelScan(catalog::TableCatalogEntry* tableEntry,
-        const std::string& property) = 0;
+    virtual std::unique_ptr<NbrScanState> prepareRelScan(catalog::TableCatalogEntry* relEntry,
+        catalog::TableCatalogEntry* nbrNodeEntry, const std::string& relProperty) = 0;
 
     // Get dst nodeIDs for given src nodeID using forward adjList.
     virtual EdgeIterator scanFwd(common::nodeID_t nodeID, NbrScanState& state) = 0;
@@ -244,6 +244,11 @@ public:
 
     virtual VertexIterator scanVertices(common::offset_t startNodeOffset,
         common::offset_t endNodeOffsetExclusive, VertexScanState& scanState) = 0;
+
+    template<class TARGET>
+    const TARGET& constCast() const {
+        return common::ku_dynamic_cast<const TARGET&>(*this);
+    }
 };
 
 } // namespace graph

--- a/src/include/graph/graph_entry.h
+++ b/src/include/graph/graph_entry.h
@@ -16,13 +16,16 @@ namespace graph {
 
 struct KUZU_API GraphEntryTableInfo {
     catalog::TableCatalogEntry* entry;
+
+    std::shared_ptr<binder::Expression> nodeOrRel;
     std::shared_ptr<binder::Expression> predicate;
 
     explicit GraphEntryTableInfo(catalog::TableCatalogEntry* entry)
         : entry{entry}, predicate{nullptr} {}
     GraphEntryTableInfo(catalog::TableCatalogEntry* entry,
+        std::shared_ptr<binder::Expression> nodeOrRel,
         std::shared_ptr<binder::Expression> predicate)
-        : entry{entry}, predicate{std::move(predicate)} {}
+        : entry{entry}, nodeOrRel{std::move(nodeOrRel)}, predicate{std::move(predicate)} {}
 
     void setPredicate(std::shared_ptr<binder::Expression> predicate_);
 };

--- a/src/include/planner/operator/logical_gds_call.h
+++ b/src/include/planner/operator/logical_gds_call.h
@@ -6,17 +6,17 @@
 namespace kuzu {
 namespace planner {
 
+struct LogicalGDSMaskInfo {
+    bool isPathNodeMask = true;
+    std::vector<std::shared_ptr<LogicalOperator>> maskRoots;
+};
+
 class LogicalGDSCall final : public LogicalOperator {
     static constexpr LogicalOperatorType operatorType_ = LogicalOperatorType::GDS_CALL;
 
 public:
     explicit LogicalGDSCall(binder::BoundGDSCallInfo info)
         : LogicalOperator{operatorType_}, info{std::move(info)}, limitNum{common::INVALID_LIMIT} {}
-    LogicalGDSCall(binder::BoundGDSCallInfo info, common::table_id_set_t nbrTableIDSet,
-        std::shared_ptr<LogicalOperator> nodePredicateRoot)
-        : LogicalOperator{operatorType_}, info{std::move(info)},
-          nbrTableIDSet{std::move(nbrTableIDSet)}, nodePredicateRoot{std::move(nodePredicateRoot)},
-          limitNum{common::INVALID_LIMIT} {}
 
     void computeFlatSchema() override;
     void computeFactorizedSchema() override;
@@ -28,11 +28,16 @@ public:
     bool hasNbrTableIDSet() const { return !nbrTableIDSet.empty(); }
     common::table_id_set_t getNbrTableIDSet() const { return nbrTableIDSet; }
 
-    void setNodePredicateRoot(std::shared_ptr<LogicalOperator> op) {
-        nodePredicateRoot = std::move(op);
+    void addPathNodeMask(std::shared_ptr<LogicalOperator> maskRoot) {
+        maskInfo.isPathNodeMask = true;
+        maskInfo.maskRoots = {std::move(maskRoot)};
     }
-    bool hasNodePredicate() const { return nodePredicateRoot != nullptr; }
-    std::shared_ptr<LogicalOperator> getNodePredicateRoot() const { return nodePredicateRoot; }
+    void addGraphNodeMask(std::vector<std::shared_ptr<LogicalOperator>> maskRoots) {
+        maskInfo.isPathNodeMask = false;
+        maskInfo.maskRoots = std::move(maskRoots);
+    }
+    bool hasNodePredicate() const { return !maskInfo.maskRoots.empty(); }
+    const LogicalGDSMaskInfo& getMaskInfo() const { return maskInfo; }
 
     void setLimitNum(common::offset_t num) { limitNum = num; }
     common::offset_t getLimitNum() const { return limitNum; }
@@ -40,14 +45,18 @@ public:
     std::string getExpressionsForPrinting() const override { return info.func.name; }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return std::make_unique<LogicalGDSCall>(info.copy(), nbrTableIDSet, nodePredicateRoot);
+        auto result = std::make_unique<LogicalGDSCall>(info.copy());
+        result->nbrTableIDSet = nbrTableIDSet;
+        result->limitNum = limitNum;
+        result->maskInfo = maskInfo;
+        return result;
     }
 
 private:
     binder::BoundGDSCallInfo info;
     common::table_id_set_t nbrTableIDSet;
-    std::shared_ptr<LogicalOperator> nodePredicateRoot;
     common::offset_t limitNum;
+    LogicalGDSMaskInfo maskInfo;
 };
 
 } // namespace planner

--- a/src/include/planner/operator/sip/logical_semi_masker.h
+++ b/src/include/planner/operator/sip/logical_semi_masker.h
@@ -3,6 +3,7 @@
 #include "common/enums/extend_direction.h"
 #include "common/exception/runtime.h"
 #include "planner/operator/logical_operator.h"
+#include "semi_mask_target_type.h"
 
 namespace kuzu {
 namespace planner {
@@ -20,13 +21,6 @@ enum class SemiMaskKeyType : uint8_t {
     NODE = 0,
     PATH = 1,
     NODE_ID_LIST = 2,
-};
-
-enum class SemiMaskTargetType : uint8_t {
-    SCAN_NODE = 0,
-    GDS_INPUT_NODE = 2,
-    GDS_PATH_NODE = 3,
-    GDS_OUTPUT_NODE = 4,
 };
 
 struct ExtraKeyInfo {

--- a/src/include/planner/operator/sip/semi_mask_target_type.h
+++ b/src/include/planner/operator/sip/semi_mask_target_type.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+
+namespace kuzu {
+namespace planner {
+
+enum class SemiMaskTargetType : uint8_t {
+    SCAN_NODE = 0,
+    GDS_INPUT_NODE = 2,
+    GDS_OUTPUT_NODE = 3,
+    // Used for recursive join.
+    GDS_PATH_NODE = 4,
+    // Used for GDS algorithms.
+    GDS_GRAPH_NODE = 5,
+};
+
+}
+} // namespace kuzu

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -8,6 +8,7 @@
 #include "planner/join_order/cardinality_estimator.h"
 #include "planner/join_order_enumerator_context.h"
 #include "planner/operator/logical_plan.h"
+#include "planner/operator/sip/semi_mask_target_type.h"
 
 namespace kuzu {
 namespace binder {
@@ -210,6 +211,10 @@ public:
         std::vector<std::unique_ptr<LogicalPlan>> leftPlans,
         std::vector<std::unique_ptr<LogicalPlan>> rightPlans);
 
+    // Plan semi mask
+    LogicalPlan planNodeSemiMask(SemiMaskTargetType targetType, const binder::NodeExpression& node,
+        std::shared_ptr<binder::Expression> nodePredicate);
+
     // Append empty result
     void appendEmptyResult(LogicalPlan& plan);
 
@@ -249,8 +254,6 @@ public:
         const std::shared_ptr<binder::NodeExpression>& nbrNode,
         const std::shared_ptr<binder::RelExpression>& rel, common::ExtendDirection direction,
         LogicalPlan& plan);
-    void createPathNodeFilterPlan(const std::shared_ptr<binder::NodeExpression>& node,
-        std::shared_ptr<binder::Expression> nodePredicate, LogicalPlan& plan);
     void createPathNodePropertyScanPlan(const std::shared_ptr<binder::NodeExpression>& node,
         const binder::expression_vector& properties, LogicalPlan& plan);
     void createPathRelPropertyScanPlan(const std::shared_ptr<binder::NodeExpression>& boundNode,
@@ -294,8 +297,7 @@ public:
         std::shared_ptr<binder::Expression> mark, const LogicalPlan& probePlan,
         const LogicalPlan& buildPlan, LogicalPlan& resultPlan);
 
-    /* Append accumulate */
-
+    // Append accumulate operators
     // Skip if plan has been accumulated.
     void tryAppendAccumulate(LogicalPlan& plan);
     // Accumulate everything.

--- a/src/planner/plan/CMakeLists.txt
+++ b/src/planner/plan/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(kuzu_planner_plan_operator
         append_unwind.cpp
         plan_copy.cpp
         plan_join_order.cpp
+        plan_node_semi_mask.cpp
         plan_projection.cpp
         plan_read.cpp
         plan_single_query.cpp

--- a/src/planner/plan/append_gds_call.cpp
+++ b/src/planner/plan/append_gds_call.cpp
@@ -8,7 +8,9 @@ namespace kuzu {
 namespace planner {
 
 std::shared_ptr<LogicalOperator> Planner::getGDSCall(const BoundGDSCallInfo& info) {
-    return std::make_shared<LogicalGDSCall>(info.copy());
+    auto op = std::make_shared<LogicalGDSCall>(info.copy());
+    op->computeFactorizedSchema();
+    return op;
 }
 
 } // namespace planner

--- a/src/planner/plan/plan_node_semi_mask.cpp
+++ b/src/planner/plan/plan_node_semi_mask.cpp
@@ -1,0 +1,38 @@
+#include "binder/expression/expression_util.h"
+#include "binder/expression/property_expression.h"
+#include "binder/expression_visitor.h"
+#include "main/client_context.h"
+#include "planner/operator/sip/logical_semi_masker.h"
+#include "planner/planner.h"
+
+using namespace kuzu::binder;
+using namespace kuzu::common;
+
+namespace kuzu {
+namespace planner {
+
+// Create a plan with a root semi masker for given node and node predicate.
+LogicalPlan Planner::planNodeSemiMask(SemiMaskTargetType targetType, const NodeExpression& node,
+    std::shared_ptr<Expression> nodePredicate) {
+    auto plan = LogicalPlan();
+    auto prevCollection = enterNewPropertyExprCollection();
+    auto collector = PropertyExprCollector();
+    collector.visit(nodePredicate);
+    for (auto& expr : ExpressionUtil::removeDuplication(collector.getPropertyExprs())) {
+        auto& propExpr = expr->constCast<PropertyExpression>();
+        propertyExprCollection.addProperties(propExpr.getVariableName(), expr);
+    }
+    cardinalityEstimator.addNodeIDDomAndStats(clientContext->getTransaction(),
+        *node.getInternalID(), node.getTableIDs());
+    appendScanNodeTable(node.getInternalID(), node.getTableIDs(), getProperties(node), plan);
+    appendFilter(nodePredicate, plan);
+    exitPropertyExprCollection(std::move(prevCollection));
+    auto semiMasker = std::make_shared<LogicalSemiMasker>(SemiMaskKeyType::NODE, targetType,
+        node.getInternalID(), node.getTableIDs(), plan.getLastOperator());
+    semiMasker->computeFactorizedSchema();
+    plan.setLastOperator(semiMasker);
+    return plan;
+}
+
+} // namespace planner
+} // namespace kuzu

--- a/src/processor/map/map_scan_node_table.cpp
+++ b/src/processor/map/map_scan_node_table.cpp
@@ -43,8 +43,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapScanNodeTable(
     std::vector<std::shared_ptr<ScanNodeTableSharedState>> sharedStates;
     for (auto& tableID : tableIDs) {
         auto table = storageManager->getTable(tableID)->ptrCast<storage::NodeTable>();
-        auto semiMask = RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(
-            table->getNumTotalRows(transaction));
+        auto semiMask = RoaringBitmapSemiMaskUtil::createMask(table->getNumTotalRows(transaction));
         sharedStates.push_back(std::make_shared<ScanNodeTableSharedState>(std::move(semiMask)));
     }
     auto alias = scan.getNodeID()->cast<PropertyExpression>().getRawVariableName();

--- a/src/processor/operator/gds_call_shared_state.cpp
+++ b/src/processor/operator/gds_call_shared_state.cpp
@@ -2,18 +2,25 @@
 
 #include <mutex>
 
+#include "graph/on_disk_graph.h"
+
 using namespace kuzu::common;
 
 namespace kuzu {
 namespace processor {
 
 offset_t NodeOffsetMaskMap::getNumMaskedNode() const {
-    KU_ASSERT(enabled_);
     offset_t numNodes = 0;
     for (auto& [tableID, mask] : maskMap) {
         numNodes += mask->getNumMaskedNodes();
     }
     return numNodes;
+}
+
+void GDSCallSharedState::setGraphNodeMask(std::unique_ptr<NodeOffsetMaskMap> maskMap) {
+    auto onDiskGraph = ku_dynamic_cast<graph::OnDiskGraph*>(graph.get());
+    onDiskGraph->setNodeOffsetMask(maskMap.get());
+    graphNodeMask = std::move(maskMap);
 }
 
 FactorizedTable* GDSCallSharedState::claimLocalTable(storage::MemoryManager* mm) {

--- a/src/processor/operator/semi_masker.cpp
+++ b/src/processor/operator/semi_masker.cpp
@@ -13,8 +13,7 @@ SemiMaskerLocalState* SemiMaskerSharedState::appendLocalState() {
     bool isSingle = masksPerTable.size() == 1;
     for (const auto& [tableID, vector] : masksPerTable) {
         auto& mask = vector.front();
-        auto newOne =
-            common::RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(mask->getMaxOffset());
+        auto newOne = common::RoaringBitmapSemiMaskUtil::createMask(mask->getMaxOffset());
         if (isSingle) {
             localInfo->singleTableRef = newOne.get();
         }

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -92,8 +92,7 @@ struct RollbackPKDeleter final : PKColumnScanHelper {
     RollbackPKDeleter(row_idx_t startNodeOffset, row_idx_t numRows, NodeTable* table,
         PrimaryKeyIndex* pkIndex)
         : PKColumnScanHelper(table, pkIndex),
-          semiMask(
-              RoaringBitmapSemiMaskUtil::createRoaringBitmapSemiMask(startNodeOffset + numRows)) {
+          semiMask(RoaringBitmapSemiMaskUtil::createMask(startNodeOffset + numRows)) {
         semiMask->maskRange(startNodeOffset, startNodeOffset + numRows);
         semiMask->enable();
     }

--- a/test/storage/rel_scan_test.cpp
+++ b/test/storage/rel_scan_test.cpp
@@ -57,9 +57,11 @@ class RelScanTestAmazon : public RelScanTest {
 
 // Test correctness of scan fwd
 TEST_F(RelScanTest, ScanFwd) {
-    auto tableID = catalog->getTableCatalogEntry(context->getTransaction(), "person")->getTableID();
-    auto relEntry = catalog->getTableCatalogEntry(context->getTransaction(), "knows");
-    auto scanState = graph->prepareRelScan(relEntry, "date");
+    auto transaction = context->getTransaction();
+    auto nodeEntry = catalog->getTableCatalogEntry(transaction, "person");
+    auto tableID = nodeEntry->getTableID();
+    auto relEntry = catalog->getTableCatalogEntry(transaction, "knows");
+    auto scanState = graph->prepareRelScan(relEntry, nodeEntry, "date");
 
     std::unordered_map<offset_t, common::date_t> expectedDates = {
         {0, Date::fromDate(2021, 6, 30)},

--- a/test/test_files/function/gds/k_core.test
+++ b/test/test_files/function/gds/k_core.test
@@ -4,20 +4,20 @@
 
 -CASE KCoreDecomposition 
 
--STATEMENT CREATE NODE TABLE User(name STRING PRIMARY KEY);
+-STATEMENT CREATE NODE TABLE User(name STRING PRIMARY KEY, id INT64);
 ---- ok
 -STATEMENT CREATE REL TABLE FRIEND(FROM User to User, id INT64);
 ---- ok
--STATEMENT CREATE (alice:User {name: 'Alice'}),
-            (bridget:User {name: 'Bridget'}),
-            (charles:User {name: 'Charles'}),
-            (doug:User {name: 'Doug'}),
-            (eli:User {name: 'Eli'}),
-            (filip:User {name: 'Filip'}),
-            (greg:User {name: 'Greg'}),
-            (harry:User {name: 'Harry'}),
-            (ian:User {name: 'Ian'}),
-            (james:User {name: 'James'}),
+-STATEMENT CREATE (alice:User {name: 'Alice', id:1}),
+            (bridget:User {name: 'Bridget', id:2}),
+            (charles:User {name: 'Charles', id:3}),
+            (doug:User {name: 'Doug', id:4}),
+            (eli:User {name: 'Eli', id:5}),
+            (filip:User {name: 'Filip', id:6}),
+            (greg:User {name: 'Greg', id:7}),
+            (harry:User {name: 'Harry', id:8}),
+            (ian:User {name: 'Ian', id:9}),
+            (james:User {name: 'James', id:10}),
             (alice)-[:FRIEND {id:1}]->(bridget),
             (bridget)-[:FRIEND {id:2}]->(charles),
             (charles)-[:FRIEND {id:3}]->(doug),
@@ -59,3 +59,21 @@ Greg|2
 Harry|1
 Ian|0
 James|0
+-STATEMENT CALL create_projected_graph('PK3', {'User': {'filter': 'n.id > 3'}}, {'friend': {'filter': 'r.id <= 11'}});
+---- ok
+-STATEMENT CALL k_core_decomposition('PK3') RETURN node.name, k_degree;
+---- 7
+Doug|3
+Eli|3
+Filip|3
+Greg|3
+Harry|1
+Ian|0
+James|0
+-STATEMENT CALL create_projected_graph('PK4', {'User': {'filter': 'n.id > 3 AND n.id < 7'}}, {'friend': {'filter': 'r.id >= 0'}});
+---- ok
+-STATEMENT CALL k_core_decomposition('PK4') RETURN node.name, k_degree;
+---- 3
+Doug|2
+Eli|2
+Filip|2

--- a/test/test_files/function/gds/page_rank.test
+++ b/test/test_files/function/gds/page_rank.test
@@ -15,7 +15,27 @@ Elizabeth|0.018750
 Farooq|0.026719
 Greg|0.026719
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|0.018750
-
+-STATEMENT CALL create_projected_graph('PK2', ['person'], {'knows': {'filter': 'r.date > date("1906-01-01")'}})
+---- ok
+-STATEMENT CALL page_rank('PK2') RETURN node.fName, rank;
+---- 8
+Alice|0.125000
+Bob|0.125000
+Carol|0.125000
+Dan|0.125000
+Elizabeth|0.018750
+Farooq|0.018750
+Greg|0.018750
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|0.018750
+-STATEMENT CALL create_projected_graph('PK3', {'person': {'filter': 'n.ID > 3'}}, {'knows': {'filter': 'r.date > date("1906-01-01")'}})
+---- ok
+-STATEMENT CALL page_rank('PK3') RETURN node.fName, rank;
+---- 5
+Dan|0.030000
+Elizabeth|0.030000
+Farooq|0.030000
+Greg|0.030000
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|0.030000
 -STATEMENT CALL page_rank('PK', dampingFactor := 0.5) RETURN node.fName, rank;
 ---- 8
 Alice|0.125000
@@ -26,7 +46,6 @@ Elizabeth|0.062500
 Farooq|0.078125
 Greg|0.078125
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|0.062500
-
 -STATEMENT CALL page_rank('PK', dampingFactor := 0.3, maxIterations := 10) RETURN node.fName, rank;
 ---- 8
 Alice|0.125000
@@ -37,7 +56,6 @@ Elizabeth|0.087500
 Farooq|0.100625
 Greg|0.100625
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|0.087500
-
 -STATEMENT CALL page_rank('PK', dampingFactor := 0.1, maxIterations := 15, tolerance := 0.00024) RETURN node.fName, rank;
 ---- 8
 Alice|0.125000
@@ -48,15 +66,12 @@ Elizabeth|0.112500
 Farooq|0.118125
 Greg|0.118125
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|0.112500
-
 -STATEMENT CALL page_rank('PK', dampingFactOR := 5.2) RETURN node.fName, rank;
 ---- error
 Binder exception: Damping factor must be in the [0, 1).
-
 -STATEMENT CALL page_rank('PK', MAXITerations := -9) RETURN node.fName, rank;
 ---- error
 Binder exception: Max iteration must be a positive integer.
-
 -STATEMENT CALL page_rank('PK', maxIteratioN := 4) RETURN node.fName, rank;
 ---- error
 Binder exception: Unknown optional parameter: maxIteratioN

--- a/test/test_files/function/gds/special_projected_graph.test
+++ b/test/test_files/function/gds/special_projected_graph.test
@@ -46,6 +46,9 @@
 -STATEMENT CALL create_projected_graph('err', ['person'], ['studyAt']);
 ---- error
 Binder exception: organisation is connected to studyAt but not projected.
+-STATEMENT CALL create_projected_graph('err', true, 'studyAt');
+---- error
+Binder exception: Input argument True has data type BOOL. STRUCT or LIST was expected.
 -STATEMENT CALL create_projected_graph('err', ['person'], 'studyAt');
 ---- error
 Binder exception: Input argument studyAt has data type STRING. STRUCT or LIST was expected.

--- a/test/test_files/function/gds/wcc.test
+++ b/test/test_files/function/gds/wcc.test
@@ -3,7 +3,6 @@
 --
 
 -CASE WCC
-
 -STATEMENT CALL create_projected_graph('PK', ['person'], ['knows'])
 ---- ok
 -STATEMENT CALL weakly_connected_component('PK') RETURN node.fName, group_id;
@@ -24,6 +23,38 @@ Alice|0
 Bob|0
 Carol|0
 Dan|0
+Elizabeth|4
+Farooq|5
+Greg|6
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|7
+
+-STATEMENT CALL create_projected_graph('PK3', {'person': {'filter': 'n.ID > 2'}}, ['knows'])
+---- ok
+-STATEMENT CALL weakly_connected_component('PK3') RETURN node.fName, group_id;
+---- 6
+Carol|2
+Dan|2
+Elizabeth|4
+Farooq|4
+Greg|4
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|7
+
+-STATEMENT CALL create_projected_graph('PK4', {'person': {'filter': 'n.ID <> 7'}}, ['knows'])
+---- ok
+-STATEMENT CALL weakly_connected_component('PK4') RETURN node.fName, group_id;
+---- 7
+Alice|0
+Bob|0
+Carol|0
+Dan|0
+Farooq|5
+Greg|6
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|7
+
+-STATEMENT CALL create_projected_graph('PK5', {'person': {'filter': 'n.ID > 5'}}, {'knows': {'filter': 'r.date > date("1999-01-01")'}})
+---- ok
+-STATEMENT CALL weakly_connected_component('PK5') RETURN node.fName, group_id;
+---- 4
 Elizabeth|4
 Farooq|5
 Greg|6

--- a/test/test_files/shortest_path/all_shortest_path_tinysnb.test
+++ b/test/test_files/shortest_path/all_shortest_path_tinysnb.test
@@ -3,7 +3,6 @@
 --
 
 -CASE AllShortestPath
-
 -LOG MultiLabel1
 -STATEMENT MATCH (a:person)-[e:knows|:meets|:marries* ALL SHORTEST 1..5]->(b:person) WHERE a.fName='Alice' RETURN b.fName, length(e)
 ---- 9


### PR DESCRIPTION
# Description

This PR adds node filter to projected graph. 

For node filter, we do lazy evaluation to make sure data is always up to date, i.e. the node filter is evaluated on each GDS call. Prior to GDS evaluation, node filters are converted to semi masks and pass to GDS shared state & on disk graph.

With node filter, on-disk-graph edge scan will filtered out nbr nodes that doesn't pass the mask. I didn't implement the same logic for vertex scan because it is used for full text search only. Instead, GDS does not scan anything from on-disk-graph so the logic to check mask is implemented in vertex compute. This design is still debatable and may change in the future.

An immediate problem revealed from this PR is that we should separate recursive join from GDS into different operators. 

Btw I skipped SCC in this PR.

