### PR TITLE
Tie rust QueryResult lifetime to that of the Database

### DIFF
--- a/tools/rust_api/Cargo.toml
+++ b/tools/rust_api/Cargo.toml
@@ -3,7 +3,7 @@ name = "kuzu"
 version = "0.8.0"
 description = "An in-process property graph database management system built for query speed and scalability"
 # Note: 1.72 required for testing due to latest dependencies of the arrow feature
-rust-version = "1.60"
+rust-version = "1.67"
 readme = "kuzu-src/README.md"
 homepage = "http://kuzudb.com/"
 repository = "https://github.com/kuzudb/kuzu"

--- a/tools/rust_api/build.rs
+++ b/tools/rust_api/build.rs
@@ -16,16 +16,12 @@ fn get_target() -> String {
 fn link_libraries() {
     if cfg!(windows) && link_mode() == "dylib" {
         println!("cargo:rustc-link-lib=dylib=kuzu_shared");
+    } else if link_mode() == "dylib" {
+        println!("cargo:rustc-link-lib={}=kuzu", link_mode());
+    } else if rustversion::cfg!(since(1.82)) {
+        println!("cargo:rustc-link-lib=static:+whole-archive=kuzu");
     } else {
-        if link_mode() == "dylib" {
-            println!("cargo:rustc-link-lib={}=kuzu", link_mode());
-        } else {
-            if rustversion::cfg!(since(1.82)) {
-                println!("cargo:rustc-link-lib=static:+whole-archive=kuzu");
-            } else {
-                println!("cargo:rustc-link-lib=static=kuzu");
-            }
-        }
+        println!("cargo:rustc-link-lib=static=kuzu");
     }
     if link_mode() == "static" {
         if cfg!(windows) {

--- a/tools/rust_api/src/connection.rs
+++ b/tools/rust_api/src/connection.rs
@@ -71,8 +71,8 @@ pub struct Connection<'a> {
 
 // Connections are synchronized on the C++ side and should be safe to move and access across
 // threads
-unsafe impl<'a> Send for Connection<'a> {}
-unsafe impl<'a> Sync for Connection<'a> {}
+unsafe impl Send for Connection<'_> {}
+unsafe impl Sync for Connection<'_> {}
 
 impl<'a> Connection<'a> {
     /// Creates a connection to the database.
@@ -132,7 +132,7 @@ impl<'a> Connection<'a> {
     // let result: QueryResult<kuzu::value::Int64> = conn.query("...")?;
     //
     // But this would really just be syntactic sugar wrapping the current system
-    pub fn query(&self, query: &str) -> Result<QueryResult, Error> {
+    pub fn query(&self, query: &str) -> Result<QueryResult<'a>, Error> {
         let conn = unsafe { (*self.conn.get()).pin_mut() };
         let result = ffi::connection_query(conn, ffi::StringView::new(query))?;
         if !result.isSuccess() {

--- a/tools/rust_api/src/database.rs
+++ b/tools/rust_api/src/database.rs
@@ -51,7 +51,7 @@ impl Default for SystemConfig {
             // This is a little weird, but it's a temporary interface
             max_db_size: u32::MAX as u64,
             auto_checkpoint: true,
-            checkpoint_threshold: -1 as i64,
+            checkpoint_threshold: -1_i64,
         }
     }
 }

--- a/tools/rust_api/src/ffi/arrow.rs
+++ b/tools/rust_api/src/ffi/arrow.rs
@@ -20,15 +20,15 @@ pub(crate) mod ffi_arrow {
         include!("kuzu/include/kuzu_arrow.h");
 
         #[namespace = "kuzu::main"]
-        type QueryResult = crate::ffi::ffi::QueryResult;
+        type QueryResult<'db> = crate::ffi::ffi::QueryResult<'db>;
     }
 
     unsafe extern "C++" {
         type ArrowArray = crate::ffi::arrow::ArrowArray;
 
         #[namespace = "kuzu_arrow"]
-        fn query_result_get_next_arrow_chunk(
-            result: Pin<&mut QueryResult>,
+        fn query_result_get_next_arrow_chunk<'db>(
+            result: Pin<&mut QueryResult<'db>>,
             chunk_size: u64,
         ) -> Result<ArrowArray>;
     }
@@ -37,6 +37,6 @@ pub(crate) mod ffi_arrow {
         type ArrowSchema = crate::ffi::arrow::ArrowSchema;
 
         #[namespace = "kuzu_arrow"]
-        fn query_result_get_arrow_schema(result: &QueryResult) -> Result<ArrowSchema>;
+        fn query_result_get_arrow_schema<'db>(result: &QueryResult<'db>) -> Result<ArrowSchema>;
     }
 }

--- a/tools/rust_api/src/value.rs
+++ b/tools/rust_api/src/value.rs
@@ -82,10 +82,7 @@ impl NodeVal {
     }
 }
 
-fn properties_display(
-    f: &mut fmt::Formatter<'_>,
-    properties: &Vec<(String, Value)>,
-) -> fmt::Result {
+fn properties_display(f: &mut fmt::Formatter<'_>, properties: &[(String, Value)]) -> fmt::Result {
     write!(f, "{{")?;
     for (index, (name, value)) in properties.iter().enumerate() {
         write!(f, "{}:{}", name, value)?;
@@ -269,7 +266,7 @@ pub enum Value {
     Decimal(rust_decimal::Decimal),
 }
 
-fn display_list<T: std::fmt::Display>(f: &mut fmt::Formatter<'_>, list: &Vec<T>) -> fmt::Result {
+fn display_list<T: std::fmt::Display>(f: &mut fmt::Formatter<'_>, list: &[T]) -> fmt::Result {
     write!(f, "[")?;
     for (i, value) in list.iter().enumerate() {
         write!(f, "{}", value)?;


### PR DESCRIPTION
It should be safe to use QueryResults after the connection has been destroyed, but it isn't after the Database has been destroyed.

I've also fixed some warnings and bumped the MSRV since clippy helpfully pointed out that we're using a function that has only been stable since rust 1.67.