### PR TITLE
Distinct Aggregate vectorization

### DIFF
--- a/src/include/planner/operator/factorization/flatten_resolver.h
+++ b/src/include/planner/operator/factorization/flatten_resolver.h
@@ -8,8 +8,8 @@ namespace planner {
 class GroupDependencyAnalyzer;
 
 struct FlattenAllButOne {
-    static f_group_pos_set getGroupsPosToFlatten(const binder::expression_vector& exprs,
-        const Schema& schema);
+    static std::pair<f_group_pos, f_group_pos_set> getGroupsPosToFlatten(
+        const binder::expression_vector& exprs, const Schema& schema);
     static f_group_pos_set getGroupsPosToFlatten(std::shared_ptr<binder::Expression> expr,
         const Schema& schema);
     // Assume no requiredFlatGroups

--- a/src/include/planner/operator/logical_aggregate.h
+++ b/src/include/planner/operator/logical_aggregate.h
@@ -40,8 +40,7 @@ public:
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
 
-    f_group_pos_set getGroupsPosToFlattenForGroupBy();
-    f_group_pos_set getGroupsPosToFlattenForAggregate();
+    f_group_pos_set getGroupsPosToFlatten();
 
     std::string getExpressionsForPrinting() const override;
 

--- a/src/include/planner/operator/logical_aggregate.h
+++ b/src/include/planner/operator/logical_aggregate.h
@@ -66,7 +66,6 @@ public:
     }
 
 private:
-    bool hasDistinctAggregate();
     void insertAllExpressionsToGroupAndScope(f_group_pos groupPos);
 
 private:

--- a/src/include/processor/operator/aggregate/aggregate_hash_table.h
+++ b/src/include/processor/operator/aggregate/aggregate_hash_table.h
@@ -89,17 +89,19 @@ public:
     }
 
     void appendDistinct(const std::vector<common::ValueVector*>& keyVectors,
-        common::ValueVector* aggregateVector);
+        common::ValueVector* aggregateVector, const common::DataChunkState* leadingState);
 
 protected:
     virtual uint64_t append(const std::vector<common::ValueVector*>& keyVectors,
+        const common::DataChunkState* leadingState,
         const std::vector<AggregateInput>& aggregateInputs, uint64_t resultSetMultiplicity) {
         return append(keyVectors, std::vector<common::ValueVector*>{} /*dependentKeyVectors*/,
-            aggregateInputs, resultSetMultiplicity);
+            leadingState, aggregateInputs, resultSetMultiplicity);
     }
 
     virtual uint64_t append(const std::vector<common::ValueVector*>& keyVectors,
         const std::vector<common::ValueVector*>& dependentKeyVectors,
+        const common::DataChunkState* leadingState,
         const std::vector<AggregateInput>& aggregateInputs, uint64_t resultSetMultiplicity);
 
     virtual uint64_t matchFTEntries(std::span<const common::ValueVector*> keyVectors,
@@ -121,7 +123,8 @@ protected:
         uint64_t& numNoMatches, uint32_t colIdx);
 
     void findHashSlots(const std::vector<common::ValueVector*>& keyVectors,
-        const std::vector<common::ValueVector*>& dependentKeyVectors);
+        const std::vector<common::ValueVector*>& dependentKeyVectors,
+        const common::DataChunkState* leadingState);
 
     void findHashSlots(const FactorizedTable& data, uint64_t startOffset, uint64_t numTuples);
 
@@ -304,6 +307,7 @@ public:
 
     uint64_t append(const std::vector<common::ValueVector*>& keyVectors,
         const std::vector<common::ValueVector*>& dependentKeyVectors,
+        const common::DataChunkState* leadingState,
         const std::vector<AggregateInput>& aggregateInputs,
         uint64_t resultSetMultiplicity) override;
 

--- a/src/include/processor/operator/aggregate/aggregate_hash_table.h
+++ b/src/include/processor/operator/aggregate/aggregate_hash_table.h
@@ -4,6 +4,7 @@
 
 #include "aggregate_input.h"
 #include "common/copy_constructors.h"
+#include "common/data_chunk/data_chunk_state.h"
 #include "common/types/types.h"
 #include "common/vector/value_vector.h"
 #include "function/aggregate_function.h"
@@ -67,17 +68,11 @@ public:
         const std::vector<common::LogicalType>& distinctAggKeyTypes, uint64_t numEntriesToAllocate,
         FactorizedTableSchema tableSchema);
 
-    // Returns true if the value was distinct and was inserted
-    // otherwise if the value already existed, returns false and the hash table is unchanged
-    virtual bool insertAggregateValueIfDistinctForGroupByKeys(
-        const std::vector<common::ValueVector*>& groupByKeyVectors,
-        common::ValueVector* aggregateVector);
-
     //! merge aggregate hash table by combining aggregate states under the same key
     void merge(FactorizedTable&& other);
     void merge(AggregateHashTable&& other) { merge(std::move(*other.factorizedTable)); }
-    // Must be called after merging hash tables with distinct functions, but only when the merged
-    // distinct tuples match the merged non-distinct tuples
+    // Must be called after merging hash tables with distinct functions, but only when the
+    // merged distinct tuples match the merged non-distinct tuples
     void mergeDistinctAggregateInfo();
 
     void finalizeAggregateStates();
@@ -93,16 +88,27 @@ public:
         return distinctHashTables[aggregateFunctionIdx].get();
     }
 
+    void appendDistinct(const std::vector<common::ValueVector*>& keyVectors,
+        common::ValueVector* aggregateVector);
+
 protected:
-    virtual uint64_t matchFTEntries(std::span<const common::ValueVector*> flatKeyVectors,
-        std::span<const common::ValueVector*> unFlatKeyVectors, uint64_t numMayMatches,
-        uint64_t numNoMatches);
+    virtual uint64_t append(const std::vector<common::ValueVector*>& keyVectors,
+        const std::vector<AggregateInput>& aggregateInputs, uint64_t resultSetMultiplicity) {
+        return append(keyVectors, std::vector<common::ValueVector*>{} /*dependentKeyVectors*/,
+            aggregateInputs, resultSetMultiplicity);
+    }
+
+    virtual uint64_t append(const std::vector<common::ValueVector*>& keyVectors,
+        const std::vector<common::ValueVector*>& dependentKeyVectors,
+        const std::vector<AggregateInput>& aggregateInputs, uint64_t resultSetMultiplicity);
+
+    virtual uint64_t matchFTEntries(std::span<const common::ValueVector*> keyVectors,
+        uint64_t numMayMatches, uint64_t numNoMatches);
 
     uint64_t matchFTEntries(const FactorizedTable& srcTable, uint64_t startOffset,
         uint64_t numMayMatches, uint64_t numNoMatches);
 
