### PR TITLE
Make QueryResult::toString const

### DIFF
--- a/examples/rust/src/main.rs
+++ b/examples/rust/src/main.rs
@@ -16,9 +16,9 @@ fn main() -> Result<(), Error> {
     connection.query("CREATE (:Person {name: 'Bob', age: 30});")?;
 
     // Execute a simple query.
-    let mut result = connection.query("MATCH (a:Person) RETURN a.name AS NAME, a.age AS AGE;")?;
+    let result = connection.query("MATCH (a:Person) RETURN a.name AS NAME, a.age AS AGE;")?;
 
     // Print query result.
-    println!("{}", result.display());
+    println!("{}", result);
     Ok(())
 }

--- a/src/include/main/query_result.h
+++ b/src/include/main/query_result.h
@@ -104,7 +104,7 @@ public:
     /**
      * @return string of first query result.
      */
-    KUZU_API std::string toString();
+    KUZU_API std::string toString() const;
 
     /**
      * @brief Resets the result tuple iterator.
@@ -140,6 +140,8 @@ private:
         std::vector<common::LogicalType> columnTypes);
     void initResultTableAndIterator(std::shared_ptr<processor::FactorizedTable> factorizedTable_);
     void validateQuerySucceed() const;
+    std::pair<std::unique_ptr<processor::FlatTuple>, std::unique_ptr<processor::FlatTupleIterator>>
+    getIterator() const;
 
 private:
     // execution status

--- a/tools/rust_api/include/kuzu_rs.h
+++ b/tools/rust_api/include/kuzu_rs.h
@@ -112,7 +112,7 @@ inline std::unique_ptr<kuzu::main::QueryResult> connection_query(kuzu::main::Con
 rust::String prepared_statement_error_message(const kuzu::main::PreparedStatement& statement);
 
 /* QueryResult */
-rust::String query_result_to_string(kuzu::main::QueryResult& result);
+rust::String query_result_to_string(const kuzu::main::QueryResult& result);
 rust::String query_result_get_error_message(const kuzu::main::QueryResult& result);
 
 double query_result_get_compiling_time(const kuzu::main::QueryResult& result);

--- a/tools/rust_api/src/ffi.rs
+++ b/tools/rust_api/src/ffi.rs
@@ -205,7 +205,7 @@ pub(crate) mod ffi {
         type QueryResult<'db>;
 
         #[namespace = "kuzu_rs"]
-        fn query_result_to_string(query_result: Pin<&mut QueryResult>) -> String;
+        fn query_result_to_string(query_result: &QueryResult) -> String;
         fn isSuccess(&self) -> bool;
         #[namespace = "kuzu_rs"]
         fn query_result_get_error_message(query_result: &QueryResult) -> String;

--- a/tools/rust_api/src/kuzu_rs.cpp
+++ b/tools/rust_api/src/kuzu_rs.cpp
@@ -100,7 +100,7 @@ rust::String prepared_statement_error_message(const kuzu::main::PreparedStatemen
     return rust::String(statement.getErrorMessage());
 }
 
-rust::String query_result_to_string(kuzu::main::QueryResult& result) {
+rust::String query_result_to_string(const kuzu::main::QueryResult& result) {
     return rust::String(result.toString());
 }
 

--- a/tools/rust_api/src/lib.rs
+++ b/tools/rust_api/src/lib.rs
@@ -15,7 +15,7 @@
 //! conn.query("CREATE (:Person {name: 'Bob', age: 30});")?;
 //!
 //! let mut result = conn.query("MATCH (a:Person) RETURN a.name AS NAME, a.age AS AGE;")?;
-//! println!("{}", result.display());
+//! println!("{}", result);
 //! # temp_dir.close()?;
 //! # Ok(())
 //! # }


### PR DESCRIPTION
Having toString mutate the query result means that in rust we can't use the Display trait (safely anyway). I think it's also somewhat unintuitive for it to mutate itself in this case.

I'd actually looked at this a while ago but had been attempting to separate the iterator from the QueryResult entirely (e.g. have a `QueryResult::iter` method that produces an iterator which has getNext/hasNext functions instead of having that be directly on the QueryResult, but that affected a lot of stuff so I never finished it. 
Instead, I've made it so that QueryResult::toString uses its own FlatTupleIterator/FlatTuple and avoids mutating the one from the QueryResult. 

There will be a subtle difference in behaviour, as you can no longer start consuming the results and then use `toString` to print the remaining results, but [hopefully](https://xkcd.com/1172/) that's not behaviour anyone was relying on.