### PR TITLE
Add job for testing simsimd dynamic dispatch to nightly build-and-deploy workflow

### DIFF
--- a/.github/workflows/linux-precompiled-bin-workflow.yml
+++ b/.github/workflows/linux-precompiled-bin-workflow.yml
@@ -8,6 +8,10 @@ on:
         type: boolean
         required: true
         default: false
+      x86_64Only:
+        type: boolean
+        required: false
+        default: false
 
 env:
   PIP_BREAK_SYSTEM_PACKAGES: 1
@@ -53,6 +57,7 @@ jobs:
           path: kuzu_cli-linux-x86_64.tar.gz
 
   build-precompiled-bin-aarch64:
+    if: ${{ github.event.inputs.x86_64Only != 'true' }}
     runs-on: kuzu-self-hosted-linux-building-aarch64
     steps:
       - uses: actions/checkout@v4
@@ -92,6 +97,7 @@ jobs:
           path: kuzu_cli-linux-aarch64.tar.gz
 
   build-precompiled-bin-android-armv8a:
+    if: ${{ github.event.inputs.x86_64Only != 'true' }}
     runs-on: kuzu-self-hosted-testing
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux-precompiled-bin-workflow.yml
+++ b/.github/workflows/linux-precompiled-bin-workflow.yml
@@ -57,7 +57,7 @@ jobs:
           path: kuzu_cli-linux-x86_64.tar.gz
 
   build-precompiled-bin-aarch64:
-    if: ${{ github.event.inputs.x86_64Only != true }}
+    if: ${{ inputs.x86_64Only != true }}
     runs-on: kuzu-self-hosted-linux-building-aarch64
     steps:
       - uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
 
       - name: Build precompiled binaries
         run: |
-          echo ${{ github.event.inputs.x86_64Only }}
+          echo ${{ inputs.x86_64Only }}
           make NUM_THREADS=$(nproc)
           make install
 
@@ -98,7 +98,7 @@ jobs:
           path: kuzu_cli-linux-aarch64.tar.gz
 
   build-precompiled-bin-android-armv8a:
-    if: ${{ github.event.inputs.x86_64Only != true }}
+    if: ${{ inputs.x86_64Only != true }}
     runs-on: kuzu-self-hosted-testing
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linux-precompiled-bin-workflow.yml
+++ b/.github/workflows/linux-precompiled-bin-workflow.yml
@@ -71,7 +71,6 @@ jobs:
 
       - name: Build precompiled binaries
         run: |
-          echo ${{ inputs.x86_64Only }}
           make NUM_THREADS=$(nproc)
           make install
 

--- a/.github/workflows/linux-precompiled-bin-workflow.yml
+++ b/.github/workflows/linux-precompiled-bin-workflow.yml
@@ -71,6 +71,7 @@ jobs:
 
       - name: Build precompiled binaries
         run: |
+          echo ${{ github.event.inputs.x86_64Only }}
           make NUM_THREADS=$(nproc)
           make install
 

--- a/.github/workflows/linux-precompiled-bin-workflow.yml
+++ b/.github/workflows/linux-precompiled-bin-workflow.yml
@@ -57,7 +57,7 @@ jobs:
           path: kuzu_cli-linux-x86_64.tar.gz
 
   build-precompiled-bin-aarch64:
-    if: ${{ github.event.inputs.x86_64Only != 'true' }}
+    if: ${{ github.event.inputs.x86_64Only != true }}
     runs-on: kuzu-self-hosted-linux-building-aarch64
     steps:
       - uses: actions/checkout@v4
@@ -97,7 +97,7 @@ jobs:
           path: kuzu_cli-linux-aarch64.tar.gz
 
   build-precompiled-bin-android-armv8a:
-    if: ${{ github.event.inputs.x86_64Only != 'true' }}
+    if: ${{ github.event.inputs.x86_64Only != true }}
     runs-on: kuzu-self-hosted-testing
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/simsimd-dispatch-test.yml
+++ b/.github/workflows/simsimd-dispatch-test.yml
@@ -1,9 +1,5 @@
 name: SimSIMD Dispatch Test
 on:
-  # TODO(Royi) remove once done testing
-  pull_request:
-    branches:
-      - master
   schedule:
     - cron: "0 5 * * *"
 

--- a/.github/workflows/simsimd-dispatch-test.yml
+++ b/.github/workflows/simsimd-dispatch-test.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   build-precompiled-bin-linux:
-    if: ${{ github.event_name == 'schedule' || github.event.inputs.skipBinaries != 'true' }}
     uses: ./.github/workflows/linux-precompiled-bin-workflow.yml
     with:
       isNightly: true

