### PR TITLE
Fix json casting issue

### DIFF
--- a/extension/json/src/CMakeLists.txt
+++ b/extension/json/src/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(functions/cast_functions)
 add_subdirectory(functions/creation_functions)
 add_subdirectory(functions/export_functions)
 add_subdirectory(functions/extract_functions)

--- a/extension/json/src/functions/cast_functions/CMakeLists.txt
+++ b/extension/json/src/functions/cast_functions/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(kuzu_json_cast_functions
+        OBJECT
+        json_cast.cpp)
+
+set(JSON_OBJECT_FILES
+        ${JSON_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_json_cast_functions>
+        PARENT_SCOPE)

--- a/extension/json/src/functions/cast_functions/json_cast.cpp
+++ b/extension/json/src/functions/cast_functions/json_cast.cpp
@@ -24,9 +24,11 @@ static void execFunc(const std::vector<std::shared_ptr<common::ValueVector>>& pa
         auto doc = JSONCommon::readDocumentUnsafe(str.getDataUnsafe(), str.len,
             JSONCommon::READ_FLAG, &error);
         if (!doc) {
+            yyjson_doc_free(doc);
             throw common::ConversionException{
                 common::stringFormat("Cannot convert {} to JSON.", str.getAsString())};
         }
+        yyjson_doc_free(doc);
         StringVector::addString(&result, resultPos, str);
     }
 }

--- a/extension/json/src/functions/cast_functions/json_cast.cpp
+++ b/extension/json/src/functions/cast_functions/json_cast.cpp
@@ -1,0 +1,58 @@
+#include "common/exception/conversion.h"
+#include "common/json_common.h"
+#include "common/string_format.h"
+#include "function/scalar_function.h"
+#include "json_cast_functions.h"
+#include "json_creation_functions.h"
+#include "json_type.h"
+#include "json_utils.h"
+
+namespace kuzu {
+namespace json_extension {
+
+using namespace function;
+using namespace common;
+
+static void execFunc(const std::vector<std::shared_ptr<common::ValueVector>>& parameters,
+    const std::vector<common::SelectionVector*>& /*parameterSelVectors*/,
+    common::ValueVector& result, common::SelectionVector* resultSelVector, void* /*dataPtr*/) {
+    result.resetAuxiliaryBuffer();
+    for (auto i = 0u; i < resultSelVector->getSelSize(); ++i) {
+        auto resultPos = (*resultSelVector)[i];
+        auto str = parameters[0]->getValue<common::ku_string_t>(resultPos);
+        yyjson_read_err error;
+        auto doc = JSONCommon::readDocumentUnsafe(str.getDataUnsafe(), str.len,
+            JSONCommon::READ_FLAG, &error);
+        if (!doc) {
+            throw common::ConversionException{
+                common::stringFormat("Cannot convert {} to JSON.", str.getAsString())};
+        }
+        StringVector::addString(&result, resultPos, str);
+    }
+}
+
+static std::unique_ptr<FunctionBindData> bindFunc(ScalarBindFuncInput input) {
+    LogicalType type = input.arguments[0]->getDataType().copy();
+    if (type.getLogicalTypeID() == LogicalTypeID::ANY) {
+        type = LogicalType::INT64();
+    }
+    auto bindData = std::make_unique<FunctionBindData>(JsonType::getJsonType());
+    bindData->paramTypes.push_back(std::move(type));
+    return bindData;
+}
+
+function_set CastToJsonFunction::getFunctionSet() {
+    function_set result;
+    auto function =
+        std::make_unique<ScalarFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::ANY},
+            LogicalTypeID::STRING, ToJsonFunction::execFunc);
+    function->bindFunc = bindFunc;
+    result.push_back(function->copy());
+    function = std::make_unique<ScalarFunction>(name,
+        std::vector<LogicalTypeID>{LogicalTypeID::STRING}, LogicalTypeID::STRING, execFunc);
+    result.push_back(std::move(function));
+    return result;
+}
+
+} // namespace json_extension
+} // namespace kuzu

