### PR TITLE
Refactor gds output writer

### DIFF
--- a/src/function/gds/asp_destinations.cpp
+++ b/src/function/gds/asp_destinations.cpp
@@ -83,7 +83,7 @@ public:
         std::shared_ptr<Multiplicities> multiplicities)
         : RJOutputWriter{context, outputNodeMask, sourceNodeID},
           pathLengths{std::move(pathLengths)}, multiplicities{std::move(multiplicities)} {
-        lengthVector = createVector(LogicalType::UINT16(), context->getMemoryManager());
+        lengthVector = createVector(LogicalType::UINT16());
     }
 
     void beginWritingOutputsInternal(common::table_id_t tableID) override {

--- a/src/function/gds/awsp_paths.cpp
+++ b/src/function/gds/awsp_paths.cpp
@@ -49,7 +49,7 @@ public:
     AWSPPathsOutputWriter(main::ClientContext* context, common::NodeOffsetMaskMap* outputNodeMask,
         common::nodeID_t sourceNodeID, PathsOutputWriterInfo info, BFSGraph& bfsGraph)
         : PathsOutputWriter{context, outputNodeMask, sourceNodeID, info, bfsGraph} {
-        costVector = createVector(LogicalType::DOUBLE(), context->getMemoryManager());
+        costVector = createVector(LogicalType::DOUBLE());
     }
 
     void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID,

--- a/src/function/gds/gds_vertex_compute.h
+++ b/src/function/gds/gds_vertex_compute.h
@@ -43,9 +43,18 @@ public:
     }
 
 protected:
+    std::unique_ptr<common::ValueVector> createVector(const common::LogicalType& type) {
+        auto vector = std::make_unique<common::ValueVector>(type.copy(), mm);
+        vector->state = common::DataChunkState::getSingleValueDataChunkState();
+        vectors.push_back(vector.get());
+        return vector;
+    }
+
+protected:
     processor::GDSCallSharedState* sharedState;
     storage::MemoryManager* mm;
     processor::FactorizedTable* localFT = nullptr;
+    std::vector<common::ValueVector*> vectors;
 };
 
 } // namespace function

--- a/src/function/gds/ssp_destinations.cpp
+++ b/src/function/gds/ssp_destinations.cpp
@@ -16,7 +16,7 @@ public:
         nodeID_t sourceNodeID, std::shared_ptr<PathLengths> pathLengths)
         : RJOutputWriter{context, outputNodeMask, sourceNodeID},
           pathLengths{std::move(pathLengths)} {
-        lengthVector = createVector(LogicalType::UINT16(), context->getMemoryManager());
+        lengthVector = createVector(LogicalType::UINT16());
     }
 
     void beginWritingOutputsInternal(common::table_id_t tableID) override {

--- a/src/function/gds/wsp_destinations.cpp
+++ b/src/function/gds/wsp_destinations.cpp
@@ -98,7 +98,7 @@ public:
         common::NodeOffsetMaskMap* outputNodeMask, common::nodeID_t sourceNodeID,
         std::shared_ptr<Costs> costs)
         : RJOutputWriter{context, outputNodeMask, sourceNodeID}, costs{std::move(costs)} {
-        costVector = createVector(LogicalType::DOUBLE(), context->getMemoryManager());
+        costVector = createVector(LogicalType::DOUBLE());
     }
 
     void write(processor::FactorizedTable& fTable, nodeID_t dstNodeID,

--- a/src/function/gds/wsp_paths.cpp
+++ b/src/function/gds/wsp_paths.cpp
@@ -50,7 +50,7 @@ public:
     WSPPathsOutputWriter(main::ClientContext* context, common::NodeOffsetMaskMap* outputNodeMask,
         common::nodeID_t sourceNodeID, PathsOutputWriterInfo info, BFSGraph& bfsGraph)
         : PathsOutputWriter{context, outputNodeMask, sourceNodeID, info, bfsGraph} {
-        costVector = createVector(LogicalType::DOUBLE(), context->getMemoryManager());
+        costVector = createVector(LogicalType::DOUBLE());
     }
 
     void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID,

--- a/src/include/function/gds/rec_joins.h
+++ b/src/include/function/gds/rec_joins.h
@@ -4,8 +4,8 @@
 #include "common/enums/path_semantic.h"
 #include "function/gds/gds.h"
 #include "function/gds/gds_state.h"
-#include "output_writer.h"
 #include "processor/operator/recursive_extend_shared_state.h"
+#include "rj_output_writer.h"
 
 namespace kuzu {
 namespace function {

--- a/src/include/function/gds/rj_output_writer.h
+++ b/src/include/function/gds/rj_output_writer.h
@@ -9,26 +9,11 @@
 namespace kuzu {
 namespace function {
 
-class GDSOutputWriter {
-public:
-    explicit GDSOutputWriter(main::ClientContext* context) : context{context} {}
-    virtual ~GDSOutputWriter() = default;
-
-public:
-    std::vector<common::ValueVector*> vectors;
-
-protected:
-    std::unique_ptr<common::ValueVector> createVector(const common::LogicalType& type,
-        storage::MemoryManager* mm);
-
-protected:
-    main::ClientContext* context;
-};
-
-class RJOutputWriter : public GDSOutputWriter {
+class RJOutputWriter {
 public:
     RJOutputWriter(main::ClientContext* context, common::NodeOffsetMaskMap* outputNodeMask,
         common::nodeID_t sourceNodeID);
+    virtual ~RJOutputWriter() = default;
 
     void beginWritingOutputs(common::table_id_t tableID);
 
@@ -42,11 +27,14 @@ public:
 protected:
     virtual void beginWritingOutputsInternal(common::table_id_t tableID) = 0;
     virtual bool skipInternal(common::nodeID_t dstNodeID) const = 0;
+    std::unique_ptr<common::ValueVector> createVector(const common::LogicalType& type);
 
 protected:
+    main::ClientContext* context;
     common::NodeOffsetMaskMap* outputNodeMask;
     common::nodeID_t sourceNodeID;
 
+    std::vector<common::ValueVector*> vectors;
     std::unique_ptr<common::ValueVector> srcNodeIDVector;
     std::unique_ptr<common::ValueVector> dstNodeIDVector;
 };


### PR DESCRIPTION
# Description

Continue to separate recursive extend and gds. Remove GDSOutputWriter as an abstraction level.