### PR TITLE
Implement synchronous APIs for Node.js bindings

### DIFF
--- a/tools/nodejs_api/src_cpp/include/node_connection.h
+++ b/tools/nodejs_api/src_cpp/include/node_connection.h
@@ -26,11 +26,14 @@ public:
 
 private:
     Napi::Value InitAsync(const Napi::CallbackInfo& info);
+    Napi::Value InitSync(const Napi::CallbackInfo& info);
     void InitCppConnection();
     void SetMaxNumThreadForExec(const Napi::CallbackInfo& info);
     void SetQueryTimeout(const Napi::CallbackInfo& info);
     Napi::Value ExecuteAsync(const Napi::CallbackInfo& info);
     Napi::Value QueryAsync(const Napi::CallbackInfo& info);
+    Napi::Value ExecuteSync(const Napi::CallbackInfo& info);
+    Napi::Value QuerySync(const Napi::CallbackInfo& info);
     void Close(const Napi::CallbackInfo& info);
 
 private:

--- a/tools/nodejs_api/src_cpp/include/node_database.h
+++ b/tools/nodejs_api/src_cpp/include/node_database.h
@@ -18,6 +18,7 @@ public:
 
 private:
     Napi::Value InitAsync(const Napi::CallbackInfo& info);
+    Napi::Value InitSync(const Napi::CallbackInfo& info);
     void InitCppDatabase();
     void Close(const Napi::CallbackInfo& info);
     static Napi::Value GetVersion(const Napi::CallbackInfo& info);

--- a/tools/nodejs_api/src_cpp/include/node_prepared_statement.h
+++ b/tools/nodejs_api/src_cpp/include/node_prepared_statement.h
@@ -17,6 +17,7 @@ public:
 
 private:
     Napi::Value InitAsync(const Napi::CallbackInfo& info);
+    Napi::Value InitSync(const Napi::CallbackInfo& info);
     void InitCppPreparedStatement();
     Napi::Value IsSuccess(const Napi::CallbackInfo& info);
     Napi::Value GetErrorMessage(const Napi::CallbackInfo& info);

--- a/tools/nodejs_api/src_cpp/include/node_query_result.h
+++ b/tools/nodejs_api/src_cpp/include/node_query_result.h
@@ -34,11 +34,13 @@ private:
     Napi::Value GetColumnDataTypesSync(const Napi::CallbackInfo& info);
     Napi::Value GetColumnNamesAsync(const Napi::CallbackInfo& info);
     Napi::Value GetColumnNamesSync(const Napi::CallbackInfo& info);
+    void PopulateColumnNames();
     void Close(const Napi::CallbackInfo& info);
     void Close();
 
 private:
     QueryResult* queryResult = nullptr;
+    std::unique_ptr<std::vector<std::string>> columnNames = nullptr;
     bool isOwned = false;
 };
 
