### PR TITLE
Use copyNullMask instead of looping during copies of nulls

### DIFF
--- a/src/common/null_mask.cpp
+++ b/src/common/null_mask.cpp
@@ -28,11 +28,7 @@ bool NullMask::copyNullMask(const uint64_t* srcNullEntries, uint64_t srcOffset,
         bool anyNull = false;
         for (size_t i = 0; i < numBitsToCopy; i++) {
             bool isNull = NullMask::isNull(srcNullEntries, srcOffset + i);
-            if (invert) {
-                NullMask::setNull(dstNullEntries, dstOffset + i, !isNull);
-            } else {
-                NullMask::setNull(dstNullEntries, dstOffset + i, isNull);
-            }
+            NullMask::setNull(dstNullEntries, dstOffset + i, isNull ^ invert);
             anyNull |= isNull;
         }
         return anyNull;

--- a/src/common/null_mask.cpp
+++ b/src/common/null_mask.cpp
@@ -266,10 +266,10 @@ std::pair<bool, bool> NullMask::getMinMax(const uint64_t* nullEntries, uint64_t 
         // Check last entry
         auto mask = NULL_LOWER_MASKS[numValues];
         auto masked = *nullEntries & mask;
-        if (masked == 0 && !min) {
-            return std::make_pair(false, false);
-        } else if (masked == mask && max) {
-            return std::make_pair(true, true);
+        if (masked == 0) {
+            return std::make_pair(false, max);
+        } else if (masked == mask) {
+            return std::make_pair(min, true);
         } else {
             return std::make_pair(false, true);
         }

--- a/src/include/common/null_mask.h
+++ b/src/include/common/null_mask.h
@@ -171,7 +171,8 @@ public:
 
     // Fast calculation of the minimum and maximum null values
     // (essentially just three states, all null, all non-null and some null)
-    static std::pair<bool, bool> getMinMax(const uint64_t* nullEntries, uint64_t numValues);
+    static std::pair<bool, bool> getMinMax(const uint64_t* nullEntries, uint64_t offset,
+        uint64_t numValues);
 
 private:
     static inline std::pair<uint64_t, uint64_t> getNullEntryAndBitPos(uint64_t pos) {

--- a/src/include/storage/store/column_chunk_data.h
+++ b/src/include/storage/store/column_chunk_data.h
@@ -355,7 +355,7 @@ public:
         inMemoryStats.min = inMemoryStats.max = true;
     }
 
-    void copyFromBuffer(uint64_t* srcBuffer, uint64_t srcOffset, uint64_t dstOffset,
+    void copyFromBuffer(const uint64_t* srcBuffer, uint64_t srcOffset, uint64_t dstOffset,
         uint64_t numBits, bool invert = false) {
         if (common::NullMask::copyNullMask(srcBuffer, srcOffset, getData<uint64_t>(), dstOffset,
                 numBits, invert)) {
@@ -365,6 +365,9 @@ public:
             inMemoryStats.max = true;
         }
     }
+
+    void append(const common::ValueVector* vector, const common::SelectionView& selView,
+        common::offset_t startPosInChunk);
 
     // NullChunkData::scan updates the null mask of output vector
     void scan(common::ValueVector& output, common::offset_t offset, common::length_t length,

--- a/src/include/storage/store/column_chunk_data.h
+++ b/src/include/storage/store/column_chunk_data.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <optional>
 #include <variant>
 
 #include "common/data_chunk/sel_vector.h"
@@ -343,8 +344,9 @@ public:
     bool haveAllNullsGuaranteed() const;
 
     void resetToEmpty() override {
-        resetToNoNull();
+        memset(getData(), 0 /* non null */, getBufferSize());
         numValues = 0;
+        inMemoryStats.min = inMemoryStats.max = std::nullopt;
     }
     void resetToNoNull() {
         memset(getData(), 0 /* non null */, getBufferSize());
@@ -356,17 +358,21 @@ public:
     }
 
     void copyFromBuffer(const uint64_t* srcBuffer, uint64_t srcOffset, uint64_t dstOffset,
-        uint64_t numBits, bool invert = false) {
-        if (common::NullMask::copyNullMask(srcBuffer, srcOffset, getData<uint64_t>(), dstOffset,
-                numBits, invert)) {
-            // we pessimistically assume that the buffer contains both true/false values
-            // so the zone map won't skip scans
-            inMemoryStats.min = false;
-            inMemoryStats.max = true;
+        uint64_t numBits) {
+        KU_ASSERT(numBits > 0);
+        common::NullMask::copyNullMask(srcBuffer, srcOffset, getData<uint64_t>(), dstOffset,
+            numBits);
+        auto [min, max] = common::NullMask::getMinMax(srcBuffer, srcOffset, numBits);
+        if (!inMemoryStats.min.has_value() || min < inMemoryStats.min->get<bool>()) {
+            inMemoryStats.min = min;
+        }
+        if (!inMemoryStats.max.has_value() || max > inMemoryStats.max->get<bool>()) {
+            inMemoryStats.max = max;
         }
     }
 
-    void append(const common::ValueVector* vector, const common::SelectionView& selView,
+    // Appends the null data from the vector's null mask
+    void appendNulls(const common::ValueVector* vector, const common::SelectionView& selView,
         common::offset_t startPosInChunk);
 
     // NullChunkData::scan updates the null mask of output vector

--- a/src/storage/compression/compression.cpp
+++ b/src/storage/compression/compression.cpp
@@ -1144,12 +1144,12 @@ std::pair<std::optional<StorageValue>, std::optional<StorageValue>> getMinMaxSto
             if (numValues > 0) {
                 const auto boolData = reinterpret_cast<const uint64_t*>(data);
                 if (!nullMask || nullMask->hasNoNullsGuarantee()) {
-                    auto [minRaw, maxRaw] = NullMask::getMinMax(boolData, numValues);
+                    auto [minRaw, maxRaw] = NullMask::getMinMax(boolData, offset, numValues);
                     returnValue = std::make_pair(std::optional(StorageValue(minRaw)),
                         std::optional(StorageValue(maxRaw)));
                 } else {
                     std::optional<StorageValue> min, max;
-                    for (size_t i = 0; i < numValues; i++) {
+                    for (size_t i = offset; i < offset + numValues; i++) {
                         if (!nullMask || !nullMask->isNull(i)) {
                             auto boolValue = NullMask::isNull(boolData, i);
                             if (!max || boolValue > max->get<bool>()) {

--- a/src/storage/store/column_chunk_data.cpp
+++ b/src/storage/store/column_chunk_data.cpp
@@ -5,6 +5,7 @@
 
 #include "common/data_chunk/sel_vector.h"
 #include "common/exception/copy.h"
+#include "common/null_mask.h"
 #include "common/serializer/deserializer.h"
 #include "common/serializer/serializer.h"
 #include "common/system_config.h"
@@ -507,26 +508,16 @@ void ColumnChunkData::copyVectorToBuffer(ValueVector* vector, offset_t startPosI
     auto bufferToWrite = buffer->getBuffer().data() + startPosInChunk * numBytesPerValue;
     KU_ASSERT(startPosInChunk + selView.getSelSize() <= capacity);
     const auto vectorDataToWriteFrom = vector->getData();
+    if (nullData) {
+        nullData->append(vector, selView, startPosInChunk);
+    }
     if (selView.isUnfiltered()) {
         memcpy(bufferToWrite, vectorDataToWriteFrom, selView.getSelSize() * numBytesPerValue);
-        if (nullData) {
-            // TODO(Guodong): Should be wrapped into nullChunk->append(vector);
-            for (auto i = 0u; i < selView.getSelSize(); i++) {
-                nullData->setNull(startPosInChunk + i, vector->isNull(i));
-            }
-        }
     } else {
         selView.forEach([&](auto pos) {
             memcpy(bufferToWrite, vectorDataToWriteFrom + pos * numBytesPerValue, numBytesPerValue);
             bufferToWrite += numBytesPerValue;
         });
-        if (nullData) {
-            // TODO(Guodong): Should be wrapped into nullChunk->append(vector);
-            for (auto i = 0u; i < selView.getSelSize(); i++) {
-                const auto pos = selView[i];
-                nullData->setNull(startPosInChunk + i, vector->isNull(pos));
-            }
-        }
     }
 }
 
@@ -620,10 +611,7 @@ void BoolChunkData::append(ValueVector* vector, const SelectionView& selView) {
         NullMask::setNull(getData<uint64_t>(), numValues + i, vector->getValue<bool>(pos));
     }
     if (nullData) {
-        for (auto i = 0u; i < selView.getSelSize(); i++) {
-            const auto pos = selView[i];
-            nullData->setNull(numValues + i, vector->isNull(pos));
-        }
+        nullData->append(vector, selView, numValues);
     }
     numValues += selView.getSelSize();
     updateStats(vector, selView);
@@ -778,6 +766,19 @@ std::unique_ptr<NullChunkData> NullChunkData::deserialize(MemoryManager& memoryM
 void NullChunkData::scan(ValueVector& output, offset_t offset, length_t length,
     sel_t posInOutputVector) const {
     output.setNullFromBits(getNullMask().getData(), offset, posInOutputVector, length);
+}
+
+void NullChunkData::append(const common::ValueVector* vector, const common::SelectionView& selView,
+    common::offset_t startPosInChunk) {
+    if (selView.isUnfiltered()) {
+        copyFromBuffer(vector->getNullMask().getData(), 0, startPosInChunk, selView.getSelSize());
+        numValues += selView.getSelSize();
+    } else {
+        for (auto i = 0u; i < selView.getSelSize(); i++) {
+            const auto pos = selView[i];
+            setNull(startPosInChunk + i, vector->isNull(pos));
+        }
+    }
 }
 
 void InternalIDChunkData::append(ValueVector* vector, const SelectionView& selView) {

--- a/src/storage/store/column_chunk_data.cpp
+++ b/src/storage/store/column_chunk_data.cpp
@@ -509,7 +509,7 @@ void ColumnChunkData::copyVectorToBuffer(ValueVector* vector, offset_t startPosI
     KU_ASSERT(startPosInChunk + selView.getSelSize() <= capacity);
     const auto vectorDataToWriteFrom = vector->getData();
     if (nullData) {
-        nullData->append(vector, selView, startPosInChunk);
+        nullData->appendNulls(vector, selView, startPosInChunk);
     }
     if (selView.isUnfiltered()) {
         memcpy(bufferToWrite, vectorDataToWriteFrom, selView.getSelSize() * numBytesPerValue);
@@ -611,7 +611,7 @@ void BoolChunkData::append(ValueVector* vector, const SelectionView& selView) {
         NullMask::setNull(getData<uint64_t>(), numValues + i, vector->getValue<bool>(pos));
     }
     if (nullData) {
-        nullData->append(vector, selView, numValues);
+        nullData->appendNulls(vector, selView, numValues);
     }
     numValues += selView.getSelSize();
     updateStats(vector, selView);
@@ -723,20 +723,20 @@ void NullChunkData::write(const ValueVector* vector, offset_t offsetInVector,
 
 void NullChunkData::write(ColumnChunkData* srcChunk, offset_t srcOffsetInChunk,
     offset_t dstOffsetInChunk, offset_t numValuesToCopy) {
+    if (numValuesToCopy == 0) {
+        return;
+    }
+    KU_ASSERT(srcChunk->getBufferSize() >= sizeof(uint64_t));
+    copyFromBuffer(srcChunk->getData<uint64_t>(), srcOffsetInChunk, dstOffsetInChunk,
+        numValuesToCopy);
     if ((dstOffsetInChunk + numValuesToCopy) >= numValues) {
         numValues = dstOffsetInChunk + numValuesToCopy;
     }
-    copyFromBuffer(srcChunk->getData<uint64_t>(), srcOffsetInChunk, dstOffsetInChunk,
-        numValuesToCopy);
-    updateInMemoryStats(inMemoryStats, srcChunk, srcOffsetInChunk, numValuesToCopy);
 }
 
 void NullChunkData::append(ColumnChunkData* other, offset_t startOffsetInOtherChunk,
     uint32_t numValuesToAppend) {
-    copyFromBuffer(other->getData<uint64_t>(), startOffsetInOtherChunk, numValues,
-        numValuesToAppend);
-    numValues += numValuesToAppend;
-    updateInMemoryStats(inMemoryStats, other, startOffsetInOtherChunk, numValuesToAppend);
+    write(other, startOffsetInOtherChunk, numValues, numValuesToAppend);
 }
 
 bool NullChunkData::haveNoNullsGuaranteed() const {
@@ -768,8 +768,8 @@ void NullChunkData::scan(ValueVector& output, offset_t offset, length_t length,
     output.setNullFromBits(getNullMask().getData(), offset, posInOutputVector, length);
 }
 
-void NullChunkData::append(const common::ValueVector* vector, const common::SelectionView& selView,
-    common::offset_t startPosInChunk) {
+void NullChunkData::appendNulls(const common::ValueVector* vector,
+    const common::SelectionView& selView, common::offset_t startPosInChunk) {
     if (selView.isUnfiltered()) {
         copyFromBuffer(vector->getNullMask().getData(), 0, startPosInChunk, selView.getSelSize());
         numValues += selView.getSelSize();


### PR DESCRIPTION
The performance improvement isn't as good as I was first expecting, I think it was somewhat over-represented in the profiling.

Copying 100000000 edges from datagen-9_0-fb (as nodes in a parquet file) took ~12.8s before and ~12.2s after (~5% speedup).

I also noticed that the way we are calculating the statistics for nulls/bools was bugged in certain cases since for bools we weren't taking into account the offset of the input data in `getMinMaxStorageValue` (which required rewriting NullMask::getMinMax). That deficiency was being offset by `copyFromBuffer` just assuming that there are always both `false` and `true` values (but only if there are at least some true values, so it wasn't hiding the issue always). 
So this might improve read performance and compression of nulls in some cases where it was previously miscalculating/over-estimating the statistics, but I think in the trivial case where we're just appending full vectors at a time without any nulls it won't make a difference.