### PR TITLE
Implement SQL_QUERY function

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1015,11 +1015,12 @@ jobs:
       - name: Update PostgreSQL host
         working-directory: extension/postgres/test/test_files
         env:
-          FNAME: postgres.test
+          PG_FNAME: postgres.test
+          SQL_FNAME: sql_query.test
           FIND: "localhost"
         run: |
-          node -e 'fs=require("fs");fs.readFile(process.env.FNAME,"utf8",(err,data)=>{if(err!=null)throw err;fs.writeFile(process.env.FNAME,data.replaceAll(process.env.FIND,process.env.PG_HOST),"utf8",e=>{if(e!=null)throw e;});});'
-          cat postgres.test
+          node -e 'fs=require("fs");fs.readFile(process.env.PG_FNAME,"utf8",(err,data)=>{if(err!=null)throw err;fs.writeFile(process.env.PG_FNAME,data.replaceAll(process.env.FIND,process.env.PG_HOST),"utf8",e=>{if(e!=null)throw e;});});'
+          node -e 'fs=require("fs");fs.readFile(process.env.SQL_FNAME,"utf8",(err,data)=>{if(err!=null)throw err;fs.writeFile(process.env.SQL_FNAME,data.replaceAll(process.env.FIND,process.env.PG_HOST),"utf8",e=>{if(e!=null)throw e;});});'
 
       - name: Install dependencies
         run: pip install rangehttpserver requests
@@ -1079,11 +1080,12 @@ jobs:
       - name: Update PostgreSQL host
         working-directory: extension/postgres/test/test_files
         env:
-          FNAME: postgres.test
+          PG_TEST_FNAME: postgres.test
+          SQL_TEST_FNAME: sql_query.test
           FIND: "localhost"
         run: |
-          node -e 'fs=require("fs");fs.readFile(process.env.FNAME,"utf8",(err,data)=>{if(err!=null)throw err;fs.writeFile(process.env.FNAME,data.replaceAll(process.env.FIND,process.env.PG_HOST),"utf8",e=>{if(e!=null)throw e;});});'
-          cat postgres.test
+          node -e 'fs=require("fs");fs.readFile(process.env.PG_TEST_FNAME,"utf8",(err,data)=>{if(err!=null)throw err;fs.writeFile(process.env.PG_TEST_FNAME,data.replaceAll(process.env.FIND,process.env.PG_HOST),"utf8",e=>{if(e!=null)throw e;});});'
+          node -e 'fs=require("fs");fs.readFile(process.env.SQL_TEST_FNAME,"utf8",(err,data)=>{if(err!=null)throw err;fs.writeFile(process.env.SQL_TEST_FNAME,data.replaceAll(process.env.FIND,process.env.PG_HOST),"utf8",e=>{if(e!=null)throw e;});});'
 
       - name: Install dependencies
         run: pip3 install rangehttpserver requests
@@ -1136,16 +1138,22 @@ jobs:
       - name: Update PostgreSQL host
         working-directory: extension/postgres/test/test_files
         env:
-          FNAME: postgres.test
+          PG_FNAME: postgres.test
+          SQL_FNAME: sql_query.test
           FIND: "localhost"
         run: |
-          $fname = $env:FNAME
+          $fname = $env:PG_FNAME
           $find = $env:FIND
           $replace = $env:PG_HOST
           $content = Get-Content -Path $fname
           $content = $content -replace [regex]::Escape($find), $replace
           Set-Content -Path $fname -Value $content
-          cat $fname
+          $fname = $env:SQL_FNAME
+          $find = $env:FIND
+          $replace = $env:PG_HOST
+          $content = Get-Content -Path $fname
+          $content = $content -replace [regex]::Escape($find), $replace
+          Set-Content -Path $fname -Value $content
 
       - name: Extension test build
         shell: cmd

