### PR TITLE
Fix json output mode with meta-data

### DIFF
--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -714,6 +714,7 @@ void EmbeddedShell::setMode(const std::string& modeString) {
         printModeInfo();
         return;
     }
+    stats = modePrinter->defaultPrintStats();
     printer = std::move(modePrinter);
     printf("mode set as %s\n", modeString.c_str());
 }

--- a/tools/shell/include/printer/json_printer.h
+++ b/tools/shell/include/printer/json_printer.h
@@ -16,6 +16,8 @@ public:
 
     std::string print(QueryResult& queryResult, storage::MemoryManager& mm) const;
 
+    bool defaultPrintStats() const override { return false; }
+
 private:
     virtual std::string printHeader() const = 0;
     virtual std::string printFooter() const = 0;

--- a/tools/shell/include/printer/printer.h
+++ b/tools/shell/include/printer/printer.h
@@ -77,6 +77,8 @@ struct Printer {
 
     virtual ~Printer() = default;
 
+    virtual bool defaultPrintStats() const { return true; }
+
 protected:
     explicit Printer(PrinterType pt) : printType(pt) {}
 };
@@ -104,7 +106,7 @@ struct BaseTablePrinter : public Printer {
     bool Types = true;
 
 protected:
-    explicit BaseTablePrinter(PrinterType pt) : Printer(pt){};
+    explicit BaseTablePrinter(PrinterType pt) : Printer(pt) {};
 };
 
 struct BoxPrinter : public BaseTablePrinter {

--- a/tools/shell/include/printer/printer.h
+++ b/tools/shell/include/printer/printer.h
@@ -106,7 +106,7 @@ struct BaseTablePrinter : public Printer {
     bool Types = true;
 
 protected:
-    explicit BaseTablePrinter(PrinterType pt) : Printer(pt) {};
+    explicit BaseTablePrinter(PrinterType pt) : Printer(pt){};
 };
 
 struct BoxPrinter : public BaseTablePrinter {

--- a/tools/shell/shell_runner.cpp
+++ b/tools/shell/shell_runner.cpp
@@ -17,6 +17,7 @@ int setConfigOutputMode(const std::string& mode, ShellConfig& shell) {
         std::cerr << "Cannot parse '" << mode << "' as output mode." << '\n';
         return 1;
     }
+    shell.stats = shell.printer->defaultPrintStats();
     return 0;
 }
 
@@ -168,13 +169,15 @@ int main(int argc, char* argv[]) {
     try {
         auto shell = EmbeddedShell(database, conn, shellConfig);
         processRunCommands(shell, initFile);
-        if (DBConfig::isDBPathInMemory(databasePath)) {
-            std::cout << "Opening the database under in-memory mode." << '\n';
-        } else {
-            std::cout << "Opening the database at path: " << databasePath << " in "
-                      << (readOnlyMode ? "read-only mode" : "read-write mode") << "." << '\n';
+        if (shellConfig.stats) {
+            if (DBConfig::isDBPathInMemory(databasePath)) {
+                std::cout << "Opening the database under in-memory mode." << '\n';
+            } else {
+                std::cout << "Opening the database at path: " << databasePath << " in "
+                          << (readOnlyMode ? "read-only mode" : "read-write mode") << "." << '\n';
+            }
+            std::cout << "Enter \":help\" for usage hints." << '\n' << std::flush;
         }
-        std::cout << "Enter \":help\" for usage hints." << '\n' << std::flush;
         shell.run();
     } catch (std::exception& e) {
         std::cerr << e.what() << '\n';


### PR DESCRIPTION
This PR sets the `stats` to false if the user executes the query in JSON mode.
If the user wants to see the `stats` in JSON mode, they can enable `stats` by `:stats on`

closes #4992 
Sample output:
```
./build/release/tools/shell/kuzu dsadadww -m json <<EOF
MATCH (u:User) RETURN u.name;
EOF
[
{"u.name":"Adam"},
{"u.name":"Karissa"},
{"u.name":"Zhang"},
{"u.name":"Noura"}
]
```