### PR TITLE
Refactor table function

### DIFF
--- a/extension/delta/src/function/delta_scan.cpp
+++ b/extension/delta/src/function/delta_scan.cpp
@@ -32,25 +32,18 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
         TableFunction::extractYieldVariables(returnColumnNames, input->yieldVariables);
     auto columns = input->binder->createVariables(returnColumnNames, returnTypes);
     return std::make_unique<DeltaScanBindData>(std::move(query), connector,
-        duckdb_extension::DuckDBResultConverter{returnTypes}, columns, FileScanInfo{}, context);
+        duckdb_extension::DuckDBResultConverter{returnTypes}, columns);
 }
-
-struct DeltaScanSharedState final : TableFuncSharedState {
-    explicit DeltaScanSharedState(std::unique_ptr<duckdb::MaterializedQueryResult> queryResult)
-        : TableFuncSharedState{queryResult->RowCount()}, queryResult{std::move(queryResult)} {}
-
-    std::unique_ptr<duckdb::MaterializedQueryResult> queryResult;
-};
 
 std::unique_ptr<TableFuncSharedState> initDeltaScanSharedState(
     const TableFunctionInitInput& input) {
     auto deltaScanBindData = input.bindData->constPtrCast<DeltaScanBindData>();
     auto queryResult = deltaScanBindData->connector->executeQuery(deltaScanBindData->query);
-    return std::make_unique<DeltaScanSharedState>(std::move(queryResult));
+    return std::make_unique<duckdb_extension::DuckDBScanSharedState>(std::move(queryResult));
 }
 
 offset_t tableFunc(const TableFuncInput& input, TableFuncOutput& output) {
-    auto sharedState = input.sharedState->ptrCast<DeltaScanSharedState>();
+    auto sharedState = input.sharedState->ptrCast<duckdb_extension::DuckDBScanSharedState>();
     auto deltaScanBindData = input.bindData->constPtrCast<DeltaScanBindData>();
     std::unique_ptr<duckdb::DataChunk> result;
     try {

--- a/extension/delta/src/function/delta_scan.cpp
+++ b/extension/delta/src/function/delta_scan.cpp
@@ -32,7 +32,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
         TableFunction::extractYieldVariables(returnColumnNames, input->yieldVariables);
     auto columns = input->binder->createVariables(returnColumnNames, returnTypes);
     return std::make_unique<DeltaScanBindData>(std::move(query), connector,
-        duckdb_extension::DuckDBResultConverter{returnTypes}, columns);
+        duckdb_extension::DuckDBResultConverter{returnTypes}, columns, context);
 }
 
 std::unique_ptr<TableFuncSharedState> initDeltaScanSharedState(

--- a/extension/delta/src/include/function/delta_scan.h
+++ b/extension/delta/src/include/function/delta_scan.h
@@ -25,7 +25,8 @@ struct DeltaScanBindData final : function::ScanFileBindData {
         std::shared_ptr<duckdb_extension::DuckDBConnector> connector,
         duckdb_extension::DuckDBResultConverter converter, binder::expression_vector columns,
         main::ClientContext* context)
-        : function::ScanFileBindData{std::move(columns), common::FileScanInfo{}, context},
+        : function::ScanFileBindData{std::move(columns), 0 /* numRows */, common::FileScanInfo{},
+              context},
           query{std::move(query)}, connector{std::move(connector)},
           converter{std::move(converter)} {}
 

--- a/extension/delta/src/include/function/delta_scan.h
+++ b/extension/delta/src/include/function/delta_scan.h
@@ -16,15 +16,16 @@ struct DeltaScanFunction {
     static function::function_set getFunctionSet();
 };
 
-struct DeltaScanBindData final : function::TableFuncBindData {
+struct DeltaScanBindData final : function::ScanFileBindData {
     std::string query;
     std::shared_ptr<duckdb_extension::DuckDBConnector> connector;
     duckdb_extension::DuckDBResultConverter converter;
 
     DeltaScanBindData(std::string query,
         std::shared_ptr<duckdb_extension::DuckDBConnector> connector,
-        duckdb_extension::DuckDBResultConverter converter, binder::expression_vector columns, main::ClientContext* ctx)
-        : ScanFileBindData{std::move(columns), 0 /* numRows */, FileScanInfo, ctx},
+        duckdb_extension::DuckDBResultConverter converter, binder::expression_vector columns,
+        main::ClientContext* context)
+        : function::ScanFileBindData{std::move(columns), common::FileScanInfo{}, context},
           query{std::move(query)}, connector{std::move(connector)},
           converter{std::move(converter)} {}
 

--- a/extension/delta/src/include/function/delta_scan.h
+++ b/extension/delta/src/include/function/delta_scan.h
@@ -16,16 +16,15 @@ struct DeltaScanFunction {
     static function::function_set getFunctionSet();
 };
 
-struct DeltaScanBindData final : function::ScanFileBindData {
+struct DeltaScanBindData final : function::TableFuncBindData {
     std::string query;
     std::shared_ptr<duckdb_extension::DuckDBConnector> connector;
     duckdb_extension::DuckDBResultConverter converter;
 
     DeltaScanBindData(std::string query,
         std::shared_ptr<duckdb_extension::DuckDBConnector> connector,
-        duckdb_extension::DuckDBResultConverter converter, binder::expression_vector columns,
-        common::FileScanInfo fileScanInfo, main::ClientContext* ctx)
-        : ScanFileBindData{std::move(columns), 0 /* numRows */, std::move(fileScanInfo), ctx},
+        duckdb_extension::DuckDBResultConverter converter, binder::expression_vector columns, main::ClientContext* ctx)
+        : ScanFileBindData{std::move(columns), 0 /* numRows */, FileScanInfo, ctx},
           query{std::move(query)}, connector{std::move(connector)},
           converter{std::move(converter)} {}
 

--- a/extension/duckdb/src/function/duckdb_scan.cpp
+++ b/extension/duckdb/src/function/duckdb_scan.cpp
@@ -19,7 +19,7 @@ DuckDBScanBindData::DuckDBScanBindData(std::string query,
       columnNames{std::move(columnNames)}, converter{columnTypes}, connector{connector} {}
 
 DuckDBScanSharedState::DuckDBScanSharedState(
-    std::unique_ptr<duckdb::MaterializedQueryResult> queryResult)
+    std::shared_ptr<duckdb::MaterializedQueryResult> queryResult)
     : function::TableFuncSharedState{queryResult->RowCount()}, queryResult{std::move(queryResult)} {
 }
 

--- a/extension/duckdb/src/include/function/duckdb_scan.h
+++ b/extension/duckdb/src/include/function/duckdb_scan.h
@@ -36,9 +36,9 @@ struct DuckDBScanBindData : function::TableFuncBindData {
 };
 
 struct DuckDBScanSharedState final : function::TableFuncSharedState {
-    explicit DuckDBScanSharedState(std::unique_ptr<duckdb::MaterializedQueryResult> queryResult);
+    explicit DuckDBScanSharedState(std::shared_ptr<duckdb::MaterializedQueryResult> queryResult);
 
-    std::unique_ptr<duckdb::MaterializedQueryResult> queryResult;
+    std::shared_ptr<duckdb::MaterializedQueryResult> queryResult;
 };
 
 function::TableFunction getScanFunction(std::shared_ptr<DuckDBScanBindData> bindData);

--- a/extension/iceberg/src/function/iceberg_bindfunc.cpp
+++ b/extension/iceberg/src/function/iceberg_bindfunc.cpp
@@ -74,7 +74,8 @@ std::unique_ptr<TableFuncBindData> bindFuncHelper(main::ClientContext* context,
         TableFunction::extractYieldVariables(returnColumnNames, input->yieldVariables);
     auto columns = input->binder->createVariables(returnColumnNames, returnTypes);
     return std::make_unique<delta_extension::DeltaScanBindData>(std::move(query), connector,
-        duckdb_extension::DuckDBResultConverter{returnTypes}, columns);
+        duckdb_extension::DuckDBResultConverter{returnTypes}, columns, context);
 }
+
 } // namespace iceberg_extension
 } // namespace kuzu

