### PR TITLE
Disable compression on floating point values in array/list

### DIFF
--- a/src/function/gds/strongly_connected_components.cpp
+++ b/src/function/gds/strongly_connected_components.cpp
@@ -305,8 +305,8 @@ public:
             }
         }
 
-        auto writeSccIdsToOutput = std::make_unique<SccWriteIdsToOutput>(mm, sharedState.get(),
-            computationState);
+        auto writeSccIdsToOutput =
+            std::make_unique<SccWriteIdsToOutput>(mm, sharedState.get(), computationState);
         GDSUtils::runVertexCompute(context, graph, *writeSccIdsToOutput);
 
         sharedState->factorizedTablePool.mergeLocalTables();

--- a/src/include/function/gds/gds_object_manager.h
+++ b/src/include/function/gds/gds_object_manager.h
@@ -39,7 +39,8 @@ private:
 template<typename T>
 class ObjectArray {
 public:
-    ObjectArray(const common::offset_t size, storage::MemoryManager* mm, bool initializeToZero = false)
+    ObjectArray(const common::offset_t size, storage::MemoryManager* mm,
+        bool initializeToZero = false)
         : allocation{mm->allocateBuffer(initializeToZero, size * sizeof(T))} {
         data = std::span<T>(reinterpret_cast<T*>(allocation->getData()), size);
     }
@@ -53,8 +54,10 @@ public:
         KU_ASSERT(pos < data.size());
         return data[pos];
     }
+
 private:
-    template<typename U> friend class AtomicObjectArray;
+    template<typename U>
+    friend class AtomicObjectArray;
     std::span<T> data;
     std::unique_ptr<storage::MemoryBuffer> allocation;
 };
@@ -63,9 +66,9 @@ private:
 template<typename T>
 class AtomicObjectArray {
 public:
-    AtomicObjectArray(const common::offset_t size, storage::MemoryManager* mm, bool initializeToZero = false)
-        : array{ObjectArray<std::atomic<T>>(size, mm, initializeToZero)} {
-    }
+    AtomicObjectArray(const common::offset_t size, storage::MemoryManager* mm,
+        bool initializeToZero = false)
+        : array{ObjectArray<std::atomic<T>>(size, mm, initializeToZero)} {}
 
     void setRelaxed(common::offset_t pos, const T& value) {
         KU_ASSERT(pos < array.data.size());
@@ -87,6 +90,7 @@ public:
         }
         return false;
     }
+
 private:
     ObjectArray<std::atomic<T>> array;
 };

--- a/src/include/storage/store/list_column.h
+++ b/src/include/storage/store/list_column.h
@@ -52,6 +52,8 @@ public:
     ListColumn(std::string name, common::LogicalType dataType, FileHandle* dataFH,
         MemoryManager* mm, ShadowFile* shadowFile, bool enableCompression);
 
+    static bool disableCompressionOnData(const common::LogicalType& dataType);
+
     static std::unique_ptr<ColumnChunkData> flushChunkData(const ColumnChunkData& chunk,
         FileHandle& dataFH);
 

--- a/src/storage/store/list_column.cpp
+++ b/src/storage/store/list_column.cpp
@@ -76,8 +76,9 @@ ListColumn::ListColumn(std::string name, LogicalType dataType, FileHandle* dataF
 }
 
 bool ListColumn::disableCompressionOnData(const LogicalType& dataType) {
-    if (ListType::getChildType(dataType).getPhysicalType() == PhysicalTypeID::FLOAT ||
-        ListType::getChildType(dataType).getPhysicalType() == PhysicalTypeID::DOUBLE) {
+    if (dataType.getLogicalTypeID() == LogicalTypeID::ARRAY &&
+        (ListType::getChildType(dataType).getPhysicalType() == PhysicalTypeID::FLOAT ||
+            ListType::getChildType(dataType).getPhysicalType() == PhysicalTypeID::DOUBLE)) {
         // Force disable compression for floating point types.
         return true;
     }

--- a/test/test_files/function/call/storage_info.test
+++ b/test/test_files/function/call/storage_info.test
@@ -22,3 +22,11 @@
 -STATEMENT CALL storage_info('person') WHERE column_name='person_null' AND compression<>'CONSTANT' RETURN COUNT(*)
 ---- 1
 0
+
+-CASE DisableFloatListDataCompression
+-STATEMENT CALL storage_info('meets') WHERE column_name='fwd_location_data' AND compression <> 'UNCOMPRESSED' RETURN COUNT(*);
+---- 1
+0
+-STATEMENT CALL storage_info('meets') WHERE column_name='bwd_location_data' AND compression <> 'UNCOMPRESSED' RETURN COUNT(*);
+---- 1
+0


### PR DESCRIPTION
# Description

This is mainly for the case of vector index.
Compression is generally complicating and adds overheads when it comes to read from the array of floating point columns.
Moreover, ALP is imposing quite large overheads for random lookups due to `populateExtraChunkState`, which we should optimize in the future. But for now, I'd like to turn the compression off on float/double array data column to simplify our life here.