--- a/.github/workflows/simsimd-dispatch-test.yml
+++ b/.github/workflows/simsimd-dispatch-test.yml
@@ -1,0 +1,40 @@
+name: SimSIMD Dispatch Test
+on:
+  # TODO(Royi) remove once done testing
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 5 * * *"
+
+  workflow_dispatch:
+
+jobs:
+  build-precompiled-bin-linux:
+    if: ${{ github.event_name == 'schedule' || github.event.inputs.skipBinaries != 'true' }}
+    uses: ./.github/workflows/linux-precompiled-bin-workflow.yml
+    with:
+      isNightly: true
+    secrets: inherit
+
+  simsimd-dispatch-test:
+    name: simsimd-dispatch-test
+    needs: build-precompiled-bin-linux
+    runs-on: kuzu-self-hosted-testing
+    env:
+      NUM_THREADS: 32
+      GEN: Ninja
+      CC: gcc
+      CXX: g++
+    steps:
+      - name: Download nightly build
+        uses: actions/download-artifact@v4
+        with:
+          name: kuzu_cli-linux-x86_64
+
+      - name: Extract kuzu shell
+        run: |
+          tar xf kuzu_cli-linux-x86_64.tar.gz
+
+      - name: Test
+        run: gdb --batch -x scripts/test-simsimd-dispatch.py --args ./kuzu

--- a/.github/workflows/simsimd-dispatch-test.yml
+++ b/.github/workflows/simsimd-dispatch-test.yml
@@ -15,6 +15,7 @@ jobs:
     uses: ./.github/workflows/linux-precompiled-bin-workflow.yml
     with:
       isNightly: true
+      x86_64Only: true
     secrets: inherit
 
   simsimd-dispatch-test:

--- a/scripts/simd-dispatch-test.cypher
+++ b/scripts/simd-dispatch-test.cypher
@@ -1,0 +1,4 @@
+CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+COPY embeddings FROM "dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
+CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec', distFunc := 'l2');
+CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;

--- a/scripts/simd-dispatch-test.cypher
+++ b/scripts/simd-dispatch-test.cypher
@@ -1,4 +1,4 @@
 CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
 COPY embeddings FROM "dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
-CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec', distFunc := 'l2');
-CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
+CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'l2');
+CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;

--- a/scripts/test-simsimd-dispatch.py
+++ b/scripts/test-simsimd-dispatch.py
@@ -1,0 +1,45 @@
+import gdb
+import subprocess
+
+
+def get_machine_architecture():
+    output = subprocess.check_output(["cat", "/proc/cpuinfo"])
+    flags_str = ""
+    for line in output.decode("utf-8").split("\n"):
+        line = line.strip()
+        if line.startswith("flags"):
+            flags_str = line
+            break
+    assert len(line) > 0
+
+    # Uses the same way as _simsimd_capabilities_x86() in simsimd.h to detect supported features
+    # The only simsimd functions we use in the vector index are cos/l2/l2_sq/dot which only branch for the targets 'skylake', 'haswell', and 'serial' so we only test for those
+    if "avx512f" in flags_str:
+        return "skylake"
+    elif "avx2" in flags_str and "f16c" in flags_str and "fma" in flags_str:
+        return "haswell"
+    else:
+        return "serial"
+
+
+bp = gdb.Breakpoint(f"simsimd_l2_f32_{get_machine_architecture()}")
+
+gdb.execute("run < scripts/simd-dispatch-test.cypher")
+
+try:
+    gdb.execute("continue")
+    # we only care if the breakpoint is hit at all
+    # disable it now to prevent the test from needing to execute 'continue' many times to reach completion
+    bp.enabled = False
+except gdb.error:
+    # the program has terminated
+    pass
+
+# Check if the breakpoint was hit
+if bp.hit_count == 0:
+    print(
+        f"Error: did not hit the expected simsimd function for machine architecture '{get_machine_architecture()}'"
+    )
+    gdb.execute("quit 1")
+
+gdb.execute("quit")


### PR DESCRIPTION
# Description

Add a job to the nightly `build-and-deploy` workflow that tests to see if simsimd's dynamic dispatch is working as expected. The job will download the nightly build of the kuzu shell and run the test on a newly-selected CI runner. Ideally this would over time test out all the combinations of build + execution machines.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).