### PR TITLE
Fix pin table error in page rank

### DIFF
--- a/src/function/gds/degrees.h
+++ b/src/function/gds/degrees.h
@@ -62,6 +62,18 @@ struct DegreeEdgeCompute : public EdgeCompute {
     }
 };
 
+class DegreesGDSAuxiliaryState : public GDSAuxiliaryState {
+public:
+    explicit DegreesGDSAuxiliaryState(Degrees* degrees) : degrees{degrees} {};
+
+    void beginFrontierCompute(common::table_id_t curTableID, common::table_id_t) override {
+        degrees->pinTable(curTableID);
+    }
+
+private:
+    Degrees* degrees;
+};
+
 struct DegreesUtils {
     static void computeDegree(processor::ExecutionContext* context, graph::Graph* graph,
         common::NodeOffsetMaskMap* nodeOffsetMaskMap, Degrees* degrees, ExtendDirection direction) {
@@ -71,7 +83,7 @@ struct DegreesUtils {
             std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier, nextFrontier);
         frontierPair->initGDS();
         auto ec = std::make_unique<DegreeEdgeCompute>(degrees);
-        auto auxiliaryState = std::make_unique<EmptyGDSAuxiliaryState>();
+        auto auxiliaryState = std::make_unique<DegreesGDSAuxiliaryState>(degrees);
         auto computeState = GDSComputeState(std::move(frontierPair), std::move(ec),
             std::move(auxiliaryState), nullptr);
         GDSUtils::runFrontiersUntilConvergence(context, computeState, graph, direction,


### PR DESCRIPTION
# Description

In a multi-label graph like SF100, when running page_rank, ther memory error occurs mainly because Degrees & pValues are not correctly pinned with the pinTable operation:

1. The calculation of degrees uses EmptyGDSAuxiliaryState, which does not have pinTable.
2. In the PageRankAuxiliaryState, pNext should use pinTable(fromTableID) because pNext updates with boundNodeID.
3. It is necessary to inherit from FrontierPair to implement PageRankFrontierPair, because the activesNode added to nextDenseFrontier is boundNodeID.


# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).