--- a/extension/json/src/functions/creation_functions/to_json.cpp
+++ b/extension/json/src/functions/creation_functions/to_json.cpp
@@ -9,7 +9,7 @@ namespace json_extension {
 using namespace function;
 using namespace common;
 
-static void execFunc(const std::vector<std::shared_ptr<common::ValueVector>>& parameters,
+void ToJsonFunction::execFunc(const std::vector<std::shared_ptr<common::ValueVector>>& parameters,
     const std::vector<common::SelectionVector*>& parameterSelVectors, common::ValueVector& result,
     common::SelectionVector* resultSelVector, void* /*dataPtr*/) {
     KU_ASSERT(parameters.size() == 1);

--- a/extension/json/src/include/json_cast_functions.h
+++ b/extension/json/src/include/json_cast_functions.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "function/function.h"
+
+namespace kuzu {
+namespace json_extension {
+
+struct CastToJsonFunction {
+    static constexpr const char* name = "cast_to_json";
+
+    static function::function_set getFunctionSet();
+};
+
+} // namespace json_extension
+} // namespace kuzu

--- a/extension/json/src/include/json_creation_functions.h
+++ b/extension/json/src/include/json_creation_functions.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common/vector/value_vector.h"
 #include "function/function.h"
 
 namespace kuzu {
@@ -9,6 +10,10 @@ struct ToJsonFunction {
     static constexpr const char* name = "to_json";
 
     static function::function_set getFunctionSet();
+
+    static void execFunc(const std::vector<std::shared_ptr<common::ValueVector>>& parameters,
+        const std::vector<common::SelectionVector*>& parameterSelVectors,
+        common::ValueVector& result, common::SelectionVector* resultSelVector, void* /*dataPtr*/);
 };
 
 struct JsonQuoteFunction {
@@ -27,12 +32,6 @@ struct RowToJsonFunction {
     using alias = ToJsonFunction;
 
     static constexpr const char* name = "row_to_json";
-};
-
-struct CastToJsonFunction {
-    using alias = ToJsonFunction;
-
-    static constexpr const char* name = "cast_to_json";
 };
 
 struct JsonArrayFunction {

--- a/extension/json/src/json_extension.cpp
+++ b/extension/json/src/json_extension.cpp
@@ -1,5 +1,6 @@
 #include "json_extension.h"
 
+#include "json_cast_functions.h"
 #include "json_creation_functions.h"
 #include "json_export.h"
 #include "json_extract_functions.h"
@@ -19,7 +20,7 @@ static void addJsonCreationFunction(main::Database& db) {
     ExtensionUtils::addScalarFuncAlias<JsonQuoteFunction>(db);
     ExtensionUtils::addScalarFuncAlias<ArrayToJsonFunction>(db);
     ExtensionUtils::addScalarFuncAlias<RowToJsonFunction>(db);
-    ExtensionUtils::addScalarFuncAlias<CastToJsonFunction>(db);
+    ExtensionUtils::addScalarFunc<CastToJsonFunction>(db);
     ExtensionUtils::addScalarFunc<JsonArrayFunction>(db);
     ExtensionUtils::addScalarFunc<JsonObjectFunction>(db);
     ExtensionUtils::addScalarFunc<JsonMergePatchFunction>(db);

--- a/extension/json/src/utils/json_utils.cpp
+++ b/extension/json/src/utils/json_utils.cpp
@@ -149,15 +149,6 @@ yyjson_mut_val* jsonify(JsonMutWrapper& wrapper, const common::ValueVector& vec,
 
 JsonWrapper jsonify(const common::ValueVector& vec, uint64_t pos) {
     JsonMutWrapper result; // mutability necessary for manual construction
-    if (!vec.isNull(pos) && vec.dataType.getLogicalTypeID() == LogicalTypeID::STRING) {
-        auto strVal = vec.getValue<ku_string_t>(pos);
-        // check one more time in case this string a struct
-        auto strContent = strVal.getAsStringView();
-        LogicalType detectedType = function::inferMinimalTypeFromString(strContent);
-        if (detectedType.getLogicalTypeID() == LogicalTypeID::STRUCT) {
-            return stringToJson(std::string(strContent));
-        }
-    }
     yyjson_mut_val* root = jsonify(result, vec, pos);
     yyjson_mut_doc_set_root(result.ptr, root);
     return JsonWrapper(yyjson_mut_doc_imut_copy(result.ptr, nullptr));

--- a/extension/json/src/utils/json_utils.cpp
+++ b/extension/json/src/utils/json_utils.cpp
@@ -154,7 +154,7 @@ JsonWrapper jsonify(const common::ValueVector& vec, uint64_t pos) {
         // check one more time in case this string a struct
         auto strContent = strVal.getAsStringView();
         LogicalType detectedType = function::inferMinimalTypeFromString(strContent);
-        if (detectedType.getLogicalTypeID() != LogicalTypeID::STRING) {
+        if (detectedType.getLogicalTypeID() == LogicalTypeID::STRUCT) {
             return stringToJson(std::string(strContent));
         }
     }

--- a/extension/json/test/json_cast.test
+++ b/extension/json/test/json_cast.test
@@ -7,15 +7,19 @@
 ---- ok
 -STATEMENT return cast ('{"duck": 42}' as json)
 ---- 1
-{"duck":42}
+{"duck": 42}
 
 -STATEMENT return cast(cast ('2023-11-14' as DATE) as json);
 ---- 1
 "2023-11-14"
 
 -STATEMENT return cast(cast ('"{\"duck\": 42}"' as json) as STRING);
+---- error
+Conversion exception: Cannot convert "{"duck": 42}" to JSON.
+
+-STATEMENT return cast(cast ('"{\\"duck\\": 42}"' as json) as STRING);
 ---- 1
-"\"{\"duck\": 42}\""
+"{\"duck\": 42}"
 
 -STATEMENT return cast (4 as json);
 ---- 1
@@ -24,7 +28,7 @@
 
 -STATEMENT return cast ('4' as json);
 ---- 1
-"4"
+4
 
 -STATEMENT return cast(cast ('{"duck": 42}' as json) as struct(duck int64));
 ---- 1

--- a/extension/json/test/json_cast.test
+++ b/extension/json/test/json_cast.test
@@ -24,7 +24,7 @@
 
 -STATEMENT return cast ('4' as json);
 ---- 1
-4
+"4"
 
 -STATEMENT return cast(cast ('{"duck": 42}' as json) as struct(duck int64));
 ---- 1

--- a/extension/json/test/json_extract.test
+++ b/extension/json/test/json_extract.test
@@ -75,3 +75,11 @@ null
 
 -STATEMENT RETURN json_extract(NULL, '$.x');
 ---- 1
+
+-STATEMENT RETURN json_extract(json_object("foo", "5"), "foo") = to_json("5");
+---- 1
+True
+
+-STATEMENT RETURN json_extract(json_object("foo", "true"), "foo") = to_json("true");
+---- 1
+True

--- a/extension/json/test/to_json.test
+++ b/extension/json/test/to_json.test
@@ -7,9 +7,9 @@
 ---- ok
 -STATEMENT UNWIND ['1', '2', '3'] AS STR RETURN to_json(STR)
 ---- 3
-1
-2
-3
+"1"
+"2"
+"3"
 
 -STATEMENT UNWIND [{a: 1, b: {x: "a"}}, {a: 2, b: {x: "b"}}, {a: 3, b: {x: "c"}}] AS NSTD RETURN to_json(NSTD)
 ---- 3
@@ -67,3 +67,20 @@ json
 -STATEMENT RETURN cast(NULL as json)
 ---- 1
 
+
+# Related to Issue 4986, make sure our behaviour is consistent with duckdb
+-STATEMENT RETURN to_json(5);
+---- 1
+5
+
+-STATEMENT RETURN to_json('5');
+---- 1
+"5"
+
+-STATEMENT RETURN to_json(true);
+---- 1
+true
+
+-STATEMENT RETURN to_json('true');
+---- 1
+"true"


### PR DESCRIPTION
Fixes #4986
Delete the minimal type inference from the jsonify function which is only used in casting before.
The PR introduces a new execFunc for casting string->json which only needs parsing to check errors in json.