### PR TITLE
Add is ready only field to function

### DIFF
--- a/src/function/sequence/sequence_functions.cpp
+++ b/src/function/sequence/sequence_functions.cpp
@@ -45,10 +45,12 @@ function_set CurrValFunction::getFunctionSet() {
 
 function_set NextValFunction::getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(make_unique<ScalarFunction>(name,
-        std::vector<LogicalTypeID>{LogicalTypeID::STRING}, LogicalTypeID::INT64,
+    auto func = make_unique<ScalarFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING},
+        LogicalTypeID::INT64,
         ScalarFunction::UnarySequenceExecFunction<common::ku_string_t, common::ValueVector,
-            NextVal>));
+            NextVal>);
+    func->isReadOnly = false;
+    functionSet.push_back(std::move(func));
     return functionSet;
 }
 

--- a/src/include/function/function.h
+++ b/src/include/function/function.h
@@ -63,10 +63,12 @@ struct KUZU_API Function {
     std::vector<common::LogicalTypeID> parameterTypeIDs;
     // Currently we only one variable-length function which is list creation. The expectation is
     // that all parameters must have the same type as parameterTypes[0].
-    bool isVarLength;
-    bool isListLambda;
+    // For variable length function. A
+    bool isVarLength = false;
+    bool isListLambda = false;
+    bool isReadOnly = true;
 
-    Function() : isVarLength{false}, isListLambda{false} {};
+    Function() : isVarLength{false}, isListLambda{false}, isReadOnly{true} {};
     Function(std::string name, std::vector<common::LogicalTypeID> parameterTypeIDs)
         : name{std::move(name)}, parameterTypeIDs{std::move(parameterTypeIDs)}, isVarLength{false},
           isListLambda{false} {}

--- a/src/include/parser/expression/parsed_expression_visitor.h
+++ b/src/include/parser/expression/parsed_expression_visitor.h
@@ -46,13 +46,17 @@ private:
     std::vector<const ParsedExpression*> paramExprs;
 };
 
-class ParsedSequenceFunctionCollector : public ParsedExpressionVisitor {
+class ReadWriteExprAnalyzer : public ParsedExpressionVisitor {
 public:
-    bool hasSeqUpdate() const { return hasSeqUpdate_; }
+    explicit ReadWriteExprAnalyzer(main::ClientContext* context)
+        : ParsedExpressionVisitor{}, context{context} {}
+
+    bool isReadOnly() const { return readOnly; }
     void visitFunctionExpr(const ParsedExpression* expr) override;
 
 private:
-    bool hasSeqUpdate_ = false;
+    main::ClientContext* context;
+    bool readOnly = true;
 };
 
 class MacroParameterReplacer : public ParsedExpressionVisitor {

--- a/src/include/parser/visitor/statement_read_write_analyzer.h
+++ b/src/include/parser/visitor/statement_read_write_analyzer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "parser/expression/parsed_expression.h"
 #include "parser/parsed_statement_visitor.h"
 
 namespace kuzu {
@@ -7,9 +8,10 @@ namespace parser {
 
 class StatementReadWriteAnalyzer final : public StatementVisitor {
 public:
-    StatementReadWriteAnalyzer() : StatementVisitor{}, readOnly{true} {}
+    explicit StatementReadWriteAnalyzer(main::ClientContext* context)
+        : StatementVisitor{}, readOnly{true}, context{context} {}
 
-    bool isReadOnly(const Statement& statement);
+    bool isReadOnly() const { return readOnly; }
 
 private:
     void visitCreateSequence(const Statement& /*statement*/) override { readOnly = false; }
@@ -31,8 +33,11 @@ private:
         readOnly = false;
     }
 
+    bool isExprReadOnly(const ParsedExpression* expr);
+
 private:
     bool readOnly;
+    main::ClientContext* context;
 };
 
 } // namespace parser


### PR DESCRIPTION
# Description

Add readOnly field to function class. Avoid naming-based check.

Fixes #3502 

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).