### PR TITLE
Separate SemiMask interface and implementation

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -21,12 +21,13 @@ add_library(kuzu_common
         metric.cpp
         null_mask.cpp
         profiler.cpp
-        type_utils.cpp
-        utils.cpp
+        random_engine.cpp
+        roaring_mask.cpp
         sha256.cpp
         string_utils.cpp
         system_message.cpp
-        random_engine.cpp
+        type_utils.cpp
+        utils.cpp
         windows_utils.cpp)
 
 set(ALL_OBJECT_FILES

--- a/src/common/mask.cpp
+++ b/src/common/mask.cpp
@@ -1,37 +1,11 @@
 #include "common/mask.h"
 
+#include "common/roaring_mask.h"
+
 namespace kuzu {
 namespace common {
 
-offset_vec_t Roaring32BitmapSemiMask::range(uint32_t start, uint32_t end) {
-    auto it = roaring->begin();
-    it.equalorlarger(start);
-    offset_vec_t ans;
-    for (; it != roaring->end(); it++) {
-        auto value = *it;
-        if (value >= end) {
-            break;
-        }
-        ans.push_back(value);
-    }
-    return ans;
-}
-
-offset_vec_t Roaring64BitmapSemiMask::range(uint32_t start, uint32_t end) {
-    auto it = roaring->begin();
-    it.move(start);
-    offset_vec_t ans;
-    for (; it != roaring->end(); it++) {
-        auto value = *it;
-        if (value >= end) {
-            break;
-        }
-        ans.push_back(value);
-    }
-    return ans;
-}
-
-std::unique_ptr<RoaringBitmapSemiMask> RoaringBitmapSemiMaskUtil::createMask(offset_t maxOffset) {
+std::unique_ptr<SemiMask> SemiMaskUtil::createMask(offset_t maxOffset) {
     if (maxOffset > std::numeric_limits<uint32_t>::max()) {
         return std::make_unique<Roaring64BitmapSemiMask>(maxOffset);
     } else {

--- a/src/common/roaring_mask.cpp
+++ b/src/common/roaring_mask.cpp
@@ -1,0 +1,35 @@
+#include "common/roaring_mask.h"
+
+namespace kuzu {
+namespace common {
+
+offset_vec_t Roaring32BitmapSemiMask::range(uint32_t start, uint32_t end) {
+    auto it = roaring->begin();
+    it.equalorlarger(start);
+    offset_vec_t ans;
+    for (; it != roaring->end(); it++) {
+        auto value = *it;
+        if (value >= end) {
+            break;
+        }
+        ans.push_back(value);
+    }
+    return ans;
+}
+
+offset_vec_t Roaring64BitmapSemiMask::range(uint32_t start, uint32_t end) {
+    auto it = roaring->begin();
+    it.move(start);
+    offset_vec_t ans;
+    for (; it != roaring->end(); it++) {
+        auto value = *it;
+        if (value >= end) {
+            break;
+        }
+        ans.push_back(value);
+    }
+    return ans;
+}
+
+} // namespace common
+} // namespace kuzu

--- a/src/function/gds/strongly_connected_components.cpp
+++ b/src/function/gds/strongly_connected_components.cpp
@@ -305,8 +305,8 @@ public:
             }
         }
 
-        auto writeSccIdsToOutput = std::make_unique<SccWriteIdsToOutput>(mm, sharedState.get(),
-            computationState);
+        auto writeSccIdsToOutput =
+            std::make_unique<SccWriteIdsToOutput>(mm, sharedState.get(), computationState);
         GDSUtils::runVertexCompute(context, graph, *writeSccIdsToOutput);
 
         sharedState->factorizedTablePool.mergeLocalTables();

--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -230,7 +230,7 @@ std::unique_ptr<VertexScanState> OnDiskGraph::prepareVertexScan(TableCatalogEntr
 }
 
 bool OnDiskGraphNbrScanState::InnerIterator::next(evaluator::ExpressionEvaluator* predicate,
-    semi_mask_t* nbrNodeMask_) {
+    SemiMask* nbrNodeMask_) {
     bool hasAtLeastOneSelectedValue = false;
     do {
         restoreSelVector(*tableScanState->outState);

--- a/src/include/common/mask.h
+++ b/src/include/common/mask.h
@@ -8,84 +8,35 @@
 namespace kuzu {
 namespace common {
 
-class RoaringBitmapSemiMask;
-
-using semi_mask_t = RoaringBitmapSemiMask;
-
-// unsafe
-class RoaringBitmapSemiMask {
+// Note that this class is not thread-safe.
+class SemiMask {
 public:
-    explicit RoaringBitmapSemiMask(common::offset_t maxOffset)
-        : maxOffset{maxOffset}, enabled{false} {}
+    explicit SemiMask(offset_t maxOffset) : maxOffset{maxOffset}, enabled{false} {}
 
-    virtual ~RoaringBitmapSemiMask() = default;
+    virtual ~SemiMask() = default;
 
-    virtual void mask(common::offset_t nodeOffset) = 0;
-    virtual void maskRange(common::offset_t startNodeOffset, common::offset_t endNodeOffset) = 0;
+    virtual void mask(offset_t nodeOffset) = 0;
+    virtual void maskRange(offset_t startNodeOffset, offset_t endNodeOffset) = 0;
 
-    virtual bool isMasked(common::offset_t startNodeOffset) = 0;
+    virtual bool isMasked(offset_t startNodeOffset) = 0;
 
     // include&exclude
     virtual offset_vec_t range(uint32_t start, uint32_t end) = 0;
 
     virtual uint64_t getNumMaskedNodes() const = 0;
 
-    common::offset_t getMaxOffset() const { return maxOffset; }
+    offset_t getMaxOffset() const { return maxOffset; }
 
     bool isEnabled() const { return enabled; }
     void enable() { enabled = true; }
 
 private:
-    common::offset_t maxOffset;
+    offset_t maxOffset;
     bool enabled;
 };
 
-class Roaring32BitmapSemiMask : public RoaringBitmapSemiMask {
-public:
-    explicit Roaring32BitmapSemiMask(common::offset_t maxOffset)
-        : RoaringBitmapSemiMask(maxOffset), roaring(std::make_shared<roaring::Roaring>()) {}
-
-    void mask(common::offset_t nodeOffset) override { roaring->add(nodeOffset); }
-    void maskRange(common::offset_t startNodeOffset, common::offset_t endNodeOffset) override {
-        roaring->addRange(startNodeOffset, endNodeOffset);
-    }
-
-    bool isMasked(common::offset_t startNodeOffset) override {
-        return roaring->contains(startNodeOffset);
-    }
-
-    uint64_t getNumMaskedNodes() const override { return roaring->cardinality(); }
-
-    // include&exclude
-    offset_vec_t range(uint32_t start, uint32_t end) override;
-
-    std::shared_ptr<roaring::Roaring> roaring;
-};
-
-class Roaring64BitmapSemiMask : public RoaringBitmapSemiMask {
-public:
-    explicit Roaring64BitmapSemiMask(common::offset_t maxOffset)
-        : RoaringBitmapSemiMask(maxOffset), roaring(std::make_shared<roaring::Roaring64Map>()) {}
-
-    void mask(common::offset_t nodeOffset) override { roaring->add(nodeOffset); }
-    void maskRange(common::offset_t startNodeOffset, common::offset_t endNodeOffset) override {
-        roaring->addRange(startNodeOffset, endNodeOffset);
-    }
-
-    bool isMasked(common::offset_t startNodeOffset) override {
-        return roaring->contains(startNodeOffset);
-    }
-
-    uint64_t getNumMaskedNodes() const override { return roaring->cardinality(); }
-
-    // include&exclude
-    offset_vec_t range(uint32_t start, uint32_t end) override;
-
-    std::shared_ptr<roaring::Roaring64Map> roaring;
-};
-
-struct RoaringBitmapSemiMaskUtil {
-    static std::unique_ptr<RoaringBitmapSemiMask> createMask(common::offset_t maxOffset);
+struct SemiMaskUtil {
+    static std::unique_ptr<SemiMask> createMask(offset_t maxOffset);
 };
 
 class NodeOffsetMaskMap {
@@ -95,28 +46,28 @@ public:
     void enable() { enabled_ = true; }
     bool enabled() const { return enabled_; }
 
-    common::offset_t getNumMaskedNode() const;
+    offset_t getNumMaskedNode() const;
 
-    void addMask(common::table_id_t tableID, std::unique_ptr<common::semi_mask_t> mask) {
+    void addMask(table_id_t tableID, std::unique_ptr<SemiMask> mask) {
         KU_ASSERT(!maskMap.contains(tableID));
         maskMap.insert({tableID, std::move(mask)});
     }
 
-    common::table_id_map_t<common::semi_mask_t*> getMasks() const {
-        common::table_id_map_t<common::semi_mask_t*> result;
+    table_id_map_t<SemiMask*> getMasks() const {
+        table_id_map_t<SemiMask*> result;
         for (auto& [tableID, mask] : maskMap) {
             result.emplace(tableID, mask.get());
         }
         return result;
     }
 
-    bool containsTableID(common::table_id_t tableID) const { return maskMap.contains(tableID); }
-    common::semi_mask_t* getOffsetMask(common::table_id_t tableID) const {
+    bool containsTableID(table_id_t tableID) const { return maskMap.contains(tableID); }
+    SemiMask* getOffsetMask(table_id_t tableID) const {
         KU_ASSERT(containsTableID(tableID));
         return maskMap.at(tableID).get();
     }
 
-    void pin(common::table_id_t tableID) {
+    void pin(table_id_t tableID) {
         if (maskMap.contains(tableID)) {
             pinnedMask = maskMap.at(tableID).get();
         } else {
@@ -124,20 +75,20 @@ public:
         }
     }
     bool hasPinnedMask() const { return pinnedMask != nullptr; }
-    common::semi_mask_t* getPinnedMask() const { return pinnedMask; }
+    SemiMask* getPinnedMask() const { return pinnedMask; }
 
-    bool valid(common::offset_t offset) {
+    bool valid(offset_t offset) const {
         KU_ASSERT(pinnedMask != nullptr);
         return pinnedMask->isMasked(offset);
     }
-    bool valid(common::nodeID_t nodeID) {
+    bool valid(nodeID_t nodeID) const {
         KU_ASSERT(maskMap.contains(nodeID.tableID));
         return maskMap.at(nodeID.tableID)->isMasked(nodeID.offset);
     }
 
 private:
-    common::table_id_map_t<std::unique_ptr<common::semi_mask_t>> maskMap;
-    common::semi_mask_t* pinnedMask = nullptr;
+    table_id_map_t<std::unique_ptr<SemiMask>> maskMap;
+    SemiMask* pinnedMask = nullptr;
     // If mask map is enabled, then some nodes might be masked.
     bool enabled_;
 };

--- a/src/include/common/roaring_mask.h
+++ b/src/include/common/roaring_mask.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "common/mask.h"
+
+namespace kuzu {
+namespace common {
+
+class Roaring32BitmapSemiMask final : public SemiMask {
+public:
+    explicit Roaring32BitmapSemiMask(offset_t maxOffset)
+        : SemiMask(maxOffset), roaring(std::make_shared<roaring::Roaring>()) {}
+
+    void mask(offset_t nodeOffset) override { roaring->add(nodeOffset); }
+    void maskRange(offset_t startNodeOffset, offset_t endNodeOffset) override {
+        roaring->addRange(startNodeOffset, endNodeOffset);
+    }
+
+    bool isMasked(offset_t startNodeOffset) override { return roaring->contains(startNodeOffset); }
+
+    uint64_t getNumMaskedNodes() const override { return roaring->cardinality(); }
+
+    // include&exclude
+    offset_vec_t range(uint32_t start, uint32_t end) override;
+
+    std::shared_ptr<roaring::Roaring> roaring;
+};
+
+class Roaring64BitmapSemiMask final : public SemiMask {
+public:
+    explicit Roaring64BitmapSemiMask(offset_t maxOffset)
+        : SemiMask(maxOffset), roaring(std::make_shared<roaring::Roaring64Map>()) {}
+
+    void mask(offset_t nodeOffset) override { roaring->add(nodeOffset); }
+    void maskRange(offset_t startNodeOffset, offset_t endNodeOffset) override {
+        roaring->addRange(startNodeOffset, endNodeOffset);
+    }
+
+    bool isMasked(offset_t startNodeOffset) override { return roaring->contains(startNodeOffset); }
+
+    uint64_t getNumMaskedNodes() const override { return roaring->cardinality(); }
+
+    // include&exclude
+    offset_vec_t range(uint32_t start, uint32_t end) override;
+
+    std::shared_ptr<roaring::Roaring64Map> roaring;
+};
+
+} // namespace common
+} // namespace kuzu

--- a/src/include/function/gds/gds_object_manager.h
+++ b/src/include/function/gds/gds_object_manager.h
@@ -39,7 +39,8 @@ private:
 template<typename T>
 class ObjectArray {
 public:
-    ObjectArray(const common::offset_t size, storage::MemoryManager* mm, bool initializeToZero = false)
+    ObjectArray(const common::offset_t size, storage::MemoryManager* mm,
+        bool initializeToZero = false)
         : allocation{mm->allocateBuffer(initializeToZero, size * sizeof(T))} {
         data = std::span<T>(reinterpret_cast<T*>(allocation->getData()), size);
     }
@@ -53,8 +54,10 @@ public:
         KU_ASSERT(pos < data.size());
         return data[pos];
     }
+
 private:
-    template<typename U> friend class AtomicObjectArray;
+    template<typename U>
+    friend class AtomicObjectArray;
     std::span<T> data;
     std::unique_ptr<storage::MemoryBuffer> allocation;
 };
@@ -63,9 +66,9 @@ private:
 template<typename T>
 class AtomicObjectArray {
 public:
-    AtomicObjectArray(const common::offset_t size, storage::MemoryManager* mm, bool initializeToZero = false)
-        : array{ObjectArray<std::atomic<T>>(size, mm, initializeToZero)} {
-    }
+    AtomicObjectArray(const common::offset_t size, storage::MemoryManager* mm,
+        bool initializeToZero = false)
+        : array{ObjectArray<std::atomic<T>>(size, mm, initializeToZero)} {}
 
     void setRelaxed(common::offset_t pos, const T& value) {
         KU_ASSERT(pos < array.data.size());
@@ -87,6 +90,7 @@ public:
         }
         return false;
     }
+
 private:
     ObjectArray<std::atomic<T>> array;
 };

--- a/src/include/graph/on_disk_graph.h
+++ b/src/include/graph/on_disk_graph.h
@@ -73,7 +73,7 @@ public:
             return tableScanState->outState->getSelVector();
         }
 
-        bool next(evaluator::ExpressionEvaluator* predicate, common::semi_mask_t* nbrNodeMask);
+        bool next(evaluator::ExpressionEvaluator* predicate, common::SemiMask* nbrNodeMask);
         void initScan() const;
 
         common::RelDataDirection getDirection() const { return tableScanState->direction; }
@@ -94,7 +94,7 @@ private:
     std::unique_ptr<common::ValueVector> propertyVector;
 
     std::unique_ptr<evaluator::ExpressionEvaluator> relPredicateEvaluator;
-    common::semi_mask_t* nbrNodeMask = nullptr;
+    common::SemiMask* nbrNodeMask = nullptr;
 
     std::vector<InnerIterator> directedIterators;
     InnerIterator* currentIter = nullptr;

--- a/src/include/processor/operator/scan/scan_node_table.h
+++ b/src/include/processor/operator/scan/scan_node_table.h
@@ -16,7 +16,7 @@ struct ScanNodeTableProgressSharedState {
 
 class ScanNodeTableSharedState {
 public:
-    explicit ScanNodeTableSharedState(std::unique_ptr<common::semi_mask_t> semiMask)
+    explicit ScanNodeTableSharedState(std::unique_ptr<common::SemiMask> semiMask)
         : table{nullptr}, currentCommittedGroupIdx{common::INVALID_NODE_GROUP_IDX},
           currentUnCommittedGroupIdx{common::INVALID_NODE_GROUP_IDX}, numCommittedNodeGroups{0},
           numUnCommittedNodeGroups{0}, semiMask{std::move(semiMask)} {};
@@ -27,7 +27,7 @@ public:
     void nextMorsel(storage::NodeTableScanState& scanState,
         ScanNodeTableProgressSharedState& progressSharedState);
 
-    common::semi_mask_t* getSemiMask() const { return semiMask.get(); }
+    common::SemiMask* getSemiMask() const { return semiMask.get(); }
 
 private:
     std::mutex mtx;
@@ -36,7 +36,7 @@ private:
     common::node_group_idx_t currentUnCommittedGroupIdx;
     common::node_group_idx_t numCommittedNodeGroups;
     common::node_group_idx_t numUnCommittedNodeGroups;
-    std::unique_ptr<common::semi_mask_t> semiMask;
+    std::unique_ptr<common::SemiMask> semiMask;
 };
 
 struct ScanNodeTableInfo {
@@ -93,7 +93,7 @@ public:
         KU_ASSERT(this->nodeInfos.size() == this->sharedStates.size());
     }
 
-    common::table_id_map_t<common::semi_mask_t*> getSemiMasks() const;
+    common::table_id_map_t<common::SemiMask*> getSemiMasks() const;
 
     bool isSource() const override { return true; }
 

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -8,7 +8,7 @@
 namespace kuzu {
 namespace common {
 enum class RelDataDirection : uint8_t;
-class RoaringBitmapSemiMask;
+class SemiMask;
 class NodeOffsetMaskMap;
 } // namespace common
 namespace main {
@@ -231,7 +231,7 @@ private:
         const planner::Schema& schema);
     FactorizedTableSchema createFlatFTableSchema(const binder::expression_vector& expressions,
         const planner::Schema& schema);
-    std::unique_ptr<common::RoaringBitmapSemiMask> getSemiMask(common::table_id_t tableID) const;
+    std::unique_ptr<common::SemiMask> getSemiMask(common::table_id_t tableID) const;
     std::unique_ptr<common::NodeOffsetMaskMap> getNodeOffsetMaskMap(const binder::Expression& expr);
 
 public:

--- a/src/include/storage/store/table.h
+++ b/src/include/storage/store/table.h
@@ -26,7 +26,7 @@ struct KUZU_API TableScanState {
     std::vector<common::ValueVector*> outputVectors;
     std::shared_ptr<common::DataChunkState> outState;
     std::vector<common::column_id_t> columnIDs;
-    common::semi_mask_t* semiMask;
+    common::SemiMask* semiMask;
     bool randomLookup = false;
 
     // Only used when scan from persistent data.

--- a/src/processor/map/map_scan_node_table.cpp
+++ b/src/processor/map/map_scan_node_table.cpp
@@ -43,7 +43,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapScanNodeTable(
     std::vector<std::shared_ptr<ScanNodeTableSharedState>> sharedStates;
     for (auto& tableID : tableIDs) {
         auto table = storageManager->getTable(tableID)->ptrCast<storage::NodeTable>();
-        auto semiMask = RoaringBitmapSemiMaskUtil::createMask(table->getNumTotalRows(transaction));
+        auto semiMask = SemiMaskUtil::createMask(table->getNumTotalRows(transaction));
         sharedStates.push_back(std::make_shared<ScanNodeTableSharedState>(std::move(semiMask)));
     }
     auto alias = scan.getNodeID()->cast<PropertyExpression>().getRawVariableName();

--- a/src/processor/map/map_semi_masker.cpp
+++ b/src/processor/map/map_semi_masker.cpp
@@ -16,8 +16,8 @@ namespace processor {
 // Normally the two maps should have the same tableIDs.
 // An exception is in GDS with filtered projected graph, multiple semiMasker will work on
 // the same target GDS operator so masksPerTable may have fewer tableIDs.
-static void initMask(table_id_map_t<std::vector<semi_mask_t*>>& masksPerTable,
-    const table_id_map_t<semi_mask_t*>& maskPerTable) {
+static void initMask(table_id_map_t<std::vector<SemiMask*>>& masksPerTable,
+    const table_id_map_t<SemiMask*>& maskPerTable) {
     for (auto& [tableID, masks] : masksPerTable) {
         KU_ASSERT(maskPerTable.contains(tableID));
         auto mask = maskPerTable.at(tableID);
@@ -32,9 +32,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapSemiMasker(
     const auto inSchema = semiMasker.getChild(0)->getSchema();
     auto prevOperator = mapOperator(logicalOperator->getChild(0).get());
     const auto tableIDs = semiMasker.getNodeTableIDs();
-    table_id_map_t<std::vector<semi_mask_t*>> masksPerTable;
+    table_id_map_t<std::vector<SemiMask*>> masksPerTable;
     for (auto tableID : tableIDs) {
-        masksPerTable.insert({tableID, std::vector<semi_mask_t*>{}});
+        masksPerTable.insert({tableID, std::vector<SemiMask*>{}});
     }
     std::vector<std::string> operatorNames;
     for (auto& op : semiMasker.getTargetOperators()) {

--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -210,8 +210,7 @@ FactorizedTableSchema PlanMapper::createFlatFTableSchema(const expression_vector
 
 std::unique_ptr<SemiMask> PlanMapper::getSemiMask(table_id_t tableID) const {
     auto table = clientContext->getStorageManager()->getTable(tableID)->ptrCast<NodeTable>();
-    return SemiMaskUtil::createMask(
-        table->getNumTotalRows(clientContext->getTransaction()));
+    return SemiMaskUtil::createMask(table->getNumTotalRows(clientContext->getTransaction()));
 }
 
 std::unique_ptr<NodeOffsetMaskMap> PlanMapper::getNodeOffsetMaskMap(

--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -208,9 +208,9 @@ FactorizedTableSchema PlanMapper::createFlatFTableSchema(const expression_vector
     return tableSchema;
 }
 
-std::unique_ptr<RoaringBitmapSemiMask> PlanMapper::getSemiMask(table_id_t tableID) const {
+std::unique_ptr<SemiMask> PlanMapper::getSemiMask(table_id_t tableID) const {
     auto table = clientContext->getStorageManager()->getTable(tableID)->ptrCast<NodeTable>();
-    return RoaringBitmapSemiMaskUtil::createMask(
+    return SemiMaskUtil::createMask(
         table->getNumTotalRows(clientContext->getTransaction()));
 }
 

--- a/src/processor/operator/scan/scan_node_table.cpp
+++ b/src/processor/operator/scan/scan_node_table.cpp
@@ -63,8 +63,8 @@ void ScanNodeTableSharedState::nextMorsel(NodeTableScanState& scanState,
     scanState.source = TableScanSource::NONE;
 }
 
-table_id_map_t<semi_mask_t*> ScanNodeTable::getSemiMasks() const {
-    table_id_map_t<semi_mask_t*> result;
+table_id_map_t<SemiMask*> ScanNodeTable::getSemiMasks() const {
+    table_id_map_t<SemiMask*> result;
     KU_ASSERT(nodeInfos.size() == sharedStates.size());
     for (auto i = 0u; i < sharedStates.size(); ++i) {
         result.insert({nodeInfos[i].table->getTableID(), sharedStates[i]->getSemiMask()});

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -92,7 +92,7 @@ struct RollbackPKDeleter final : PKColumnScanHelper {
     RollbackPKDeleter(row_idx_t startNodeOffset, row_idx_t numRows, NodeTable* table,
         PrimaryKeyIndex* pkIndex)
         : PKColumnScanHelper(table, pkIndex),
-          semiMask(RoaringBitmapSemiMaskUtil::createMask(startNodeOffset + numRows)) {
+          semiMask(SemiMaskUtil::createMask(startNodeOffset + numRows)) {
         semiMask->maskRange(startNodeOffset, startNodeOffset + numRows);
         semiMask->enable();
     }
@@ -103,7 +103,7 @@ struct RollbackPKDeleter final : PKColumnScanHelper {
     bool processScanOutput(const Transaction* transaction, NodeGroupScanResult scanResult,
         const ValueVector& scannedVector) override;
 
-    std::unique_ptr<semi_mask_t> semiMask;
+    std::unique_ptr<SemiMask> semiMask;
 };
 
 void insertPK(const Transaction* transaction, const ValueVector& nodeIDVector,


### PR DESCRIPTION
# Description

Rename `RoaringBitmapSemiMask` to `SemiMask`.
Separate the interface for `SemiMask` and the roaring implementation, which makes the include of `mask.h` much cleaner.