-    void initializeFTEntries(const std::vector<common::ValueVector*>& flatKeyVectors,
-        const std::vector<common::ValueVector*>& unFlatKeyVectors,
+    void initializeFTEntries(const std::vector<common::ValueVector*>& keyVectors,
         const std::vector<common::ValueVector*>& dependentKeyVectors,
         uint64_t numFTEntriesToInitialize);
     void initializeFTEntries(const FactorizedTable& sourceTable, uint64_t sourceStartOffset,
@@ -114,10 +120,8 @@ protected:
     uint64_t matchFlatVecWithFTColumn(const common::ValueVector* vector, uint64_t numMayMatches,
         uint64_t& numNoMatches, uint32_t colIdx);
 
-    void findHashSlots(const std::vector<common::ValueVector*>& flatKeyVectors,
-        const std::vector<common::ValueVector*>& unFlatKeyVectors,
-        const std::vector<common::ValueVector*>& dependentKeyVectors,
-        common::DataChunkState* leadingState);
+    void findHashSlots(const std::vector<common::ValueVector*>& keyVectors,
+        const std::vector<common::ValueVector*>& dependentKeyVectors);
 
     void findHashSlots(const FactorizedTable& data, uint64_t startOffset, uint64_t numTuples);
 
@@ -129,8 +133,8 @@ protected:
 
     void initializeTmpVectors();
 
-    // ! This function will only be used by distinct aggregate, which assumes that all groupByKeys
-    // are flat.
+    // ! This function will only be used by distinct aggregate, which assumes that all
+    // groupByKeys are flat.
     uint8_t* findEntryInDistinctHT(const std::vector<common::ValueVector*>& groupByKeyVectors,
         common::hash_t hash);
 
@@ -151,18 +155,19 @@ protected:
 
     void increaseHashSlotIdxes(uint64_t numNoMatches);
 
-    void updateAggState(const std::vector<common::ValueVector*>& flatKeyVectors,
-        const std::vector<common::ValueVector*>& unFlatKeyVectors,
+    void updateAggState(const std::vector<common::ValueVector*>& keyVectors,
         function::AggregateFunction& aggregateFunction, common::ValueVector* aggVector,
-        uint64_t multiplicity, uint32_t colIdx, uint32_t aggStateOffset);
+        uint64_t multiplicity, uint32_t aggStateOffset,
+        const common::DataChunkState* firstUnFlatState);
 
-    void updateAggStates(const std::vector<common::ValueVector*>& flatKeyVectors,
-        const std::vector<common::ValueVector*>& unFlatKeyVectors,
-        const std::vector<AggregateInput>& aggregateInputs, uint64_t resultSetMultiplicity);
+    void updateAggStates(const std::vector<common::ValueVector*>& keyVectors,
+        const std::vector<AggregateInput>& aggregateInputs, uint64_t resultSetMultiplicity,
+        const common::DataChunkState* firstUnFlatState);
 
     void fillEntryWithInitialNullAggregateState(FactorizedTable& table, uint8_t* entry);
 
-    //! find an uninitialized hash slot for given hash and fill hash slot with block id and offset
+    //! find an uninitialized hash slot for given hash and fill hash slot with block id and
+    //! offset
     void fillHashSlot(common::hash_t hash, uint8_t* groupByKeysAndAggregateStateBuffer);
 
     inline HashSlot* getHashSlot(uint64_t slotIdx) {
@@ -177,18 +182,14 @@ protected:
 
     void addDataBlocksIfNecessary(uint64_t maxNumHashSlots);
 
-    void updateNullAggVectorState(const std::vector<common::ValueVector*>& flatKeyVectors,
-        const std::vector<common::ValueVector*>& unFlatKeyVectors,
+    void updateNullAggVectorState(const common::DataChunkState& keyState,
         function::AggregateFunction& aggregateFunction, uint64_t multiplicity,
         uint32_t aggStateOffset);
 
-    void updateBothFlatAggVectorState(const std::vector<common::ValueVector*>& flatKeyVectors,
-        function::AggregateFunction& aggregateFunction, common::ValueVector* aggVector,
-        uint64_t multiplicity, uint32_t aggStateOffset);
+    void updateBothFlatAggVectorState(function::AggregateFunction& aggregateFunction,
+        common::ValueVector* aggVector, uint64_t multiplicity, uint32_t aggStateOffset);
 
-    void updateFlatUnFlatKeyFlatAggVectorState(
-        const std::vector<common::ValueVector*>& flatKeyVectors,
-        const std::vector<common::ValueVector*>& unFlatKeyVectors,
+    void updateFlatUnFlatKeyFlatAggVectorState(const common::DataChunkState& unFlatKeyState,
         function::AggregateFunction& aggregateFunction, common::ValueVector* aggVector,
         uint64_t multiplicity, uint32_t aggStateOffset);
 
@@ -196,15 +197,10 @@ protected:
         function::AggregateFunction& aggregateFunction, common::ValueVector* aggVector,
         uint64_t multiplicity, uint32_t aggStateOffset);
 
-    void updateBothUnFlatSameDCAggVectorState(
-        const std::vector<common::ValueVector*>& flatKeyVectors,
-        const std::vector<common::ValueVector*>& unFlatKeyVectors,
-        function::AggregateFunction& aggregateFunction, common::ValueVector* aggVector,
-        uint64_t multiplicity, uint32_t aggStateOffset);
+    void updateBothUnFlatSameDCAggVectorState(function::AggregateFunction& aggregateFunction,
+        common::ValueVector* aggVector, uint64_t multiplicity, uint32_t aggStateOffset);
 
-    void updateBothUnFlatDifferentDCAggVectorState(
-        const std::vector<common::ValueVector*>& flatKeyVectors,
-        const std::vector<common::ValueVector*>& unFlatKeyVectors,
+    void updateBothUnFlatDifferentDCAggVectorState(const common::DataChunkState& unFlatKeyState,
         function::AggregateFunction& aggregateFunction, common::ValueVector* aggVector,
         uint64_t multiplicity, uint32_t aggStateOffset);
 
@@ -306,17 +302,12 @@ public:
               common::DEFAULT_VECTOR_CAPACITY /*minimum size*/, tableSchema.copy()),
           tableSchema{std::move(tableSchema)}, partitioningData{partitioningData} {}
 
-    uint64_t append(const std::vector<common::ValueVector*>& flatKeyVectors,
-        const std::vector<common::ValueVector*>& unFlatKeyVectors,
+    uint64_t append(const std::vector<common::ValueVector*>& keyVectors,
         const std::vector<common::ValueVector*>& dependentKeyVectors,
-        common::DataChunkState* leadingState, const std::vector<AggregateInput>& aggregateInputs,
-        uint64_t resultSetMultiplicity);
+        const std::vector<AggregateInput>& aggregateInputs,
+        uint64_t resultSetMultiplicity) override;
 
     void mergeIfFull(uint64_t tuplesToAdd, bool mergeAll = false);
-
-    bool insertAggregateValueIfDistinctForGroupByKeys(
-        const std::vector<common::ValueVector*>& groupByKeyVectors,
-        common::ValueVector* aggregateVector) override;
 
 private:
     FactorizedTableSchema tableSchema;

--- a/src/include/processor/operator/aggregate/hash_aggregate.h
+++ b/src/include/processor/operator/aggregate/hash_aggregate.h
@@ -114,10 +114,8 @@ public:
 };
 
 struct HashAggregateLocalState {
-    std::vector<common::ValueVector*> flatKeyVectors;
-    std::vector<common::ValueVector*> unFlatKeyVectors;
+    std::vector<common::ValueVector*> keyVectors;
     std::vector<common::ValueVector*> dependentKeyVectors;
-    common::DataChunkState* leadingState = nullptr;
     std::unique_ptr<PartitioningAggregateHashTable> aggregateHashTable;
 
     void init(HashAggregateSharedState* sharedState, ResultSet& resultSet,

--- a/src/include/processor/operator/aggregate/hash_aggregate.h
+++ b/src/include/processor/operator/aggregate/hash_aggregate.h
@@ -9,6 +9,7 @@
 #include "aggregate_hash_table.h"
 #include "common/cast.h"
 #include "common/copy_constructors.h"
+#include "common/data_chunk/data_chunk_state.h"
 #include "common/in_mem_overflow_buffer.h"
 #include "common/mpsc_queue.h"
 #include "common/types/types.h"
@@ -116,6 +117,7 @@ public:
 struct HashAggregateLocalState {
     std::vector<common::ValueVector*> keyVectors;
     std::vector<common::ValueVector*> dependentKeyVectors;
+    common::DataChunkState* leadingState = nullptr;
     std::unique_ptr<PartitioningAggregateHashTable> aggregateHashTable;
 
     void init(HashAggregateSharedState* sharedState, ResultSet& resultSet,

--- a/src/include/processor/result/base_hash_table.h
+++ b/src/include/processor/result/base_hash_table.h
@@ -40,15 +40,11 @@ protected:
 
     uint64_t getSlotIdxForHash(common::hash_t hash) const { return hash & bitmask; }
     void setMaxNumHashSlots(uint64_t newSize);
-    void computeAndCombineVecHash(std::span<const common::ValueVector*> unFlatKeyVectors,
-        uint32_t startVecIdx);
 
-    void computeVectorHashes(const std::vector<common::ValueVector*>& flatKeyVectors,
-        const std::vector<common::ValueVector*>& unFlatKeyVectors) {
-        computeVectorHashes(constSpan(flatKeyVectors), constSpan(unFlatKeyVectors));
+    void computeVectorHashes(const std::vector<common::ValueVector*>& flatKeyVectors) {
+        computeVectorHashes(constSpan(flatKeyVectors));
     }
-    void computeVectorHashes(std::span<const common::ValueVector*> flatKeyVectors,
-        std::span<const common::ValueVector*> unFlatKeyVectors);
+    void computeVectorHashes(std::span<const common::ValueVector*> flatKeyVectors);
     void initSlotConstant(uint64_t numSlotsPerBlock);
     bool matchFlatVecWithEntry(const std::vector<common::ValueVector*>& keyVectors,
         const uint8_t* entry);

--- a/src/include/processor/result/pattern_creation_info_table.h
+++ b/src/include/processor/result/pattern_creation_info_table.h
@@ -25,9 +25,8 @@ public:
 
     PatternCreationInfo getPatternCreationInfo(const std::vector<common::ValueVector*>& keyVectors);
 
-    uint64_t matchFTEntries(std::span<const common::ValueVector*> flatKeyVectors,
-        std::span<const common::ValueVector*> unFlatKeyVectors, uint64_t numMayMatches,
-        uint64_t numNoMatches) override;
+    uint64_t matchFTEntries(std::span<const common::ValueVector*> keyVectors,
+        uint64_t numMayMatches, uint64_t numNoMatches) override;
 
 private:
     uint8_t* tuple;

--- a/src/optimizer/factorization_rewriter.cpp
+++ b/src/optimizer/factorization_rewriter.cpp
@@ -92,10 +92,8 @@ void FactorizationRewriter::visitAccumulate(planner::LogicalOperator* op) {
 
 void FactorizationRewriter::visitAggregate(planner::LogicalOperator* op) {
     auto& aggregate = op->cast<LogicalAggregate>();
-    auto groupsPosToFlattenForGroupBy = aggregate.getGroupsPosToFlattenForGroupBy();
-    aggregate.setChild(0, appendFlattens(aggregate.getChild(0), groupsPosToFlattenForGroupBy));
-    auto groupsPosToFlattenForAggregate = aggregate.getGroupsPosToFlattenForAggregate();
-    aggregate.setChild(0, appendFlattens(aggregate.getChild(0), groupsPosToFlattenForAggregate));
+    auto groupsPosToFlatten = aggregate.getGroupsPosToFlatten();
+    aggregate.setChild(0, appendFlattens(aggregate.getChild(0), groupsPosToFlatten));
 }
 
 void FactorizationRewriter::visitOrderBy(planner::LogicalOperator* op) {

--- a/src/planner/operator/factorization/flatten_resolver.cpp
+++ b/src/planner/operator/factorization/flatten_resolver.cpp
@@ -7,6 +7,7 @@
 #include "binder/expression/scalar_function_expression.h"
 #include "binder/expression/subquery_expression.h"
 #include "common/exception/not_implemented.h"
+#include "planner/operator/schema.h"
 
 using namespace kuzu::common;
 using namespace kuzu::binder;
@@ -14,8 +15,8 @@ using namespace kuzu::binder;
 namespace kuzu {
 namespace planner {
 
-f_group_pos_set FlattenAllButOne::getGroupsPosToFlatten(const expression_vector& exprs,
-    const Schema& schema) {
+std::pair<f_group_pos, f_group_pos_set> FlattenAllButOne::getGroupsPosToFlatten(
+    const expression_vector& exprs, const Schema& schema) {
     f_group_pos_set result;
     f_group_pos_set dependentGroups;
     for (auto expr : exprs) {
@@ -37,7 +38,11 @@ f_group_pos_set FlattenAllButOne::getGroupsPosToFlatten(const expression_vector&
     for (auto i = 1u; i < candidates.size(); ++i) {
         result.insert(candidates[i]);
     }
-    return result;
+    if (candidates.empty()) {
+        return std::make_pair(INVALID_F_GROUP_POS, result);
+    } else {
+        return std::make_pair(candidates[0], result);
+    }
 }
 
 f_group_pos_set FlattenAllButOne::getGroupsPosToFlatten(std::shared_ptr<Expression> expr,

--- a/src/planner/operator/logical_aggregate.cpp
+++ b/src/planner/operator/logical_aggregate.cpp
@@ -1,6 +1,5 @@
 #include "planner/operator/logical_aggregate.h"
 
-#include "binder/expression/aggregate_function_expression.h"
 #include "binder/expression/expression_util.h"
 #include "planner/operator/factorization/flatten_resolver.h"
 
@@ -29,17 +28,10 @@ void LogicalAggregate::computeFlatSchema() {
 }
 
 f_group_pos_set LogicalAggregate::getGroupsPosToFlattenForGroupBy() {
-    if (hasDistinctAggregate()) {
-        return FlattenAll::getGroupsPosToFlatten(getAllKeys(), *children[0]->getSchema());
-    } else {
-        return FlattenAllButOne::getGroupsPosToFlatten(getAllKeys(), *children[0]->getSchema());
-    }
+    return FlattenAllButOne::getGroupsPosToFlatten(getAllKeys(), *children[0]->getSchema());
 }
 
 f_group_pos_set LogicalAggregate::getGroupsPosToFlattenForAggregate() {
-    if (hasDistinctAggregate()) {
-        return FlattenAll::getGroupsPosToFlatten(aggregates, *children[0]->getSchema());
-    }
     return f_group_pos_set{};
 }
 
@@ -57,16 +49,6 @@ std::string LogicalAggregate::getExpressionsForPrinting() const {
     }
     result += "]";
     return result;
-}
-
-bool LogicalAggregate::hasDistinctAggregate() {
-    for (auto& expression : aggregates) {
-        auto funcExpr = expression->constPtrCast<binder::AggregateFunctionExpression>();
-        if (funcExpr->isDistinct()) {
-            return true;
-        }
-    }
-    return false;
 }
 
 void LogicalAggregate::insertAllExpressionsToGroupAndScope(f_group_pos groupPos) {

--- a/src/planner/operator/logical_aggregate.cpp
+++ b/src/planner/operator/logical_aggregate.cpp
@@ -1,5 +1,6 @@
 #include "planner/operator/logical_aggregate.h"
 
+#include "binder/expression/aggregate_function_expression.h"
 #include "binder/expression/expression_util.h"
 #include "planner/operator/factorization/flatten_resolver.h"
 #include "planner/operator/schema.h"
@@ -31,18 +32,23 @@ void LogicalAggregate::computeFlatSchema() {
 f_group_pos_set LogicalAggregate::getGroupsPosToFlatten() {
     auto [unflatGroup, flattenedGroups] =
         FlattenAllButOne::getGroupsPosToFlatten(getAllKeys(), *children[0]->getSchema());
-    // Flatten aggregates if they are from a different group than the unflat key group
+    // Flatten distinct aggregates if they are from a different group than the unflat key group
+    // Regular aggregates can be processed when unflat, but distinct aggregates get added to their
+    // own AggregateHashTable and have the same input limitations as the aggregate groups
     if (unflatGroup != INVALID_F_GROUP_POS) {
         for (const auto& aggregate : aggregates) {
+            auto funcExpr = aggregate->constPtrCast<binder::AggregateFunctionExpression>();
             auto analyzer = GroupDependencyAnalyzer(false /* collectDependentExpr */,
                 *children[0]->getSchema());
             analyzer.visit(aggregate);
             for (const auto& group : analyzer.getRequiredFlatGroups()) {
                 flattenedGroups.insert(group);
             }
-            for (const auto& group : analyzer.getDependentGroups()) {
-                if (group != unflatGroup) {
-                    flattenedGroups.insert(group);
+            if (funcExpr->isDistinct()) {
+                for (const auto& group : analyzer.getDependentGroups()) {
+                    if (group != unflatGroup) {
+                        flattenedGroups.insert(group);
+                    }
                 }
             }
         }

--- a/src/planner/plan/append_aggregate.cpp
+++ b/src/planner/plan/append_aggregate.cpp
@@ -10,9 +10,7 @@ void Planner::appendAggregate(const expression_vector& expressionsToGroupBy,
     const expression_vector& expressionsToAggregate, LogicalPlan& plan) {
     auto aggregate = make_shared<LogicalAggregate>(expressionsToGroupBy, expressionsToAggregate,
         plan.getLastOperator());
-    appendFlattens(aggregate->getGroupsPosToFlattenForGroupBy(), plan);
-    aggregate->setChild(0, plan.getLastOperator());
-    appendFlattens(aggregate->getGroupsPosToFlattenForAggregate(), plan);
+    appendFlattens(aggregate->getGroupsPosToFlatten(), plan);
     aggregate->setChild(0, plan.getLastOperator());
     aggregate->computeFactorizedSchema();
     aggregate->setCardinality(cardinalityEstimator.estimateAggregate(*aggregate));

--- a/src/processor/operator/aggregate/aggregate_hash_table.cpp
+++ b/src/processor/operator/aggregate/aggregate_hash_table.cpp
@@ -6,11 +6,13 @@
 #include "common/assert.h"
 #include "common/constants.h"
 #include "common/data_chunk/data_chunk_state.h"
+#include "common/data_chunk/sel_vector.h"
 #include "common/in_mem_overflow_buffer.h"
 #include "common/type_utils.h"
 #include "common/types/types.h"
 #include "common/utils.h"
 #include "common/vector/value_vector.h"
+#include "processor/operator/aggregate/aggregate_input.h"
 #include "processor/result/factorized_table.h"
 #include "processor/result/factorized_table_schema.h"
 
@@ -45,33 +47,30 @@ AggregateHashTable::AggregateHashTable(MemoryManager& memoryManager,
     initializeTmpVectors();
 }
 
-bool PartitioningAggregateHashTable::insertAggregateValueIfDistinctForGroupByKeys(
-    const std::vector<ValueVector*>& groupByFlatKeyVectors, ValueVector* aggregateVector) {
-    mergeIfFull(1);
-    return AggregateHashTable::insertAggregateValueIfDistinctForGroupByKeys(groupByFlatKeyVectors,
-        aggregateVector);
+static DataChunkState* getFirstUnflatState(const std::vector<ValueVector*>& keyVectors) {
+    for (auto vector : keyVectors) {
+        if (!vector->state->isFlat()) {
+            KU_ASSERT(all_of(keyVectors.begin(), keyVectors.end(), [&](auto* otherVector) {
+                return otherVector->state->isFlat() ||
+                       otherVector->state.get() == vector->state.get();
+            }));
+            return vector->state.get();
+        }
+    }
+    return nullptr;
 }
 
-bool AggregateHashTable::insertAggregateValueIfDistinctForGroupByKeys(
-    const std::vector<ValueVector*>& groupByFlatKeyVectors, ValueVector* aggregateVector) {
-    auto pos = aggregateVector->state->getSelVector()[0];
-    if (aggregateVector->isNull(pos)) {
-        return false;
-    }
-    std::vector<ValueVector*> distinctKeyVectors(groupByFlatKeyVectors.size() + 1);
-    for (auto i = 0u; i < groupByFlatKeyVectors.size(); i++) {
-        distinctKeyVectors[i] = groupByFlatKeyVectors[i];
-    }
-    distinctKeyVectors[groupByFlatKeyVectors.size()] = aggregateVector;
-    computeVectorHashes(distinctKeyVectors, std::vector<ValueVector*>() /* unFlatKeyVectors */);
-    auto hash = hashVector->getValue<hash_t>(hashVector->state->getSelVector()[0]);
-    auto distinctHTEntry = findEntryInDistinctHT(distinctKeyVectors, hash);
-    if (distinctHTEntry == nullptr) {
-        resizeHashTableIfNecessary(1);
-        createEntryInDistinctHT(distinctKeyVectors, hash);
-        return true;
-    }
-    return false;
+uint64_t AggregateHashTable::append(const std::vector<ValueVector*>& keyVectors,
+    const std::vector<ValueVector*>& dependentKeyVectors,
+    const std::vector<AggregateInput>& aggregateInputs, uint64_t resultSetMultiplicity) {
+    const auto firstUnFlatState = getFirstUnflatState(keyVectors);
+    // If there is no first unflat state, then the states must all be flat and have a size of 1
+    const auto numFlatTuples = firstUnFlatState ? firstUnFlatState->getSelVector().getSelSize() : 1;
+    resizeHashTableIfNecessary(numFlatTuples);
+    computeVectorHashes(keyVectors);
+    findHashSlots(keyVectors, dependentKeyVectors);
+    updateAggStates(keyVectors, aggregateInputs, resultSetMultiplicity, firstUnFlatState);
+    return numFlatTuples;
 }
 
 hash_t getHash(const FactorizedTable& table, ft_tuple_idx_t tupleIdx) {
@@ -143,15 +142,16 @@ void AggregateHashTable::mergeDistinctAggregateInfo() {
                     distinctHashEntriesProcessed[distinctIdx], numTuplesToScan, colIdxToScan);
                 // Compute hashes for the scanned keys but not the distinct key (i.e. the groups in
                 // the main hash table)
-                computeVectorHashes(std::span<const ValueVector*>{},
-                    std::span(const_cast<const ValueVector**>(vectorPtrs.data()),
-                        vectorPtrs.size() - 1));
+                computeVectorHashes(std::span(const_cast<const ValueVector**>(vectorPtrs.data()),
+                    vectorPtrs.size() - 1));
                 for (size_t i = 0; i < numTuplesToScan; i++) {
                     // Find slot in current hash table corresponding to the entry in the distinct
                     // hash table
                     // updatePosState may not check nulls, and we avoid inserting any nulls into
                     // distinct hash tables
-                    KU_ASSERT(!vectors.back()->isNull(i));
+                    if (vectors.back()->isNull(i)) {
+                        continue;
+                    }
                     auto hash = hashVector->getValue<hash_t>(i);
                     // matchFTEntries expects that the index is the same as the index in the vector
                     // Doesn't need to be done each time, but maybe this can be vectorized so that
@@ -160,7 +160,7 @@ void AggregateHashTable::mergeDistinctAggregateInfo() {
                     auto entry = findEntry(hash, [&](auto entry) {
                         HashSlot slot{hash, entry};
                         hashSlotsToUpdateAggState[i] = &slot;
-                        return matchFTEntries(std::span<const ValueVector*>{},
+                        return matchFTEntries(
                                    std::span(const_cast<const ValueVector**>(vectorPtrs.data()),
                                        vectorPtrs.size() - 1),
                                    1, 0) == 0;
@@ -250,16 +250,17 @@ void AggregateHashTable::resize(uint64_t newSize) {
         [&](auto tuple) { fillHashSlot(*(hash_t*)(tuple + hashColOffsetInFT), tuple); });
 }
 
-uint64_t AggregateHashTable::matchFTEntries(std::span<const ValueVector*> flatKeyVectors,
-    std::span<const ValueVector*> unFlatKeyVectors, uint64_t numMayMatches, uint64_t numNoMatches) {
+uint64_t AggregateHashTable::matchFTEntries(std::span<const ValueVector*> keyVectors,
+    uint64_t numMayMatches, uint64_t numNoMatches) {
     auto colIdx = 0u;
-    for (const auto& flatKeyVector : flatKeyVectors) {
-        numMayMatches =
-            matchFlatVecWithFTColumn(flatKeyVector, numMayMatches, numNoMatches, colIdx++);
-    }
-    for (auto& unFlatKeyVector : unFlatKeyVectors) {
-        numMayMatches =
-            matchUnFlatVecWithFTColumn(unFlatKeyVector, numMayMatches, numNoMatches, colIdx++);
+    for (const auto& keyVector : keyVectors) {
+        if (keyVector->state->isFlat()) {
+            numMayMatches =
+                matchFlatVecWithFTColumn(keyVector, numMayMatches, numNoMatches, colIdx++);
+        } else {
+            numMayMatches =
+                matchUnFlatVecWithFTColumn(keyVector, numMayMatches, numNoMatches, colIdx++);
+        }
     }
     return numNoMatches;
 }
@@ -294,15 +295,15 @@ uint64_t AggregateHashTable::matchFTEntries(const FactorizedTable& srcTable, uin
     return numNoMatches;
 }
 
-void AggregateHashTable::initializeFTEntries(const std::vector<ValueVector*>& flatKeyVectors,
-    const std::vector<ValueVector*>& unFlatKeyVectors,
+void AggregateHashTable::initializeFTEntries(const std::vector<ValueVector*>& keyVectors,
     const std::vector<ValueVector*>& dependentKeyVectors, uint64_t numFTEntriesToInitialize) {
     auto colIdx = 0u;
-    for (auto flatKeyVector : flatKeyVectors) {
-        initializeFTEntryWithFlatVec(flatKeyVector, numFTEntriesToInitialize, colIdx++);
-    }
-    for (auto unFlatKeyVector : unFlatKeyVectors) {
-        initializeFTEntryWithUnFlatVec(unFlatKeyVector, numFTEntriesToInitialize, colIdx++);
+    for (auto keyVector : keyVectors) {
+        if (keyVector->state->isFlat()) {
+            initializeFTEntryWithFlatVec(keyVector, numFTEntriesToInitialize, colIdx++);
+        } else {
+            initializeFTEntryWithUnFlatVec(keyVector, numFTEntriesToInitialize, colIdx++);
+        }
     }
     for (auto dependentKeyVector : dependentKeyVectors) {
         if (dependentKeyVector->state->isFlat()) {
@@ -513,11 +514,10 @@ void AggregateHashTable::increaseHashSlotIdxes(uint64_t numNoMatches) {
     }
 }
 
-void AggregateHashTable::findHashSlots(const std::vector<ValueVector*>& flatKeyVectors,
-    const std::vector<ValueVector*>& unFlatKeyVectors,
-    const std::vector<ValueVector*>& dependentKeyVectors, DataChunkState* leadingState) {
+void AggregateHashTable::findHashSlots(const std::vector<ValueVector*>& keyVectors,
+    const std::vector<ValueVector*>& dependentKeyVectors) {
     initTmpHashSlotsAndIdxes();
-    auto numEntriesToFindHashSlots = leadingState->getSelVector().getSelSize();
+    auto numEntriesToFindHashSlots = hashVector->state->getSelSize();
     KU_ASSERT(getNumEntries() + numEntriesToFindHashSlots < maxNumHashSlots);
     while (numEntriesToFindHashSlots > 0) {
         uint64_t numFTEntriesToUpdate = 0;
@@ -537,10 +537,8 @@ void AggregateHashTable::findHashSlots(const std::vector<ValueVector*>& flatKeyV
                 noMatchIdxes[numNoMatches++] = idx;
             }
         }
-        initializeFTEntries(flatKeyVectors, unFlatKeyVectors, dependentKeyVectors,
-            numFTEntriesToUpdate);
-        numNoMatches = matchFTEntries(constSpan(flatKeyVectors), constSpan(unFlatKeyVectors),
-            numMayMatches, numNoMatches);
+        initializeFTEntries(keyVectors, dependentKeyVectors, numFTEntriesToUpdate);
+        numNoMatches = matchFTEntries(constSpan(keyVectors), numMayMatches, numNoMatches);
         increaseHashSlotIdxes(numNoMatches);
         KU_ASSERT(numNoMatches <= numEntriesToFindHashSlots);
         numEntriesToFindHashSlots = numNoMatches;
@@ -579,33 +577,63 @@ void AggregateHashTable::findHashSlots(const FactorizedTable& srcTable, uint64_t
     }
 }
 
-void AggregateHashTable::updateAggState(const std::vector<ValueVector*>& flatKeyVectors,
-    const std::vector<ValueVector*>& unFlatKeyVectors, AggregateFunction& aggregateFunction,
-    ValueVector* aggVector, uint64_t multiplicity, uint32_t /*colIdx*/, uint32_t aggStateOffset) {
-    if (!aggVector) {
-        updateNullAggVectorState(flatKeyVectors, unFlatKeyVectors, aggregateFunction, multiplicity,
-            aggStateOffset);
-    } else if (aggVector->state->isFlat() && unFlatKeyVectors.empty()) {
-        updateBothFlatAggVectorState(flatKeyVectors, aggregateFunction, aggVector, multiplicity,
-            aggStateOffset);
-    } else if (aggVector->state->isFlat()) {
-        updateFlatUnFlatKeyFlatAggVectorState(flatKeyVectors, unFlatKeyVectors, aggregateFunction,
-            aggVector, multiplicity, aggStateOffset);
-    } else if (unFlatKeyVectors.empty()) {
-        updateFlatKeyUnFlatAggVectorState(flatKeyVectors, aggregateFunction, aggVector,
-            multiplicity, aggStateOffset);
-    } else if (!unFlatKeyVectors.empty() && (aggVector->state == unFlatKeyVectors[0]->state)) {
-        updateBothUnFlatSameDCAggVectorState(flatKeyVectors, unFlatKeyVectors, aggregateFunction,
-            aggVector, multiplicity, aggStateOffset);
+void AggregateHashTable::appendDistinct(const std::vector<ValueVector*>& keyVectors,
+    ValueVector* aggregateVector) {
+    std::vector<ValueVector*> distinctKeyVectors(keyVectors);
+    distinctKeyVectors.push_back(aggregateVector);
+    if (!keyVectors.empty() && !aggregateVector->state->isFlat() &&
+        getFirstUnflatState(keyVectors) != aggregateVector->state.get()) {
+        // If the aggregateVector is unFlat, with a different state from the unflat vectors in the
+        // keys, flatten the aggregate vector and append values one by one since there can be at
+        // most one unflat group in the keyVectors.
+        auto oldState = std::move(aggregateVector->state);
+        aggregateVector->state = std::make_unique<DataChunkState>(1);
+        aggregateVector->state->setToFlat();
+        aggregateVector->state->getSelVectorUnsafe().setToFiltered(1);
+        // Append sets the leading state to select all distinct positions inserted
+        oldState->getSelVector().forEach([&](auto pos) {
+            aggregateVector->state->getSelVectorUnsafe()[0] = pos;
+            append(distinctKeyVectors, std::vector<AggregateInput>{}, 1 /*multiplicity*/);
+        });
+        aggregateVector->state = oldState;
     } else {
-        updateBothUnFlatDifferentDCAggVectorState(flatKeyVectors, unFlatKeyVectors,
-            aggregateFunction, aggVector, multiplicity, aggStateOffset);
+        append(distinctKeyVectors, std::vector<AggregateInput>{}, 1 /*multiplicity*/);
     }
 }
 
-void AggregateHashTable::updateAggStates(const std::vector<ValueVector*>& flatKeyVectors,
-    const std::vector<ValueVector*>& unFlatKeyVectors,
-    const std::vector<AggregateInput>& aggregateInputs, uint64_t resultSetMultiplicity) {
+void AggregateHashTable::updateAggState(const std::vector<ValueVector*>& keyVectors,
+    AggregateFunction& aggregateFunction, ValueVector* aggVector, uint64_t multiplicity,
+    uint32_t aggStateOffset, const DataChunkState* firstUnFlatState) {
+    //  There may be a mix of flat and unflat states, but any unflat states will be the same
+    bool allFlat = firstUnFlatState == nullptr;
+    if (!aggVector) {
+        const DataChunkState* keyState = nullptr;
+        if (firstUnFlatState) {
+            keyState = firstUnFlatState;
+        } else {
+            keyState = keyVectors[0]->state.get();
+        }
+        updateNullAggVectorState(*keyState, aggregateFunction, multiplicity, aggStateOffset);
+    } else if (aggVector->state->isFlat() && allFlat) {
+        updateBothFlatAggVectorState(aggregateFunction, aggVector, multiplicity, aggStateOffset);
+    } else if (aggVector->state->isFlat()) {
+        updateFlatUnFlatKeyFlatAggVectorState(*firstUnFlatState, aggregateFunction, aggVector,
+            multiplicity, aggStateOffset);
+    } else if (allFlat) {
+        updateFlatKeyUnFlatAggVectorState(keyVectors, aggregateFunction, aggVector, multiplicity,
+            aggStateOffset);
+    } else if (aggVector->state.get() == firstUnFlatState) {
+        updateBothUnFlatSameDCAggVectorState(aggregateFunction, aggVector, multiplicity,
+            aggStateOffset);
+    } else {
+        updateBothUnFlatDifferentDCAggVectorState(*firstUnFlatState, aggregateFunction, aggVector,
+            multiplicity, aggStateOffset);
+    }
+}
+
+void AggregateHashTable::updateAggStates(const std::vector<ValueVector*>& keyVectors,
+    const std::vector<AggregateInput>& aggregateInputs, uint64_t resultSetMultiplicity,
+    const DataChunkState* firstUnFlatState) {
     auto aggregateStateOffset = aggStateColOffsetInFT;
     for (auto i = 0u; i < aggregateFunctions.size(); i++) {
         if (!aggregateFunctions[i].isDistinct) {
@@ -613,14 +641,13 @@ void AggregateHashTable::updateAggStates(const std::vector<ValueVector*>& flatKe
             for (auto& dataChunk : aggregateInputs[i].multiplicityChunks) {
                 multiplicity *= dataChunk->state->getSelVector().getSelSize();
             }
-            updateAggState(flatKeyVectors, unFlatKeyVectors, aggregateFunctions[i],
-                aggregateInputs[i].aggregateVector, multiplicity, i, aggregateStateOffset);
+            updateAggState(keyVectors, aggregateFunctions[i], aggregateInputs[i].aggregateVector,
+                multiplicity, aggregateStateOffset, firstUnFlatState);
             aggregateStateOffset += aggregateFunctions[i].getAggregateStateSize();
         } else {
-            // If a function is distinct we still need to insert the value into the distinct hash
-            // table
-            distinctHashTables[i]->insertAggregateValueIfDistinctForGroupByKeys(flatKeyVectors,
-                aggregateInputs[i].aggregateVector);
+            // If a function is distinct we still need to insert the value into the distinct
+            // hash table
+            distinctHashTables[i]->appendDistinct(keyVectors, aggregateInputs[i].aggregateVector);
         }
     }
 }
@@ -666,23 +693,21 @@ void AggregateHashTable::resizeHashTableIfNecessary(uint32_t maxNumDistinctHashK
     }
 }
 
-void AggregateHashTable::updateNullAggVectorState(const std::vector<ValueVector*>& flatKeyVectors,
-    const std::vector<ValueVector*>& unFlatKeyVectors, AggregateFunction& aggregateFunction,
-    uint64_t multiplicity, uint32_t aggStateOffset) {
-    if (unFlatKeyVectors.empty()) {
-        auto pos = flatKeyVectors[0]->state->getSelVector()[0];
+void AggregateHashTable::updateNullAggVectorState(const DataChunkState& keyState,
+    AggregateFunction& aggregateFunction, uint64_t multiplicity, uint32_t aggStateOffset) {
+    if (keyState.isFlat()) {
+        auto pos = keyState.getSelVector()[0];
         aggregateFunction.updatePosState(hashSlotsToUpdateAggState[pos]->entry + aggStateOffset,
             nullptr, multiplicity, 0 /* dummy pos */, memoryManager);
     } else {
-        unFlatKeyVectors[0]->state->getSelVector().forEach([&](auto pos) {
+        keyState.getSelVector().forEach([&](auto pos) {
             aggregateFunction.updatePosState(hashSlotsToUpdateAggState[pos]->entry + aggStateOffset,
                 nullptr, multiplicity, 0 /* dummy pos */, memoryManager);
         });
     }
 }
 
-void AggregateHashTable::updateBothFlatAggVectorState(
-    const std::vector<ValueVector*>& /*flatKeyVectors*/, AggregateFunction& aggregateFunction,
+void AggregateHashTable::updateBothFlatAggVectorState(AggregateFunction& aggregateFunction,
     ValueVector* aggVector, uint64_t multiplicity, uint32_t aggStateOffset) {
     auto aggPos = aggVector->state->getSelVector()[0];
     if (!aggVector->isNull(aggPos)) {
@@ -692,13 +717,12 @@ void AggregateHashTable::updateBothFlatAggVectorState(
     }
 }
 
-void AggregateHashTable::updateFlatUnFlatKeyFlatAggVectorState(
-    const std::vector<ValueVector*>& /*flatKeyVectors*/,
-    const std::vector<ValueVector*>& unFlatKeyVectors, AggregateFunction& aggregateFunction,
-    ValueVector* aggVector, uint64_t multiplicity, uint32_t aggStateOffset) {
+void AggregateHashTable::updateFlatUnFlatKeyFlatAggVectorState(const DataChunkState& unFlatKeyState,
+    AggregateFunction& aggregateFunction, ValueVector* aggVector, uint64_t multiplicity,
+    uint32_t aggStateOffset) {
     auto aggPos = aggVector->state->getSelVector()[0];
     if (!aggVector->isNull(aggPos)) {
-        unFlatKeyVectors[0]->state->getSelVector().forEach([&](auto pos) {
+        unFlatKeyState.getSelVector().forEach([&](auto pos) {
             aggregateFunction.updatePosState(hashSlotsToUpdateAggState[pos]->entry + aggStateOffset,
                 aggVector, multiplicity, aggPos, memoryManager);
         });
@@ -716,9 +740,7 @@ void AggregateHashTable::updateFlatKeyUnFlatAggVectorState(
     });
 }
 
-void AggregateHashTable::updateBothUnFlatSameDCAggVectorState(
-    const std::vector<ValueVector*>& /*flatKeyVectors*/,
-    const std::vector<ValueVector*>& /*unFlatKeyVectors*/, AggregateFunction& aggregateFunction,
+void AggregateHashTable::updateBothUnFlatSameDCAggVectorState(AggregateFunction& aggregateFunction,
     ValueVector* aggVector, uint64_t multiplicity, uint32_t aggStateOffset) {
     aggVector->forEachNonNull([&](auto pos) {
         aggregateFunction.updatePosState(hashSlotsToUpdateAggState[pos]->entry + aggStateOffset,
@@ -727,10 +749,9 @@ void AggregateHashTable::updateBothUnFlatSameDCAggVectorState(
 }
 
 void AggregateHashTable::updateBothUnFlatDifferentDCAggVectorState(
-    const std::vector<ValueVector*>& /*flatKeyVectors*/,
-    const std::vector<ValueVector*>& unFlatKeyVectors, AggregateFunction& aggregateFunction,
+    const DataChunkState& unFlatKeyState, AggregateFunction& aggregateFunction,
     ValueVector* aggVector, uint64_t multiplicity, uint32_t aggStateOffset) {
-    unFlatKeyVectors[0]->state->getSelVector().forEach([&](auto pos) {
+    unFlatKeyState.getSelVector().forEach([&](auto pos) {
         aggregateFunction.updateAllState(hashSlotsToUpdateAggState[pos]->entry + aggStateOffset,
             aggVector, multiplicity, memoryManager);
     });
@@ -775,20 +796,23 @@ std::unique_ptr<AggregateHashTable> AggregateHashTableUtils::createDistinctHashT
         getTableSchemaForKeys(groupByKeyTypes, distinctKeyType));
 }
 
-uint64_t PartitioningAggregateHashTable::append(const std::vector<ValueVector*>& flatKeyVectors,
-    const std::vector<ValueVector*>& unFlatKeyVectors,
-    const std::vector<ValueVector*>& dependentKeyVectors, DataChunkState* leadingState,
+uint64_t PartitioningAggregateHashTable::append(const std::vector<ValueVector*>& keyVectors,
+    const std::vector<ValueVector*>& dependentKeyVectors,
     const std::vector<AggregateInput>& aggregateInputs, uint64_t resultSetMultiplicity) {
-    const auto numFlatTuples = leadingState->getSelVector().getSelSize();
+    const auto firstUnFlatState = getFirstUnflatState(keyVectors);
+    // If there is no first unflat state, then the states must all be flat and have a size of 1
+    const auto numFlatTuples = firstUnFlatState ? firstUnFlatState->getSelVector().getSelSize() : 1;
 
     mergeIfFull(numFlatTuples);
 
     // mergeAll makes use of the hashVector, so it needs to be called before computeVectorHashes
-    computeVectorHashes(flatKeyVectors, unFlatKeyVectors);
-    findHashSlots(flatKeyVectors, unFlatKeyVectors, dependentKeyVectors, leadingState);
-    // Don't update distinct states since they can't be merged into the global hash tables. Instead
-    // we'll calculate them from scratch when merging.
-    updateAggStates(flatKeyVectors, unFlatKeyVectors, aggregateInputs, resultSetMultiplicity);
+    computeVectorHashes(keyVectors);
+    KU_ASSERT(hashVector->getSelVectorPtr()->getSelSize() ==
+              (firstUnFlatState ? firstUnFlatState->getSelSize() : 1));
+    findHashSlots(keyVectors, dependentKeyVectors);
+    // Don't update distinct states since they can't be merged into the global hash tables.
+    // Instead we'll calculate them from scratch when merging.
+    updateAggStates(keyVectors, aggregateInputs, resultSetMultiplicity, firstUnFlatState);
     return numFlatTuples;
 }
 
@@ -802,8 +826,8 @@ void PartitioningAggregateHashTable::mergeIfFull(uint64_t tuplesToAdd, bool merg
     if (mergeAll || outOfSpace(*this, tuplesToAdd)) {
         partitioningData->appendTuples(*factorizedTable,
             tableSchema.getColOffset(tableSchema.getNumColumns() - 1));
-        // Move overflow data into the shared state so that it isn't obliterated when we clear the
-        // factorized table
+        // Move overflow data into the shared state so that it isn't obliterated when we clear
+        // the factorized table
         partitioningData->appendOverflow(std::move(*factorizedTable->getInMemOverflowBuffer()));
         clear();
     }
@@ -825,9 +849,9 @@ void PartitioningAggregateHashTable::mergeIfFull(uint64_t tuplesToAdd, bool merg
     std::vector<ft_col_idx_t> colIdxToScan;
     if (distinctHashTables.size() > 0) {
         // We need the hashes of the key columns to partition them appropriately.
-        // These will be the same for each of the distinct hash tables since we exclude the distinct
-        // aggregate key Reserve inside here so that we don't unnecessarily allocate memory if there
-        // are no distinct hash tables
+        // These will be the same for each of the distinct hash tables since we exclude the
+        // distinct aggregate key Reserve inside here so that we don't unnecessarily allocate
+        // memory if there are no distinct hash tables
         colIdxToScan.resize(keyTypes.size());
         std::iota(colIdxToScan.begin(), colIdxToScan.end(), 0);
         vectors.reserve(keyTypes.size());
@@ -851,12 +875,12 @@ void PartitioningAggregateHashTable::mergeIfFull(uint64_t tuplesToAdd, bool merg
             while (startTupleIdx < distinctFactorizedTable->getNumTuples()) {
                 distinctFactorizedTable->scan(vectors, startTupleIdx, numTuplesToScan,
                     colIdxToScan);
-                computeVectorHashes(std::vector<ValueVector*>{}, vectors);
+                computeVectorHashes(vectors);
                 for (uint64_t tupleIdx = 0; tupleIdx < numTuplesToScan; tupleIdx++) {
                     auto* tuple = distinctFactorizedTable->getTuple(startTupleIdx + tupleIdx);
-                    // The distinct value needs to be partitioned according to the group that stores
-                    // its aggregate state So we need to ignore the aggregate key when calculating
-                    // the hash for partitioning
+                    // The distinct value needs to be partitioned according to the group that
+                    // stores its aggregate state So we need to ignore the aggregate key when
+                    // calculating the hash for partitioning
                     const auto hash = hashVector->getValue<hash_t>(tupleIdx);
                     partitioningData->appendDistinctTuple(distinctIdx,
                         std::span(tuple, distinctTableSchema->getNumBytesPerTuple()), hash);

--- a/src/processor/operator/aggregate/hash_aggregate.cpp
+++ b/src/processor/operator/aggregate/hash_aggregate.cpp
@@ -213,6 +213,11 @@ void HashAggregateLocalState::init(HashAggregateSharedState* sharedState, Result
         auto vector = resultSet.getValueVector(pos).get();
         keyVectors.push_back(vector);
         keyDataTypes.push_back(vector->dataType.copy());
+        leadingState = vector->state.get();
+    }
+    if (leadingState == nullptr) {
+        // All vectors are flat, so any can be the leading state
+        leadingState = keyVectors.front()->state.get();
     }
     std::vector<LogicalType> payloadDataTypes;
     for (auto& pos : info.dependentKeysPos) {
@@ -228,8 +233,8 @@ void HashAggregateLocalState::init(HashAggregateSharedState* sharedState, Result
 
 uint64_t HashAggregateLocalState::append(const std::vector<AggregateInput>& aggregateInputs,
     uint64_t multiplicity) const {
-    return aggregateHashTable->append(keyVectors, dependentKeyVectors, aggregateInputs,
-        multiplicity);
+    return aggregateHashTable->append(keyVectors, dependentKeyVectors, leadingState,
+        aggregateInputs, multiplicity);
 }
 
 void HashAggregate::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {

--- a/src/processor/operator/aggregate/simple_aggregate.cpp
+++ b/src/processor/operator/aggregate/simple_aggregate.cpp
@@ -207,10 +207,10 @@ void SimpleAggregate::executeInternal(ExecutionContext* context) {
         for (auto i = 0u; i < aggregateFunctions.size(); i++) {
             auto aggregateFunction = &aggregateFunctions[i];
             if (aggregateFunction->isFunctionDistinct()) {
-                // Just add distinct value to the hash table. We'll calculate the final hash table
-                // once it's been merged into the global state
-                distinctHashTables[i].get()->insertAggregateValueIfDistinctForGroupByKeys(
-                    std::vector<ValueVector*>{}, aggInputs[i].aggregateVector);
+                // Just add distinct value to the hash table. We'll calculate the aggregate state
+                // once it's been merged into the shared state
+                distinctHashTables[i]->appendDistinct(std::vector<ValueVector*>{},
+                    aggInputs[i].aggregateVector);
             } else {
                 computeAggregate(aggregateFunction, &aggInputs[i], localAggregateStates[i].get(),
                     memoryManager);

--- a/src/processor/operator/aggregate/simple_aggregate.cpp
+++ b/src/processor/operator/aggregate/simple_aggregate.cpp
@@ -210,7 +210,7 @@ void SimpleAggregate::executeInternal(ExecutionContext* context) {
                 // Just add distinct value to the hash table. We'll calculate the aggregate state
                 // once it's been merged into the shared state
                 distinctHashTables[i]->appendDistinct(std::vector<ValueVector*>{},
-                    aggInputs[i].aggregateVector);
+                    aggInputs[i].aggregateVector, aggInputs[i].aggregateVector->state.get());
             } else {
                 computeAggregate(aggregateFunction, &aggInputs[i], localAggregateStates[i].get(),
                     memoryManager);

--- a/src/processor/operator/hash_join/join_hash_table.cpp
+++ b/src/processor/operator/hash_join/join_hash_table.cpp
@@ -201,8 +201,7 @@ uint8_t* JoinHashTable::insertEntry(uint8_t* tuple) const {
 }
 
 void JoinHashTable::computeVectorHashes(std::vector<common::ValueVector*> keyVectors) {
-    std::vector<ValueVector*> dummyUnFlatKeyVectors;
-    BaseHashTable::computeVectorHashes(keyVectors, dummyUnFlatKeyVectors);
+    BaseHashTable::computeVectorHashes(keyVectors);
 }
 
 offset_t JoinHashTable::getHashValueColOffset() const {

--- a/src/processor/result/pattern_creation_info_table.cpp
+++ b/src/processor/result/pattern_creation_info_table.cpp
@@ -34,7 +34,7 @@ PatternCreationInfo PatternCreationInfoTable::getPatternCreationInfo(
     } else {
         resizeHashTableIfNecessary(1);
         computeVectorHashes(keyVectors);
-        findHashSlots(keyVectors, std::vector<common::ValueVector*>{});
+        findHashSlots(keyVectors, std::vector<common::ValueVector*>{}, keyVectors[0]->state.get());
         hasCreated = tuple != nullptr;
         auto idTuple = tuple == nullptr ?
                            factorizedTable->getTuple(factorizedTable->getNumTuples() - 1) :

--- a/src/processor/result/pattern_creation_info_table.cpp
+++ b/src/processor/result/pattern_creation_info_table.cpp
@@ -33,9 +33,8 @@ PatternCreationInfo PatternCreationInfoTable::getPatternCreationInfo(
         return PatternCreationInfo{tuple, hasCreated};
     } else {
         resizeHashTableIfNecessary(1);
-        computeVectorHashes(keyVectors, std::vector<common::ValueVector*>{});
-        findHashSlots(keyVectors, std::vector<common::ValueVector*>{},
-            std::vector<common::ValueVector*>{}, keyVectors[0]->state.get());
+        computeVectorHashes(keyVectors);
+        findHashSlots(keyVectors, std::vector<common::ValueVector*>{});
         hasCreated = tuple != nullptr;
         auto idTuple = tuple == nullptr ?
                            factorizedTable->getTuple(factorizedTable->getNumTuples() - 1) :
@@ -44,13 +43,9 @@ PatternCreationInfo PatternCreationInfoTable::getPatternCreationInfo(
     }
 }
 
-uint64_t PatternCreationInfoTable::matchFTEntries(
-    std::span<const common::ValueVector*> flatKeyVectors,
-    std::span<const common::ValueVector*> unFlatKeyVectors, uint64_t numMayMatches,
-    uint64_t numNoMatches) {
-    KU_ASSERT(unFlatKeyVectors.empty());
-    numNoMatches = AggregateHashTable::matchFTEntries(flatKeyVectors, unFlatKeyVectors,
-        numMayMatches, numNoMatches);
+uint64_t PatternCreationInfoTable::matchFTEntries(std::span<const common::ValueVector*> keyVectors,
+    uint64_t numMayMatches, uint64_t numNoMatches) {
+    numNoMatches = AggregateHashTable::matchFTEntries(keyVectors, numMayMatches, numNoMatches);
     KU_ASSERT(numMayMatches <= 1);
     // If we found the entry for the target key, we set tuple to the key tuple. Otherwise, simply
     // set tuple to nullptr.


### PR DESCRIPTION
This involved refactoring the AggregateHashTable a bit, since the distinct tables end up having mixed flat/unflat vectors when you add the distinct key (since it always is the last column, but may be flat when there are unflat vectors, so the existing split of flat vectors first, then unflat vectors didn't really work).

The performance difference isn't huge for most queries, but it makes a much bigger difference for aggregation over complex data types where there is more overhead when calculating the hashes (the list and struct hashing functions allocate a temporary ValueVector, which is probably the main difference in the performance).

Performance (first is from Clickbench, the others were just constructed to see how similar queries perform with lists/structs as the keys):
| Query | Before | After |
| --- | --- | --- |
| `MATCH (h:hits) RETURN h.RegionID, COUNT(DISTINCT h.UserID) AS u ORDER BY u DESC LIMIT 10;` | 2.25s | 2.1s |
| `MATCH (h:hits) RETURN h.RegionID, COUNT(DISTINCT [h.UserID]) AS u ORDER BY u DESC LIMIT 10;` | 17.5s | 2.7s |
| `MATCH (h:hits) RETURN h.RegionID, COUNT(DISTINCT {"id": h.UserID}) AS u ORDER BY u DESC LIMIT 10;` | 3.7s | 2.3s |