### PR TITLE
Refactor gds frontier

### DIFF
--- a/src/function/gds/asp_destinations.cpp
+++ b/src/function/gds/asp_destinations.cpp
@@ -188,7 +188,8 @@ private:
         auto graph = sharedState->graph.get();
         auto frontier = PathLengths::getUnvisitedFrontier(context, graph);
         auto mm = clientContext->getMemoryManager();
-        auto multiplicities = std::make_shared<Multiplicities>(graph->getMaxOffsetMap(clientContext->getTransaction()), mm);
+        auto multiplicities = std::make_shared<Multiplicities>(
+            graph->getMaxOffsetMap(clientContext->getTransaction()), mm);
         auto outputWriter = std::make_unique<ASPDestinationsOutputWriter>(clientContext,
             sharedState->getOutputNodeMaskMap(), sourceNodeID, frontier, multiplicities);
         auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(frontier);

--- a/src/function/gds/asp_destinations.cpp
+++ b/src/function/gds/asp_destinations.cpp
@@ -14,13 +14,13 @@ namespace function {
 
 class Multiplicities {
 public:
-    Multiplicities(const std::unordered_map<table_id_t, uint64_t>& numNodesMap,
+    Multiplicities(const std::unordered_map<table_id_t, uint64_t>& maxOffsetMap,
         storage::MemoryManager* mm) {
-        for (auto& [tableID, numNodes] : numNodesMap) {
-            multiplicityArray.allocate(tableID, numNodes, mm);
+        for (auto& [tableID, maxOffset] : maxOffsetMap) {
+            multiplicityArray.allocate(tableID, maxOffset, mm);
             // Question to Trevor: Do I need to use atomics? If so, why?
             auto data = multiplicityArray.getData(tableID);
-            for (uint64_t i = 0; i < numNodes; ++i) {
+            for (uint64_t i = 0; i < maxOffset; ++i) {
                 data[i].store(0);
             }
         }
@@ -185,10 +185,10 @@ public:
 private:
     RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
-        auto frontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
-        auto numNodesMap = sharedState->graph->getNumNodesMap(clientContext->getTransaction());
+        auto graph = sharedState->graph.get();
+        auto frontier = PathLengths::getUnvisitedFrontier(context, graph);
         auto mm = clientContext->getMemoryManager();
-        auto multiplicities = std::make_shared<Multiplicities>(numNodesMap, mm);
+        auto multiplicities = std::make_shared<Multiplicities>(graph->getMaxOffsetMap(clientContext->getTransaction()), mm);
         auto outputWriter = std::make_unique<ASPDestinationsOutputWriter>(clientContext,
             sharedState->getOutputNodeMaskMap(), sourceNodeID, frontier, multiplicities);
         auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(frontier);

--- a/src/function/gds/awsp_paths.cpp
+++ b/src/function/gds/awsp_paths.cpp
@@ -141,9 +141,9 @@ private:
     RJCompState getRJCompState(processor::ExecutionContext* context,
         nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
-        auto numNodes = sharedState->graph->getNumNodesMap(clientContext->getTransaction());
-        auto curFrontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
-        auto nextFrontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
+        auto graph = sharedState->graph.get();
+        auto curFrontier = PathLengths::getUnvisitedFrontier(context, graph);
+        auto nextFrontier = PathLengths::getUnvisitedFrontier(context, graph);
         auto frontierPair =
             std::make_unique<DoublePathLengthsFrontierPair>(curFrontier, nextFrontier);
         auto bfsGraph = getBFSGraph(context);

--- a/src/function/gds/degrees.h
+++ b/src/function/gds/degrees.h
@@ -17,11 +17,11 @@ static constexpr degree_t INVALID_DEGREE = UINT64_MAX;
 
 class Degrees {
 public:
-    Degrees(const table_id_map_t<offset_t>& numNodesMap, MemoryManager* mm) {
-        for (const auto& [tableID, numNodes] : numNodesMap) {
-            degreeValuesMap.allocate(tableID, numNodes, mm);
+    Degrees(const table_id_map_t<offset_t>& maxOffsetMap, MemoryManager* mm) {
+        for (const auto& [tableID, maxOffset] : maxOffsetMap) {
+            degreeValuesMap.allocate(tableID, maxOffset, mm);
             pinTable(tableID);
-            for (auto i = 0u; i < numNodes; ++i) {
+            for (auto i = 0u; i < maxOffset; ++i) {
                 degreeValues[i].store(0, std::memory_order_relaxed);
             }
         }

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -47,8 +47,8 @@ static void scheduleFrontierTask(catalog::TableCatalogEntry* fromEntry,
     // more generally decrease the number of worker threads by 1. Therefore, we instruct
     // scheduleTaskAndWaitOrError to start a new thread by passing true as the last
     // argument.
-    auto numNodes = graph->getNumNodes(transaction, fromEntry->getTableID());
-    sharedState->morselDispatcher.init(numNodes);
+    auto maxOffset = graph->getMaxOffset(transaction, fromEntry->getTableID());
+    sharedState->morselDispatcher.init(maxOffset);
     clientContext->getTaskScheduler()->scheduleTaskAndWaitOrError(task, context,
         true /* launchNewWorkerThread */);
 }
@@ -98,10 +98,10 @@ void GDSUtils::runFrontiersUntilConvergence(processor::ExecutionContext* context
 
 static void runVertexComputeInternal(catalog::TableCatalogEntry* currentEntry, graph::Graph* graph,
     std::shared_ptr<VertexComputeTask> task, processor::ExecutionContext* context) {
-    auto numNodes =
-        graph->getNumNodes(context->clientContext->getTransaction(), currentEntry->getTableID());
+    auto maxOffset =
+        graph->getMaxOffset(context->clientContext->getTransaction(), currentEntry->getTableID());
     auto sharedState = task->getSharedState();
-    sharedState->morselDispatcher.init(numNodes);
+    sharedState->morselDispatcher.init(maxOffset);
     context->clientContext->getTaskScheduler()->scheduleTaskAndWaitOrError(task, context,
         true /* launchNewWorkerThread */);
 }

--- a/src/function/gds/strongly_connected_components_kosaraju.cpp
+++ b/src/function/gds/strongly_connected_components_kosaraju.cpp
@@ -219,14 +219,13 @@ public:
         auto clientContext = context->clientContext;
         auto mm = clientContext->getMemoryManager();
         auto graph = sharedState->graph.get();
-        auto numNodesMap = graph->getNumNodesMap(clientContext->getTransaction());
-        auto it = numNodesMap.begin();
-        const table_id_t tableID = it->first;
-        const offset_t numNodes = it->second;
+        KU_ASSERT(graph->getNodeTableIDs().size() == 1);
+        auto tableID = graph->getNodeTableIDs()[0];
+        auto maxOffset = graph->getMaxOffset(clientContext->getTransaction(), tableID);
 
-        auto sccState = SCCState(tableID, numNodes, mm);
+        auto sccState = SCCState(tableID, maxOffset, mm);
         auto edgeCompute = make_unique<SCCCompute>(graph, sccState);
-        edgeCompute->compute(tableID, numNodes);
+        edgeCompute->compute(tableID, maxOffset);
 
         auto writer = make_unique<SCCOutputWriter>(clientContext);
         auto vertexCompute =

--- a/src/function/gds/weakly_connected_components.cpp
+++ b/src/function/gds/weakly_connected_components.cpp
@@ -168,7 +168,8 @@ public:
         auto frontierPair =
             std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier, nextFrontier);
         frontierPair->initGDS();
-        auto componentIDs = ComponentIDs(graph->getMaxOffsetMap(clientContext->getTransaction()), clientContext->getMemoryManager());
+        auto componentIDs = ComponentIDs(graph->getMaxOffsetMap(clientContext->getTransaction()),
+            clientContext->getMemoryManager());
         auto edgeCompute = std::make_unique<WCCEdgeCompute>(componentIDs);
         auto writer = std::make_unique<WCCOutputWriter>(clientContext);
         auto vertexCompute = std::make_unique<WCCVertexCompute>(clientContext->getMemoryManager(),

--- a/src/function/gds/wsp_destinations.cpp
+++ b/src/function/gds/wsp_destinations.cpp
@@ -13,7 +13,7 @@ namespace function {
 
 class Costs {
 public:
-    Costs(const table_id_map_t<offset_t>& numNodesMap, MemoryManager* mm) { init(numNodesMap, mm); }
+    Costs(const table_id_map_t<offset_t>& maxOffsetMap, MemoryManager* mm) { init(maxOffsetMap, mm); }
 
     void pinTable(table_id_t tableID) { costs = costsMap.getData(tableID); }
 
@@ -36,11 +36,11 @@ public:
     }
 
 private:
-    void init(const table_id_map_t<offset_t>& numNodesMap, MemoryManager* mm) {
-        for (const auto& [tableID, numNodes] : numNodesMap) {
-            costsMap.allocate(tableID, numNodes, mm);
+    void init(const table_id_map_t<offset_t>& maxOffsetMap, MemoryManager* mm) {
+        for (const auto& [tableID, maxOffset] : maxOffsetMap) {
+            costsMap.allocate(tableID, maxOffset, mm);
             pinTable(tableID);
-            for (auto i = 0u; i < numNodes; ++i) {
+            for (auto i = 0u; i < maxOffset; ++i) {
                 costs[i].store(std::numeric_limits<double>::max(), std::memory_order_relaxed);
             }
         }
@@ -150,13 +150,13 @@ private:
     RJCompState getRJCompState(processor::ExecutionContext* context,
         nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
-        auto numNodes = sharedState->graph->getNumNodesMap(clientContext->getTransaction());
+        auto graph = sharedState->graph.get();
         auto curFrontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
         auto nextFrontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
         auto frontierPair =
             std::make_unique<DoublePathLengthsFrontierPair>(curFrontier, nextFrontier);
         auto rjBindData = bindData->ptrCast<RJBindData>();
-        auto costs = std::make_shared<Costs>(numNodes, clientContext->getMemoryManager());
+        auto costs = std::make_shared<Costs>(graph->getMaxOffsetMap(clientContext->getTransaction()), clientContext->getMemoryManager());
         auto auxiliaryState = std::make_unique<WSPDestinationsAuxiliaryState>(costs);
         auto outputWriter = std::make_unique<WSPDestinationsOutputWriter>(clientContext,
             sharedState->getOutputNodeMaskMap(), sourceNodeID, costs);

--- a/src/function/gds/wsp_destinations.cpp
+++ b/src/function/gds/wsp_destinations.cpp
@@ -13,7 +13,9 @@ namespace function {
 
 class Costs {
 public:
-    Costs(const table_id_map_t<offset_t>& maxOffsetMap, MemoryManager* mm) { init(maxOffsetMap, mm); }
+    Costs(const table_id_map_t<offset_t>& maxOffsetMap, MemoryManager* mm) {
+        init(maxOffsetMap, mm);
+    }
 
     void pinTable(table_id_t tableID) { costs = costsMap.getData(tableID); }
 
@@ -156,7 +158,9 @@ private:
         auto frontierPair =
             std::make_unique<DoublePathLengthsFrontierPair>(curFrontier, nextFrontier);
         auto rjBindData = bindData->ptrCast<RJBindData>();
-        auto costs = std::make_shared<Costs>(graph->getMaxOffsetMap(clientContext->getTransaction()), clientContext->getMemoryManager());
+        auto costs =
+            std::make_shared<Costs>(graph->getMaxOffsetMap(clientContext->getTransaction()),
+                clientContext->getMemoryManager());
         auto auxiliaryState = std::make_unique<WSPDestinationsAuxiliaryState>(costs);
         auto outputWriter = std::make_unique<WSPDestinationsOutputWriter>(clientContext,
             sharedState->getOutputNodeMaskMap(), sourceNodeID, costs);

--- a/src/function/gds/wsp_paths.cpp
+++ b/src/function/gds/wsp_paths.cpp
@@ -119,9 +119,9 @@ private:
     RJCompState getRJCompState(processor::ExecutionContext* context,
         nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
-        auto numNodes = sharedState->graph->getNumNodesMap(clientContext->getTransaction());
-        auto curFrontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
-        auto nextFrontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
+        auto graph = sharedState->graph.get();
+        auto curFrontier = PathLengths::getUnvisitedFrontier(context, graph);
+        auto nextFrontier = PathLengths::getUnvisitedFrontier(context, graph);
         auto frontierPair =
             std::make_unique<DoublePathLengthsFrontierPair>(curFrontier, nextFrontier);
         auto bfsGraph = getBFSGraph(context);

--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -152,7 +152,8 @@ OnDiskGraph::OnDiskGraph(ClientContext* context, GraphEntry entry)
     }
 }
 
-common::table_id_map_t<common::offset_t> OnDiskGraph::getMaxOffsetMap(transaction::Transaction* transaction) const {
+common::table_id_map_t<common::offset_t> OnDiskGraph::getMaxOffsetMap(
+    transaction::Transaction* transaction) const {
     table_id_map_t<offset_t> result;
     for (auto tableID : getNodeTableIDs()) {
         result[tableID] = getMaxOffset(transaction, tableID);
@@ -160,7 +161,8 @@ common::table_id_map_t<common::offset_t> OnDiskGraph::getMaxOffsetMap(transactio
     return result;
 }
 
-common::offset_t OnDiskGraph::getMaxOffset(transaction::Transaction* transaction, table_id_t id) const {
+common::offset_t OnDiskGraph::getMaxOffset(transaction::Transaction* transaction,
+    table_id_t id) const {
     KU_ASSERT(nodeIDToNodeTable.contains(id));
     return nodeIDToNodeTable.at(id)->getNumTotalRows(transaction);
 }

--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -152,12 +152,17 @@ OnDiskGraph::OnDiskGraph(ClientContext* context, GraphEntry entry)
     }
 }
 
-table_id_map_t<offset_t> OnDiskGraph::getNumNodesMap(transaction::Transaction* transaction) const {
-    table_id_map_t<offset_t> retVal;
+common::table_id_map_t<common::offset_t> OnDiskGraph::getMaxOffsetMap(transaction::Transaction* transaction) const {
+    table_id_map_t<offset_t> result;
     for (auto tableID : getNodeTableIDs()) {
-        retVal[tableID] = getNumNodes(transaction, tableID);
+        result[tableID] = getMaxOffset(transaction, tableID);
     }
-    return retVal;
+    return result;
+}
+
+common::offset_t OnDiskGraph::getMaxOffset(transaction::Transaction* transaction, table_id_t id) const {
+    KU_ASSERT(nodeIDToNodeTable.contains(id));
+    return nodeIDToNodeTable.at(id)->getNumTotalRows(transaction);
 }
 
 offset_t OnDiskGraph::getNumNodes(transaction::Transaction* transaction) const {
@@ -166,14 +171,9 @@ offset_t OnDiskGraph::getNumNodes(transaction::Transaction* transaction) const {
     }
     offset_t numNodes = 0u;
     for (auto id : getNodeTableIDs()) {
-        numNodes += getNumNodes(transaction, id);
+        numNodes += getMaxOffset(transaction, id);
     }
     return numNodes;
-}
-
-offset_t OnDiskGraph::getNumNodes(transaction::Transaction* transaction, table_id_t id) const {
-    KU_ASSERT(nodeIDToNodeTable.contains(id));
-    return nodeIDToNodeTable.at(id)->getNumTotalRows(transaction);
 }
 
 std::vector<NbrTableInfo> OnDiskGraph::getForwardNbrTableInfos(table_id_t srcNodeTableID) {

--- a/src/include/function/gds/bfs_graph.h
+++ b/src/include/function/gds/bfs_graph.h
@@ -47,10 +47,10 @@ class BFSGraph {
     using parent_entry_t = std::atomic<ParentList*>;
 
 public:
-    BFSGraph(common::table_id_map_t<common::offset_t> numNodesMap, storage::MemoryManager* mm)
+    BFSGraph(common::table_id_map_t<common::offset_t> maxOffsetMap, storage::MemoryManager* mm)
         : mm{mm} {
-        for (auto& [tableID, numNodes] : numNodesMap) {
-            parentArray.allocate(tableID, numNodes, mm);
+        for (auto& [tableID, maxOffset] : maxOffsetMap) {
+            parentArray.allocate(tableID, maxOffset, mm);
         }
     }
 

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -128,7 +128,9 @@ public:
         storage::MemoryManager* mm);
     ~PathLengths();
 
-    const common::table_id_map_t<common::offset_t>& getNodeMaxOffsetMap() const { return nodeMaxOffsetMap; }
+    const common::table_id_map_t<common::offset_t>& getNodeMaxOffsetMap() const {
+        return nodeMaxOffsetMap;
+    }
 
     uint16_t getMaskValueFromCurFrontier(common::offset_t offset) {
         return curFrontier[offset].load(std::memory_order_relaxed);
@@ -137,9 +139,7 @@ public:
         return nextFrontier[offset].load(std::memory_order_relaxed);
     }
 
-    bool isActive(common::offset_t offset) {
-        return curFrontier[offset] == curIter - 1;
-    }
+    bool isActive(common::offset_t offset) { return curFrontier[offset] == curIter - 1; }
 
     void setActive(std::span<const common::nodeID_t> nodeIDs) {
         for (const auto nodeID : nodeIDs) {
@@ -157,12 +157,8 @@ public:
     void incrementCurIter() { curIter++; }
 
     void pinTableID(common::table_id_t tableID) { pinCurFrontierTableID(tableID); }
-    void pinCurFrontierTableID(common::table_id_t tableID) {
-        curFrontier = getMaskData(tableID);
-    }
-    void pinNextFrontierTableID(common::table_id_t tableID) {
-        nextFrontier = getMaskData(tableID);
-    }
+    void pinCurFrontierTableID(common::table_id_t tableID) { curFrontier = getMaskData(tableID); }
+    void pinNextFrontierTableID(common::table_id_t tableID) { nextFrontier = getMaskData(tableID); }
 
     // Init frontier to UNVISITED
     static std::shared_ptr<PathLengths> getUnvisitedFrontier(processor::ExecutionContext* context,

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -118,7 +118,7 @@ private:
  *
  * However, this is not necessary and the caller can also use this to represent a single frontier.
  */
-class PathLengths {
+class KUZU_API PathLengths {
     using frontier_entry_t = std::atomic<uint16_t>;
 
 public:
@@ -126,6 +126,8 @@ public:
 
     PathLengths(const common::table_id_map_t<common::offset_t>& nodeMaxOffsetMap,
         storage::MemoryManager* mm);
+    PathLengths(const PathLengths& other) = delete;
+    PathLengths(const PathLengths&& other) = delete;
     ~PathLengths();
 
     const common::table_id_map_t<common::offset_t>& getNodeMaxOffsetMap() const {

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -118,7 +118,7 @@ private:
  *
  * However, this is not necessary and the caller can also use this to represent a single frontier.
  */
-class KUZU_API PathLengths {
+class PathLengths {
     using frontier_entry_t = std::atomic<uint16_t>;
 
 public:

--- a/src/include/function/gds/gds_object_manager.h
+++ b/src/include/function/gds/gds_object_manager.h
@@ -39,9 +39,9 @@ private:
 template<typename T>
 class ObjectArraysMap {
 public:
-    void allocate(common::table_id_t tableID, common::offset_t numNodes,
+    void allocate(common::table_id_t tableID, common::offset_t maxOffset,
         storage::MemoryManager* mm) {
-        auto buffer = mm->allocateBuffer(false, numNodes * sizeof(T));
+        auto buffer = mm->allocateBuffer(false, maxOffset * sizeof(T));
         bufferPerTable.insert({tableID, std::move(buffer)});
     }
 

--- a/src/include/function/gds/gds_state.h
+++ b/src/include/function/gds/gds_state.h
@@ -20,7 +20,7 @@ struct GDSComputeState {
         : frontierPair{std::move(frontierPair)}, edgeCompute{std::move(edgeCompute)},
           auxiliaryState{std::move(auxiliaryState)}, outputNodeMask{outputNodeMask} {}
 
-    KUZU_API void initSource(common::nodeID_t sourceNodeID) const;
+    void initSource(common::nodeID_t sourceNodeID) const;
     // When performing computations on multi-label graphs, it is beneficial to fix a single
     // node table of nodes in the current frontier and a single node table of nodes for the next
     // frontier. That is because algorithms will perform extensions using a single relationship
@@ -31,8 +31,7 @@ struct GDSComputeState {
     // extensions are be given to the data structures of the computation, e.g., FrontierPairs and
     // RJOutputs, to possibly avoid them doing lookups of S and T-related data structures,
     // e.g., maps, internally.
-    KUZU_API void beginFrontierCompute(common::table_id_t currTableID,
-        common::table_id_t nextTableID) const;
+    void beginFrontierCompute(common::table_id_t currTableID, common::table_id_t nextTableID) const;
 };
 
 } // namespace function

--- a/src/include/function/gds/gds_state.h
+++ b/src/include/function/gds/gds_state.h
@@ -6,7 +6,7 @@
 namespace kuzu {
 namespace function {
 
-struct KUZU_API GDSComputeState {
+struct GDSComputeState {
     std::unique_ptr<function::FrontierPair> frontierPair = nullptr;
     std::unique_ptr<function::EdgeCompute> edgeCompute = nullptr;
     std::unique_ptr<function::GDSAuxiliaryState> auxiliaryState = nullptr;
@@ -20,7 +20,7 @@ struct KUZU_API GDSComputeState {
         : frontierPair{std::move(frontierPair)}, edgeCompute{std::move(edgeCompute)},
           auxiliaryState{std::move(auxiliaryState)}, outputNodeMask{outputNodeMask} {}
 
-    void initSource(common::nodeID_t sourceNodeID) const;
+    KUZU_API void initSource(common::nodeID_t sourceNodeID) const;
     // When performing computations on multi-label graphs, it is beneficial to fix a single
     // node table of nodes in the current frontier and a single node table of nodes for the next
     // frontier. That is because algorithms will perform extensions using a single relationship
@@ -31,7 +31,7 @@ struct KUZU_API GDSComputeState {
     // extensions are be given to the data structures of the computation, e.g., FrontierPairs and
     // RJOutputs, to possibly avoid them doing lookups of S and T-related data structures,
     // e.g., maps, internally.
-    void beginFrontierCompute(common::table_id_t currTableID, common::table_id_t nextTableID) const;
+    KUZU_API void beginFrontierCompute(common::table_id_t currTableID, common::table_id_t nextTableID) const;
 };
 
 } // namespace function

--- a/src/include/function/gds/gds_state.h
+++ b/src/include/function/gds/gds_state.h
@@ -31,7 +31,8 @@ struct GDSComputeState {
     // extensions are be given to the data structures of the computation, e.g., FrontierPairs and
     // RJOutputs, to possibly avoid them doing lookups of S and T-related data structures,
     // e.g., maps, internally.
-    KUZU_API void beginFrontierCompute(common::table_id_t currTableID, common::table_id_t nextTableID) const;
+    KUZU_API void beginFrontierCompute(common::table_id_t currTableID,
+        common::table_id_t nextTableID) const;
 };
 
 } // namespace function

--- a/src/include/graph/graph.h
+++ b/src/include/graph/graph.h
@@ -185,16 +185,17 @@ public:
     // Get id for all relationship tables.
     virtual std::vector<common::table_id_t> getRelTableIDs() const = 0;
 
-    // Get num rows of each table as a map
-    virtual common::table_id_map_t<common::offset_t> getNumNodesMap(
+    // Get max offset of each table as a map.
+    virtual common::table_id_map_t<common::offset_t> getMaxOffsetMap(
         transaction::Transaction* transaction) const = 0;
 
-    // Get num rows for all node tables.
-    virtual common::offset_t getNumNodes(transaction::Transaction* transaction) const = 0;
-    // Get num rows for given node table.
-    virtual common::offset_t getNumNodes(transaction::Transaction* transaction,
-        common::table_id_t id) const = 0;
+    // Get max offset of given table.
+    virtual common::offset_t getMaxOffset(transaction::Transaction* transaction,  common::table_id_t id) const = 0;
 
+    // Get num nodes for all node tables.
+    virtual common::offset_t getNumNodes(transaction::Transaction* transaction) const = 0;
+
+    
     // Get all possible forward (toNodeTable, relTable)s.
     virtual std::vector<NbrTableInfo> getForwardNbrTableInfos(
         common::table_id_t srcNodeTableID) = 0;

--- a/src/include/graph/graph.h
+++ b/src/include/graph/graph.h
@@ -190,12 +190,12 @@ public:
         transaction::Transaction* transaction) const = 0;
 
     // Get max offset of given table.
-    virtual common::offset_t getMaxOffset(transaction::Transaction* transaction,  common::table_id_t id) const = 0;
+    virtual common::offset_t getMaxOffset(transaction::Transaction* transaction,
+        common::table_id_t id) const = 0;
 
     // Get num nodes for all node tables.
     virtual common::offset_t getNumNodes(transaction::Transaction* transaction) const = 0;
 
-    
     // Get all possible forward (toNodeTable, relTable)s.
     virtual std::vector<NbrTableInfo> getForwardNbrTableInfos(
         common::table_id_t srcNodeTableID) = 0;

--- a/src/include/graph/on_disk_graph.h
+++ b/src/include/graph/on_disk_graph.h
@@ -146,12 +146,12 @@ public:
         return graphEntry.getRelTableIDs();
     }
 
-    common::table_id_map_t<common::offset_t> getNumNodesMap(
-        transaction::Transaction* transaction) const override;
 
-    common::offset_t getNumNodes(transaction::Transaction* transaction) const override;
-    common::offset_t getNumNodes(transaction::Transaction* transaction,
-        common::table_id_t id) const override;
+    common::table_id_map_t<common::offset_t> getMaxOffsetMap(transaction::Transaction *transaction) const override;
+
+    common::offset_t getMaxOffset(transaction::Transaction *transaction, common::table_id_t id) const override;
+
+    common::offset_t getNumNodes(transaction::Transaction *transaction) const override;
 
     std::vector<NbrTableInfo> getForwardNbrTableInfos(common::table_id_t srcNodeTableID) override;
 

--- a/src/include/graph/on_disk_graph.h
+++ b/src/include/graph/on_disk_graph.h
@@ -146,12 +146,13 @@ public:
         return graphEntry.getRelTableIDs();
     }
 
+    common::table_id_map_t<common::offset_t> getMaxOffsetMap(
+        transaction::Transaction* transaction) const override;
 
-    common::table_id_map_t<common::offset_t> getMaxOffsetMap(transaction::Transaction *transaction) const override;
+    common::offset_t getMaxOffset(transaction::Transaction* transaction,
+        common::table_id_t id) const override;
 
-    common::offset_t getMaxOffset(transaction::Transaction *transaction, common::table_id_t id) const override;
-
-    common::offset_t getNumNodes(transaction::Transaction *transaction) const override;
+    common::offset_t getNumNodes(transaction::Transaction* transaction) const override;
 
     std::vector<NbrTableInfo> getForwardNbrTableInfos(common::table_id_t srcNodeTableID) override;
 


### PR DESCRIPTION
# Description

Remove unnecessary usage of std::atomic in `PathLengths`.

Remove `GDSFrontier` abstraction level, we don't have a second child class and I don't see we will have one in the foreseeable future.

Rename `getNumNodes` to `getMaxOffset` in graph interface. `NumNodes` is confusing/inaccurate when we introduce filtered graph. What we need is maxOffset that is used to initialize dense data structure.