### PR TITLE
Selection vector slicing with lightweight SelectionView

### DIFF
--- a/src/common/data_chunk/sel_vector.cpp
+++ b/src/common/data_chunk/sel_vector.cpp
@@ -18,15 +18,19 @@ static const std::array<sel_t, DEFAULT_VECTOR_CAPACITY> INCREMENTAL_SELECTED_POS
         return selectedPos;
     }();
 
+SelectionView::SelectionView(sel_t startPos, sel_t selectedSize)
+    : selectedPositions{INCREMENTAL_SELECTED_POS.data() + startPos}, selectedSize{selectedSize},
+      state{State::STATIC} {}
+
 SelectionVector::SelectionVector() : SelectionVector{DEFAULT_VECTOR_CAPACITY} {}
 
 void SelectionVector::setToUnfiltered() {
-    selectedPositions = const_cast<sel_t*>(INCREMENTAL_SELECTED_POS.data());
+    selectedPositions = INCREMENTAL_SELECTED_POS.data();
     state = State::STATIC;
 }
 void SelectionVector::setToUnfiltered(sel_t size) {
     KU_ASSERT(size <= capacity);
-    selectedPositions = const_cast<sel_t*>(INCREMENTAL_SELECTED_POS.data());
+    selectedPositions = INCREMENTAL_SELECTED_POS.data();
     selectedSize = size;
     state = State::STATIC;
 }

--- a/src/include/storage/store/column_chunk_data.h
+++ b/src/include/storage/store/column_chunk_data.h
@@ -148,7 +148,7 @@ public:
     // Note that the startPageIdx is not known, so it will always be common::INVALID_PAGE_IDX
     virtual ColumnChunkMetadata getMetadataToFlush() const;
 
-    virtual void append(common::ValueVector* vector, const common::SelectionVector& selVector);
+    virtual void append(common::ValueVector* vector, const common::SelectionView& selView);
     virtual void append(ColumnChunkData* other, common::offset_t startPosInOtherChunk,
         uint32_t numValuesToAppend);
 
@@ -230,7 +230,7 @@ public:
 
     MergedColumnChunkStats getMergedColumnChunkStats() const;
 
-    void updateStats(const common::ValueVector* vector, const common::SelectionVector& selVector);
+    void updateStats(const common::ValueVector* vector, const common::SelectionView& selVector);
 
 protected:
     // Initializes the data buffer and functions. They are (and should be) only called in
@@ -243,7 +243,7 @@ protected:
     void setToOnDisk(const ColumnChunkMetadata& metadata);
 
     virtual void copyVectorToBuffer(common::ValueVector* vector, common::offset_t startPosInChunk,
-        const common::SelectionVector& selVector);
+        const common::SelectionView& selView);
 
     void resetInMemoryStats();
 
@@ -304,7 +304,7 @@ public:
         : ColumnChunkData{mm, common::LogicalType::BOOL(), enableCompression, metadata, hasNullData,
               true} {}
 
-    void append(common::ValueVector* vector, const common::SelectionVector& sel) final;
+    void append(common::ValueVector* vector, const common::SelectionView& sel) final;
     void append(ColumnChunkData* other, common::offset_t startPosInOtherChunk,
         uint32_t numValuesToAppend) override;
 
@@ -400,13 +400,13 @@ public:
               false /*hasNullData*/},
           commonTableID{common::INVALID_TABLE_ID} {}
 
-    void append(common::ValueVector* vector, const common::SelectionVector& selVector) override;
+    void append(common::ValueVector* vector, const common::SelectionView& selView) override;
 
     void copyVectorToBuffer(common::ValueVector* vector, common::offset_t startPosInChunk,
-        const common::SelectionVector& selVector) override;
+        const common::SelectionView& selView) override;
 
     void copyInt64VectorToBuffer(common::ValueVector* vector, common::offset_t startPosInChunk,
-        const common::SelectionVector& selVector) const;
+        const common::SelectionView& selView) const;
 
     void scan(common::ValueVector& output, common::offset_t offset, common::length_t length,
         common::sel_t posInOutputVector = 0) const override;

--- a/src/include/storage/store/list_chunk_data.h
+++ b/src/include/storage/store/list_chunk_data.h
@@ -54,7 +54,7 @@ public:
         metadata.numValues = numValues;
     }
 