--- a/extension/duckdb/src/include/storage/attached_duckdb_database.h
+++ b/extension/duckdb/src/include/storage/attached_duckdb_database.h
@@ -6,9 +6,7 @@
 namespace kuzu {
 namespace duckdb_extension {
 
-class DuckDBConnector;
-
-class AttachedDuckDBDatabase final : public main::AttachedDatabase {
+class AttachedDuckDBDatabase : public main::AttachedDatabase {
 public:
     AttachedDuckDBDatabase(std::string dbName, std::string dbType,
         std::unique_ptr<extension::CatalogExtension> catalog,
@@ -16,7 +14,7 @@ public:
         : main::AttachedDatabase{std::move(dbName), std::move(dbType), std::move(catalog)},
           connector{std::move(connector)} {}
 
-private:
+protected:
     std::unique_ptr<DuckDBConnector> connector;
 };
 

--- a/extension/postgres/CMakeLists.txt
+++ b/extension/postgres/CMakeLists.txt
@@ -18,6 +18,7 @@ add_subdirectory(src/connector)
 add_subdirectory(src/storage)
 add_subdirectory(src/main)
 add_subdirectory(src/installer)
+add_subdirectory(src/function)
 
 add_library(postgres_extension
         SHARED

--- a/extension/postgres/src/function/CMakeLists.txt
+++ b/extension/postgres/src/function/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(kuzu_postgres_function
+        OBJECT
+        sql_query.cpp)
+
+set(POSTGRES_EXTENSION_OBJECT_FILES
+        ${POSTGRES_EXTENSION_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_postgres_function>
+        PARENT_SCOPE)

--- a/extension/postgres/src/function/sql_query.cpp
+++ b/extension/postgres/src/function/sql_query.cpp
@@ -1,0 +1,103 @@
+#include "function/sql_query.h"
+
+#include "catalog/duckdb_catalog.h"
+#include "common/exception/binder.h"
+#include "connector/duckdb_type_converter.h"
+#include "main/database_manager.h"
+#include "storage/attached_postgres_database.h"
+#include "storage/postgres_storage.h"
+
+using namespace kuzu::function;
+using namespace kuzu::main;
+using namespace kuzu::common;
+
+namespace kuzu {
+namespace postgres_extension {
+
+struct SqlQuerySharedState final : function::BaseScanSharedStateWithNumRows {
+    explicit SqlQuerySharedState(std::shared_ptr<duckdb::MaterializedQueryResult> queryResult)
+        : BaseScanSharedStateWithNumRows{queryResult->RowCount()},
+          queryResult{std::move(queryResult)} {}
+
+    std::shared_ptr<duckdb::MaterializedQueryResult> queryResult;
+};
+
+struct SqlQueryBindData final : function::TableFuncBindData {
+    std::shared_ptr<duckdb::MaterializedQueryResult> queryResult;
+    duckdb_extension::DuckDBResultConverter converter;
+
+    SqlQueryBindData(std::shared_ptr<duckdb::MaterializedQueryResult> queryResult,
+        duckdb_extension::DuckDBResultConverter converter, binder::expression_vector columns)
+        : TableFuncBindData{std::move(columns), 1 /* maxOffset */},
+          queryResult{std::move(queryResult)}, converter{std::move(converter)} {}
+
+    std::unique_ptr<TableFuncBindData> copy() const override {
+        return std::make_unique<SqlQueryBindData>(*this);
+    }
+};
+
+static std::unique_ptr<TableFuncBindData> bindFunc(const ClientContext* context,
+    const TableFuncBindInput* input) {
+    auto dbName = input->getLiteralVal<std::string>(0);
+    auto query = input->getLiteralVal<std::string>(1);
+    auto attachedDB = context->getDatabaseManager()->getAttachedDatabase(dbName);
+    if (attachedDB->getDBType() != PostgresStorageExtension::DB_TYPE) {
+        throw common::BinderException{"sql queries can only be executed in attached postgres."};
+    }
+    auto queryToExecuteInDuckDB = common::stringFormat("select * from postgres_query({}, '{}');",
+        attachedDB->constCast<AttachedPostgresDatabase>().getAttachedCatalogNameInDuckDB(), query);
+    auto& attachedPostgresDB = attachedDB->constCast<AttachedPostgresDatabase>();
+    auto queryResult = attachedPostgresDB.executeQuery(queryToExecuteInDuckDB);
+    std::vector<common::LogicalType> returnTypes;
+    std::vector<std::string> returnColumnNames;
+    for (auto i = 0u; i < queryResult->names.size(); i++) {
+        returnColumnNames.push_back(queryResult->ColumnName(i));
+        returnTypes.push_back(duckdb_extension::DuckDBTypeConverter::convertDuckDBType(
+            queryResult->types[i].ToString()));
+    }
+    duckdb_extension::DuckDBResultConverter duckdbResultConverter{returnTypes};
+    returnColumnNames =
+        TableFunction::extractYieldVariables(returnColumnNames, input->yieldVariables);
+    auto columns = input->binder->createVariables(returnColumnNames, returnTypes);
+    return std::make_unique<SqlQueryBindData>(std::move(queryResult),
+        std::move(duckdbResultConverter), columns);
+}
+
+std::unique_ptr<TableFuncSharedState> initSharedState(const TableFunctionInitInput& input) {
+    auto scanBindData = input.bindData->constPtrCast<SqlQueryBindData>();
+    return std::make_unique<SqlQuerySharedState>(scanBindData->queryResult);
+}
+
+offset_t tableFunc(const TableFuncInput& input, TableFuncOutput& output) {
+    auto sharedState = input.sharedState->ptrCast<SqlQuerySharedState>();
+    auto bindData = input.bindData->constPtrCast<SqlQueryBindData>();
+    std::unique_ptr<duckdb::DataChunk> result;
+    try {
+        // Duckdb queryResult.fetch() is not thread safe, we have to acquire a lock there.
+        std::lock_guard<std::mutex> lock{sharedState->lock};
+        result = sharedState->queryResult->Fetch();
+    } catch (std::exception& e) {
+        return 0;
+    }
+    if (result == nullptr) {
+        return 0;
+    }
+    bindData->converter.convertDuckDBResultToVector(*result, output.dataChunk,
+        bindData->getColumnSkips());
+    return output.dataChunk.state->getSelVector().getSelSize();
+}
+
+function_set SqlQueryFunction::getFunctionSet() {
+    function_set functionSet;
+    auto function = std::make_unique<TableFunction>(name,
+        std::vector<LogicalTypeID>{LogicalTypeID::STRING, LogicalTypeID::STRING});
+    function->tableFunc = tableFunc;
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = initSharedState;
+    function->initLocalStateFunc = TableFunction::initEmptyLocalState;
+    functionSet.push_back(std::move(function));
+    return functionSet;
+}
+
+} // namespace postgres_extension
+} // namespace kuzu

--- a/extension/postgres/src/include/function/sql_query.h
+++ b/extension/postgres/src/include/function/sql_query.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "common/types/types.h"
+#include "function/table/bind_data.h"
+#include "function/table/table_function.h"
+
+namespace kuzu {
+namespace postgres_extension {
+
+struct SqlQueryFunction final {
+    static constexpr const char* name = "sql_query";
+
+    static function::function_set getFunctionSet();
+};
+
+} // namespace postgres_extension
+} // namespace kuzu

--- a/extension/postgres/src/include/storage/attached_postgres_database.h
+++ b/extension/postgres/src/include/storage/attached_postgres_database.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "connector/postgres_connector.h"
+#include "storage/attached_duckdb_database.h"
+
+namespace kuzu {
+namespace postgres_extension {
+
+class AttachedPostgresDatabase final : public duckdb_extension::AttachedDuckDBDatabase {
+public:
+    AttachedPostgresDatabase(std::string dbName, std::string dbType,
+        std::unique_ptr<extension::CatalogExtension> catalog,
+        std::unique_ptr<PostgresConnector> connector, std::string attachedCatalogNameInDuckDB)
+        : duckdb_extension::AttachedDuckDBDatabase{std::move(dbName), std::move(dbType),
+              std::move(catalog), std::move(connector)},
+          attachedCatalogNameInDuckDB{std::move(attachedCatalogNameInDuckDB)} {}
+
+    std::unique_ptr<duckdb::MaterializedQueryResult> executeQuery(const std::string& query) const {
+        return connector->executeQuery(query);
+    }
+
+public:
+    std::string getAttachedCatalogNameInDuckDB() const { return attachedCatalogNameInDuckDB; }
+
+private:
+    std::string attachedCatalogNameInDuckDB;
+};
+
+} // namespace postgres_extension
+} // namespace kuzu

--- a/extension/postgres/src/main/postgres_extension.cpp
+++ b/extension/postgres/src/main/postgres_extension.cpp
@@ -1,5 +1,6 @@
 #include "main/postgres_extension.h"
 
+#include "function/sql_query.h"
 #include "main/client_context.h"
 #include "main/database.h"
 #include "storage/postgres_storage.h"
@@ -10,6 +11,7 @@ namespace postgres_extension {
 void PostgresExtension::load(main::ClientContext* context) {
     auto db = context->getDatabase();
     db->registerStorageExtension(EXTENSION_NAME, std::make_unique<PostgresStorageExtension>(db));
+    extension::ExtensionUtils::addTableFunc<SqlQueryFunction>(*db);
 }
 
 } // namespace postgres_extension

--- a/extension/postgres/src/storage/postgres_storage.cpp
+++ b/extension/postgres/src/storage/postgres_storage.cpp
@@ -8,8 +8,7 @@
 #include "connector/postgres_connector.h"
 #include "extension/extension.h"
 #include "function/clear_cache.h"
-#include "storage/attached_duckdb_database.h"
-#include "storage/duckdb_storage.h"
+#include "storage/attached_postgres_database.h"
 
 namespace kuzu {
 namespace postgres_extension {
@@ -36,8 +35,8 @@ std::unique_ptr<main::AttachedDatabase> attachPostgres(std::string dbName, std::
     auto catalog = std::make_unique<duckdb_extension::DuckDBCatalog>(dbPath, catalogName,
         schemaName, clientContext, *connector, attachOption);
     catalog->init();
-    return std::make_unique<duckdb_extension::AttachedDuckDBDatabase>(dbName,
-        PostgresStorageExtension::DB_TYPE, std::move(catalog), std::move(connector));
+    return std::make_unique<AttachedPostgresDatabase>(dbName, PostgresStorageExtension::DB_TYPE,
+        std::move(catalog), std::move(connector), catalogName);
 }
 
 PostgresStorageExtension::PostgresStorageExtension(main::Database* database)

--- a/extension/postgres/test/test_files/sql_query.test
+++ b/extension/postgres/test/test_files/sql_query.test
@@ -7,13 +7,64 @@
 ---- ok
 -STATEMENT ATTACH 'dbname=pgscan user=ci host=localhost' as tinysnb (dbtype POSTGRES);
 ---- ok
+-STATEMENT CALL SQL_QUERY('tinysnb', 'select * from person') RETURN *
+---- 8
+0|Alice|1|True|False|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10,5]|[Aida]|1.731000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
+10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|2|False|True|83|4.900000|1990-11-27|2023-02-21 13:25:30|3 years 2 days 13:02:00|[10,11,12,3,4,5,6,7]|[Ad,De,Hi,Kye,Orlan]|1.323000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a18
+2|Bob|2|True|False|30|5.100000|1900-01-01|2008-11-03 15:25:30.000526|10 years 5 months 13:00:00.000024|[12,8]|[Bobby]|0.990000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+3|Carol|1|False|True|45|5.000000|1940-06-22|1911-08-20 02:32:21|48:24:11|[4,5]|[Carmen,Fred]|1.000000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13
+5|Dan|2|False|True|20|4.800000|1950-07-23|2031-11-30 12:25:30|10 years 5 months 13:00:00.000024|[1,9]|[Wolfeschlegelstein,Daniel]|1.300000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14
+7|Elizabeth|1|False|True|20|4.700000|1980-10-26|1976-12-23 11:21:42|48:24:11|[2]|[Ein]|1.463000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15
+8|Farooq|2|True|False|25|4.500000|1980-10-26|1972-07-31 13:22:30.678559|00:18:00.024|[3,4,5,6,7]|[Fesdwe]|1.510000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a16
+9|Greg|2|False|False|40|4.900000|1980-10-26|1976-12-23 11:21:42|10 years 5 months 13:00:00.000024|[1]|[Grad]|1.600000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a17
+-STATEMENT create node table person_copy (ID INt64, fName StRING, gender INT64, isStudent BoOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration interval, workedHours INT64[], usedNames STRING[], height double, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT COPY person_copy FROM (CALL SQL_QUERY('tinysnb', 'select * from person') RETURN *);
+---- ok
+-STATEMENT MATCH (p:person_copy) return p.*;
+---- 8
+0|Alice|1|True|False|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10,5]|[Aida]|1.731000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
+10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|2|False|True|83|4.900000|1990-11-27|2023-02-21 13:25:30|3 years 2 days 13:02:00|[10,11,12,3,4,5,6,7]|[Ad,De,Hi,Kye,Orlan]|1.323000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a18
+2|Bob|2|True|False|30|5.100000|1900-01-01|2008-11-03 15:25:30.000526|10 years 5 months 13:00:00.000024|[12,8]|[Bobby]|0.990000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+3|Carol|1|False|True|45|5.000000|1940-06-22|1911-08-20 02:32:21|48:24:11|[4,5]|[Carmen,Fred]|1.000000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13
+5|Dan|2|False|True|20|4.800000|1950-07-23|2031-11-30 12:25:30|10 years 5 months 13:00:00.000024|[1,9]|[Wolfeschlegelstein,Daniel]|1.300000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14
+7|Elizabeth|1|False|True|20|4.700000|1980-10-26|1976-12-23 11:21:42|48:24:11|[2]|[Ein]|1.463000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15
+8|Farooq|2|True|False|25|4.500000|1980-10-26|1972-07-31 13:22:30.678559|00:18:00.024|[3,4,5,6,7]|[Fesdwe]|1.510000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a16
+9|Greg|2|False|False|40|4.900000|1980-10-26|1976-12-23 11:21:42|10 years 5 months 13:00:00.000024|[1]|[Grad]|1.600000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a17
+-STATEMENT CALL SQL_QUERY('tinysnb', 'select name from organisation') RETURN *
+---- 3
+ABFsUni
+CsWork
+DEsWork
+-STATEMENT CALL SQL_QUERY('tinysnb', 'select organisation.name, person.fname from organisation INNER JOIN person ON organisation.id = person.id + 1') RETURN *
+---- 3
+ABFsUni|Alice
+CsWork|Carol
+DEsWork|Dan
+-STATEMENT CALL SQL_QUERY('tinysnb', 'select organisation.name, person.fname from organisation INNER JOIN person ON organisation.id = person.id') RETURN *
+---- 0
+-STATEMENT CALL SQL_QUERY('tinysnb', 'select organisation.id, organisation.name, person.fname from organisation LEFT JOIN person ON organisation.id = person.id + 3') RETURN id, name, fname
+---- 3
+1|ABFsUni|
+4|CsWork|
+6|DEsWork|Carol
+
+-CASE SqlQueryError
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/postgres/build/libpostgres.kuzu_extension"
+---- ok
+-STATEMENT ATTACH 'dbname=pgscan user=ci host=localhost' as tinysnb (dbtype POSTGRES);
+---- ok
 -STATEMENT CALL SQL_QUERY('tinysnb', 'create table tep(id int)') RETURN *
----- 1
-
-
--STATEMENT CREATE NODE TABLE PERSON (ID INT64, PRIMARY KEY(ID));
----- ok
--STATEMENT COPY PERSON FROM (CALL SQL_QUERY('tinysnb', 'select id from person') RETURN *);
----- ok
--STATEMENT MATCH (p:person) return p.*
----- 1
+---- error
+Binder Error: No fields returned by query "create table tep(id int)" - the query must be a SELECT statement that returns at least one column
+-STATEMENT CALL SQL_QUERY('tinysnb', 'select organisation.name, person.fname as name from organisation, person') RETURN *
+---- error
+Binder Error: table "postgres_query" has duplicate column name "name"
+-STATEMENT CALL SQL_QUERY('tinysnb', 'INSERT INTO PERSON VALUES(5)') RETURN *
+---- error
+Binder Error: No fields returned by query "INSERT INTO PERSON VALUES(5)" - the query must be a SELECT statement that returns at least one column
+-STATEMENT CALL SQL_QUERY('tinysnb', 'SELECT * PERSON') RETURN *
+---- error
+Binder Error: Failed to prepare query "SELECT * PERSON": ERROR:  syntax error at or near "PERSON"
+LINE 1: SELECT * PERSON
+                 ^

--- a/extension/postgres/test/test_files/sql_query.test
+++ b/extension/postgres/test/test_files/sql_query.test
@@ -1,0 +1,19 @@
+-DATASET CSV empty
+
+--
+
+-CASE SqlQueryInPG
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/postgres/build/libpostgres.kuzu_extension"
+---- ok
+-STATEMENT ATTACH 'dbname=pgscan user=ci host=localhost' as tinysnb (dbtype POSTGRES);
+---- ok
+-STATEMENT CALL SQL_QUERY('tinysnb', 'create table tep(id int)') RETURN *
+---- 1
+
+
+-STATEMENT CREATE NODE TABLE PERSON (ID INT64, PRIMARY KEY(ID));
+---- ok
+-STATEMENT COPY PERSON FROM (CALL SQL_QUERY('tinysnb', 'select id from person') RETURN *);
+---- ok
+-STATEMENT MATCH (p:person) return p.*
+---- 1

--- a/extension/postgres/test/test_files/sql_query.test
+++ b/extension/postgres/test/test_files/sql_query.test
@@ -68,3 +68,11 @@ Binder Error: No fields returned by query "INSERT INTO PERSON VALUES(5)" - the q
 Binder Error: Failed to prepare query "SELECT * PERSON": ERROR:  syntax error at or near "PERSON"
 LINE 1: SELECT * PERSON
                  ^
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/sqlite/build/libsqlite.kuzu_extension"
+---- ok
+-STATEMENT ATTACH '${KUZU_ROOT_DIRECTORY}/extension/sqlite/test/sqlite_database/tinysnb' as sqlitets (dbtype sqlite);
+---- 1
+Attached database successfully.
+-STATEMENT CALL SQL_QUERY('sqlitets', "SELECT * FROM PERSON") RETURN *
+---- error
+Binder exception: sql queries can only be executed in attached postgres.

--- a/src/include/main/attached_database.h
+++ b/src/include/main/attached_database.h
@@ -6,6 +6,10 @@
 #include "extension/catalog_extension.h"
 #include "transaction/transaction_manager.h"
 
+namespace duckdb {
+class MaterializedQueryResult;
+}
+
 namespace kuzu {
 namespace storage {
 class StorageManager;
@@ -27,7 +31,14 @@ public:
 
     catalog::Catalog* getCatalog() { return catalog.get(); }
 
+    std::unique_ptr<duckdb::MaterializedQueryResult> executeQuery(const std::string& query);
+
     void invalidateCache();
+
+    template<class TARGET>
+    const TARGET& constCast() const {
+        return common::ku_dynamic_cast<const TARGET&>(*this);
+    }
 
 protected:
     std::string dbName;

--- a/src/include/main/database_manager.h
+++ b/src/include/main/database_manager.h
@@ -11,7 +11,7 @@ public:
 
     void registerAttachedDatabase(std::unique_ptr<AttachedDatabase> attachedDatabase);
     bool hasAttachedDatabase(const std::string& name);
-    AttachedDatabase* getAttachedDatabase(const std::string& name);
+    KUZU_API AttachedDatabase* getAttachedDatabase(const std::string& name);
     void detachDatabase(const std::string& databaseName);
     std::string getDefaultDatabase() const { return defaultDatabase; }
     bool hasDefaultDatabase() const { return defaultDatabase != ""; }


### PR DESCRIPTION
This PR introduces an utility function `SQL_QUERY` which allows users to execute any read sql queries in postgres and retrieve the result in kuzu.

Currently, the query to be executed in postgres must be a read-only query. 

## Grammar:
```sql
SQL_QUERY(ATTACHED_PG_DB, PG_QUERY)
```
### Parameters: 
`ATTCHED_PG_DB`: is the postgres database name attached previously.
`SQL_QUERY`: is the query to be executed in the attached postgres instance.

### Result:
The queryResult in kuzu format.

## Example:
The remote postgres database must be attached first by the attach command:
```sql
ATTACH 'dbname=university user=postgres host=localhost password=testpassword port=5432' AS uw (dbtype postgres);
```

## Features supported in this PR:
Use `CALL` statement to execute the PG_QUERY function and retrieve the result.
```
CALL SQL_QUERY(uw, 'select * from person')
```

## Features to support in the next PRs.
After attaching the postgres database, users can utilize the `LOAD FROM` statement to scan from any postgres query result:
```
LOAD FROM SQL_QUERY(uw, "select name, award from professor INNER JOIN scientist  ON professor.ID = scientist.ID;")
RETURN name, grade;
```

Or use the `COPY FROM` clause to do data ingestion from a complicated PG join query (which is request by the user: https://github.com/kuzudb/kuzu/issues/4970):
```
COPY city FROM SQL_QUERY(uw, "select city.name, country.name
from city JOIN country 
ON country.id = city.country_id
WHERE country.name in ('Germany', 'France')
```
