### PR TITLE
Support gds optioanl args

### DIFF
--- a/extension/fts/src/function/query_fts_bind_data.cpp
+++ b/extension/fts/src/function/query_fts_bind_data.cpp
@@ -37,12 +37,10 @@ QueryFTSOptionalParams::QueryFTSOptionalParams(const binder::expression_vector& 
 QueryFTSConfig QueryFTSOptionalParams::getConfig() const {
     QueryFTSConfig config;
     if (k != nullptr) {
-        config.k =
-            ExpressionUtil::evaluateLiteral<double_t>(*k, LogicalType::DOUBLE(), K::validate);
+        config.k = ExpressionUtil::evaluateLiteral<double>(*k, LogicalType::DOUBLE(), K::validate);
     }
     if (b != nullptr) {
-        config.b =
-            ExpressionUtil::evaluateLiteral<double_t>(*b, LogicalType::DOUBLE(), B::validate);
+        config.b = ExpressionUtil::evaluateLiteral<double>(*b, LogicalType::DOUBLE(), B::validate);
     }
     if (conjunctive != nullptr) {
         config.isConjunctive =

--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -113,8 +113,7 @@ private:
 
 QFTSOutputWriter::QFTSOutputWriter(const node_id_map_t<ScoreInfo>& scores, MemoryManager* mm,
     QueryFTSConfig config, const QueryFTSBindData& bindData, uint64_t numUniqueTerms)
-    : scores{scores}, mm{mm}, config{std::move(config)}, bindData{bindData},
-      numUniqueTerms{numUniqueTerms} {
+    : scores{scores}, mm{mm}, config{config}, bindData{bindData}, numUniqueTerms{numUniqueTerms} {
     docsVector = createVector(LogicalType::INTERNAL_ID());
     scoreVector = createVector(LogicalType::UINT64());
 }

--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -87,13 +87,13 @@ static void initSparseFrontier(SparseFrontier& frontier, table_id_t termsTableID
 class QFTSOutputWriter {
 public:
     QFTSOutputWriter(const node_id_map_t<ScoreInfo>& scores, MemoryManager* mm,
-        const QueryFTSBindData& bindData, uint64_t numUniqueTerms);
+        QueryFTSConfig config, const QueryFTSBindData& bindData, uint64_t numUniqueTerms);
 
     void write(processor::FactorizedTable& scoreFT, nodeID_t docNodeID, uint64_t len,
         int64_t docsID);
 
     std::unique_ptr<QFTSOutputWriter> copy() {
-        return std::make_unique<QFTSOutputWriter>(scores, mm, bindData, numUniqueTerms);
+        return std::make_unique<QFTSOutputWriter>(scores, mm, config, bindData, numUniqueTerms);
     }
 
 private:
@@ -102,6 +102,7 @@ private:
 private:
     const node_id_map_t<ScoreInfo>& scores;
     MemoryManager* mm;
+    QueryFTSConfig config;
     const QueryFTSBindData& bindData;
 
     std::unique_ptr<ValueVector> docsVector;
@@ -111,8 +112,9 @@ private:
 };
 
 QFTSOutputWriter::QFTSOutputWriter(const node_id_map_t<ScoreInfo>& scores, MemoryManager* mm,
-    const QueryFTSBindData& bindData, uint64_t numUniqueTerms)
-    : scores{scores}, mm{mm}, bindData{bindData}, numUniqueTerms{numUniqueTerms} {
+    QueryFTSConfig config, const QueryFTSBindData& bindData, uint64_t numUniqueTerms)
+    : scores{scores}, mm{mm}, config{std::move(config)}, bindData{bindData},
+      numUniqueTerms{numUniqueTerms} {
     docsVector = createVector(LogicalType::INTERNAL_ID());
     scoreVector = createVector(LogicalType::UINT64());
 }
@@ -126,8 +128,8 @@ std::unique_ptr<ValueVector> QFTSOutputWriter::createVector(const LogicalType& t
 
 void QFTSOutputWriter::write(processor::FactorizedTable& scoreFT, nodeID_t docNodeID, uint64_t len,
     int64_t docsID) {
-    auto k = bindData.config.k;
-    auto b = bindData.config.b;
+    auto k = config.k;
+    auto b = config.b;
 
     if (!scores.contains(docNodeID)) {
         return;
@@ -136,7 +138,7 @@ void QFTSOutputWriter::write(processor::FactorizedTable& scoreFT, nodeID_t docNo
     double score = 0;
     // If the query is conjunctive, the numbers of distinct terms in the doc and the number of
     // distinct terms in the query must be equal to each other.
-    if (bindData.config.isConjunctive && scoreInfo.scoreData.size() != numUniqueTerms) {
+    if (config.isConjunctive && scoreInfo.scoreData.size() != numUniqueTerms) {
         return;
     }
     auto auxInfo = bindData.entry.getAuxInfo().cast<FTSIndexAuxInfo>();
@@ -271,7 +273,8 @@ void QueryFTSAlgorithm::exec(processor::ExecutionContext* executionContext) {
     // Do vertex compute to calculate the score for doc with the length property.
     auto mm = clientContext->getMemoryManager();
     auto numUniqueTerms = getNumUniqueTerms(terms);
-    auto writer = std::make_unique<QFTSOutputWriter>(scores, mm, *qFTSBindData, numUniqueTerms);
+    auto writer = std::make_unique<QFTSOutputWriter>(scores, mm, qFTSBindData->getConfig(),
+        *qFTSBindData, numUniqueTerms);
     auto vc = std::make_unique<QFTSVertexCompute>(mm, sharedState.get(), std::move(writer));
     auto vertexPropertiesToScan = std::vector<std::string>{DOC_LEN_PROP_NAME, DOC_ID_PROP_NAME};
     auto docsEntry = graphEntry->nodeInfos[1].entry;
@@ -335,7 +338,7 @@ void QueryFTSAlgorithm::bind(const GDSBindInput& input, main::ClientContext& con
         FTSUtils::getAppearsInTableName(tableEntry->getTableID(), indexName));
     auto graphEntry = graph::GraphEntry({termsEntry, docsEntry}, {appearsInEntry});
     bindData = std::make_unique<QueryFTSBindData>(std::move(graphEntry), nodeOutput,
-        std::move(query), *ftsIndexEntry, QueryFTSConfig{input.optionalParams});
+        std::move(query), *ftsIndexEntry, QueryFTSOptionalParams{input.optionalParams});
     context.setUseInternalCatalogEntry(false /* useInternalCatalogEntry */);
 }
 

--- a/extension/fts/test/prepare_test.cpp
+++ b/extension/fts/test/prepare_test.cpp
@@ -7,11 +7,10 @@ namespace testing {
 
 TEST_F(ApiTest, PrepareFTSTest) {
     createDBAndConn();
-    printf("%s", conn->query(common::stringFormat("LOAD EXTENSION '{}'",
-                                 TestHelper::appendKuzuRootPath(
-                                     "extension/fts/build/libfts.kuzu_extension")))
-                     ->toString()
-                     .c_str());
+    ASSERT_TRUE(conn->query(common::stringFormat("LOAD EXTENSION '{}'",
+                                TestHelper::appendKuzuRootPath(
+                                    "extension/fts/build/libfts.kuzu_extension")))
+                    ->isSuccess());
     ASSERT_TRUE(
         conn->query("CALL CREATE_FTS_INDEX('person', 'personIdx', ['fName'])")->isSuccess());
     auto prepared =

--- a/extension/fts/test/prepare_test.cpp
+++ b/extension/fts/test/prepare_test.cpp
@@ -7,10 +7,11 @@ namespace testing {
 
 TEST_F(ApiTest, PrepareFTSTest) {
     createDBAndConn();
-    ASSERT_TRUE(conn->query(common::stringFormat("LOAD EXTENSION '{}'",
-                                TestHelper::appendKuzuRootPath(
-                                    "extension/fts/build/libfts.kuzu_extension")))
-                    ->isSuccess());
+    printf("%s", conn->query(common::stringFormat("LOAD EXTENSION '{}'",
+                                 TestHelper::appendKuzuRootPath(
+                                     "extension/fts/build/libfts.kuzu_extension")))
+                     ->toString()
+                     .c_str());
     ASSERT_TRUE(
         conn->query("CALL CREATE_FTS_INDEX('person', 'personIdx', ['fName'])")->isSuccess());
     auto prepared =

--- a/extension/fts/test/test_files/fts_small.test
+++ b/extension/fts/test/test_files/fts_small.test
@@ -141,7 +141,7 @@ Binder exception: 25 has data type INT64 but STRING was expected.
 -LOG QueryFTSOptionalParamError
 -STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx1', 'study', k := 0.3, c:= 0.5) RETURN node.ID, score
 ---- error
-Binder exception: Unrecognized optional parameter: c
+Binder exception: Unknown optional parameter: c
 -LOG QueryFTSBOutOfRange
 -STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx1', 'study', k := 0.3, B:= 3.88) RETURN node.ID, score
 ---- error

--- a/src/binder/bind/read/bind_in_query_call.cpp
+++ b/src/binder/bind/read/bind_in_query_call.cpp
@@ -1,6 +1,5 @@
 #include "binder/binder.h"
 #include "binder/expression/expression_util.h"
-#include "binder/expression/literal_expression.h"
 #include "binder/query/reading_clause/bound_gds_call.h"
 #include "binder/query/reading_clause/bound_table_function_call.h"
 #include "catalog/catalog.h"

--- a/src/binder/bind/read/bind_in_query_call.cpp
+++ b/src/binder/bind/read/bind_in_query_call.cpp
@@ -38,17 +38,17 @@ std::unique_ptr<BoundReadingClause> Binder::bindInQueryCall(const ReadingClause&
     case CatalogEntryType::GDS_FUNCTION_ENTRY: {
         expression_vector children;
         std::vector<LogicalType> childrenTypes;
-        optional_params_t optionalParams;
+        expression_vector optionalParams;
         for (auto i = 0u; i < functionExpr->getNumChildren(); i++) {
             auto child = expressionBinder.bindExpression(*functionExpr->getChild(i));
             if (!functionExpr->getChild(i)->hasAlias()) {
                 children.push_back(child);
                 childrenTypes.push_back(child->getDataType().copy());
             } else {
-                ExpressionUtil::validateExpressionType(*child, ExpressionType::LITERAL);
-                auto literalExpr = child->constPtrCast<LiteralExpression>();
-                optionalParams.emplace(functionExpr->getChild(i)->getAlias(),
-                    literalExpr->getValue());
+                ExpressionUtil::validateExpressionType(*child,
+                    {ExpressionType::LITERAL, ExpressionType::PARAMETER});
+                child->setAlias(functionExpr->getChild(i)->getAlias());
+                optionalParams.push_back(child);
             }
         }
         auto func = BuiltInFunctionsUtils::matchFunction(functionName, childrenTypes,

--- a/src/binder/expression/expression_util.cpp
+++ b/src/binder/expression/expression_util.cpp
@@ -469,8 +469,8 @@ template KUZU_API std::string ExpressionUtil::evaluateLiteral<std::string>(
     const Expression& expression, const common::LogicalType& type,
     validate_param_func<std::string> validateParamFunc);
 
-template KUZU_API double_t ExpressionUtil::evaluateLiteral<double_t>(const Expression& expression,
-    const common::LogicalType& type, validate_param_func<double_t> validateParamFunc);
+template KUZU_API double ExpressionUtil::evaluateLiteral<double>(const Expression& expression,
+    const common::LogicalType& type, validate_param_func<double> validateParamFunc);
 
 template KUZU_API int64_t ExpressionUtil::evaluateLiteral<int64_t>(const Expression& expression,
     const common::LogicalType& type, validate_param_func<int64_t> validateParamFunc);

--- a/src/function/gds/page_rank.cpp
+++ b/src/function/gds/page_rank.cpp
@@ -1,7 +1,10 @@
 #include "binder/binder.h"
 #include "binder/expression/expression_util.h"
+#include "common/exception/binder.h"
+#include "common/string_utils.h"
 #include "degrees.h"
 #include "function/gds/auxiliary_state/gds_auxilary_state.h"
+#include "function/gds/config/page_rank_config.h"
 #include "function/gds/gds.h"
 #include "function/gds/gds_frontier.h"
 #include "function/gds/gds_function_collection.h"
@@ -22,17 +25,60 @@ using namespace kuzu::graph;
 namespace kuzu {
 namespace function {
 
-struct PageRankBindData final : public GDSBindData {
-    double dampingFactor = 0.85;
-    int64_t maxIteration = 20;
-    double delta = 0.0000001; // Convergence delta
+struct PageRankOptionalParams {
+    std::shared_ptr<binder::Expression> dampingFactor;
+    std::shared_ptr<binder::Expression> maxIteration;
+    std::shared_ptr<binder::Expression> tolerance;
 
-    explicit PageRankBindData(graph::GraphEntry graphEntry,
-        std::shared_ptr<binder::Expression> nodeOutput)
-        : GDSBindData{std::move(graphEntry), std::move(nodeOutput)} {};
+    explicit PageRankOptionalParams(const binder::expression_vector& optionalParams);
+
+    PageRankConfig getConfig() const;
+};
+
+PageRankOptionalParams::PageRankOptionalParams(const binder::expression_vector& optionalParams) {
+    for (auto& optionalParam : optionalParams) {
+        auto paramName = StringUtils::getLower(optionalParam->getAlias());
+        if (paramName == DampingFactor::NAME) {
+            dampingFactor = optionalParam;
+        } else if (paramName == MaxIterations::NAME) {
+            maxIteration = optionalParam;
+        } else if (paramName == Tolerance::NAME) {
+            tolerance = optionalParam;
+        } else {
+            throw common::BinderException{
+                "Unknown optional parameter: " + optionalParam->getAlias()};
+        }
+    }
+}
+
+PageRankConfig PageRankOptionalParams::getConfig() const {
+    PageRankConfig config;
+    if (dampingFactor != nullptr) {
+        config.dampingFactor = ExpressionUtil::evaluateLiteral<double_t>(*dampingFactor,
+            LogicalType::DOUBLE(), DampingFactor::validate);
+    }
+    if (maxIteration != nullptr) {
+        config.maxIterations = ExpressionUtil::evaluateLiteral<int64_t>(*maxIteration,
+            LogicalType::INT64(), MaxIterations::validate);
+    }
+    if (tolerance != nullptr) {
+        config.tolerance =
+            ExpressionUtil::evaluateLiteral<double_t>(*tolerance, LogicalType::DOUBLE());
+    }
+    return config;
+}
+
+struct PageRankBindData final : public GDSBindData {
+    PageRankOptionalParams optionalParams;
+
+    PageRankBindData(graph::GraphEntry graphEntry, std::shared_ptr<binder::Expression> nodeOutput,
+        PageRankOptionalParams optionalParams)
+        : GDSBindData{std::move(graphEntry), std::move(nodeOutput)},
+          optionalParams{std::move(optionalParams)} {}
     PageRankBindData(const PageRankBindData& other)
-        : GDSBindData{other}, dampingFactor{other.dampingFactor}, maxIteration{other.maxIteration},
-          delta{other.delta} {}
+        : GDSBindData{other}, optionalParams{other.optionalParams} {}
+
+    PageRankConfig getConfig() const { return optionalParams.getConfig(); }
 
     std::unique_ptr<GDSBindData> copy() const override {
         return std::make_unique<PageRankBindData>(*this);
@@ -259,7 +305,8 @@ public:
         auto graphName = binder::ExpressionUtil::getLiteralValue<std::string>(*input.getParam(0));
         auto graphEntry = bindGraphEntry(context, graphName);
         auto nodeOutput = bindNodeOutput(input, graphEntry.getNodeEntries());
-        bindData = std::make_unique<PageRankBindData>(std::move(graphEntry), nodeOutput);
+        bindData = std::make_unique<PageRankBindData>(std::move(graphEntry), nodeOutput,
+            PageRankOptionalParams(input.optionalParams));
     }
 
     void exec(processor::ExecutionContext* context) override {
@@ -273,6 +320,7 @@ public:
         PValues* pCurrent = &p1;
         PValues* pNext = &p2;
         auto pageRankBindData = bindData->ptrCast<PageRankBindData>();
+        auto config = pageRankBindData->getConfig();
         auto currentIter = 1u;
         auto currentFrontier = getPathLengthsFrontier(context, PathLengths::UNVISITED);
         auto nextFrontier = getPathLengthsFrontier(context, 0);
@@ -284,23 +332,23 @@ public:
         frontierPair->getNextSparseFrontier().disable();
         auto computeState = GDSComputeState(std::move(frontierPair), nullptr, nullptr,
             sharedState->getOutputNodeMaskMap());
-        auto pNextUpdateConstant = (1 - pageRankBindData->dampingFactor) * ((double)1 / numNodes);
-        while (currentIter < pageRankBindData->maxIteration) {
+        auto pNextUpdateConstant = (1 - config.dampingFactor) * ((double)1 / numNodes);
+        while (currentIter < config.maxIterations) {
             computeState.edgeCompute =
                 std::make_unique<PNextUpdateEdgeCompute>(degrees, *pCurrent, *pNext);
             computeState.auxiliaryState =
                 std::make_unique<PageRankAuxiliaryState>(degrees, *pCurrent, *pNext);
             GDSUtils::runFrontiersUntilConvergence(context, computeState, graph,
                 ExtendDirection::BWD, computeState.frontierPair->getCurrentIter() + 1);
-            auto pNextUpdateVC = PNextUpdateVertexCompute(pageRankBindData->dampingFactor,
-                pNextUpdateConstant, *pNext);
+            auto pNextUpdateVC =
+                PNextUpdateVertexCompute(config.dampingFactor, pNextUpdateConstant, *pNext);
             GDSUtils::runVertexCompute(context, graph, pNextUpdateVC);
             std::atomic<double> diff;
             diff.store(0);
             auto pDiffVC = PDiffVertexCompute(diff, *pCurrent, *pNext);
             GDSUtils::runVertexCompute(context, graph, pDiffVC);
             std::swap(pCurrent, pNext);
-            if (diff.load() < pageRankBindData->delta) { // Converged.
+            if (diff.load() < config.tolerance) { // Converged.
                 break;
             }
             currentIter++;

--- a/src/function/gds/page_rank.cpp
+++ b/src/function/gds/page_rank.cpp
@@ -54,7 +54,7 @@ PageRankOptionalParams::PageRankOptionalParams(const binder::expression_vector& 
 PageRankConfig PageRankOptionalParams::getConfig() const {
     PageRankConfig config;
     if (dampingFactor != nullptr) {
-        config.dampingFactor = ExpressionUtil::evaluateLiteral<double_t>(*dampingFactor,
+        config.dampingFactor = ExpressionUtil::evaluateLiteral<double>(*dampingFactor,
             LogicalType::DOUBLE(), DampingFactor::validate);
     }
     if (maxIteration != nullptr) {
@@ -63,7 +63,7 @@ PageRankConfig PageRankOptionalParams::getConfig() const {
     }
     if (tolerance != nullptr) {
         config.tolerance =
-            ExpressionUtil::evaluateLiteral<double_t>(*tolerance, LogicalType::DOUBLE());
+            ExpressionUtil::evaluateLiteral<double>(*tolerance, LogicalType::DOUBLE());
     }
     return config;
 }

--- a/src/include/binder/expression/expression_util.h
+++ b/src/include/binder/expression/expression_util.h
@@ -63,6 +63,13 @@ struct KUZU_API ExpressionUtil {
     static bool canEvaluateAsLiteral(const Expression& expr);
 
     static common::Value evaluateAsLiteralValue(const Expression& expr);
+
+    template<typename T>
+    using validate_param_func = void(T);
+
+    template<typename T>
+    static T evaluateLiteral(const Expression& expression, const common::LogicalType& type,
+        validate_param_func<T> validateParamFunc = nullptr);
 };
 
 } // namespace binder

--- a/src/include/function/gds/config/page_rank_config.h
+++ b/src/include/function/gds/config/page_rank_config.h
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "common/exception/binder.h"
 #include "common/types/types.h"
 #include "function/table/bind_input.h"
 

--- a/src/include/function/gds/config/page_rank_config.h
+++ b/src/include/function/gds/config/page_rank_config.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <string>
+
+#include "common/types/types.h"
+#include "function/table/bind_input.h"
+
+namespace kuzu {
+namespace function {
+
+struct DampingFactor {
+    // The damping factor of the Page Rank calculation. Must be in [0, 1).
+    static constexpr const char* NAME = "dampingfactor";
+    static constexpr common::LogicalTypeID TYPE = common::LogicalTypeID::DOUBLE;
+    static constexpr double DEFAULT_VALUE = 0.85;
+
+    static void validate(double dampingFactor);
+};
+
+void DampingFactor::validate(double dampingFactor) {
+    if (dampingFactor < 0 || dampingFactor >= 1) {
+        throw common::BinderException{"Damping factor must be in the [0, 1)."};
+    }
+}
+
+struct MaxIterations {
+    // The maximum number of iterations of Page Rank to run.
+    static constexpr const char* NAME = "maxiterations";
+    static constexpr common::LogicalTypeID TYPE = common::LogicalTypeID::INT64;
+    static constexpr uint64_t DEFAULT_VALUE = 20;
+
+    static void validate(int64_t dampingFactor);
+};
+
+void MaxIterations::validate(int64_t maxIterations) {
+    if (maxIterations < 0) {
+        throw common::BinderException{"Max iteration must be a positive integer."};
+    }
+}
+
+struct Tolerance {
+    // Minimum change in scores between iterations. If all scores change less than the tolerance
+    // value the result is considered stable and the algorithm returns.
+    static constexpr const char* NAME = "tolerance";
+    static constexpr common::LogicalTypeID TYPE = common::LogicalTypeID::DOUBLE;
+    static constexpr double DEFAULT_VALUE = 0.0000001;
+};
+
+struct PageRankConfig {
+    double dampingFactor = DampingFactor::DEFAULT_VALUE;
+    uint64_t maxIterations = MaxIterations::DEFAULT_VALUE;
+    double tolerance = Tolerance::DEFAULT_VALUE;
+
+    PageRankConfig() = default;
+};
+
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/gds/config/page_rank_config.h
+++ b/src/include/function/gds/config/page_rank_config.h
@@ -4,7 +4,6 @@
 
 #include "common/exception/binder.h"
 #include "common/types/types.h"
-#include "function/table/bind_input.h"
 
 namespace kuzu {
 namespace function {

--- a/src/include/function/gds/gds.h
+++ b/src/include/function/gds/gds.h
@@ -19,19 +19,20 @@ struct ExecutionContext;
 
 namespace function {
 
-using optional_params_t = common::case_insensitive_map_t<common::Value>;
-
 class PathLengths;
 
 struct GDSBindInput {
     binder::expression_vector params;
-    optional_params_t optionalParams;
+    binder::expression_vector optionalParams;
     binder::Binder* binder = nullptr;
     std::vector<parser::YieldVariable> yieldVariables;
 
     GDSBindInput() = default;
 
     std::shared_ptr<binder::Expression> getParam(common::idx_t idx) const { return params[idx]; }
+    std::shared_ptr<binder::Expression> getOptionalParam(common::idx_t idx) const {
+        return optionalParams[idx];
+    }
     common::idx_t getNumParams() const { return params.size(); }
 };
 

--- a/test/main/prepare_test.cpp
+++ b/test/main/prepare_test.cpp
@@ -254,3 +254,17 @@ TEST_F(ApiTest, ParameterWith) {
     auto groupTruth = std::vector<std::string>{"abc"};
     ASSERT_EQ(groupTruth, TestHelper::convertResultToString(*result));
 }
+
+TEST_F(ApiTest, GDSPrepare) {
+    ASSERT_TRUE(
+        conn->query("CALL create_projected_graph('PK', ['person'], ['knows'])")->isSuccess());
+    auto preparedStatement = conn->prepare("CALL page_rank('PK', dampingFactor := $dp, "
+                                           "tolerance := $tl) RETURN node.fName, rank;");
+    std::unordered_map<std::string, std::unique_ptr<Value>> params;
+    auto result = conn->execute(preparedStatement.get(), std::make_pair(std::string("dp"), 0.56),
+        std::make_pair(std::string("tl"), 0.0002));
+    auto groundTruth = std::vector<std::string>{"Alice|0.125000", "Bob|0.125000", "Carol|0.125000",
+        "Dan|0.125000", "Elizabeth|0.055000", "Farooq|0.070400", "Greg|0.070400",
+        "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|0.055000"};
+    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
+}

--- a/test/test_files/function/gds/page_rank.test
+++ b/test/test_files/function/gds/page_rank.test
@@ -15,3 +15,48 @@ Elizabeth|0.018750
 Farooq|0.026719
 Greg|0.026719
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|0.018750
+
+-STATEMENT CALL page_rank('PK', dampingFactor := 0.5) RETURN node.fName, rank;
+---- 8
+Alice|0.125000
+Bob|0.125000
+Carol|0.125000
+Dan|0.125000
+Elizabeth|0.062500
+Farooq|0.078125
+Greg|0.078125
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|0.062500
+
+-STATEMENT CALL page_rank('PK', dampingFactor := 0.3, maxIterations := 10) RETURN node.fName, rank;
+---- 8
+Alice|0.125000
+Bob|0.125000
+Carol|0.125000
+Dan|0.125000
+Elizabeth|0.087500
+Farooq|0.100625
+Greg|0.100625
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|0.087500
+
+-STATEMENT CALL page_rank('PK', dampingFactor := 0.1, maxIterations := 15, tolerance := 0.00024) RETURN node.fName, rank;
+---- 8
+Alice|0.125000
+Bob|0.125000
+Carol|0.125000
+Dan|0.125000
+Elizabeth|0.112500
+Farooq|0.118125
+Greg|0.118125
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|0.112500
+
+-STATEMENT CALL page_rank('PK', dampingFactOR := 5.2) RETURN node.fName, rank;
+---- error
+Binder exception: Damping factor must be in the [0, 1).
+
+-STATEMENT CALL page_rank('PK', MAXITerations := -9) RETURN node.fName, rank;
+---- error
+Binder exception: Max iteration must be a positive integer.
+
+-STATEMENT CALL page_rank('PK', maxIteratioN := 4) RETURN node.fName, rank;
+---- error
+Binder exception: Unknown optional parameter: maxIteratioN


### PR DESCRIPTION
This PR supports optional arguments in GDS functions (PAGE_RANK).
The optional arguments to the GDS functions should either be:
1. Literal expression,
2. Paramater expression and should be evaluated as a literal at execution time.

The grammar is the same as other functions with optional parameters:
```
CALL GDS_FUNC('PK', OPTIONAL_ARG1 := VAL1, OPTIONAL_ARG2 := VAL2)
```

Optional parameter casting is not supported right now and will be implemented in the next PR.