@@ -61,7 +63,8 @@ public:
                     result[i] = columnDataTypes[i].toString();
                 }
             } else {
-                result = nodeQueryResult->queryResult->getColumnNames();
+                nodeQueryResult->PopulateColumnNames();
+                result = *nodeQueryResult->columnNames;
             }
         } catch (const std::exception& exc) {
             SetError(std::string(exc.what()));

--- a/tools/nodejs_api/src_cpp/include/node_query_result.h
+++ b/tools/nodejs_api/src_cpp/include/node_query_result.h
@@ -26,10 +26,14 @@ private:
     Napi::Value HasNext(const Napi::CallbackInfo& info);
     Napi::Value HasNextQueryResult(const Napi::CallbackInfo& info);
     Napi::Value GetNextQueryResultAsync(const Napi::CallbackInfo& info);
+    Napi::Value GetNextQueryResultSync(const Napi::CallbackInfo& info);
     Napi::Value GetNumTuples(const Napi::CallbackInfo& info);
     Napi::Value GetNextAsync(const Napi::CallbackInfo& info);
+    Napi::Value GetNextSync(const Napi::CallbackInfo& info);
     Napi::Value GetColumnDataTypesAsync(const Napi::CallbackInfo& info);
+    Napi::Value GetColumnDataTypesSync(const Napi::CallbackInfo& info);
     Napi::Value GetColumnNamesAsync(const Napi::CallbackInfo& info);
+    Napi::Value GetColumnNamesSync(const Napi::CallbackInfo& info);
     void Close(const Napi::CallbackInfo& info);
     void Close();
 

--- a/tools/nodejs_api/src_cpp/node_connection.cpp
+++ b/tools/nodejs_api/src_cpp/node_connection.cpp
@@ -11,8 +11,7 @@ Napi::Object NodeConnection::Init(Napi::Env env, Napi::Object exports) {
     Napi::HandleScope scope(env);
 
     Napi::Function t = DefineClass(env, "NodeConnection",
-        {
-            InstanceMethod("initAsync", &NodeConnection::InitAsync),
+        {InstanceMethod("initAsync", &NodeConnection::InitAsync),
             InstanceMethod("initSync", &NodeConnection::InitSync),
             InstanceMethod("executeAsync", &NodeConnection::ExecuteAsync),
             InstanceMethod("queryAsync", &NodeConnection::QueryAsync),
@@ -20,8 +19,7 @@ Napi::Object NodeConnection::Init(Napi::Env env, Napi::Object exports) {
             InstanceMethod("querySync", &NodeConnection::QuerySync),
             InstanceMethod("setMaxNumThreadForExec", &NodeConnection::SetMaxNumThreadForExec),
             InstanceMethod("setQueryTimeout", &NodeConnection::SetQueryTimeout),
-            InstanceMethod("close", &NodeConnection::Close)
-        });
+            InstanceMethod("close", &NodeConnection::Close)});
 
     exports.Set("NodeConnection", t);
     return exports;
@@ -135,7 +133,8 @@ Napi::Value NodeConnection::ExecuteSync(const Napi::CallbackInfo& info) {
     try {
         auto params = Util::TransformParametersForExec(info[2].As<Napi::Array>());
         auto result = connection
-                          ->executeWithParams(nodePreparedStatement->preparedStatement.get(), std::move(params))
+                          ->executeWithParams(nodePreparedStatement->preparedStatement.get(),
+                              std::move(params))
                           .release();
         nodeQueryResult->SetQueryResult(result, true);
         if (!result->isSuccess()) {

--- a/tools/nodejs_api/src_cpp/node_database.cpp
+++ b/tools/nodejs_api/src_cpp/node_database.cpp
@@ -6,6 +6,7 @@ Napi::Object NodeDatabase::Init(Napi::Env env, Napi::Object exports) {
     Napi::Function t = DefineClass(env, "NodeDatabase",
         {
             InstanceMethod("initAsync", &NodeDatabase::InitAsync),
+            InstanceMethod("initSync", &NodeDatabase::InitSync),
             InstanceMethod("close", &NodeDatabase::Close),
             StaticMethod("getVersion", &NodeDatabase::GetVersion),
             StaticMethod("getStorageVersion", &NodeDatabase::GetStorageVersion),
@@ -25,6 +26,17 @@ NodeDatabase::NodeDatabase(const Napi::CallbackInfo& info) : Napi::ObjectWrap<No
     maxDBSize = info[4].As<Napi::Number>().Int64Value();
     autoCheckpoint = info[5].As<Napi::Boolean>().Value();
     checkpointThreshold = info[6].As<Napi::Number>().Int64Value();
+}
+
+Napi::Value NodeDatabase::InitSync(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    Napi::HandleScope scope(env);
+    try {
+        InitCppDatabase();
+    } catch (const std::exception& exc) {
+        Napi::Error::New(env, exc.what()).ThrowAsJavaScriptException();
+    }
+    return env.Undefined();
 }
 
 Napi::Value NodeDatabase::InitAsync(const Napi::CallbackInfo& info) {

--- a/tools/nodejs_api/src_cpp/node_prepared_statement.cpp
+++ b/tools/nodejs_api/src_cpp/node_prepared_statement.cpp
@@ -6,6 +6,7 @@ Napi::Object NodePreparedStatement::Init(Napi::Env env, Napi::Object exports) {
     Napi::Function t = DefineClass(env, "NodePreparedStatement",
         {
             InstanceMethod("initAsync", &NodePreparedStatement::InitAsync),
+            InstanceMethod("initSync", &NodePreparedStatement::InitSync),
             InstanceMethod("isSuccess", &NodePreparedStatement::IsSuccess),
             InstanceMethod("getErrorMessage", &NodePreparedStatement::GetErrorMessage),
         });
@@ -30,6 +31,11 @@ Napi::Value NodePreparedStatement::InitAsync(const Napi::CallbackInfo& info) {
     auto callback = info[0].As<Napi::Function>();
     auto* asyncWorker = new PreparedStatementInitAsyncWorker(callback, this);
     asyncWorker->Queue();
+    return info.Env().Undefined();
+}
+
+Napi::Value NodePreparedStatement::InitSync(const Napi::CallbackInfo& info) {
+    InitCppPreparedStatement();
     return info.Env().Undefined();
 }
 

--- a/tools/nodejs_api/src_cpp/node_query_result.cpp
+++ b/tools/nodejs_api/src_cpp/node_query_result.cpp
@@ -198,8 +198,8 @@ void NodeQueryResult::PopulateColumnNames() {
     if (this->columnNames != nullptr) {
         return;
     }
-        this->columnNames = std::make_unique<std::vector<std::string>>(
-            this->queryResult->getColumnNames());
+    this->columnNames =
+        std::make_unique<std::vector<std::string>>(this->queryResult->getColumnNames());
 }
 
 void NodeQueryResult::Close(const Napi::CallbackInfo& info) {

--- a/tools/nodejs_api/src_cpp/node_query_result.cpp
+++ b/tools/nodejs_api/src_cpp/node_query_result.cpp
@@ -92,7 +92,8 @@ Napi::Value NodeQueryResult::GetNextQueryResultSync(const Napi::CallbackInfo& in
         if (!nextResult->isSuccess()) {
             Napi::Error::New(env, nextResult->getErrorMessage()).ThrowAsJavaScriptException();
         }
-        auto nodeQueryResult = Napi::ObjectWrap<NodeQueryResult>::Unwrap(info[0].As<Napi::Object>());
+        auto nodeQueryResult =
+            Napi::ObjectWrap<NodeQueryResult>::Unwrap(info[0].As<Napi::Object>());
         nodeQueryResult->SetQueryResult(nextResult, false);
     } catch (const std::exception& exc) {
         Napi::Error::New(env, std::string(exc.what())).ThrowAsJavaScriptException();

--- a/tools/nodejs_api/src_cpp/node_query_result.cpp
+++ b/tools/nodejs_api/src_cpp/node_query_result.cpp
@@ -15,10 +15,14 @@ Napi::Object NodeQueryResult::Init(Napi::Env env, Napi::Object exports) {
             InstanceMethod("hasNext", &NodeQueryResult::HasNext),
             InstanceMethod("hasNextQueryResult", &NodeQueryResult::HasNextQueryResult),
             InstanceMethod("getNextQueryResultAsync", &NodeQueryResult::GetNextQueryResultAsync),
+            InstanceMethod("getNextQueryResultSync", &NodeQueryResult::GetNextQueryResultSync),
             InstanceMethod("getNumTuples", &NodeQueryResult::GetNumTuples),
+            InstanceMethod("getNextSync", &NodeQueryResult::GetNextSync),
             InstanceMethod("getNextAsync", &NodeQueryResult::GetNextAsync),
             InstanceMethod("getColumnDataTypesAsync", &NodeQueryResult::GetColumnDataTypesAsync),
+            InstanceMethod("getColumnDataTypesSync", &NodeQueryResult::GetColumnDataTypesSync),
             InstanceMethod("getColumnNamesAsync", &NodeQueryResult::GetColumnNamesAsync),
+            InstanceMethod("getColumnNamesSync", &NodeQueryResult::GetColumnNamesSync),
             InstanceMethod("close", &NodeQueryResult::Close)});
 
     exports.Set("NodeQueryResult", t);
@@ -80,6 +84,22 @@ Napi::Value NodeQueryResult::GetNextQueryResultAsync(const Napi::CallbackInfo& i
     return info.Env().Undefined();
 }
 
+Napi::Value NodeQueryResult::GetNextQueryResultSync(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    Napi::HandleScope scope(env);
+    try {
+        auto nextResult = this->queryResult->getNextQueryResult();
+        if (!nextResult->isSuccess()) {
+            Napi::Error::New(env, nextResult->getErrorMessage()).ThrowAsJavaScriptException();
+        }
+        auto nodeQueryResult = Napi::ObjectWrap<NodeQueryResult>::Unwrap(info[0].As<Napi::Object>());
+        nodeQueryResult->SetQueryResult(nextResult, false);
+    } catch (const std::exception& exc) {
+        Napi::Error::New(env, std::string(exc.what())).ThrowAsJavaScriptException();
+    }
+    return info.Env().Undefined();
+}
+
 Napi::Value NodeQueryResult::GetNumTuples(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
     Napi::HandleScope scope(env);
@@ -100,6 +120,27 @@ Napi::Value NodeQueryResult::GetNextAsync(const Napi::CallbackInfo& info) {
     return info.Env().Undefined();
 }
 
+Napi::Value NodeQueryResult::GetNextSync(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    Napi::HandleScope scope(env);
+    try {
+        if (!this->queryResult->hasNext()) {
+            return env.Null();
+        }
+        auto cppTuple = this->queryResult->getNext();
+        Napi::Object nodeTuple = Napi::Object::New(env);
+        auto columnNames = this->queryResult->getColumnNames();
+        for (auto i = 0u; i < cppTuple->len(); ++i) {
+            Napi::Value value = Util::ConvertToNapiObject(*cppTuple->getValue(i), env);
+            nodeTuple.Set(columnNames[i], value);
+        }
+        return nodeTuple;
+    } catch (const std::exception& exc) {
+        Napi::Error::New(env, std::string(exc.what())).ThrowAsJavaScriptException();
+    }
+    return env.Undefined();
+}
+
 Napi::Value NodeQueryResult::GetColumnDataTypesAsync(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
     Napi::HandleScope scope(env);
@@ -110,6 +151,22 @@ Napi::Value NodeQueryResult::GetColumnDataTypesAsync(const Napi::CallbackInfo& i
     return info.Env().Undefined();
 }
 
+Napi::Value NodeQueryResult::GetColumnDataTypesSync(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    Napi::HandleScope scope(env);
+    try {
+        auto columnDataTypes = this->queryResult->getColumnDataTypes();
+        Napi::Array nodeColumnDataTypes = Napi::Array::New(env, columnDataTypes.size());
+        for (auto i = 0u; i < columnDataTypes.size(); ++i) {
+            nodeColumnDataTypes.Set(i, Napi::String::New(env, columnDataTypes[i].toString()));
+        }
+        return nodeColumnDataTypes;
+    } catch (const std::exception& exc) {
+        Napi::Error::New(env, std::string(exc.what())).ThrowAsJavaScriptException();
+    }
+    return env.Undefined();
+}
+
 Napi::Value NodeQueryResult::GetColumnNamesAsync(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
     Napi::HandleScope scope(env);
@@ -118,6 +175,22 @@ Napi::Value NodeQueryResult::GetColumnNamesAsync(const Napi::CallbackInfo& info)
         GetColumnMetadataType::NAME);
     asyncWorker->Queue();
     return info.Env().Undefined();
+}
+
+Napi::Value NodeQueryResult::GetColumnNamesSync(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    Napi::HandleScope scope(env);
+    try {
+        auto columnNames = this->queryResult->getColumnNames();
+        Napi::Array nodeColumnNames = Napi::Array::New(env, columnNames.size());
+        for (auto i = 0u; i < columnNames.size(); ++i) {
+            nodeColumnNames.Set(i, Napi::String::New(env, columnNames[i]));
+        }
+        return nodeColumnNames;
+    } catch (const std::exception& exc) {
+        Napi::Error::New(env, std::string(exc.what())).ThrowAsJavaScriptException();
+    }
+    return env.Undefined();
 }
 
 void NodeQueryResult::Close(const Napi::CallbackInfo& info) {

--- a/tools/nodejs_api/src_js/connection.js
+++ b/tools/nodejs_api/src_js/connection.js
@@ -444,6 +444,10 @@ class Connection {
     this._isClosed = true;
   }
 
+  /**
+   * Close the connection synchronously.
+   * @throws {Error} if there is an undergoing asynchronous initialization.
+   */
   closeSync() {
     if (this._isClosed) {
       return;

--- a/tools/nodejs_api/src_js/database.js
+++ b/tools/nodejs_api/src_js/database.js
@@ -171,6 +171,10 @@ class Database {
     this._isClosed = true;
   }
 
+  /**
+   * Close the database synchronously.
+   * @throws {Error} if there is an ongoing asynchronous initialization.
+   */
   closeSync() {
     if (this._isClosed) {
       return;

--- a/tools/nodejs_api/src_js/database.js
+++ b/tools/nodejs_api/src_js/database.js
@@ -37,7 +37,7 @@ class Database {
       throw new Error("Buffer manager size must be a positive integer.");
     }
     if (typeof maxDBSize !== "number" || maxDBSize < 0) {
-    throw new Error("Max DB size must be a positive integer.");
+      throw new Error("Max DB size must be a positive integer.");
     }
     if (typeof checkpointThreshold !== "number" || maxDBSize < -1) {
       throw new Error("Checkpoint threshold must be a positive integer.");
@@ -121,12 +121,28 @@ class Database {
   /**
    * Internal function to get the underlying native database object.
    * @returns {KuzuNative.NodeDatabase} the underlying native database.
+   * @throws {Error} if the database is closed.
    */
   async _getDatabase() {
     if (this._isClosed) {
       throw new Error("Database is closed.");
     }
     await this.init();
+    return this._database;
+  }
+
+  /**
+   * Internal function to get the underlying native database object synchronously.
+   * @returns {KuzuNative.NodeDatabase} the underlying native database.
+   * @throws {Error} if the database is closed.
+   */
+  _getDatabaseSync() {
+    if (this._isClosed) {
+      throw new Error("Database is closed.");
+    }
+    if (!this._isInitialized) {
+      this.initSync();
+    }
     return this._database;
   }
 
@@ -150,6 +166,25 @@ class Database {
       }
     }
     // Database is initialized, close it.
+    this._database.close();
+    delete this._database;
+    this._isClosed = true;
+  }
+
+  closeSync() {
+    if (this._isClosed) {
+      return;
+    }
+    if (!this._isInitialized) {
+      if (this._initPromise) {
+        throw new Error("There is an ongoing asynchronous initialization. Please wait for it to finish.");
+      } else {
+        this._isInitialized = true;
+        this._isClosed = true;
+        delete this._database;
+        return;
+      }
+    }
     this._database.close();
     delete this._database;
     this._isClosed = true;

--- a/tools/nodejs_api/src_js/database.js
+++ b/tools/nodejs_api/src_js/database.js
@@ -103,6 +103,22 @@ class Database {
   }
 
   /**
+   * Initialize the database synchronously. Calling this function is optional, as the
+   * database is initialized automatically when the first query is executed. This function
+   * may block the main thread, so use it with caution.
+   */
+  initSync() {
+    if (this._initPromise) {
+      throw new Error("There is an ongoing asynchronous initialization. Please wait for it to finish.");
+    }
+    if (this._isInitialized) {
+      return;
+    }
+    this._database.initSync();
+    this._isInitialized = true;
+  }
+
+  /**
    * Internal function to get the underlying native database object.
    * @returns {KuzuNative.NodeDatabase} the underlying native database.
    */

--- a/tools/nodejs_api/src_js/query_result.js
+++ b/tools/nodejs_api/src_js/query_result.js
@@ -66,6 +66,10 @@ class QueryResult {
     });
   }
 
+  /**
+   * Get the next row of the query result synchronously.
+   * @returns {Object} the next row of the query result.
+   */
   getNextSync() {
     this._checkClosed();
     return this._queryResult.getNextSync();
@@ -106,6 +110,10 @@ class QueryResult {
     return result;
   }
 
+  /**
+   * Get all rows of the query result synchronously. Note that this function can block the main thread if the number of rows is large, so use it with caution.
+   * @returns {Array<Object>} all rows of the query result.
+   */
   getAllSync() {
     this._checkClosed();
     this._queryResult.resetIterator();
@@ -148,6 +156,10 @@ class QueryResult {
     });
   }
 
+  /**
+   * Get the data types of the columns of the query result synchronously.
+   * @returns {Array<String>} the data types of the columns of the query result.
+   */
   getColumnDataTypesSync() {
     this._checkClosed();
     return this._queryResult.getColumnDataTypesSync();
@@ -169,6 +181,10 @@ class QueryResult {
     });
   }
 
+  /**
+   * Get the names of the columns of the query result synchronously.
+   * @returns {Array<String>} the names of the columns of the query result.
+   */
   getColumnNamesSync() {
     this._checkClosed();
     return this._queryResult.getColumnNamesSync();

--- a/tools/nodejs_api/src_js/query_result.js
+++ b/tools/nodejs_api/src_js/query_result.js
@@ -66,6 +66,11 @@ class QueryResult {
     });
   }
 
+  getNextSync() {
+    this._checkClosed();
+    return this._queryResult.getNextSync();
+  }
+
   /**
    * Iterate through the query result with callback functions.
    * @param {Function} resultCallback the callback function that is called for each row of the query result.
@@ -97,6 +102,16 @@ class QueryResult {
     const result = [];
     while (this.hasNext()) {
       result.push(await this.getNext());
+    }
+    return result;
+  }
+
+  getAllSync() {
+    this._checkClosed();
+    this._queryResult.resetIterator();
+    const result = [];
+    while (this.hasNext()) {
+      result.push(this.getNextSync());
     }
     return result;
   }
@@ -133,6 +148,11 @@ class QueryResult {
     });
   }
 
+  getColumnDataTypesSync() {
+    this._checkClosed();
+    return this._queryResult.getColumnDataTypesSync();
+  }
+
   /**
    * Get the names of the columns of the query result.
    * @returns {Promise<Array<String>>} a promise that resolves to the names of the columns of the query result. The promise is rejected if there is an error.
@@ -147,6 +167,11 @@ class QueryResult {
         return resolve(result);
       });
     });
+  }
+
+  getColumnNamesSync() {
+    this._checkClosed();
+    return this._queryResult.getColumnNamesSync();
   }
 
   /**

--- a/tools/nodejs_api/test/test.js
+++ b/tools/nodejs_api/test/test.js
@@ -17,4 +17,5 @@ describe("kuzu", () => {
   importTest("Query parameters", "./test_parameter.js");
   importTest("Concurrent query execution", "./test_concurrency.js");
   importTest("Version", "./test_version.js");
+  importTest("Synchronous API", "./test_sync_api.js");
 });

--- a/tools/nodejs_api/test/test_sync_api.js
+++ b/tools/nodejs_api/test/test_sync_api.js
@@ -1,0 +1,116 @@
+const { assert } = require("chai");
+
+const PERSON_IDS = [0, 2, 3, 5, 7, 8, 9, 10];
+
+describe("Query execution", function () {
+  it("should execute a query synchronously", function () {
+    const queryResult = conn.querySync(
+      "MATCH (a:person) RETURN a.ID ORDER BY a.ID"
+    );
+    assert.isTrue(queryResult.hasNext());
+    for (let id of PERSON_IDS) {
+      const tuple = queryResult.getNextSync();
+      assert.equal(tuple["a.ID"], id);
+    }
+  });
+
+  it("should execute a query with multiple statements synchronously", function () {
+    const queryResults = conn.querySync(
+      "RETURN 1 AS a; RETURN 2 AS a; RETURN 3 AS a;"
+    );
+    for (let i = 1; i <= 3; ++i) {
+      const queryResult = queryResults[i - 1];
+      assert.isTrue(queryResult.hasNext());
+      const tuple = queryResult.getNextSync();
+      assert.equal(tuple["a"], i);
+      assert.isFalse(queryResult.hasNext());
+    }
+  });
+
+  it("should execute a prepared statement synchronously", function () {
+    const preparedStatement = conn.prepareSync(
+      "RETURN $a as id"
+    );
+    const queryResult = conn.executeSync(
+      preparedStatement,
+      { a: 3 }
+    );
+    assert.isTrue(queryResult.hasNext());
+    const tuple = queryResult.getNextSync();
+    assert.equal(tuple["id"], 3);
+    assert.isFalse(queryResult.hasNext());
+  });
+});
+
+
+describe("Query result", function () {
+  it("should get all rows of a query result synchronously", function () {
+    const queryResult = conn.querySync(
+      "MATCH (a:person) RETURN a.ID ORDER BY a.ID"
+    );
+    const rows = queryResult.getAllSync();
+    assert.equal(rows.length, PERSON_IDS.length);
+    for (let i = 0; i < PERSON_IDS.length; ++i) {
+      assert.equal(rows[i]["a.ID"], PERSON_IDS[i]);
+    }
+  });
+
+  it("should get column names of a query result synchronously", function () {
+    const queryResult = conn.querySync(
+      "MATCH (a:person) RETURN a.ID, a.fName ORDER BY a.ID"
+    );
+    const columnNames = queryResult.getColumnNamesSync();
+    assert.deepEqual(columnNames, ["a.ID", "a.fName"]);
+  });
+
+  it("should get column data types of a query result synchronously", function () {
+    const queryResult = conn.querySync(
+      "MATCH (a:person) RETURN a.ID, a.fName ORDER BY a.ID"
+    );
+    const columnDataTypes = queryResult.getColumnDataTypesSync();
+    assert.deepEqual(columnDataTypes, ["INT64", "STRING"]);
+  });
+});
+
+describe("Synchronous initialization", function () {
+  it("should initialize a database synchronously", function () {
+    const database = new kuzu.Database(":memory:", 1 << 28 /* 256 MB */);
+    database.initSync();
+    assert.isTrue(database._isInitialized);
+    assert.isFalse(database._isClosed);
+    database.closeSync();
+    assert.isTrue(database._isClosed);
+  });
+
+  it("should initialize a connection synchronously", function () {
+    const connection = new kuzu.Connection(db);
+    connection.initSync();
+    assert.isTrue(connection._isInitialized);
+    assert.isFalse(connection._isClosed);
+    connection.closeSync();
+    assert.isTrue(connection._isClosed);
+  });
+
+  it("should perform initialization automatically for lazily-constructed database and connection", function () {
+    const database = new kuzu.Database(":memory:", 1 << 28 /* 256 MB */);
+    const connection = new kuzu.Connection(database);
+    assert.isFalse(database._isInitialized);
+    assert.isFalse(connection._isInitialized);
+    const queryResult = connection.querySync(
+      "RETURN 1 AS a, 'hello' AS b"
+    );
+    assert.isTrue(database._isInitialized);
+    assert.isTrue(connection._isInitialized);
+
+    const rows = queryResult.getAllSync();
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]["a"], 1);
+    assert.equal(rows[0]["b"], "hello");
+    queryResult.close();
+    connection.closeSync();
+    assert.isTrue(connection._isClosed);
+    assert.isFalse(database._isClosed);
+    database.closeSync();
+    assert.isTrue(database._isClosed);
+  });
+});


### PR DESCRIPTION
# Description

This PR adds synchronous API interfaces for Node.js bindings. These functions can block main thread, but is easier to use and more efficient if the query is small or being used for scripting (so that blocking main thread is fine).