--- a/extension/iceberg/src/function/iceberg_bindfunc.cpp
+++ b/extension/iceberg/src/function/iceberg_bindfunc.cpp
@@ -74,7 +74,7 @@ std::unique_ptr<TableFuncBindData> bindFuncHelper(main::ClientContext* context,
         TableFunction::extractYieldVariables(returnColumnNames, input->yieldVariables);
     auto columns = input->binder->createVariables(returnColumnNames, returnTypes);
     return std::make_unique<delta_extension::DeltaScanBindData>(std::move(query), connector,
-        duckdb_extension::DuckDBResultConverter{returnTypes}, columns, FileScanInfo{}, context);
+        duckdb_extension::DuckDBResultConverter{returnTypes}, columns);
 }
 } // namespace iceberg_extension
 } // namespace kuzu

--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -21,6 +21,7 @@
 #include "function/struct/vector_struct_functions.h"
 #include "function/table/hnsw/hnsw_index_functions.h"
 #include "function/table/simple_table_function.h"
+#include "function/table/standalone_call_function.h"
 #include "function/timestamp/vector_timestamp_functions.h"
 #include "function/union/vector_union_functions.h"
 #include "function/utility/vector_utility_functions.h"
@@ -37,23 +38,22 @@ namespace kuzu {
 namespace function {
 
 #define SCALAR_FUNCTION_BASE(_PARAM, _NAME)                                                        \
-    { _PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
 #define SCALAR_FUNCTION(_PARAM) SCALAR_FUNCTION_BASE(_PARAM, _PARAM::name)
 #define SCALAR_FUNCTION_ALIAS(_PARAM) SCALAR_FUNCTION_BASE(_PARAM::alias, _PARAM::name)
 #define REWRITE_FUNCTION(_PARAM)                                                                   \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY}
 #define AGGREGATE_FUNCTION(_PARAM)                                                                 \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY}
 #define EXPORT_FUNCTION(_PARAM)                                                                    \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY}
 #define TABLE_FUNCTION(_PARAM)                                                                     \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY}
 #define STANDALONE_TABLE_FUNCTION(_PARAM)                                                          \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY}
 #define ALGORITHM_FUNCTION(_PARAM)                                                                 \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY }
-#define FINAL_FUNCTION                                                                             \
-    { nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY}
+#define FINAL_FUNCTION {nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
 
 FunctionCollection* FunctionCollection::getFunctions() {
     static FunctionCollection functions[] = {

--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -38,22 +38,23 @@ namespace kuzu {
 namespace function {
 
 #define SCALAR_FUNCTION_BASE(_PARAM, _NAME)                                                        \
-    {_PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
 #define SCALAR_FUNCTION(_PARAM) SCALAR_FUNCTION_BASE(_PARAM, _PARAM::name)
 #define SCALAR_FUNCTION_ALIAS(_PARAM) SCALAR_FUNCTION_BASE(_PARAM::alias, _PARAM::name)
 #define REWRITE_FUNCTION(_PARAM)                                                                   \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY }
 #define AGGREGATE_FUNCTION(_PARAM)                                                                 \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY }
 #define EXPORT_FUNCTION(_PARAM)                                                                    \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY }
 #define TABLE_FUNCTION(_PARAM)                                                                     \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY }
 #define STANDALONE_TABLE_FUNCTION(_PARAM)                                                          \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY }
 #define ALGORITHM_FUNCTION(_PARAM)                                                                 \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY}
-#define FINAL_FUNCTION {nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY }
+#define FINAL_FUNCTION                                                                             \
+    { nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
 
 FunctionCollection* FunctionCollection::getFunctions() {
     static FunctionCollection functions[] = {

--- a/src/function/table/clear_warnings.cpp
+++ b/src/function/table/clear_warnings.cpp
@@ -1,5 +1,5 @@
 #include "function/table/bind_data.h"
-#include "function/table/simple_table_function.h"
+#include "function/table/standalone_call_function.h"
 #include "processor/execution_context.h"
 #include "processor/warning_context.h"
 
@@ -23,7 +23,7 @@ function_set ClearWarningsFunction::getFunctionSet() {
     auto func = std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{});
     func->tableFunc = tableFunc;
     func->bindFunc = bindFunc;
-    func->initSharedStateFunc = SimpleTableFunc::initSharedState;
+    func->initSharedStateFunc = TableFunction::initEmptySharedState;
     func->initLocalStateFunc = TableFunction::initEmptyLocalState;
     func->canParallelFunc = []() { return false; };
     functionSet.push_back(std::move(func));

--- a/src/function/table/create_project_graph.cpp
+++ b/src/function/table/create_project_graph.cpp
@@ -6,7 +6,7 @@
 #include "common/string_utils.h"
 #include "common/types/value/nested.h"
 #include "function/table/bind_data.h"
-#include "function/table/simple_table_function.h"
+#include "function/table/standalone_call_function.h"
 #include "graph/graph_entry.h"
 #include "parser/parser.h"
 #include "processor/execution_context.h"
@@ -201,7 +201,7 @@ function_set CreateProjectedGraphFunction::getFunctionSet() {
         std::vector{LogicalTypeID::STRING, LogicalTypeID::ANY, LogicalTypeID::ANY});
     func->bindFunc = bindFunc;
     func->tableFunc = tableFunc;
-    func->initSharedStateFunc = SimpleTableFunc::initSharedState;
+    func->initSharedStateFunc = TableFunction::initEmptySharedState;
     func->initLocalStateFunc = TableFunction::initEmptyLocalState;
     func->canParallelFunc = []() { return false; };
     functionSet.push_back(std::move(func));

--- a/src/function/table/drop_project_graph.cpp
+++ b/src/function/table/drop_project_graph.cpp
@@ -1,6 +1,6 @@
 #include "common/exception/runtime.h"
 #include "function/table/bind_data.h"
-#include "function/table/simple_table_function.h"
+#include "function/table/standalone_call_function.h"
 #include "graph/graph_entry.h"
 #include "processor/execution_context.h"
 
@@ -42,7 +42,7 @@ function_set DropProjectedGraphFunction::getFunctionSet() {
     auto func = std::make_unique<TableFunction>(name, std::vector{LogicalTypeID::STRING});
     func->bindFunc = bindFunc;
     func->tableFunc = tableFunc;
-    func->initSharedStateFunc = SimpleTableFunc::initSharedState;
+    func->initSharedStateFunc = TableFunction::initEmptySharedState;
     func->initLocalStateFunc = TableFunction::initEmptyLocalState;
     func->canParallelFunc = []() { return false; };
     functionSet.push_back(std::move(func));

--- a/src/function/table/show_connection.cpp
+++ b/src/function/table/show_connection.cpp
@@ -7,7 +7,7 @@
 #include "function/table/bind_data.h"
 #include "function/table/bind_input.h"
 #include "function/table/simple_table_function.h"
-#include "main/client_context.h"
+#include "processor/execution_context.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;
@@ -17,22 +17,20 @@ namespace kuzu {
 namespace function {
 
 struct ShowConnectionBindData final : TableFuncBindData {
-    const ClientContext* context;
     std::vector<TableCatalogEntry*> entries;
 
-    ShowConnectionBindData(const ClientContext* context, std::vector<TableCatalogEntry*> entries,
+    ShowConnectionBindData(std::vector<TableCatalogEntry*> entries,
         binder::expression_vector columns, offset_t maxOffset)
-        : TableFuncBindData{std::move(columns), maxOffset}, context{context},
-          entries{std::move(entries)} {}
+        : TableFuncBindData{std::move(columns), maxOffset}, entries{std::move(entries)} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
-        return std::make_unique<ShowConnectionBindData>(context, entries, columns, numRows);
+        return std::make_unique<ShowConnectionBindData>(entries, columns, numRows);
     }
 };
 
-static void outputRelTableConnection(const DataChunk& outputDataChunk, uint64_t outputPos,
-    const ClientContext* context, TableCatalogEntry* entry) {
-    const auto catalog = context->getCatalog();
+static void outputRelTableConnection(DataChunk& outputDataChunk, uint64_t outputPos,
+    const ClientContext& context, TableCatalogEntry* entry) {
+    const auto catalog = context.getCatalog();
     KU_ASSERT(entry->getType() == CatalogEntryType::REL_TABLE_ENTRY);
     const auto relTableEntry = ku_dynamic_cast<RelTableCatalogEntry*>(entry);
 
@@ -40,8 +38,8 @@ static void outputRelTableConnection(const DataChunk& outputDataChunk, uint64_t 
     const auto srcTableID = relTableEntry->getSrcTableID();
     const auto dstTableID = relTableEntry->getDstTableID();
     // Get src and dst primary key
-    const auto srcTableEntry = catalog->getTableCatalogEntry(context->getTransaction(), srcTableID);
-    const auto dstTableEntry = catalog->getTableCatalogEntry(context->getTransaction(), dstTableID);
+    const auto srcTableEntry = catalog->getTableCatalogEntry(context.getTransaction(), srcTableID);
+    const auto dstTableEntry = catalog->getTableCatalogEntry(context.getTransaction(), dstTableID);
     const auto srcTablePrimaryKey =
         srcTableEntry->constCast<NodeTableCatalogEntry>().getPrimaryKeyName();
     const auto dstTablePrimaryKey =
@@ -53,19 +51,16 @@ static void outputRelTableConnection(const DataChunk& outputDataChunk, uint64_t 
     outputDataChunk.getValueVectorMutable(3).setValue(outputPos, dstTablePrimaryKey);
 }
 
-static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput& output) {
-    auto& dataChunk = output.dataChunk;
-    const auto morsel = input.sharedState->ptrCast<SimpleTableFuncSharedState>()->getMorsel();
-    if (!morsel.hasMoreToOutput()) {
-        return 0;
-    }
+static offset_t internalTableFunc(const TableFuncMorsel& morsel, const TableFuncInput& input,
+    DataChunk& output) {
     const auto bindData = input.bindData->constPtrCast<ShowConnectionBindData>();
-    auto vectorPos = 0u;
-    for (auto& entry : bindData->entries) {
-        outputRelTableConnection(dataChunk, vectorPos, bindData->context, entry);
-        vectorPos++;
+    auto i = 0u;
+    auto size = morsel.getMorselSize();
+    for (; i < size; i++) {
+        outputRelTableConnection(output, i, *input.context->clientContext,
+            bindData->entries[i + morsel.startOffset]);
     }
-    return vectorPos;
+    return i;
 }
 
 static std::unique_ptr<TableFuncBindData> bindFunc(const ClientContext* context,
@@ -80,7 +75,6 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const ClientContext* context,
     columnTypes.emplace_back(LogicalType::STRING());
     columnNames.emplace_back("destination table primary key");
     columnTypes.emplace_back(LogicalType::STRING());
-    offset_t maxOffset = 1;
     const auto name = input->getLiteralVal<std::string>(0);
     const auto catalog = context->getCatalog();
     auto transaction = context->getTransaction();
@@ -99,16 +93,15 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const ClientContext* context,
     } else {
         throw BinderException{"Show connection can only be called on a rel table!"};
     }
-    maxOffset = entries.size();
     columnNames = TableFunction::extractYieldVariables(columnNames, input->yieldVariables);
     auto columns = input->binder->createVariables(columnNames, columnTypes);
-    return std::make_unique<ShowConnectionBindData>(context, entries, columns, maxOffset);
+    return std::make_unique<ShowConnectionBindData>(entries, columns, entries.size());
 }
 
 function_set ShowConnectionFunction::getFunctionSet() {
     function_set functionSet;
     auto function = std::make_unique<TableFunction>(name, std::vector{LogicalTypeID::STRING});
-    function->tableFunc = tableFunc;
+    function->tableFunc = SimpleTableFunc::getTableFunc(internalTableFunc);
     function->bindFunc = bindFunc;
     function->initSharedStateFunc = SimpleTableFunc::initSharedState;
     function->initLocalStateFunc = TableFunction::initEmptyLocalState;

--- a/src/function/table/simple_table_function.cpp
+++ b/src/function/table/simple_table_function.cpp
@@ -21,5 +21,19 @@ std::unique_ptr<TableFuncSharedState> SimpleTableFunc::initSharedState(
     return std::make_unique<SimpleTableFuncSharedState>(input.bindData->numRows);
 }
 
+common::offset_t tableFunc(simple_internal_table_func internalTableFunc,
+    const TableFuncInput& input, TableFuncOutput& output) {
+    const auto sharedState = input.sharedState->ptrCast<SimpleTableFuncSharedState>();
+    auto morsel = sharedState->getMorsel();
+    if (!morsel.hasMoreToOutput()) {
+        return 0;
+    }
+    return internalTableFunc(morsel, input, output.dataChunk);
+}
+
+table_func_t SimpleTableFunc::getTableFunc(simple_internal_table_func internalTableFunc) {
+    return std::bind(tableFunc, internalTableFunc, std::placeholders::_1, std::placeholders::_2);
+}
+
 } // namespace function
 } // namespace kuzu

--- a/src/function/table/table_function.cpp
+++ b/src/function/table/table_function.cpp
@@ -19,6 +19,11 @@ std::unique_ptr<TableFuncLocalState> TableFunction::initEmptyLocalState(
     return std::make_unique<TableFuncLocalState>();
 }
 
+std::unique_ptr<TableFuncSharedState> TableFunction::initEmptySharedState(
+    const kuzu::function::TableFunctionInitInput& /*input*/) {
+    return std::make_unique<TableFuncSharedState>();
+}
+
 std::vector<std::string> TableFunction::extractYieldVariables(const std::vector<std::string>& names,
     const std::vector<parser::YieldVariable>& yieldVariables) {
     std::vector<std::string> variableNames;

--- a/src/include/function/table/simple_table_function.h
+++ b/src/include/function/table/simple_table_function.h
@@ -19,10 +19,15 @@ struct TableFuncMorsel {
         return {common::INVALID_OFFSET, common::INVALID_OFFSET};
     }
 
+    uint64_t getMorselSize() const { return endOffset - startOffset; }
+
     bool isInvalid() const {
         return startOffset == common::INVALID_OFFSET && endOffset == common::INVALID_OFFSET;
     }
 };
+
+using simple_internal_table_func = std::function<common::offset_t(const TableFuncMorsel&,
+    const TableFuncInput&, common::DataChunk& output)>;
 
 class KUZU_API SimpleTableFuncSharedState : public TableFuncSharedState {
 public:
@@ -41,6 +46,8 @@ public:
 struct KUZU_API SimpleTableFunc {
     static std::unique_ptr<TableFuncSharedState> initSharedState(
         const TableFunctionInitInput& input);
+
+    static table_func_t getTableFunc(simple_internal_table_func internalTableFunc);
 };
 
 struct CurrentSettingFunction final {
@@ -69,12 +76,6 @@ struct ShowTablesFunction final {
 
 struct ShowWarningsFunction final {
     static constexpr const char* name = "SHOW_WARNINGS";
-
-    static function_set getFunctionSet();
-};
-
-struct ClearWarningsFunction final {
-    static constexpr const char* name = "CLEAR_WARNINGS";
 
     static function_set getFunctionSet();
 };
@@ -123,18 +124,6 @@ struct ShowAttachedDatabasesFunction final {
 
 struct ShowFunctionsFunction final {
     static constexpr const char* name = "SHOW_FUNCTIONS";
-
-    static function_set getFunctionSet();
-};
-
-struct CreateProjectedGraphFunction final {
-    static constexpr const char* name = "CREATE_PROJECTED_GRAPH";
-
-    static function_set getFunctionSet();
-};
-
-struct DropProjectedGraphFunction final {
-    static constexpr const char* name = "DROP_PROJECTED_GRAPH";
 
     static function_set getFunctionSet();
 };

--- a/src/include/function/table/standalone_call_function.h
+++ b/src/include/function/table/standalone_call_function.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "function/table/table_function.h"
+#include "function/function.h"
 
 namespace kuzu {
 namespace function {

--- a/src/include/function/table/standalone_call_function.h
+++ b/src/include/function/table/standalone_call_function.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "function/table/table_function.h"
+
+namespace kuzu {
+namespace function {
+
+struct ClearWarningsFunction final {
+    static constexpr const char* name = "CLEAR_WARNINGS";
+
+    static function_set getFunctionSet();
+};
+
+struct CreateProjectedGraphFunction final {
+    static constexpr const char* name = "CREATE_PROJECTED_GRAPH";
+
+    static function_set getFunctionSet();
+};
+
+struct DropProjectedGraphFunction final {
+    static constexpr const char* name = "DROP_PROJECTED_GRAPH";
+
+    static function_set getFunctionSet();
+};
+
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/table/table_function.h
+++ b/src/include/function/table/table_function.h
@@ -147,6 +147,8 @@ struct KUZU_API TableFunction final : Function {
     static std::unique_ptr<TableFuncLocalState> initEmptyLocalState(
         const TableFunctionInitInput& input, TableFuncSharedState* state,
         storage::MemoryManager* mm);
+    static std::unique_ptr<TableFuncSharedState> initEmptySharedState(
+        const TableFunctionInitInput& input);
     static std::vector<std::string> extractYieldVariables(const std::vector<std::string>& names,
         const std::vector<parser::YieldVariable>& yieldVariables);
     static void getLogicalPlan(const transaction::Transaction* transaction,

--- a/test/test_files/function/call/call.test
+++ b/test/test_files/function/call/call.test
@@ -284,7 +284,7 @@ Binder exception: a.fName has type PROPERTY but LITERAL,PARAMETER was expected.
 
 -LOG ShowOfficialExtensions
 -STATEMENT CALL SHOW_OFFICIAL_EXTENSIONS() RETURN *
----- 8
+---- 9
 DELTA|Adds support for reading from delta tables
 DUCKDB|Adds support for reading from duckdb tables
 FTS|Adds support for full-text search indexes
@@ -293,11 +293,12 @@ ICEBERG|Adds support for reading from iceberg tables
 JSON|Adds support for JSON operations
 POSTGRES|Adds support for reading from POSTGRES tables
 SQLITE|Adds support for reading from SQLITE tables
+UNITY_CATALOG|Adds support for scanning delta tables registered in unity catalog
 
 -CASE CallFuncWithYield
 -LOG CallWithYield
 -STATEMENT CALL SHOW_OFFICIAL_EXTENSIONS() yield name, description return name, description
----- 8
+---- 9
 DELTA|Adds support for reading from delta tables
 DUCKDB|Adds support for reading from duckdb tables
 FTS|Adds support for full-text search indexes
@@ -306,8 +307,9 @@ ICEBERG|Adds support for reading from iceberg tables
 JSON|Adds support for JSON operations
 POSTGRES|Adds support for reading from POSTGRES tables
 SQLITE|Adds support for reading from SQLITE tables
+UNITY_CATALOG|Adds support for scanning delta tables registered in unity catalog
 -STATEMENT CALL SHOW_OFFICIAL_EXTENSIONS() yield name as extension_name, description as extension_description return extension_name, extension_description
----- 8
+---- 9
 DELTA|Adds support for reading from delta tables
 DUCKDB|Adds support for reading from duckdb tables
 FTS|Adds support for full-text search indexes
@@ -316,13 +318,14 @@ ICEBERG|Adds support for reading from iceberg tables
 JSON|Adds support for JSON operations
 POSTGRES|Adds support for reading from POSTGRES tables
 SQLITE|Adds support for reading from SQLITE tables
+UNITY_CATALOG|Adds support for scanning delta tables registered in unity catalog
 -LOG ShowConnectionWithoutYieldError
 -STATEMENT CALL show_connection('workAt') CALL show_connection('workAt') RETURN *
 ---- error
 Binder exception: Variable source table name already exists.
 -LOG ShowExtensionWithYield
 -STATEMENT CALL SHOW_OFFICIAL_EXTENSIONS() yield name as extension_name, description as extension_description CALL SHOW_OFFICIAL_EXTENSIONS() WHERE extension_name = 'SQLITE' RETURN *
----- 8
+---- 9
 SQLITE|Adds support for reading from SQLITE tables|DELTA|Adds support for reading from delta tables
 SQLITE|Adds support for reading from SQLITE tables|DUCKDB|Adds support for reading from duckdb tables
 SQLITE|Adds support for reading from SQLITE tables|FTS|Adds support for full-text search indexes
@@ -331,9 +334,11 @@ SQLITE|Adds support for reading from SQLITE tables|ICEBERG|Adds support for read
 SQLITE|Adds support for reading from SQLITE tables|JSON|Adds support for JSON operations
 SQLITE|Adds support for reading from SQLITE tables|POSTGRES|Adds support for reading from POSTGRES tables
 SQLITE|Adds support for reading from SQLITE tables|SQLITE|Adds support for reading from SQLITE tables
+SQLITE|Adds support for reading from SQLITE tables|UNITY_CATALOG|Adds support for scanning delta tables registered in unity catalog
+
 -LOG ShowExtensionPartialAlias
 -STATEMENT CALL SHOW_OFFICIAL_EXTENSIONS() yield name, description as extension_description RETURN *
----- 8
+---- 9
 DELTA|Adds support for reading from delta tables
 DUCKDB|Adds support for reading from duckdb tables
 FTS|Adds support for full-text search indexes
@@ -342,6 +347,7 @@ ICEBERG|Adds support for reading from iceberg tables
 JSON|Adds support for JSON operations
 POSTGRES|Adds support for reading from POSTGRES tables
 SQLITE|Adds support for reading from SQLITE tables
+UNITY_CATALOG|Adds support for scanning delta tables registered in unity catalog
 
 -CASE CallFuncWithYieldError
 -STATEMENT CALL TABLE_INFO('person') yield `property id` as id RETURN *;

--- a/tools/python_api/src_cpp/include/pandas/pandas_scan.h
+++ b/tools/python_api/src_cpp/include/pandas/pandas_scan.h
@@ -16,14 +16,6 @@ struct PandasScanLocalState final : public function::TableFuncLocalState {
     uint64_t end;
 };
 
-struct PandasScanSharedState final : public function::TableFuncSharedState {
-    PandasScanSharedState(uint64_t startRow, uint64_t numRows)
-        : function::TableFuncSharedState{numRows}, startRow(startRow), numRowsRead{0} {}
-
-    uint64_t startRow;
-    uint64_t numRowsRead;
-};
-
 struct PandasScanFunction {
     static constexpr const char* name = "READ_PANDAS";
 


### PR DESCRIPTION
1. Remove the DeltaScanSharedState and reuse duckdbScansharedState.
2. Simplifiy the table function for simple functions.
3. Remove the pandasScanSharedState and reuse SimpleSharedstate