### PR TITLE
Improve SelectionVector::fromValueVectors

### DIFF
--- a/src/common/data_chunk/sel_vector.cpp
+++ b/src/common/data_chunk/sel_vector.cpp
@@ -36,10 +36,11 @@ void SelectionVector::setToUnfiltered(sel_t size) {
 }
 
 std::vector<SelectionVector*> SelectionVector::fromValueVectors(
-    const std::vector<std::shared_ptr<common::ValueVector>>& vec) {
-    std::vector<SelectionVector*> ret;
-    std::transform(vec.begin(), vec.end(), std::back_inserter(ret),
-        [](const auto& vec) -> SelectionVector* { return vec->getSelVectorPtr(); });
+    const std::vector<std::shared_ptr<ValueVector>>& vec) {
+    std::vector<SelectionVector*> ret(vec.size());
+    for (size_t i = 0; i < vec.size(); ++i) {
+        ret[i] = vec[i]->getSelVectorPtr();
+    }
     return ret;
 }
 

--- a/src/expression_evaluator/lambda_evaluator.cpp
+++ b/src/expression_evaluator/lambda_evaluator.cpp
@@ -57,10 +57,10 @@ void ListLambdaEvaluator::evaluateInternal() {
     }
     ListSliceInfo sliceInfo{inputVector};
     bindData.sliceInfo = &sliceInfo;
+    auto selVectors = SelectionVector::fromValueVectors(params);
     do {
         sliceInfo.nextSlice();
-        execFunc(params, SelectionVector::fromValueVectors(params), *resultVector,
-            resultVector->getSelVectorPtr(), &bindData);
+        execFunc(params, selVectors, *resultVector, resultVector->getSelVectorPtr(), &bindData);
     } while (!sliceInfo.done());
 }
 


### PR DESCRIPTION
# Description

On a MacMini desktop with M4 Max.
The following query `match (p1:person), (p2:person) where p1.id=p2.id return p1, p2;` can be improved from ~230ms to ~200ms under in-mem mode on the LDBC100 dataset.

I didn't benchmark on lambda evaluator, but I think it's a common sense change.