### PR TITLE
Support handling null/deleted nodes during vector index creation

### DIFF
--- a/src/function/table/hnsw/create_hnsw_index.cpp
+++ b/src/function/table/hnsw/create_hnsw_index.cpp
@@ -69,7 +69,7 @@ static offset_t createInMemHNSWTableFunc(const TableFuncInput& input, TableFuncO
     }
     const auto& hnswIndex = sharedState->hnswIndex;
     offset_t numNodesInserted = 0;
-    for (auto i = morsel.startOffset; i <= morsel.endOffset; i++) {
+    for (auto i = morsel.startOffset; i < morsel.endOffset; i++) {
         numNodesInserted += hnswIndex->insert(i,
             input.localState->ptrCast<CreateInMemHNSWLocalState>()->upperVisited,
             input.localState->ptrCast<CreateInMemHNSWLocalState>()->lowerVisited);

--- a/src/function/table/hnsw/create_hnsw_index.cpp
+++ b/src/function/table/hnsw/create_hnsw_index.cpp
@@ -68,12 +68,14 @@ static offset_t createInMemHNSWTableFunc(const TableFuncInput& input, TableFuncO
         return 0;
     }
     const auto& hnswIndex = sharedState->hnswIndex;
+    offset_t numNodesInserted = 0;
     for (auto i = morsel.startOffset; i <= morsel.endOffset; i++) {
-        hnswIndex->insert(i, input.localState->ptrCast<CreateInMemHNSWLocalState>()->upperVisited,
+        numNodesInserted += hnswIndex->insert(i,
+            input.localState->ptrCast<CreateInMemHNSWLocalState>()->upperVisited,
             input.localState->ptrCast<CreateInMemHNSWLocalState>()->lowerVisited);
     }
-    sharedState->numNodesInserted.fetch_add(morsel.endOffset - morsel.startOffset);
-    return morsel.endOffset - morsel.startOffset;
+    sharedState->numNodesInserted.fetch_add(numNodesInserted);
+    return numNodesInserted;
 }
 
 static double createInMemHNSWProgressFunc(TableFuncSharedState* sharedState) {

--- a/src/function/table/hnsw/create_hnsw_index.cpp
+++ b/src/function/table/hnsw/create_hnsw_index.cpp
@@ -26,7 +26,7 @@ CreateInMemHNSWSharedState::CreateInMemHNSWSharedState(const CreateHNSWIndexBind
       nodeTable{bindData.context->getStorageManager()
                     ->getTable(bindData.tableEntry->getTableID())
                     ->cast<storage::NodeTable>()},
-      numNodes{bindData.numNodes}, bindData{&bindData} {
+      numNodes{bindData.maxOffset}, bindData{&bindData} {
     hnswIndex = std::make_shared<storage::InMemHNSWIndex>(bindData.context, nodeTable,
         bindData.tableEntry->getColumnID(bindData.propertyID), bindData.config.copy());
 }
@@ -44,9 +44,8 @@ static std::unique_ptr<TableFuncBindData> createInMemHNSWBindFunc(main::ClientCo
     auto propertyID = tableEntry->getPropertyID(columnName);
     auto config = storage::HNSWIndexConfig{input->optionalParams};
     auto numNodes = table.getStats(context->getTransaction()).getTableCard();
-    auto maxOffset = numNodes > 0 ? numNodes - 1 : 0;
     return std::make_unique<CreateHNSWIndexBindData>(context, indexName, tableEntry, propertyID,
-        numNodes, maxOffset, std::move(config));
+        numNodes, std::move(config));
 }
 
 static std::unique_ptr<TableFuncSharedState> initCreateInMemHNSWSharedState(
@@ -75,7 +74,7 @@ static offset_t createInMemHNSWTableFunc(const TableFuncInput& input, TableFuncO
             input.localState->ptrCast<CreateInMemHNSWLocalState>()->lowerVisited);
     }
     sharedState->numNodesInserted.fetch_add(numNodesInserted);
-    return numNodesInserted;
+    return morsel.endOffset - morsel.startOffset;
 }
 
 static double createInMemHNSWProgressFunc(TableFuncSharedState* sharedState) {
@@ -125,7 +124,7 @@ static std::unique_ptr<processor::PhysicalOperator> getPhysicalPlan(
         finalizeSharedState->funcState->ptrCast<FinalizeHNSWSharedState>();
     finalizeFuncSharedState->hnswIndex = createFuncSharedState->hnswIndex;
     finalizeFuncSharedState->numRows =
-        (logicalCallBoundData->numNodes + StorageConfig::NODE_GROUP_SIZE - 1) /
+        (logicalCallBoundData->numRows + StorageConfig::NODE_GROUP_SIZE - 1) /
         StorageConfig::NODE_GROUP_SIZE;
     finalizeFuncSharedState->maxMorselSize = 1;
     finalizeFuncSharedState->bindData = logicalCallBoundData->copy();

--- a/src/function/table/hnsw/create_hnsw_index.cpp
+++ b/src/function/table/hnsw/create_hnsw_index.cpp
@@ -26,7 +26,7 @@ CreateInMemHNSWSharedState::CreateInMemHNSWSharedState(const CreateHNSWIndexBind
       nodeTable{bindData.context->getStorageManager()
                     ->getTable(bindData.tableEntry->getTableID())
                     ->cast<storage::NodeTable>()},
-      numNodes{bindData.maxOffset}, bindData{&bindData} {
+      numNodes{bindData.numRows}, bindData{&bindData} {
     hnswIndex = std::make_shared<storage::InMemHNSWIndex>(bindData.context, nodeTable,
         bindData.tableEntry->getColumnID(bindData.propertyID), bindData.config.copy());
 }

--- a/src/include/function/table/hnsw/hnsw_index_functions.h
+++ b/src/include/function/table/hnsw/hnsw_index_functions.h
@@ -14,18 +14,16 @@ struct CreateHNSWIndexBindData final : TableFuncBindData {
     catalog::TableCatalogEntry* tableEntry;
     common::property_id_t propertyID;
     storage::HNSWIndexConfig config;
-    common::offset_t numNodes;
 
     CreateHNSWIndexBindData(main::ClientContext* context, std::string indexName,
         catalog::TableCatalogEntry* tableEntry, common::property_id_t propertyID,
-        common::offset_t numNodes, common::offset_t maxOffset, storage::HNSWIndexConfig config)
-        : TableFuncBindData{maxOffset}, context{context}, indexName{std::move(indexName)},
-          tableEntry{tableEntry}, propertyID{propertyID}, config{std::move(config)},
-          numNodes{numNodes} {}
+        common::offset_t numNodes, storage::HNSWIndexConfig config)
+        : TableFuncBindData{numNodes}, context{context}, indexName{std::move(indexName)},
+          tableEntry{tableEntry}, propertyID{propertyID}, config{std::move(config)} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
         return std::make_unique<CreateHNSWIndexBindData>(context, indexName, tableEntry, propertyID,
-            numNodes, numRows, config.copy());
+            numRows, config.copy());
     }
 };
 

--- a/src/include/storage/index/hnsw_graph.h
+++ b/src/include/storage/index/hnsw_graph.h
@@ -31,6 +31,7 @@ public:
         common::table_id_t tableID, common::column_id_t columnID);
 
     float* getEmbedding(common::offset_t offset) const;
+    bool isNull(common::offset_t offset) const;
 
 private:
     CachedColumn* data;

--- a/src/include/storage/index/hnsw_index.h
+++ b/src/include/storage/index/hnsw_index.h
@@ -104,7 +104,11 @@ struct InMemHNSWLayerInfo {
 class InMemHNSWLayer {
 public:
     explicit InMemHNSWLayer(MemoryManager* mm, InMemHNSWLayerInfo info);
-    void setEntryPoint(common::offset_t offset) { entryPoint.store(offset); }
+    common::offset_t compareAndSwapEntryPoint(common::offset_t offset) {
+        common::offset_t oldOffset = common::INVALID_OFFSET;
+        entryPoint.compare_exchange_strong(oldOffset, offset);
+        return oldOffset;
+    }
     common::offset_t getEntryPoint() const { return entryPoint.load(); }
 
     void insert(common::offset_t offset, common::offset_t entryPoint_, VisitedState& visited);

--- a/src/include/storage/index/hnsw_index.h
+++ b/src/include/storage/index/hnsw_index.h
@@ -135,7 +135,7 @@ public:
     common::offset_t getLowerEntryPoint() const override { return lowerLayer->getEntryPoint(); }
 
     // Note that the input is only `offset`, as we assume embeddings are already cached in memory.
-    void insert(common::offset_t offset, VisitedState& upperVisited, VisitedState& lowerVisited);
+    bool insert(common::offset_t offset, VisitedState& upperVisited, VisitedState& lowerVisited);
     void finalize(MemoryManager& mm, common::node_group_idx_t nodeGroupIdx,
         const HNSWIndexPartitionerSharedState& partitionerSharedState);
 

--- a/src/storage/index/hnsw_graph.cpp
+++ b/src/storage/index/hnsw_graph.cpp
@@ -27,6 +27,13 @@ float* InMemEmbeddings::getEmbedding(common::offset_t offset) const {
     return &listChunk.getDataColumnChunk()->getData<float>()[offsetInGroup * typeInfo.dimension];
 }
 
+bool InMemEmbeddings::isNull(common::offset_t offset) const {
+    auto [nodeGroupIdx, offsetInGroup] = StorageUtils::getNodeGroupIdxAndOffsetInChunk(offset);
+    KU_ASSERT(nodeGroupIdx < data->columnChunks.size());
+    const auto& listChunk = data->columnChunks[nodeGroupIdx]->cast<ListChunkData>();
+    return listChunk.isNull(offsetInGroup);
+}
+
 OnDiskEmbeddingScanState::OnDiskEmbeddingScanState(const transaction::Transaction* transaction,
     MemoryManager* mm, NodeTable& nodeTable, common::column_id_t columnID) {
     std::vector<common::column_id_t> columnIDs;

--- a/src/storage/index/hnsw_graph.cpp
+++ b/src/storage/index/hnsw_graph.cpp
@@ -11,8 +11,8 @@ namespace storage {
 InMemEmbeddings::InMemEmbeddings(transaction::Transaction* transaction, EmbeddingTypeInfo typeInfo,
     common::table_id_t tableID, common::column_id_t columnID)
     : EmbeddingColumn{std::move(typeInfo)} {
-    auto key = common::stringFormat("{}-{}", tableID, columnID);
     auto& cacheManager = transaction->getLocalCacheManager();
+    auto key = CachedColumn::getKey(tableID, columnID);
     if (cacheManager.contains(key)) {
         data = transaction->getLocalCacheManager().at(key).cast<CachedColumn>();
     } else {

--- a/src/storage/index/hnsw_index.cpp
+++ b/src/storage/index/hnsw_index.cpp
@@ -248,10 +248,10 @@ InMemHNSWIndex::InMemHNSWIndex(const main::ClientContext* context, NodeTable& ta
             this->config.alpha, this->config.efc});
 }
 
-void InMemHNSWIndex::insert(common::offset_t offset, VisitedState& upperVisited,
+bool InMemHNSWIndex::insert(common::offset_t offset, VisitedState& upperVisited,
     VisitedState& lowerVisited) {
     if (embeddings->isNull(offset)) {
-        return;
+        return false;
     }
     auto lowerEntryPoint = upperLayer->searchNN(offset, upperLayer->getEntryPoint());
     lowerLayer->insert(offset, lowerEntryPoint, lowerVisited);
@@ -259,6 +259,7 @@ void InMemHNSWIndex::insert(common::offset_t offset, VisitedState& upperVisited,
     if (rand <= INSERT_TO_UPPER_LAYER_RAND_UPPER_BOUND * config.pu) {
         upperLayer->insert(offset, upperLayer->getEntryPoint(), upperVisited);
     }
+    return true;
 }
 
 // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const function.

--- a/src/storage/index/hnsw_index.cpp
+++ b/src/storage/index/hnsw_index.cpp
@@ -28,9 +28,8 @@ InMemHNSWLayer::InMemHNSWLayer(MemoryManager* mm, InMemHNSWLayerInfo info)
 void InMemHNSWLayer::insert(common::offset_t offset, common::offset_t entryPoint_,
     VisitedState& visited) {
     if (entryPoint_ == common::INVALID_OFFSET) {
-        const auto entryPointInCurrentLayer = getEntryPoint();
+        const auto entryPointInCurrentLayer = compareAndSwapEntryPoint(offset);
         if (entryPointInCurrentLayer == common::INVALID_OFFSET) {
-            setEntryPoint(offset);
             // The layer is empty. No edges need to be created.
             return;
         }

--- a/src/storage/index/hnsw_index.cpp
+++ b/src/storage/index/hnsw_index.cpp
@@ -250,6 +250,9 @@ InMemHNSWIndex::InMemHNSWIndex(const main::ClientContext* context, NodeTable& ta
 
 void InMemHNSWIndex::insert(common::offset_t offset, VisitedState& upperVisited,
     VisitedState& lowerVisited) {
+    if (embeddings->isNull(offset)) {
+        return;
+    }
     auto lowerEntryPoint = upperLayer->searchNN(offset, upperLayer->getEntryPoint());
     lowerLayer->insert(offset, lowerEntryPoint, lowerVisited);
     const auto rand = randomEngine.nextRandomInteger(INSERT_TO_UPPER_LAYER_RAND_UPPER_BOUND);

--- a/src/storage/store/list_chunk_data.cpp
+++ b/src/storage/store/list_chunk_data.cpp
@@ -275,17 +275,18 @@ void ListChunkData::write(const ValueVector* vector, offset_t offsetInVector,
     auto appendSize =
         vector->isNull(offsetInVector) ? 0 : vector->getValue<list_entry_t>(offsetInVector).size;
     dataColumnChunk->resize(dataColumnChunk->getNumValues() + appendSize);
-    // TODO(Guodong): Do not set vector to a new state.
-    auto dataVector = ListVector::getDataVector(vector);
-    dataVector->setState(std::make_unique<DataChunkState>());
-    dataVector->state->getSelVectorUnsafe().setToFiltered();
-    copyListValues(vector->getValue<list_entry_t>(offsetInVector), dataVector);
     while (offsetInChunk >= numValues) {
         appendNullList();
     }
     auto isNull = vector->isNull(offsetInVector);
     nullData->setNull(offsetInChunk, isNull);
     if (!isNull) {
+        // TODO(Guodong): Do not set vector to a new state.
+        auto dataVector = ListVector::getDataVector(vector);
+        dataVector->setState(std::make_unique<DataChunkState>());
+        dataVector->state->getSelVectorUnsafe().setToFiltered();
+        copyListValues(vector->getValue<list_entry_t>(offsetInVector), dataVector);
+
         sizeColumnChunk->setValue<list_size_t>(appendSize, offsetInChunk);
         setOffsetChunkValue(dataColumnChunk->getNumValues(), offsetInChunk);
     }

--- a/src/storage/store/list_chunk_data.cpp
+++ b/src/storage/store/list_chunk_data.cpp
@@ -272,9 +272,6 @@ void ListChunkData::write(ColumnChunkData* chunk, ColumnChunkData* dstOffsets, R
 void ListChunkData::write(const ValueVector* vector, offset_t offsetInVector,
     offset_t offsetInChunk) {
     checkOffsetSortedAsc = true;
-    auto selVector = std::make_unique<SelectionVector>(1);
-    selVector->setToFiltered();
-    selVector->operator[](0) = offsetInVector;
     auto appendSize =
         vector->isNull(offsetInVector) ? 0 : vector->getValue<list_entry_t>(offsetInVector).size;
     dataColumnChunk->resize(dataColumnChunk->getNumValues() + appendSize);

--- a/test/test_files/function/hnsw/small.test
+++ b/test/test_files/function/hnsw/small.test
@@ -40,6 +40,28 @@
 996
 995
 
+-CASE NullAndDeletedVecs
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
+---- ok
+-STATEMENT MATCH (e:embeddings) WHERE e.id < 995 DELETE e
+---- ok
+-STATEMENT CREATE (e:embeddings{id: 0})
+---- ok
+-STATEMENT CREATE (e:embeddings{id: 1000})
+---- ok
+-STATEMENT CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec', distFunc := 'l2');
+---- ok
+-STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 6) RETURN nn.id ORDER BY _distance;
+-CHECK_ORDER
+---- 5
+998
+999
+997
+996
+995
+
 -CASE 8DimL2
 -STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
 ---- ok

--- a/test/test_files/function/hnsw/small.test
+++ b/test/test_files/function/hnsw/small.test
@@ -14,12 +14,31 @@
 -STATEMENT CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec', distFunc := 'l2');
 ---- ok
 -STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 6) RETURN nn.id ORDER BY _distance;
+-CHECK_ORDER
 ---- 5
-995
-996
-997
 998
 999
+997
+996
+995
+
+-CASE DeletedVecs
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
+---- ok
+-STATEMENT MATCH (e:embeddings) WHERE e.id < 995 DELETE e
+---- ok
+-STATEMENT CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec', distFunc := 'l2');
+---- ok
+-STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 6) RETURN nn.id ORDER BY _distance;
+-CHECK_ORDER
+---- 5
+998
+999
+997
+996
+995
 
 -CASE 8DimL2
 -STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));

--- a/test/test_files/function/hnsw/small.test
+++ b/test/test_files/function/hnsw/small.test
@@ -2,6 +2,25 @@
 
 --
 
+-CASE NullVecs
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT CREATE (e:embeddings{id: 0})
+---- ok
+-STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',', skip=995);
+---- ok
+-STATEMENT CREATE (e:embeddings{id: 1000})
+---- ok
+-STATEMENT CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec', distFunc := 'l2');
+---- ok
+-STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 6) RETURN nn.id ORDER BY _distance;
+---- 5
+995
+996
+997
+998
+999
+
 -CASE 8DimL2
 -STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
 ---- ok

--- a/test/test_files/function/hnsw/small.test
+++ b/test/test_files/function/hnsw/small.test
@@ -11,9 +11,9 @@
 ---- ok
 -STATEMENT CREATE (e:embeddings{id: 1000})
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'l2');
 ---- ok
--STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 6) RETURN nn.id ORDER BY _distance;
+-STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 6) RETURN nn.id ORDER BY _distance;
 -CHECK_ORDER
 ---- 5
 998
@@ -29,9 +29,9 @@
 ---- ok
 -STATEMENT MATCH (e:embeddings) WHERE e.id < 995 DELETE e
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'l2');
 ---- ok
--STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 6) RETURN nn.id ORDER BY _distance;
+-STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 6) RETURN nn.id ORDER BY _distance;
 -CHECK_ORDER
 ---- 5
 998
@@ -51,9 +51,9 @@
 ---- ok
 -STATEMENT CREATE (e:embeddings{id: 1000})
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('e_hnsw_index', 'embeddings', 'vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'l2');
 ---- ok
--STATEMENT CALL QUERY_HNSW_INDEX('e_hnsw_index', 'embeddings', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 6) RETURN nn.id ORDER BY _distance;
+-STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 6) RETURN nn.id ORDER BY _distance;
 -CHECK_ORDER
 ---- 5
 998


### PR DESCRIPTION
# Description

Skip any nodes whose embeddings vector is marked as null during vector index creation. When caching the embeddings column, mark deleted nodes as null so that they are also skipped.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).