### PR TITLE
Filtered HNSW search

### DIFF
--- a/extension/fts/src/function/create_fts_index.cpp
+++ b/extension/fts/src/function/create_fts_index.cpp
@@ -85,7 +85,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
     const TableFuncBindInput* input) {
     storage::IndexUtils::validateAutoTransaction(*context, CreateFTSFunction::name);
     auto indexName = input->getLiteralVal<std::string>(1);
-    auto nodeTableEntry = storage::IndexUtils::bindTable(*context,
+    auto nodeTableEntry = storage::IndexUtils::bindNodeTable(*context,
         input->getLiteralVal<std::string>(0), indexName, storage::IndexOperation::CREATE);
     auto propertyIDs = bindProperties(*nodeTableEntry, input->getParam(2));
     auto createFTSConfig =

--- a/extension/fts/src/function/drop_fts_index.cpp
+++ b/extension/fts/src/function/drop_fts_index.cpp
@@ -20,7 +20,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* context,
     const TableFuncBindInput* input) {
     storage::IndexUtils::validateAutoTransaction(*context, DropFTSFunction::name);
     auto indexName = input->getLiteralVal<std::string>(1);
-    const auto tableEntry = storage::IndexUtils::bindTable(*context,
+    const auto tableEntry = storage::IndexUtils::bindNodeTable(*context,
         input->getLiteralVal<std::string>(0), indexName, storage::IndexOperation::DROP);
     return std::make_unique<FTSBindData>(tableEntry->getName(), tableEntry->getTableID(), indexName,
         binder::expression_vector{});

--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -314,7 +314,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     auto query = input->getParam(2);
 
     auto tableEntry =
-        IndexUtils::bindTable(*context, inputTableName, indexName, IndexOperation::QUERY);
+        IndexUtils::bindNodeTable(*context, inputTableName, indexName, IndexOperation::QUERY);
     auto catalog = context->getCatalog();
     auto transaction = context->getTransaction();
     auto ftsIndexEntry = catalog->getIndex(transaction, tableEntry->getTableID(), indexName);

--- a/scripts/headers.txt
+++ b/scripts/headers.txt
@@ -21,6 +21,7 @@ src/include/common/exception/catalog.h
 src/include/common/exception/exception.h
 src/include/common/exception/internal.h
 src/include/common/in_mem_overflow_buffer.h
+src/include/common/mask.h
 src/include/common/null_mask.h
 src/include/common/string_format.h
 src/include/common/timer.h

--- a/src/common/mask.cpp
+++ b/src/common/mask.cpp
@@ -8,9 +8,8 @@ namespace common {
 std::unique_ptr<SemiMask> SemiMaskUtil::createMask(offset_t maxOffset) {
     if (maxOffset > std::numeric_limits<uint32_t>::max()) {
         return std::make_unique<Roaring64BitmapSemiMask>(maxOffset);
-    } else {
-        return std::make_unique<Roaring32BitmapSemiMask>(maxOffset);
     }
+    return std::make_unique<Roaring32BitmapSemiMask>(maxOffset);
 }
 
 offset_t NodeOffsetMaskMap::getNumMaskedNode() const {

--- a/src/common/roaring_mask.cpp
+++ b/src/common/roaring_mask.cpp
@@ -3,6 +3,20 @@
 namespace kuzu {
 namespace common {
 
+offset_vec_t Roaring32BitmapSemiMask::collectMaskedNodes(uint64_t size) const {
+    offset_vec_t result;
+    result.reserve(size);
+    auto it = roaring->begin();
+    for (; it != roaring->end(); it++) {
+        auto value = *it;
+        result.push_back(value);
+        if (result.size() == size) {
+            break;
+        }
+    }
+    return result;
+}
+
 offset_vec_t Roaring32BitmapSemiMask::range(uint32_t start, uint32_t end) {
     auto it = roaring->begin();
     it.equalorlarger(start);
@@ -15,6 +29,20 @@ offset_vec_t Roaring32BitmapSemiMask::range(uint32_t start, uint32_t end) {
         ans.push_back(value);
     }
     return ans;
+}
+
+offset_vec_t Roaring64BitmapSemiMask::collectMaskedNodes(uint64_t size) const {
+    offset_vec_t result;
+    result.reserve(size);
+    auto it = roaring->begin();
+    for (; it != roaring->end(); it++) {
+        auto value = *it;
+        result.push_back(value);
+        if (result.size() == size) {
+            break;
+        }
+    }
+    return result;
 }
 
 offset_vec_t Roaring64BitmapSemiMask::range(uint32_t start, uint32_t end) {

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -32,7 +32,7 @@ graph::GraphEntry GDSFunction::bindGraphEntry(main::ClientContext& context,
     if (!context.getGraphEntrySetUnsafe().hasGraph(name)) {
         throw BinderException(stringFormat("Cannot find graph {}.", name));
     }
-    return context.getGraphEntrySetUnsafe().getEntry(name);
+    return context.getGraphEntrySetUnsafe().getEntry(name).copy();
 }
 
 std::shared_ptr<Expression> GDSFunction::bindNodeOutput(const TableFuncBindInput& bindInput,
@@ -148,7 +148,7 @@ std::unique_ptr<PhysicalOperator> GDSFunction::getPhysicalPlan(PlanMapper* planM
             auto logicalSemiMasker = child->ptrCast<LogicalSemiMasker>();
             logicalSemiMasker->addTarget(logicalOp);
             for (auto tableID : logicalSemiMasker->getNodeTableIDs()) {
-                maskMap->addMask(tableID, planMapper->getSemiMask(tableID));
+                maskMap->addMask(tableID, planMapper->createSemiMask(tableID));
             }
             auto root = planMapper->mapOperator(logicalRoot.get());
             call->addChild(std::move(root));

--- a/src/function/table/hnsw/create_hnsw_index.cpp
+++ b/src/function/table/hnsw/create_hnsw_index.cpp
@@ -36,7 +36,7 @@ static std::unique_ptr<TableFuncBindData> createInMemHNSWBindFunc(main::ClientCo
     const auto tableName = input->getLiteralVal<std::string>(0);
     const auto indexName = input->getLiteralVal<std::string>(1);
     const auto columnName = input->getLiteralVal<std::string>(2);
-    auto tableEntry = storage::IndexUtils::bindTable(*context, tableName, indexName,
+    auto tableEntry = storage::IndexUtils::bindNodeTable(*context, tableName, indexName,
         storage::IndexOperation::CREATE);
     const auto tableID = tableEntry->getTableID();
     storage::HNSWIndexUtils::validateColumnType(*tableEntry, columnName);

--- a/src/function/table/hnsw/drop_hnsw_index.cpp
+++ b/src/function/table/hnsw/drop_hnsw_index.cpp
@@ -24,7 +24,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     const TableFuncBindInput* input) {
     const auto tableName = input->getLiteralVal<std::string>(0);
     const auto indexName = input->getLiteralVal<std::string>(1);
-    const auto tableEntry = storage::IndexUtils::bindTable(*context, tableName, indexName,
+    const auto tableEntry = storage::IndexUtils::bindNodeTable(*context, tableName, indexName,
         storage::IndexOperation::DROP);
     return std::make_unique<DropHNSWIndexBindData>(tableEntry, indexName);
 }

--- a/src/include/common/data_chunk/sel_vector.h
+++ b/src/include/common/data_chunk/sel_vector.h
@@ -47,6 +47,24 @@ public:
         }
     }
 
+    template<class Func>
+    void forEachBreakWhenFalse(Func&& func) const {
+        if (state == State::DYNAMIC) {
+            for (size_t i = 0; i < selectedSize; i++) {
+                if (!func(selectedPositions[i])) {
+                    break;
+                }
+            }
+        } else {
+            const auto start = selectedPositions[0];
+            for (size_t i = start; i < start + selectedSize; i++) {
+                if (!func(i)) {
+                    break;
+                }
+            }
+        }
+    }
+
     sel_t getSelSize() const { return selectedSize; }
 
     sel_t operator[](sel_t index) const {

--- a/src/include/common/mask.h
+++ b/src/include/common/mask.h
@@ -1,14 +1,11 @@
 #pragma once
 
-#include <memory>
-
 #include "common/types/types.h"
-#include "roaring.hh"
 
 namespace kuzu {
 namespace common {
 
-// Note that this class is not thread-safe.
+// Note that this class is NOT thread-safe.
 class SemiMask {
 public:
     explicit SemiMask(offset_t maxOffset) : maxOffset{maxOffset}, enabled{false} {}
@@ -24,6 +21,8 @@ public:
     virtual offset_vec_t range(uint32_t start, uint32_t end) = 0;
 
     virtual uint64_t getNumMaskedNodes() const = 0;
+
+    virtual offset_vec_t collectMaskedNodes(uint64_t size) const = 0;
 
     offset_t getMaxOffset() const { return maxOffset; }
 

--- a/src/include/common/roaring_mask.h
+++ b/src/include/common/roaring_mask.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common/mask.h"
+#include "roaring.hh"
 
 namespace kuzu {
 namespace common {
@@ -18,6 +19,8 @@ public:
     bool isMasked(offset_t startNodeOffset) override { return roaring->contains(startNodeOffset); }
 
     uint64_t getNumMaskedNodes() const override { return roaring->cardinality(); }
+
+    offset_vec_t collectMaskedNodes(uint64_t size) const override;
 
     // include&exclude
     offset_vec_t range(uint32_t start, uint32_t end) override;
@@ -38,6 +41,8 @@ public:
     bool isMasked(offset_t startNodeOffset) override { return roaring->contains(startNodeOffset); }
 
     uint64_t getNumMaskedNodes() const override { return roaring->cardinality(); }
+
+    offset_vec_t collectMaskedNodes(uint64_t size) const override;
 
     // include&exclude
     offset_vec_t range(uint32_t start, uint32_t end) override;

--- a/src/include/function/table/hnsw/hnsw_index_functions.h
+++ b/src/include/function/table/hnsw/hnsw_index_functions.h
@@ -61,6 +61,7 @@ struct FinalizeHNSWSharedState final : public SimpleTableFuncSharedState {
 
 struct BoundQueryHNSWIndexInput {
     catalog::NodeTableCatalogEntry* nodeTableEntry;
+    const graph::GraphEntry* graphEntry;
     catalog::IndexCatalogEntry* indexEntry;
     std::shared_ptr<binder::Expression> queryExpression;
     uint64_t k;
@@ -96,14 +97,12 @@ struct QueryHNSWIndexSharedState final : TableFuncSharedState {
 };
 
 struct QueryHNSWLocalState final : TableFuncLocalState {
-    storage::VisitedState visited;
     std::optional<std::vector<storage::NodeWithDistance>> result;
-    uint64_t numRowsOutput = 0;
-    storage::OnDiskEmbeddingScanState embeddingScanState;
+    storage::HNSWSearchState searchState;
+    uint64_t numRowsOutput;
 
-    QueryHNSWLocalState(const transaction::Transaction* transaction, storage::MemoryManager* mm,
-        storage::NodeTable& nodeTable, common::column_id_t columnID, common::offset_t numNodes)
-        : visited{numNodes}, embeddingScanState{transaction, mm, nodeTable, columnID} {}
+    explicit QueryHNSWLocalState(storage::HNSWSearchState searchState)
+        : searchState{std::move(searchState)}, numRowsOutput{0} {}
 
     bool hasResultToOutput() const { return result.has_value(); }
 };

--- a/src/include/graph/graph.h
+++ b/src/include/graph/graph.h
@@ -40,6 +40,11 @@ public:
         void forEach(Func&& func) const {
             selVector.forEach([&](auto i) { func(nbrNodes[i], edges[i]); });
         }
+        template<class Func>
+        void forEachBreakWhenFalse(Func&& func) const {
+            selVector.forEachBreakWhenFalse(
+                [&](auto i) -> bool { return func(nbrNodes[i], edges[i]); });
+        }
 
         // Any neighbour for which the given function returns false
         // will be omitted from future iterations

--- a/src/include/graph/graph_entry.h
+++ b/src/include/graph/graph_entry.h
@@ -57,9 +57,9 @@ private:
 class GraphEntrySet {
 public:
     bool hasGraph(const std::string& name) const { return nameToEntry.contains(name); }
-    GraphEntry getEntry(const std::string& name) const {
+    const GraphEntry& getEntry(const std::string& name) const {
         KU_ASSERT(hasGraph(name));
-        return nameToEntry.at(name).copy();
+        return nameToEntry.at(name);
     }
     void addGraph(const std::string& name, const GraphEntry& entry) {
         nameToEntry.insert({name, entry.copy()});

--- a/src/include/planner/operator/logical_table_function_call.h
+++ b/src/include/planner/operator/logical_table_function_call.h
@@ -7,7 +7,7 @@
 namespace kuzu {
 namespace planner {
 
-class LogicalTableFunctionCall : public LogicalOperator {
+class LogicalTableFunctionCall final : public LogicalOperator {
     static constexpr LogicalOperatorType operatorType_ = LogicalOperatorType::TABLE_FUNCTION_CALL;
 
 public:
@@ -46,6 +46,7 @@ private:
     function::TableFunction tableFunc;
     std::unique_ptr<function::TableFuncBindData> bindData;
 
+    // TODO(Xiyang): We should unify how masks are planned in GDS and HNSW.
     std::vector<std::shared_ptr<LogicalOperator>> nodeMaskRoots;
 };
 

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -11,6 +11,7 @@ namespace common {
 enum class RelDataDirection : uint8_t;
 class SemiMask;
 class NodeOffsetMaskMap;
+class SemiMask;
 } // namespace common
 namespace main {
 class ClientContext;
@@ -231,10 +232,12 @@ public:
 
     static std::vector<DataPos> getDataPos(const binder::expression_vector& expressions,
         const planner::Schema& schema);
+    static planner::LogicalSemiMasker* findSemiMaskerInPlan(
+        planner::LogicalOperator* logicalOperator);
     static FactorizedTableSchema createFlatFTableSchema(
         const binder::expression_vector& expressions, const planner::Schema& schema);
-    std::unique_ptr<common::SemiMask> getSemiMask(common::table_id_t tableID) const;
-    std::unique_ptr<common::NodeOffsetMaskMap> getNodeOffsetMaskMap(
+    std::unique_ptr<common::SemiMask> createSemiMask(common::table_id_t tableID) const;
+    std::unique_ptr<common::NodeOffsetMaskMap> createNodeOffsetMaskMap(
         const binder::Expression& expr) const;
 
 public:

--- a/src/include/storage/index/hnsw_graph.h
+++ b/src/include/storage/index/hnsw_graph.h
@@ -39,8 +39,7 @@ private:
 
 struct NodeTableScanState;
 struct OnDiskEmbeddingScanState {
-    common::DataChunk propertyVectors;
-    std::unique_ptr<common::ValueVector> nodeIDVector;
+    common::DataChunk scanChunk;
     std::unique_ptr<NodeTableScanState> scanState;
 
     OnDiskEmbeddingScanState(const transaction::Transaction* transaction, MemoryManager* mm,

--- a/src/include/storage/index/hnsw_index.h
+++ b/src/include/storage/index/hnsw_index.h
@@ -225,6 +225,23 @@ public:
         graph::Graph::EdgeIterator& nbrItr, HNSWSearchState& searchState,
         min_node_priority_queue_t& candidates, max_node_priority_queue_t& results) const;
 
+    void processSecondHopCandidates(transaction::Transaction* transaction, const float* queryVector,
+        HNSWSearchState& searchState, int64_t& numVisitedNbrs,
+        min_node_priority_queue_t& candidates, max_node_priority_queue_t& results,
+        const std::vector<common::offset_t>& candidateOffsets) const;
+    void processSecondHopCandidates(transaction::Transaction* transaction, const float* queryVector,
+        HNSWSearchState& searchState, int64_t& numVisitedNbrs,
+        min_node_priority_queue_t& candidates, max_node_priority_queue_t& results,
+        min_node_priority_queue_t& candidatesQueue) const;
+
+    min_node_priority_queue_t collectFirstHopNbrsDirected(transaction::Transaction* transaction,
+        const float* queryVector, graph::Graph::EdgeIterator& nbrItr, HNSWSearchState& searchState,
+        min_node_priority_queue_t& candidates, max_node_priority_queue_t& results,
+        int64_t& numVisitedNbrs) const;
+    common::offset_vec_t collectFirstHopNbrsBlind(transaction::Transaction* transaction,
+        const float* queryVector, graph::Graph::EdgeIterator& nbrItr, HNSWSearchState& searchState,
+        min_node_priority_queue_t& candidates, max_node_priority_queue_t& results,
+        int64_t& numVisitedNbrs) const;
     // Return false if we've hit Ml limit.
     bool searchOverSecondHopNbrs(transaction::Transaction* transaction, const float* queryVector,
         uint64_t ef, HNSWSearchState& searchState, common::offset_t cand, int64_t& numVisitedNbrs,

--- a/src/include/storage/index/index_utils.h
+++ b/src/include/storage/index/index_utils.h
@@ -6,6 +6,7 @@
 
 namespace kuzu {
 namespace catalog {
+class TableCatalogEntry;
 class NodeTableCatalogEntry;
 } // namespace catalog
 
@@ -18,8 +19,13 @@ namespace storage {
 enum class IndexOperation { CREATE, QUERY, DROP };
 
 struct IndexUtils {
-    static KUZU_API catalog::NodeTableCatalogEntry* bindTable(const main::ClientContext& context,
-        const std::string& tableName, const std::string& indexName, IndexOperation indexOperation);
+    static KUZU_API void validateIndexExistence(const main::ClientContext& context,
+        const catalog::TableCatalogEntry* tableEntry, const std::string& indexName,
+        IndexOperation indexOperation);
+
+    static KUZU_API catalog::NodeTableCatalogEntry* bindNodeTable(
+        const main::ClientContext& context, const std::string& tableName,
+        const std::string& indexName, IndexOperation indexOperation);
 
     static KUZU_API void validateAutoTransaction(const main::ClientContext& context,
         const std::string& funcName);

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -13,7 +13,6 @@
 #include "optimizer/remove_unnecessary_join_optimizer.h"
 #include "optimizer/schema_populator.h"
 #include "optimizer/top_k_optimizer.h"
-#include "planner/join_order/cardinality_estimator.h"
 #include "planner/operator/logical_explain.h"
 
 namespace kuzu {

--- a/src/processor/map/map_recursive_extend.cpp
+++ b/src/processor/map/map_recursive_extend.cpp
@@ -26,8 +26,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapRecursiveExtend(
     if (extend.hasNbrTableIDSet()) {
         sharedState->setNbrTableIDSet(extend.getNbrTableIDSet());
     }
-    sharedState->setInputNodeMask(getNodeOffsetMaskMap(*bindData.nodeInput));
-    sharedState->setOutputNodeMask(getNodeOffsetMaskMap(*bindData.nodeOutput));
+    sharedState->setInputNodeMask(createNodeOffsetMaskMap(*bindData.nodeInput));
+    sharedState->setOutputNodeMask(createNodeOffsetMaskMap(*bindData.nodeOutput));
     auto printInfo =
         std::make_unique<RecursiveExtendPrintInfo>(extend.getFunction().getFunctionName());
     auto descriptor = std::make_unique<ResultSetDescriptor>();
@@ -45,7 +45,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapRecursiveExtend(
         auto logicalSemiMasker = child->ptrCast<LogicalSemiMasker>();
         logicalSemiMasker->addTarget(logicalOperator);
         for (auto tableID : logicalSemiMasker->getNodeTableIDs()) {
-            maskMap->addMask(tableID, getSemiMask(tableID));
+            maskMap->addMask(tableID, createSemiMask(tableID));
         }
         auto root = mapOperator(logicalRoot.get());
         recursiveExtend->addChild(std::move(root));

--- a/src/processor/map/map_scan_node_table.cpp
+++ b/src/processor/map/map_scan_node_table.cpp
@@ -1,4 +1,5 @@
 #include "binder/expression/property_expression.h"
+#include "common/mask.h"
 #include "planner/operator/scan/logical_scan_node_table.h"
 #include "processor/expression_mapper.h"
 #include "processor/operator/scan/primary_key_scan_node_table.h"

--- a/src/processor/map/map_semi_masker.cpp
+++ b/src/processor/map/map_semi_masker.cpp
@@ -54,6 +54,10 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapSemiMasker(
                 auto funcSharedState = sharedState->ptrCast<function::GDSFuncSharedState>();
                 initMask(masksPerTable, funcSharedState->getGraphNodeMaskMap()->getMasks());
             } break;
+            case SemiMaskTargetType::SCAN_NODE: {
+                auto tableFunc = physicalOp->ptrCast<TableFunctionCall>();
+                initMask(masksPerTable, tableFunc->getSharedState()->getSemiMasks());
+            } break;
             default:
                 KU_UNREACHABLE;
             }

--- a/src/processor/map/map_table_function_call.cpp
+++ b/src/processor/map/map_table_function_call.cpp
@@ -12,7 +12,12 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapTableFunctionCall(
     auto& call = logicalOperator->constCast<LogicalTableFunctionCall>();
     auto getPhysicalPlanFunc = call.getTableFunc().getPhysicalPlanFunc;
     KU_ASSERT(getPhysicalPlanFunc);
-    return getPhysicalPlanFunc(this, logicalOperator);
+    auto res = getPhysicalPlanFunc(this, logicalOperator);
+    logicalOpToPhysicalOpMap.insert({logicalOperator, res.get()});
+    for (auto i = 0u; i < call.getNumChildren(); ++i) {
+        res->addChild(mapOperator(call.getChild(i).get()));
+    }
+    return res;
 }
 
 } // namespace processor

--- a/src/storage/index/index_utils.cpp
+++ b/src/storage/index/index_utils.cpp
@@ -9,7 +9,7 @@
 namespace kuzu {
 namespace storage {
 
-static void validateIndexExistence(const main::ClientContext& context,
+void IndexUtils::validateIndexExistence(const main::ClientContext& context,
     const catalog::TableCatalogEntry* tableEntry, const std::string& indexName,
     IndexOperation indexOperation) {
     switch (indexOperation) {
@@ -34,7 +34,7 @@ static void validateIndexExistence(const main::ClientContext& context,
     }
 }
 
-catalog::NodeTableCatalogEntry* IndexUtils::bindTable(const main::ClientContext& context,
+catalog::NodeTableCatalogEntry* IndexUtils::bindNodeTable(const main::ClientContext& context,
     const std::string& tableName, const std::string& indexName, IndexOperation indexOperation) {
     binder::Binder::validateTableExistence(context, tableName);
     const auto tableEntry =

--- a/src/storage/local_storage/local_rel_table.cpp
+++ b/src/storage/local_storage/local_rel_table.cpp
@@ -1,6 +1,7 @@
 #include "storage/local_storage/local_rel_table.h"
 
 #include <algorithm>
+#include <numeric>
 
 #include "common/enums/rel_direction.h"
 #include "storage/store/rel_table.h"

--- a/src/storage/store/csr_node_group.cpp
+++ b/src/storage/store/csr_node_group.cpp
@@ -105,9 +105,9 @@ void CSRNodeGroup::initScanForCommittedPersistent(const Transaction* transaction
         auto offsetInGroup = nodeOffset % StorageConfig::NODE_GROUP_SIZE;
         auto offsetToScanFrom = offsetInGroup == 0 ? 0 : offsetInGroup - 1;
         csrHeader.offset->scanCommitted<ResidencyState::ON_DISK>(transaction, offsetState,
-            *nodeGroupScanState.header->offset, offsetToScanFrom, offsetInGroup + 1);
+            *nodeGroupScanState.header->offset, offsetToScanFrom, 1);
         csrHeader.length->scanCommitted<ResidencyState::ON_DISK>(transaction, lengthState,
-            *nodeGroupScanState.header->length, offsetInGroup, offsetInGroup + 1);
+            *nodeGroupScanState.header->length, offsetInGroup, 1);
     } else {
         auto numBoundNodes = csrHeader.offset->getNumValues();
         csrHeader.offset->scanCommitted<ResidencyState::ON_DISK>(transaction, offsetState,

--- a/src/storage/store/list_chunk_data.cpp
+++ b/src/storage/store/list_chunk_data.cpp
@@ -21,7 +21,6 @@ ListChunkData::ListChunkData(MemoryManager& memoryManager, LogicalType dataType,
     bool enableCompression, ResidencyState residencyState)
     : ColumnChunkData{memoryManager, std::move(dataType), capacity, enableCompression,
           residencyState, true /*hasNullData*/} {
-    // TODO(Guodong): offset/size should contain no nulls.
     offsetColumnChunk =
         ColumnChunkFactory::createColumnChunkData(memoryManager, LogicalType::UINT64(),
             enableCompression, capacity, ResidencyState::IN_MEMORY, false /*hasNull*/);

--- a/test/test_files/function/hnsw/error.test
+++ b/test/test_files/function/hnsw/error.test
@@ -79,3 +79,28 @@ Binder exception: Expression LIST_CREATION(abc,def,ddd,awe,alice,bob,de,pwd) has
 ---- error
 Binder exception: Cannot match a built-in function for given function QUERY_HNSW_INDEX(STRING,STRING,DOUBLE[],STRING). Supported inputs are
 (STRING,STRING,ARRAY,INT64)
+
+-CASE ProjectedGraphError
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
+---- ok
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec');
+---- ok
+-STATEMENT CREATE NODE TABLE test(id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT CALL create_projected_graph('emb-graph', ['embeddings', 'test'], []);
+---- ok
+-STATEMENT CALL QUERY_HNSW_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
+---- error
+Binder exception: Projected graph emb-graph either contains relationship tables or multiple node tables. Projected graphs passed to QUERY_HNSW_INDEX function must contain only nodes from a single node table and no relationship tables.
+-STATEMENT CREATE REL TABLE rel(FROM embeddings TO embeddings);
+---- ok
+-STATEMENT CALL create_projected_graph('emb-graph2', ['embeddings'], ['rel']);
+---- ok
+-STATEMENT CALL QUERY_HNSW_INDEX('emb-graph2', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
+---- error
+Binder exception: Projected graph emb-graph2 either contains relationship tables or multiple node tables. Projected graphs passed to QUERY_HNSW_INDEX function must contain only nodes from a single node table and no relationship tables.
+-STATEMENT CALL QUERY_HNSW_INDEX('emb-graph3', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
+---- error
+Binder exception: Cannot find table or projected graph named as emb-graph3.

--- a/test/test_files/function/hnsw/filter.test
+++ b/test/test_files/function/hnsw/filter.test
@@ -1,0 +1,201 @@
+-DATASET CSV empty
+
+--
+
+-CASE Filtered8DimDotProduct
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
+---- ok
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'dotproduct');
+---- ok
+-STATEMENT CALL create_projected_graph('emb-graph', {'embeddings': {'filter': 'n.id < 100'}}, []);
+---- ok
+-STATEMENT CALL QUERY_HNSW_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
+-CHECK_ORDER
+---- 3
+58
+93
+28
+-STATEMENT MATCH (n:embeddings) WHERE n.id < 100 WITH n.id as id, array_dot_product(n.vec, CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]')) AS dist RETURN id ORDER BY dist LIMIT 3;
+-CHECK_ORDER
+---- 3
+58
+93
+28
+
+-CASE Filtered8DimDotProduct2
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
+---- ok
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'dotproduct');
+---- ok
+-STATEMENT CALL create_projected_graph('emb-graph', {'embeddings': {'filter': 'n.id < 50'}}, []);
+---- ok
+-STATEMENT CALL QUERY_HNSW_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
+-CHECK_ORDER
+---- 3
+28
+0
+30
+-STATEMENT MATCH (n:embeddings) WHERE n.id < 50 WITH n.id as id, array_dot_product(n.vec, CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]')) AS dist RETURN id ORDER BY dist LIMIT 3;
+-CHECK_ORDER
+---- 3
+28
+0
+30
+
+-CASE Filtered8DimDotProduct3
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
+---- ok
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'dotproduct');
+---- ok
+-STATEMENT CALL create_projected_graph('emb-graph', {'embeddings': {'filter': 'n.id < 600'}}, []);
+---- ok
+-STATEMENT CALL QUERY_HNSW_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
+-CHECK_ORDER
+---- 3
+499
+581
+58
+-STATEMENT MATCH (n:embeddings) WHERE n.id < 600 WITH n.id as id, array_dot_product(n.vec, CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]')) AS dist RETURN id ORDER BY dist LIMIT 3;
+-CHECK_ORDER
+---- 3
+499
+581
+58
+
+-CASE Filtered8DimL2
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
+---- ok
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'l2');
+---- ok
+-STATEMENT CALL create_projected_graph('emb-graph', {'embeddings': {'filter': 'n.id < 100'}}, []);
+---- ok
+-STATEMENT CALL QUERY_HNSW_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
+-CHECK_ORDER
+---- 3
+37
+40
+52
+-STATEMENT MATCH (n:embeddings) WHERE n.id < 100 WITH n.id as id, array_distance(n.vec, CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]')) AS dist RETURN id ORDER BY dist LIMIT 3;
+-CHECK_ORDER
+---- 3
+37
+40
+52
+
+-CASE Filtered8DimL22
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
+---- ok
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'l2');
+---- ok
+-STATEMENT CALL create_projected_graph('emb-graph', {'embeddings': {'filter': 'n.id < 50'}}, []);
+---- ok
+-STATEMENT CALL QUERY_HNSW_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
+-CHECK_ORDER
+---- 3
+37
+40
+43
+-STATEMENT MATCH (n:embeddings) WHERE n.id < 50 WITH n.id as id, array_distance(n.vec, CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]')) AS dist RETURN id ORDER BY dist LIMIT 3;
+-CHECK_ORDER
+---- 3
+37
+40
+43
+
+-CASE Filtered8DimL23
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
+---- ok
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'l2');
+---- ok
+-STATEMENT CALL create_projected_graph('emb-graph', {'embeddings': {'filter': 'n.id < 600'}}, []);
+---- ok
+-STATEMENT CALL QUERY_HNSW_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
+-CHECK_ORDER
+---- 3
+333
+444
+133
+-STATEMENT MATCH (n:embeddings) WHERE n.id < 600 WITH n.id as id, array_distance(n.vec, CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]')) AS dist RETURN id ORDER BY dist LIMIT 3;
+-CHECK_ORDER
+---- 3
+333
+444
+133
+
+-CASE Filtered8DimCos
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
+---- ok
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec');
+---- ok
+-STATEMENT CALL create_projected_graph('emb-graph', {'embeddings': {'filter': 'n.id < 100'}}, []);
+---- ok
+-STATEMENT CALL QUERY_HNSW_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
+-CHECK_ORDER
+---- 3
+37
+86
+40
+-STATEMENT MATCH (n:embeddings) WHERE n.id < 100 WITH n.id as id, 1-array_cosine_similarity(n.vec, CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]')) AS dist RETURN id ORDER BY dist LIMIT 3;
+-CHECK_ORDER
+---- 3
+37
+86
+40
+
+-CASE Filtered8DimCos2
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
+---- ok
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec');
+---- ok
+-STATEMENT CALL create_projected_graph('emb-graph', {'embeddings': {'filter': 'n.id < 50'}}, []);
+---- ok
+-STATEMENT CALL QUERY_HNSW_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
+-CHECK_ORDER
+---- 3
+37
+40
+43
+-STATEMENT MATCH (n:embeddings) WHERE n.id < 50 WITH n.id as id, 1-array_cosine_similarity(n.vec, CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]')) AS dist RETURN id ORDER BY dist LIMIT 3;
+-CHECK_ORDER
+---- 3
+37
+40
+43
+
+-CASE Filtered8DimCos3
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
+---- ok
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec');
+---- ok
+-STATEMENT CALL create_projected_graph('emb-graph', {'embeddings': {'filter': 'n.id < 600'}}, []);
+---- ok
+-STATEMENT CALL QUERY_HNSW_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
+-CHECK_ORDER
+---- 3
+333
+444
+146
+-STATEMENT MATCH (n:embeddings) WHERE n.id < 600 WITH n.id as id, 1-array_cosine_similarity(n.vec, CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]')) AS dist RETURN id ORDER BY dist LIMIT 3;
+-CHECK_ORDER
+---- 3
+333
+444
+146


### PR DESCRIPTION
# Description

Implement the global adaptive filtered search.
The idea is to make use of semi mask to pass the filtering information on node table to the QueryHNSWIndex function.
Inside the function, we follow a heuristic rule based on the selectivity of semi mask:
- If the selectivity is pretty low (<=0.08), we would perform `blindTwoHopFilteredSearch`, which blindly explores the first and second hop neighbours to find those that are selected.
- If the selectivity is somewhat low (<=0.4), we would perform `directedTwoHopFilteredSearch`, which explores the first hop neighbours first to gat a candidate set, and then explore the second hop neighbours in a more directed way that prioritizes nodes in the candidate set that is closest to the query vector. This will hopefully leads to faster converge to the area with closeted nodes.
- If the selectivity is high (>0.4), we would perform `oneHopFilteredSearch`, which finds all selected nodes in the first hop neighbours.

There is a more advanced way, which is based on each node's selectivity to perform adaptive searches. We can move to that in a later PR.
Also, there are two left TODOs:
- add the brute force computation into the adaptive strategy.
- provide options for configuration of the threshold for each method.