-    void append(common::ValueVector* vector, const common::SelectionVector& selVector) override;
+    void append(common::ValueVector* vector, const common::SelectionView& selVector) override;
 
     void initializeScanState(ChunkState& state, const Column* column) const override;
     void scan(common::ValueVector& output, common::offset_t offset, common::length_t length,

--- a/src/include/storage/store/string_chunk_data.h
+++ b/src/include/storage/store/string_chunk_data.h
@@ -23,7 +23,7 @@ public:
 
     void resetToEmpty() override;
 
-    void append(common::ValueVector* vector, const common::SelectionVector& selVector) override;
+    void append(common::ValueVector* vector, const common::SelectionView& selView) override;
     void append(ColumnChunkData* other, common::offset_t startPosInOtherChunk,
         uint32_t numValuesToAppend) override;
     ColumnChunkData* getIndexColumnChunk();

--- a/src/include/storage/store/struct_chunk_data.h
+++ b/src/include/storage/store/struct_chunk_data.h
@@ -54,7 +54,7 @@ public:
 protected:
     void append(ColumnChunkData* other, common::offset_t startPosInOtherChunk,
         uint32_t numValuesToAppend) override;
-    void append(common::ValueVector* vector, const common::SelectionVector& selVector) override;
+    void append(common::ValueVector* vector, const common::SelectionView& selView) override;
 
     void scan(common::ValueVector& output, common::offset_t offset, common::length_t length,
         common::sel_t posInOutputVector = 0) const override;

--- a/src/storage/store/list_chunk_data.cpp
+++ b/src/storage/store/list_chunk_data.cpp
@@ -127,8 +127,8 @@ void ListChunkData::resetNumValuesFromMetadata() {
     dataColumnChunk->resetNumValuesFromMetadata();
 }
 
-void ListChunkData::append(ValueVector* vector, const SelectionVector& selVector) {
-    auto numToAppend = selVector.getSelSize();
+void ListChunkData::append(ValueVector* vector, const SelectionView& selView) {
+    auto numToAppend = selView.getSelSize();
     auto newCapacity = capacity;
     while (numValues + numToAppend >= newCapacity) {
         newCapacity = std::ceil(newCapacity * 1.5);
@@ -138,8 +138,8 @@ void ListChunkData::append(ValueVector* vector, const SelectionVector& selVector
     }
     offset_t nextListOffsetInChunk = dataColumnChunk->getNumValues();
     const offset_t appendBaseOffset = numValues;
-    for (auto i = 0u; i < selVector.getSelSize(); i++) {
-        auto pos = selVector[i];
+    for (auto i = 0u; i < selView.getSelSize(); i++) {
+        auto pos = selView[i];
         auto listLen = vector->isNull(pos) ? 0 : vector->getValue<list_entry_t>(pos).size;
         sizeColumnChunk->setValue<list_size_t>(listLen, appendBaseOffset + i);
 
@@ -153,8 +153,8 @@ void ListChunkData::append(ValueVector* vector, const SelectionVector& selVector
     // TODO(Guodong): we should not set vector to a new state.
     dataVector->setState(std::make_unique<DataChunkState>());
     dataVector->state->getSelVectorUnsafe().setToFiltered();
-    for (auto i = 0u; i < selVector.getSelSize(); i++) {
-        auto pos = selVector[i];
+    for (auto i = 0u; i < selView.getSelSize(); i++) {
+        auto pos = selView[i];
         if (vector->isNull(pos)) {
             continue;
         }

--- a/src/storage/store/struct_chunk_data.cpp
+++ b/src/storage/store/struct_chunk_data.cpp
@@ -100,15 +100,15 @@ void StructChunkData::append(ColumnChunkData* other, offset_t startPosInOtherChu
     numValues += numValuesToAppend;
 }
 
-void StructChunkData::append(ValueVector* vector, const SelectionVector& selVector) {
+void StructChunkData::append(ValueVector* vector, const SelectionView& selView) {
     const auto numFields = StructType::getNumFields(dataType);
     for (auto i = 0u; i < numFields; i++) {
-        childChunks[i]->append(StructVector::getFieldVector(vector, i).get(), selVector);
+        childChunks[i]->append(StructVector::getFieldVector(vector, i).get(), selView);
     }
-    for (auto i = 0u; i < selVector.getSelSize(); i++) {
-        nullData->setNull(numValues + i, vector->isNull(selVector[i]));
+    for (auto i = 0u; i < selView.getSelSize(); i++) {
+        nullData->setNull(numValues + i, vector->isNull(selView[i]));
     }
-    numValues += selVector.getSelSize();
+    numValues += selView.getSelSize();
 }
 
 void StructChunkData::scan(ValueVector& output, offset_t offset, length_t length,


### PR DESCRIPTION
The goal was to remove the selection vector copy in `ChunkedNodeGroup::append`, since the partitioner used in rel table copies appends values one at a time and the allocation is relatively expensive.

I ended up creating a parent class for the SelectionVector called SelectionView which is a read-only version of the SelectionVector, and then `SelectionVector::slice` produces a SelectionView over a subsequence of the original selection vector (you can also create SelectionViews over the static `INCREMENTAL_SELECTED_POS` array which don't do any heap allocations using its constructor). I had considered just a variant of the SelectionVector which doesn't allocate anything, but I think this works out to be a cleaner interface, and it wouldn't have been possible to easily guarantee that a sliced SelectionVector wouldn't be able to modify the original data using `SelectionVector::operator[]`.

Copying 100 000 000 edges from the datagen-9_0-fb dataset took ~17s before this change and ~15s after.