### PR TITLE
Add squared distance function for arrays

### DIFF
--- a/src/function/array/array_functions.cpp
+++ b/src/function/array/array_functions.cpp
@@ -4,6 +4,7 @@
 #include "function/array/functions/array_cross_product.h"
 #include "function/array/functions/array_distance.h"
 #include "function/array/functions/array_inner_product.h"
+#include "function/array/functions/array_squared_distance.h"
 #include "function/array/vector_array_functions.h"
 #include "function/scalar_function.h"
 
@@ -186,6 +187,10 @@ function_set ArrayCosineSimilarityFunction::getFunctionSet() {
 
 function_set ArrayDistanceFunction::getFunctionSet() {
     return templateGetFunctionSet<ArrayDistance>(name);
+}
+
+function_set ArraySquaredDistanceFunction::getFunctionSet() {
+    return templateGetFunctionSet<ArraySquaredDistance>(name);
 }
 
 function_set ArrayInnerProductFunction::getFunctionSet() {

--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -37,22 +37,23 @@ namespace kuzu {
 namespace function {
 
 #define SCALAR_FUNCTION_BASE(_PARAM, _NAME)                                                        \
-    {_PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
 #define SCALAR_FUNCTION(_PARAM) SCALAR_FUNCTION_BASE(_PARAM, _PARAM::name)
 #define SCALAR_FUNCTION_ALIAS(_PARAM) SCALAR_FUNCTION_BASE(_PARAM::alias, _PARAM::name)
 #define REWRITE_FUNCTION(_PARAM)                                                                   \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY }
 #define AGGREGATE_FUNCTION(_PARAM)                                                                 \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY }
 #define EXPORT_FUNCTION(_PARAM)                                                                    \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY }
 #define TABLE_FUNCTION(_PARAM)                                                                     \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY }
 #define STANDALONE_TABLE_FUNCTION(_PARAM)                                                          \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY }
 #define ALGORITHM_FUNCTION(_PARAM)                                                                 \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY}
-#define FINAL_FUNCTION {nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY }
+#define FINAL_FUNCTION                                                                             \
+    { nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
 
 FunctionCollection* FunctionCollection::getFunctions() {
     static FunctionCollection functions[] = {

--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -37,23 +37,22 @@ namespace kuzu {
 namespace function {
 
 #define SCALAR_FUNCTION_BASE(_PARAM, _NAME)                                                        \
-    { _PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
 #define SCALAR_FUNCTION(_PARAM) SCALAR_FUNCTION_BASE(_PARAM, _PARAM::name)
 #define SCALAR_FUNCTION_ALIAS(_PARAM) SCALAR_FUNCTION_BASE(_PARAM::alias, _PARAM::name)
 #define REWRITE_FUNCTION(_PARAM)                                                                   \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY}
 #define AGGREGATE_FUNCTION(_PARAM)                                                                 \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY}
 #define EXPORT_FUNCTION(_PARAM)                                                                    \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY}
 #define TABLE_FUNCTION(_PARAM)                                                                     \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY}
 #define STANDALONE_TABLE_FUNCTION(_PARAM)                                                          \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY}
 #define ALGORITHM_FUNCTION(_PARAM)                                                                 \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY }
-#define FINAL_FUNCTION                                                                             \
-    { nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY}
+#define FINAL_FUNCTION {nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
 
 FunctionCollection* FunctionCollection::getFunctions() {
     static FunctionCollection functions[] = {
@@ -101,7 +100,8 @@ FunctionCollection* FunctionCollection::getFunctions() {
         // Array Functions
         SCALAR_FUNCTION(ArrayValueFunction), SCALAR_FUNCTION(ArrayCrossProductFunction),
         SCALAR_FUNCTION(ArrayCosineSimilarityFunction), SCALAR_FUNCTION(ArrayDistanceFunction),
-        SCALAR_FUNCTION(ArrayInnerProductFunction), SCALAR_FUNCTION(ArrayDotProductFunction),
+        SCALAR_FUNCTION(ArraySquaredDistanceFunction), SCALAR_FUNCTION(ArrayInnerProductFunction),
+        SCALAR_FUNCTION(ArrayDotProductFunction),
 
         // List functions
         SCALAR_FUNCTION(ListCreationFunction), SCALAR_FUNCTION(ListRangeFunction),

--- a/src/include/function/array/functions/array_cosine_similarity.h
+++ b/src/include/function/array/functions/array_cosine_similarity.h
@@ -3,29 +3,27 @@
 #include "math.h"
 
 #include "common/vector/value_vector.h"
+#include <simsimd.h>
 
 namespace kuzu {
 namespace function {
 
 struct ArrayCosineSimilarity {
-    template<typename T>
+    template<std::floating_point T>
     static inline void operation(common::list_entry_t& left, common::list_entry_t& right, T& result,
         common::ValueVector& leftVector, common::ValueVector& rightVector,
         common::ValueVector& /*resultVector*/) {
         auto leftElements = (T*)common::ListVector::getListValues(&leftVector, left);
         auto rightElements = (T*)common::ListVector::getListValues(&rightVector, right);
-        T distance = 0;
-        T normLeft = 0;
-        T normRight = 0;
-        for (auto i = 0u; i < left.size; i++) {
-            auto x = leftElements[i];
-            auto y = rightElements[i];
-            distance += x * y;
-            normLeft += x * x;
-            normRight += y * y;
+        KU_ASSERT(left.size == right.size);
+        simsimd_distance_t tmpResult = 0.0;
+        static_assert(std::is_same_v<T, float> || std::is_same_v<T, double>);
+        if constexpr (std::is_same_v<T, float>) {
+            simsimd_cos_f32(leftElements, rightElements, left.size, &tmpResult);
+        } else {
+            simsimd_cos_f64(leftElements, rightElements, left.size, &tmpResult);
         }
-        auto similarity = distance / (std::sqrt(normLeft) * std::sqrt(normRight));
-        result = std::max(static_cast<T>(-1), std::min(similarity, static_cast<T>(1)));
+        result = 1.0 - tmpResult;
     }
 };
 

--- a/src/include/function/array/functions/array_distance.h
+++ b/src/include/function/array/functions/array_distance.h
@@ -10,7 +10,7 @@ namespace function {
 
 // Euclidean distance between two arrays.
 struct ArrayDistance {
-    template<typename T>
+    template<std::floating_point T>
     static inline void operation(common::list_entry_t& left, common::list_entry_t& right, T& result,
         common::ValueVector& leftVector, common::ValueVector& rightVector,
         common::ValueVector& resultVector) {

--- a/src/include/function/array/functions/array_distance.h
+++ b/src/include/function/array/functions/array_distance.h
@@ -3,6 +3,7 @@
 #include "math.h"
 
 #include "common/vector/value_vector.h"
+#include "function/array/functions/array_squared_distance.h"
 
 namespace kuzu {
 namespace function {
@@ -12,15 +13,8 @@ struct ArrayDistance {
     template<typename T>
     static inline void operation(common::list_entry_t& left, common::list_entry_t& right, T& result,
         common::ValueVector& leftVector, common::ValueVector& rightVector,
-        common::ValueVector& /*resultVector*/) {
-        auto leftElements = (T*)common::ListVector::getListValues(&leftVector, left);
-        auto rightElements = (T*)common::ListVector::getListValues(&rightVector, right);
-        KU_ASSERT(left.size == right.size);
-        result = 0;
-        for (auto i = 0u; i < left.size; i++) {
-            auto diff = leftElements[i] - rightElements[i];
-            result += diff * diff;
-        }
+        common::ValueVector& resultVector) {
+        ArraySquaredDistance::operation(left, right, result, leftVector, rightVector, resultVector);
         result = std::sqrt(result);
     }
 };

--- a/src/include/function/array/functions/array_inner_product.h
+++ b/src/include/function/array/functions/array_inner_product.h
@@ -1,21 +1,27 @@
 #pragma once
 
 #include "common/vector/value_vector.h"
+#include <simsimd.h>
 
 namespace kuzu {
 namespace function {
 
 struct ArrayInnerProduct {
-    template<typename T>
+    template<std::floating_point T>
     static inline void operation(common::list_entry_t& left, common::list_entry_t& right, T& result,
         common::ValueVector& leftVector, common::ValueVector& rightVector,
         common::ValueVector& /*resultVector*/) {
         auto leftElements = (T*)common::ListVector::getListValues(&leftVector, left);
         auto rightElements = (T*)common::ListVector::getListValues(&rightVector, right);
-        result = 0;
-        for (auto i = 0u; i < left.size; i++) {
-            result += leftElements[i] * rightElements[i];
+        KU_ASSERT(left.size == right.size);
+        simsimd_distance_t tmpResult = 0.0;
+        static_assert(std::is_same_v<T, float> || std::is_same_v<T, double>);
+        if constexpr (std::is_same_v<T, float>) {
+            simsimd_dot_f32(leftElements, rightElements, left.size, &tmpResult);
+        } else {
+            simsimd_dot_f64(leftElements, rightElements, left.size, &tmpResult);
         }
+        result = tmpResult;
     }
 };
 

--- a/src/include/function/array/functions/array_squared_distance.h
+++ b/src/include/function/array/functions/array_squared_distance.h
@@ -12,6 +12,7 @@ struct ArraySquaredDistance {
         common::ValueVector& /*resultVector*/) {
         auto leftElements = (T*)common::ListVector::getListValues(&leftVector, left);
         auto rightElements = (T*)common::ListVector::getListValues(&rightVector, right);
+        KU_ASSERT(left.size == right.size);
         result = 0;
         for (auto i = 0u; i < left.size; i++) {
             const auto diff = leftElements[i] - rightElements[i];

--- a/src/include/function/array/functions/array_squared_distance.h
+++ b/src/include/function/array/functions/array_squared_distance.h
@@ -1,23 +1,27 @@
 #pragma once
 
 #include "common/vector/value_vector.h"
+#include <simsimd.h>
 
 namespace kuzu {
 namespace function {
 
 struct ArraySquaredDistance {
-    template<typename T>
+    template<std::floating_point T>
     static inline void operation(common::list_entry_t& left, common::list_entry_t& right, T& result,
         common::ValueVector& leftVector, common::ValueVector& rightVector,
         common::ValueVector& /*resultVector*/) {
         auto leftElements = (T*)common::ListVector::getListValues(&leftVector, left);
         auto rightElements = (T*)common::ListVector::getListValues(&rightVector, right);
         KU_ASSERT(left.size == right.size);
-        result = 0;
-        for (auto i = 0u; i < left.size; i++) {
-            const auto diff = leftElements[i] - rightElements[i];
-            result += diff * diff;
+        simsimd_distance_t tmpResult = 0.0;
+        static_assert(std::is_same_v<T, float> || std::is_same_v<T, double>);
+        if constexpr (std::is_same_v<T, float>) {
+            simsimd_l2sq_f32(leftElements, rightElements, left.size, &tmpResult);
+        } else {
+            simsimd_l2sq_f64(leftElements, rightElements, left.size, &tmpResult);
         }
+        result = tmpResult;
     }
 };
 

--- a/src/include/function/array/functions/array_squared_distance.h
+++ b/src/include/function/array/functions/array_squared_distance.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "common/vector/value_vector.h"
+
+namespace kuzu {
+namespace function {
+
+struct ArraySquaredDistance {
+    template<typename T>
+    static inline void operation(common::list_entry_t& left, common::list_entry_t& right, T& result,
+        common::ValueVector& leftVector, common::ValueVector& rightVector,
+        common::ValueVector& /*resultVector*/) {
+        auto leftElements = (T*)common::ListVector::getListValues(&leftVector, left);
+        auto rightElements = (T*)common::ListVector::getListValues(&rightVector, right);
+        result = 0;
+        for (auto i = 0u; i < left.size; i++) {
+            const auto diff = leftElements[i] - rightElements[i];
+            result += diff * diff;
+        }
+    }
+};
+
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/array/vector_array_functions.h
+++ b/src/include/function/array/vector_array_functions.h
@@ -30,6 +30,12 @@ struct ArrayDistanceFunction {
     static function_set getFunctionSet();
 };
 
+struct ArraySquaredDistanceFunction {
+    static constexpr const char* name = "ARRAY_SQUARED_DISTANCE";
+
+    static function_set getFunctionSet();
+};
+
 struct ArrayInnerProductFunction {
     static constexpr const char* name = "ARRAY_INNER_PRODUCT";
 

--- a/test/test_files/function/array.test
+++ b/test/test_files/function/array.test
@@ -108,6 +108,21 @@ Binder exception: ARRAY_COSINE_SIMILARITY requires argument type to be FLOAT[] o
 ---- 1
 5.000000
 
+-LOG ArraySquaredDistance
+-STATEMENT MATCH (p:person)-[e:meets]->(p1:person) return round(ARRAY_SQUARED_DISTANCE(e.location, array_value(to_float(3.4), to_float(2.7))),2)
+---- 7
+1.820000
+2.570000
+2.620000
+20.240000
+33.010000
+41.130000
+6.410000
+
+-STATEMENT RETURN ARRAY_SQUARED_DISTANCE([-1, -2, -3.0], [2, -6.0, -3])
+---- 1
+25.000000
+
 -LOG ArrayInnerProduct
 -STATEMENT MATCH (p:person)-[e:meets]->(p1:person) return round(ARRAY_INNER_PRODUCT(e.location, array_value(to_float(3.4), to_float(2.7))),2)
 ---- 7

--- a/test/test_files/function/array_embeddings.test
+++ b/test/test_files/function/array_embeddings.test
@@ -1,0 +1,39 @@
+-DATASET CSV empty
+
+--
+
+-CASE 8DimL2Naive
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
+---- ok
+-STATEMENT match (a:embeddings) with array_distance(CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), a.vec) as distance, a return a.id order by distance limit 3
+-CHECK_ORDER
+---- 3
+333
+444
+133
+
+-CASE 8DimCosNaive
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
+---- ok
+-STATEMENT match (a:embeddings) with 1 - array_cosine_similarity(CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), a.vec) as distance, a return a.id order by distance limit 3
+-CHECK_ORDER
+---- 3
+333
+444
+146
+
+-CASE 8DimDPNaive
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
+---- ok
+-STATEMENT match (a:embeddings) with array_dot_product(CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), a.vec) as distance, a return a.id order by distance limit 3
+-CHECK_ORDER
+---- 3
+499
+581
+58

--- a/test/test_files/function/hnsw/small.test
+++ b/test/test_files/function/hnsw/small.test
@@ -17,10 +17,6 @@
 133
 
 -CASE 8DimCos
-# When using dynamic dispatch simsimd uses its own approximate inverse square root
-# See third_party/simsimd/lib.c:10
-# In wasm (assumingly because it is 32-bit) that function will return slightly different distance values
--SKIP_WASM
 -STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
@@ -29,19 +25,6 @@
 ---- ok
 -STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
 -CHECK_ORDER
----- 3
-333
-444
-146
-
--CASE 8DimCosIgnoreOrder
--STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
----- ok
--STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
----- ok
--STATEMENT CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec');
----- ok
--STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
 ---- 3
 333
 444

--- a/third_party/simsimd/lib.c
+++ b/third_party/simsimd/lib.c
@@ -7,12 +7,6 @@
 #define SIMSIMD_NATIVE_F16 0
 #define SIMSIMD_NATIVE_BF16 0
 
-/*  Override the primary serial operations to avoid the LibC dependency.
- */
-#define SIMSIMD_SQRT(x) simsimd_approximate_square_root(x)
-#define SIMSIMD_RSQRT(x) simsimd_approximate_inverse_square_root(x)
-#define SIMSIMD_LOG(x) simsimd_approximate_log(x)
-
 /*  Depending on the Operating System, the following intrinsics are available
  *  on recent compiler toolchains:
  *


### PR DESCRIPTION
# Description

We offer the `l2_squared` distance function for vector index so we should offer a version for arrays as well. The other distance functions offered by vector index (`l2`, `cos`, `dot`) already exist.

Since we now have the library, I also modified the applicable array functions (distance/cos/inner product) to use simsimd for better performance.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).