### PR TITLE
Expose semi mask sub-plan in the logical plan tree

### DIFF
--- a/src/include/planner/operator/logical_dummy_sink.h
+++ b/src/include/planner/operator/logical_dummy_sink.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "planner/operator/logical_operator.h"
+
+namespace kuzu {
+namespace planner {
+
+class LogicalDummySink final : public LogicalOperator {
+    static constexpr LogicalOperatorType type_ = LogicalOperatorType::DUMMY_SINK;
+
+public:
+    explicit LogicalDummySink(std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{type_, {std::move(child)}} {}
+    explicit LogicalDummySink(logical_op_vector_t children)
+        : LogicalOperator{type_, {std::move(children)}} {}
+
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
+
+    std::string getExpressionsForPrinting() const override { return ""; }
+    std::unique_ptr<LogicalOperator> copy() override {
+        return std::make_unique<LogicalDummySink>(children);
+    }
+};
+
+} // namespace planner
+} // namespace kuzu

--- a/src/include/planner/operator/logical_operator.h
+++ b/src/include/planner/operator/logical_operator.h
@@ -27,6 +27,7 @@ enum class LogicalOperatorType : uint8_t {
     DISTINCT,
     DROP,
     DUMMY_SCAN,
+    DUMMY_SINK,
     EMPTY_RESULT,
     EXPLAIN,
     EXPRESSIONS_SCAN,
@@ -89,6 +90,7 @@ public:
     void setChild(uint64_t idx, std::shared_ptr<LogicalOperator> child) {
         children[idx] = std::move(child);
     }
+    void addChild(std::shared_ptr<LogicalOperator> child) { children.push_back(std::move(child)); }
     void setCardinality(common::cardinality_t cardinality_) { this->cardinality = cardinality_; }
 
     // Operator type.

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -26,6 +26,7 @@ class TableCatalogEntry;
 }
 
 namespace planner {
+class LogicalSemiMasker;
 struct LogicalInsertInfo;
 class LogicalCopyFrom;
 } // namespace planner
@@ -106,6 +107,7 @@ private:
     std::unique_ptr<PhysicalOperator> mapDistinct(const planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapDrop(const planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapDummyScan(const planner::LogicalOperator* logicalOperator);
+    std::unique_ptr<PhysicalOperator> mapDummySink(const planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapEmptyResult(
         const planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapExplain(const planner::LogicalOperator* logicalOperator);
@@ -233,6 +235,9 @@ private:
         const planner::Schema& schema);
     std::unique_ptr<common::SemiMask> getSemiMask(common::table_id_t tableID) const;
     std::unique_ptr<common::NodeOffsetMaskMap> getNodeOffsetMaskMap(const binder::Expression& expr);
+
+    static planner::LogicalSemiMasker* findSemiMaskerInPlan(
+        planner::LogicalOperator* logicalOperator);
 
 public:
     main::ClientContext* clientContext;

--- a/src/planner/operator/CMakeLists.txt
+++ b/src/planner/operator/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(kuzu_planner_operator
         logical_cross_product.cpp
         logical_distinct.cpp
         logical_dummy_scan.cpp
+        logical_dummy_sink.cpp
         logical_explain.cpp
         logical_filter.cpp
         logical_flatten.cpp

--- a/src/planner/operator/logical_dummy_sink.cpp
+++ b/src/planner/operator/logical_dummy_sink.cpp
@@ -1,0 +1,17 @@
+#include "planner/operator/logical_dummy_sink.h"
+
+namespace kuzu {
+namespace planner {
+
+void LogicalDummySink::computeFactorizedSchema() {
+    createEmptySchema();
+    copyChildSchema(0);
+}
+
+void LogicalDummySink::computeFlatSchema() {
+    createEmptySchema();
+    copyChildSchema(0);
+}
+
+} // namespace planner
+} // namespace kuzu

--- a/src/planner/operator/logical_operator.cpp
+++ b/src/planner/operator/logical_operator.cpp
@@ -40,6 +40,8 @@ std::string LogicalOperatorUtils::logicalOperatorTypeToString(LogicalOperatorTyp
         return "DROP";
     case LogicalOperatorType::DUMMY_SCAN:
         return "DUMMY_SCAN";
+    case LogicalOperatorType::DUMMY_SINK:
+        return "DUMMY_SINK";
     case LogicalOperatorType::EMPTY_RESULT:
         return "EMPTY_RESULT";
     case LogicalOperatorType::EXPLAIN:

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -135,7 +135,10 @@ void Planner::appendRecursiveExtend(const std::shared_ptr<NodeExpression>& bound
     }
     auto probePlan = LogicalPlan();
     auto recursiveExtend = std::make_shared<LogicalRecursiveExtend>(recursiveInfo->function->copy(),
-        *recursiveInfo->bindData, resultColumns, nbrTableIDSet, nodeMaskRoot);
+        *recursiveInfo->bindData, resultColumns, nbrTableIDSet);
+    if (nodeMaskRoot != nullptr) {
+        recursiveExtend->addChild(nodeMaskRoot);
+    }
     recursiveExtend->computeFactorizedSchema();
     probePlan.setLastOperator(std::move(recursiveExtend));
     // Scan path node property pipeline

--- a/src/planner/plan/plan_node_semi_mask.cpp
+++ b/src/planner/plan/plan_node_semi_mask.cpp
@@ -2,6 +2,7 @@
 #include "binder/expression/property_expression.h"
 #include "binder/expression_visitor.h"
 #include "main/client_context.h"
+#include "planner/operator/logical_dummy_sink.h"
 #include "planner/operator/sip/logical_semi_masker.h"
 #include "planner/planner.h"
 
@@ -30,7 +31,9 @@ LogicalPlan Planner::planNodeSemiMask(SemiMaskTargetType targetType, const NodeE
     auto semiMasker = std::make_shared<LogicalSemiMasker>(SemiMaskKeyType::NODE, targetType,
         node.getInternalID(), node.getTableIDs(), plan.getLastOperator());
     semiMasker->computeFactorizedSchema();
-    plan.setLastOperator(semiMasker);
+    auto dummySink = std::make_shared<LogicalDummySink>(semiMasker);
+    dummySink->computeFactorizedSchema();
+    plan.setLastOperator(dummySink);
     return plan;
 }
 

--- a/src/processor/map/CMakeLists.txt
+++ b/src/processor/map/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(kuzu_processor_mapper
         map_explain.cpp
         map_expressions_scan.cpp
         map_dummy_scan.cpp
+        map_dummy_sink.cpp
         map_empty_result.cpp
         map_extend.cpp
         map_filter.cpp

--- a/src/processor/map/map_dummy_sink.cpp
+++ b/src/processor/map/map_dummy_sink.cpp
@@ -1,0 +1,16 @@
+#include "processor/plan_mapper.h"
+
+using namespace kuzu::planner;
+
+namespace kuzu {
+namespace processor {
+
+std::unique_ptr<PhysicalOperator> PlanMapper::mapDummySink(const LogicalOperator* logicalOperator) {
+    auto child = mapOperator(logicalOperator->getChild(0).get());
+    return std::make_unique<DummySink>(
+        std::make_unique<ResultSetDescriptor>(logicalOperator->getSchema()), std::move(child),
+        getOperatorID(), std::make_unique<OPPrintInfo>());
+}
+
+} // namespace processor
+} // namespace kuzu

--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -82,6 +82,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapOperator(const LogicalOperator*
     case LogicalOperatorType::DUMMY_SCAN: {
         physicalOperator = mapDummyScan(logicalOperator);
     } break;
+    case LogicalOperatorType::DUMMY_SINK: {
+        physicalOperator = mapDummySink(logicalOperator);
+    } break;
     case LogicalOperatorType::EMPTY_RESULT: {
         physicalOperator = mapEmptyResult(logicalOperator);
     } break;

--- a/test/test_files/copy/copy_from_table_func.test
+++ b/test/test_files/copy/copy_from_table_func.test
@@ -7,24 +7,24 @@
 ---- ok
 -STATEMENT COPY person_info from TABLE_INFO('person')
 ---- ok
--STATEMENT MATCH (p:person_info) RETURN p.*
+-STATEMENT MATCH (p:person_info) RETURN p.id, p.name, p.type, p.defaultVal, p.pk
 ---- 16
-0|0|ID|INT64|NULL|True
-1|1|fName|STRING|NULL|False
-2|2|gender|INT64|NULL|False
-3|3|isStudent|BOOL|NULL|False
-4|4|isWorker|BOOL|NULL|False
-5|5|age|INT64|NULL|False
-6|6|eyeSight|DOUBLE|NULL|False
-7|7|birthdate|DATE|NULL|False
-8|8|registerTime|TIMESTAMP|NULL|False
-9|9|lastJobDuration|INTERVAL|NULL|False
-10|10|workedHours|INT64[]|NULL|False
-11|11|usedNames|STRING[]|NULL|False
-12|12|courseScoresPerTerm|INT64[][]|NULL|False
-13|13|grades|INT64[4]|NULL|False
-14|14|height|FLOAT|NULL|False
-15|15|u|UUID|NULL|False
+0|ID|INT64|NULL|True
+1|fName|STRING|NULL|False
+2|gender|INT64|NULL|False
+3|isStudent|BOOL|NULL|False
+4|isWorker|BOOL|NULL|False
+5|age|INT64|NULL|False
+6|eyeSight|DOUBLE|NULL|False
+7|birthdate|DATE|NULL|False
+8|registerTime|TIMESTAMP|NULL|False
+9|lastJobDuration|INTERVAL|NULL|False
+10|workedHours|INT64[]|NULL|False
+11|usedNames|STRING[]|NULL|False
+12|courseScoresPerTerm|INT64[][]|NULL|False
+13|grades|INT64[4]|NULL|False
+14|height|FLOAT|NULL|False
+15|u|UUID|NULL|False
 
 -STATEMENT CREATE NODE TABLE db_info(name string, threads int32, id int64, primary key(threads))
 ---- ok


### PR DESCRIPTION
# Description

Introduced a new logical operator: `LogicalDummySink`, which is used, in this PR, to construct a sub plan for semi masker.
With the help of `LogicalDummySink`, this PR moves the semi mask sub plan into the logical plan tree, which makes the semi mask sub plan be visible to optimizer (such as FilterPushDown).

For now, I'm keeping the semi mask sub plan as child of `LogicalGDSCall` and `LogicalRecursiveExtend`, which may not be the best idea. Open to more refactoring around this.