### PR TITLE
Clear table function signatures

### DIFF
--- a/extension/delta/src/function/delta_scan.cpp
+++ b/extension/delta/src/function/delta_scan.cpp
@@ -36,7 +36,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
 }
 
 std::unique_ptr<TableFuncSharedState> initDeltaScanSharedState(
-    const TableFunctionInitInput& input) {
+    const TableFuncInitSharedStateInput& input) {
     auto deltaScanBindData = input.bindData->constPtrCast<DeltaScanBindData>();
     auto queryResult = deltaScanBindData->connector->executeQuery(deltaScanBindData->query);
     return std::make_unique<duckdb_extension::DuckDBScanSharedState>(std::move(queryResult));
@@ -60,18 +60,13 @@ offset_t tableFunc(const TableFuncInput& input, TableFuncOutput& output) {
     return output.dataChunk.state->getSelVector().getSelSize();
 }
 
-std::unique_ptr<TableFuncLocalState> initEmptyLocalState(const TableFunctionInitInput&,
-    TableFuncSharedState*, storage::MemoryManager*) {
-    return std::make_unique<TableFuncLocalState>();
-}
-
 function_set DeltaScanFunction::getFunctionSet() {
     function_set functionSet;
     auto function = std::make_unique<TableFunction>(name, std::vector{LogicalTypeID::STRING});
     function->tableFunc = tableFunc;
     function->bindFunc = bindFunc;
     function->initSharedStateFunc = initDeltaScanSharedState;
-    function->initLocalStateFunc = initEmptyLocalState;
+    function->initLocalStateFunc = TableFunction::initEmptyLocalState;
     functionSet.push_back(std::move(function));
     return functionSet;
 }

--- a/extension/delta/src/include/function/delta_scan.h
+++ b/extension/delta/src/include/function/delta_scan.h
@@ -37,11 +37,7 @@ struct DeltaScanBindData final : function::ScanFileBindData {
 
 // Functions and structs exposed for use
 std::unique_ptr<function::TableFuncSharedState> initDeltaScanSharedState(
-    const function::TableFunctionInitInput& input);
-
-std::unique_ptr<function::TableFuncLocalState> initEmptyLocalState(
-    const function::TableFunctionInitInput&, function::TableFuncSharedState*,
-    storage::MemoryManager*);
+    const function::TableFuncInitSharedStateInput& input);
 
 common::offset_t tableFunc(const function::TableFuncInput& input,
     function::TableFuncOutput& output);

--- a/extension/iceberg/src/function/iceberg_metadata.cpp
+++ b/extension/iceberg/src/function/iceberg_metadata.cpp
@@ -17,7 +17,7 @@ function_set IcebergMetadataFunction::getFunctionSet() {
     function->tableFunc = delta_extension::tableFunc;
     function->bindFunc = metadataBindFunc;
     function->initSharedStateFunc = delta_extension::initDeltaScanSharedState;
-    function->initLocalStateFunc = delta_extension::initEmptyLocalState;
+    function->initLocalStateFunc = function::TableFunction::initEmptyLocalState;
     functionSet.push_back(std::move(function));
     return functionSet;
 }

--- a/extension/iceberg/src/function/iceberg_scan.cpp
+++ b/extension/iceberg/src/function/iceberg_scan.cpp
@@ -17,7 +17,7 @@ function_set IcebergScanFunction::getFunctionSet() {
     function->tableFunc = delta_extension::tableFunc;
     function->bindFunc = scanBindFunc;
     function->initSharedStateFunc = delta_extension::initDeltaScanSharedState;
-    function->initLocalStateFunc = delta_extension::initEmptyLocalState;
+    function->initLocalStateFunc = function::TableFunction::initEmptyLocalState;
     functionSet.push_back(std::move(function));
     return functionSet;
 }

--- a/extension/iceberg/src/function/iceberg_snapshots.cpp
+++ b/extension/iceberg/src/function/iceberg_snapshots.cpp
@@ -17,7 +17,7 @@ function_set IcebergSnapshotsFunction::getFunctionSet() {
     function->tableFunc = delta_extension::tableFunc;
     function->bindFunc = snapshotBindFunc;
     function->initSharedStateFunc = delta_extension::initDeltaScanSharedState;
-    function->initLocalStateFunc = delta_extension::initEmptyLocalState;
+    function->initLocalStateFunc = function::TableFunction::initEmptyLocalState;
     functionSet.push_back(std::move(function));
     return functionSet;
 }

--- a/extension/json/src/functions/table_functions/json_scan.cpp
+++ b/extension/json/src/functions/table_functions/json_scan.cpp
@@ -867,18 +867,19 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput& output) 
     return count;
 }
 
-static std::unique_ptr<TableFuncSharedState> initSharedState(const TableFunctionInitInput& input) {
+static std::unique_ptr<TableFuncSharedState> initSharedState(
+    const TableFuncInitSharedStateInput& input) {
     auto jsonBindData = input.bindData->constPtrCast<JsonScanBindData>();
     return std::make_unique<JSONScanSharedState>(*jsonBindData->context,
         jsonBindData->fileScanInfo.filePaths[0], jsonBindData->format);
 }
 
-static std::unique_ptr<TableFuncLocalState> initLocalState(const TableFunctionInitInput& input,
-    TableFuncSharedState* state, storage::MemoryManager* mm) {
-    auto jsonBindData = input.bindData->constPtrCast<JsonScanBindData>();
-    auto sharedState = state->ptrCast<JSONScanSharedState>();
-    auto localState =
-        std::make_unique<JSONScanLocalState>(*mm, *sharedState, jsonBindData->context);
+static std::unique_ptr<TableFuncLocalState> initLocalState(
+    const TableFuncInitLocalStateInput& input) {
+    auto jsonBindData = input.bindData.constPtrCast<JsonScanBindData>();
+    auto sharedState = input.sharedState.ptrCast<JSONScanSharedState>();
+    auto localState = std::make_unique<JSONScanLocalState>(*input.clientContext->getMemoryManager(),
+        *sharedState, jsonBindData->context);
     return localState;
 }
 

--- a/extension/postgres/src/function/sql_query.cpp
+++ b/extension/postgres/src/function/sql_query.cpp
@@ -56,7 +56,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const ClientContext* context,
         std::move(duckdbResultConverter), columns);
 }
 
-std::unique_ptr<TableFuncSharedState> initSharedState(const TableFunctionInitInput& input) {
+std::unique_ptr<TableFuncSharedState> initSharedState(const TableFuncInitSharedStateInput& input) {
     auto scanBindData = input.bindData->constPtrCast<SqlQueryBindData>();
     return std::make_unique<duckdb_extension::DuckDBScanSharedState>(scanBindData->queryResult);
 }

--- a/src/function/table/simple_table_function.cpp
+++ b/src/function/table/simple_table_function.cpp
@@ -17,7 +17,7 @@ TableFuncMorsel SimpleTableFuncSharedState::getMorsel() {
 }
 
 std::unique_ptr<TableFuncSharedState> SimpleTableFunc::initSharedState(
-    const TableFunctionInitInput& input) {
+    const TableFuncInitSharedStateInput& input) {
     return std::make_unique<SimpleTableFuncSharedState>(input.bindData->numRows);
 }
 

--- a/src/function/table/stats_info.cpp
+++ b/src/function/table/stats_info.cpp
@@ -13,11 +13,6 @@ using namespace kuzu::main;
 namespace kuzu {
 namespace function {
 
-static std::unique_ptr<TableFuncLocalState> initLocalState(const TableFunctionInitInput&,
-    const TableFuncSharedState*, const storage::MemoryManager*) {
-    return std::make_unique<TableFuncLocalState>();
-}
-
 struct StatsInfoBindData final : TableFuncBindData {
     TableCatalogEntry* tableEntry;
     storage::Table* table;
@@ -86,7 +81,7 @@ function_set StatsInfoFunction::getFunctionSet() {
     function->tableFunc = SimpleTableFunc::getTableFunc(internalTableFunc);
     function->bindFunc = bindFunc;
     function->initSharedStateFunc = SimpleTableFunc::initSharedState;
-    function->initLocalStateFunc = initLocalState;
+    function->initLocalStateFunc = TableFunction::initEmptyLocalState;
     functionSet.push_back(std::move(function));
     return functionSet;
 }

--- a/src/function/table/storage_info.cpp
+++ b/src/function/table/storage_info.cpp
@@ -84,9 +84,9 @@ struct StorageInfoBindData final : TableFuncBindData {
     }
 };
 
-static std::unique_ptr<TableFuncLocalState> initLocalState(const TableFunctionInitInput& /*input*/,
-    const TableFuncSharedState* /*state*/, MemoryManager* mm) {
-    return std::make_unique<StorageInfoLocalState>(mm);
+static std::unique_ptr<TableFuncLocalState> initLocalState(
+    const TableFuncInitLocalStateInput& input) {
+    return std::make_unique<StorageInfoLocalState>(input.clientContext->getMemoryManager());
 }
 
 struct StorageInfoOutputData {

--- a/src/include/function/gds/gds.h
+++ b/src/include/function/gds/gds.h
@@ -68,7 +68,7 @@ public:
         std::string expressionName);
 
     static std::unique_ptr<TableFuncSharedState> initSharedState(
-        const TableFunctionInitInput& input);
+        const TableFuncInitSharedStateInput& input);
     static void getLogicalPlan(planner::Planner* planner,
         const binder::BoundReadingClause& readingClause,
         std::shared_ptr<planner::LogicalOperator> logicalOp,

--- a/src/include/function/table/simple_table_function.h
+++ b/src/include/function/table/simple_table_function.h
@@ -45,7 +45,7 @@ public:
 
 struct KUZU_API SimpleTableFunc {
     static std::unique_ptr<TableFuncSharedState> initSharedState(
-        const TableFunctionInitInput& input);
+        const TableFuncInitSharedStateInput& input);
 
     static table_func_t getTableFunc(simple_internal_table_func internalTableFunc);
 };

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -2,6 +2,7 @@
 
 #include "planner/operator/logical_operator.h"
 #include "planner/operator/logical_plan.h"
+#include "processor/execution_context.h"
 #include "processor/operator/result_collector.h"
 #include "processor/physical_plan.h"
 
@@ -49,8 +50,9 @@ struct PartitionerSharedState;
 
 class PlanMapper {
 public:
-    explicit PlanMapper(main::ClientContext* clientContext)
-        : clientContext{clientContext}, physicalOperatorID{0} {}
+    explicit PlanMapper(processor::ExecutionContext* executionContext)
+        : executionContext{executionContext}, clientContext{executionContext->clientContext},
+          physicalOperatorID{0} {}
 
     std::unique_ptr<PhysicalPlan> mapLogicalPlanToPhysical(const planner::LogicalPlan* logicalPlan,
         const binder::expression_vector& expressionsToCollect);
@@ -236,6 +238,7 @@ public:
         const binder::Expression& expr) const;
 
 public:
+    processor::ExecutionContext* executionContext;
     main::ClientContext* clientContext;
     std::unordered_map<const planner::LogicalOperator*, PhysicalOperator*> logicalOpToPhysicalOpMap;
 

--- a/src/processor/map/create_factorized_table_scan.cpp
+++ b/src/processor/map/create_factorized_table_scan.cpp
@@ -35,11 +35,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createFTableScan(const expression_
     info.function = *ku_dynamic_cast<TableFunction*>(function);
     info.bindData = std::move(bindData);
     info.outPosV = std::move(outPosV);
-    info.outputType = TableScanOutputType::MULTI_DATA_CHUNK;
-    auto sharedState = std::make_shared<TableFunctionCallSharedState>();
-    TableFunctionInitInput tableFunctionInitInput{info.bindData.get(), 0 /* queryID */,
-        *clientContext};
-    sharedState->funcState = info.function.initSharedStateFunc(tableFunctionInitInput);
+    auto initInput = TableFuncInitSharedStateInput(info.bindData.get(), executionContext);
+    auto sharedState = info.function.initSharedStateFunc(initInput);
     auto printInfo = std::make_unique<FTableScanFunctionCallPrintInfo>(function->name, exprs);
     if (children.size() == 0) {
         return std::make_unique<TableFunctionCall>(std::move(info), sharedState, getOperatorID(),

--- a/src/processor/map/map_copy_from.cpp
+++ b/src/processor/map/map_copy_from.cpp
@@ -91,7 +91,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyNodeFrom(
 
     if (prevOperator->getOperatorType() == PhysicalOperatorType::TABLE_FUNCTION_CALL) {
         const auto call = prevOperator->ptrCast<TableFunctionCall>();
-        sharedState->readerSharedState = call->getSharedState();
+        sharedState->tableFuncSharedState = call->getSharedState().get();
     }
     // Map copy node.
     std::vector<column_id_t> columnIDs;

--- a/src/processor/map/map_semi_masker.cpp
+++ b/src/processor/map/map_semi_masker.cpp
@@ -51,8 +51,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapSemiMasker(
             auto sharedState = physicalOp->ptrCast<TableFunctionCall>()->getSharedState();
             switch (semiMasker.getTargetType()) {
             case SemiMaskTargetType::GDS_GRAPH_NODE: {
-                auto funcSharedState =
-                    sharedState->funcState->ptrCast<function::GDSFuncSharedState>();
+                auto funcSharedState = sharedState->ptrCast<function::GDSFuncSharedState>();
                 initMask(masksPerTable, funcSharedState->getGraphNodeMaskMap()->getMasks());
             } break;
             default:

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -24,8 +24,8 @@ std::string NodeBatchInsertPrintInfo::toString() const {
 
 void NodeBatchInsertSharedState::initPKIndex(const ExecutionContext* context) {
     uint64_t numRows = 0;
-    if (readerSharedState != nullptr) {
-        numRows = readerSharedState->funcState->getNumRows();
+    if (tableFuncSharedState != nullptr) {
+        numRows = tableFuncSharedState->getNumRows();
     }
     auto* nodeTable = ku_dynamic_cast<NodeTable*>(table);
     nodeTable->getPKIndex()->bulkReserve(numRows);

--- a/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
@@ -267,7 +267,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
         scanInput->fileScanInfo.copy(), context, numWarningDataColumns);
 }
 
-static std::unique_ptr<TableFuncSharedState> initSharedState(const TableFunctionInitInput& input) {
+static std::unique_ptr<TableFuncSharedState> initSharedState(
+    const TableFuncInitSharedStateInput& input) {
     auto bindData = input.bindData->constPtrCast<ScanFileBindData>();
     auto csvOption = CSVReaderConfig::construct(bindData->fileScanInfo.options).option;
     auto columnInfo = CSVColumnInfo(bindData->getNumColumns() - bindData->numWarningDataColumns,
@@ -285,11 +286,9 @@ static std::unique_ptr<TableFuncSharedState> initSharedState(const TableFunction
     return sharedState;
 }
 
-static std::unique_ptr<TableFuncLocalState> initLocalState(const TableFunctionInitInput&,
-    const TableFuncSharedState*, storage::MemoryManager*) {
+static std::unique_ptr<TableFuncLocalState> initLocalState(const TableFuncInitLocalStateInput&) {
     auto localState = std::make_unique<ParallelCSVLocalState>();
     localState->fileIdx = std::numeric_limits<decltype(localState->fileIdx)>::max();
-
     return localState;
 }
 

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -700,15 +700,16 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     return bindData;
 }
 
-static std::unique_ptr<TableFuncSharedState> initSharedState(const TableFunctionInitInput& input) {
+static std::unique_ptr<TableFuncSharedState> initSharedState(
+    const TableFuncInitSharedStateInput& input) {
     auto bindData = input.bindData->constPtrCast<ScanFileBindData>();
     return std::make_unique<ParquetScanSharedState>(bindData->fileScanInfo.copy(),
         bindData->numRows, bindData->context, bindData->getColumnSkips());
 }
 
-static std::unique_ptr<TableFuncLocalState> initLocalState(const TableFunctionInitInput&,
-    TableFuncSharedState* state, storage::MemoryManager*) {
-    auto sharedState = state->ptrCast<ParquetScanSharedState>();
+static std::unique_ptr<TableFuncLocalState> initLocalState(
+    const TableFuncInitLocalStateInput& input) {
+    auto sharedState = input.sharedState.ptrCast<ParquetScanSharedState>();
     auto localState = std::make_unique<ParquetScanLocalState>();
     if (!parquetSharedStateNext(*localState, *sharedState)) {
         return nullptr;

--- a/tools/python_api/src_cpp/pandas/pandas_scan.cpp
+++ b/tools/python_api/src_cpp/pandas/pandas_scan.cpp
@@ -44,12 +44,11 @@ std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* /*context*/,
         scanConfig);
 }
 
-std::unique_ptr<TableFuncLocalState> initLocalState(const TableFunctionInitInput& /*input*/,
-    TableFuncSharedState* /*sharedState*/, storage::MemoryManager* /*mm*/) {
+std::unique_ptr<TableFuncLocalState> initLocalState(const TableFuncInitLocalStateInput& /*input*/) {
     return std::make_unique<PandasScanLocalState>(0 /* start */, 0 /* end */);
 }
 
-std::unique_ptr<TableFuncSharedState> initSharedState(const TableFunctionInitInput& input) {
+std::unique_ptr<TableFuncSharedState> initSharedState(const TableFuncInitSharedStateInput& input) {
     // LCOV_EXCL_START
     if (PyGILState_Check()) {
         throw RuntimeException("PandasScan called but GIL was already held!");

--- a/tools/python_api/src_cpp/pyarrow/pyarrow_scan.cpp
+++ b/tools/python_api/src_cpp/pyarrow/pyarrow_scan.cpp
@@ -74,7 +74,8 @@ ArrowArrayWrapper* PyArrowTableScanSharedState::getNextChunk() {
     return chunks[currentChunk++].get();
 }
 
-static std::unique_ptr<TableFuncSharedState> initSharedState(const TableFuncInitSharedStateInput& input) {
+static std::unique_ptr<TableFuncSharedState> initSharedState(
+    const TableFuncInitSharedStateInput& input) {
     py::gil_scoped_acquire acquire;
     PyArrowTableScanFunctionData* bindData =
         dynamic_cast<PyArrowTableScanFunctionData*>(input.bindData);
@@ -82,7 +83,8 @@ static std::unique_ptr<TableFuncSharedState> initSharedState(const TableFuncInit
         bindData->arrowArrayBatches);
 }
 
-static std::unique_ptr<TableFuncLocalState> initLocalState(const TableFuncInitLocalStateInput& input) {
+static std::unique_ptr<TableFuncLocalState> initLocalState(
+    const TableFuncInitLocalStateInput& input) {
     PyArrowTableScanSharedState* pyArrowShared =
         dynamic_cast<PyArrowTableScanSharedState*>(&input.sharedState);
     return std::make_unique<PyArrowTableScanLocalState>(pyArrowShared->getNextChunk());

--- a/tools/python_api/src_cpp/pyarrow/pyarrow_scan.cpp
+++ b/tools/python_api/src_cpp/pyarrow/pyarrow_scan.cpp
@@ -74,7 +74,7 @@ ArrowArrayWrapper* PyArrowTableScanSharedState::getNextChunk() {
     return chunks[currentChunk++].get();
 }
 
-static std::unique_ptr<TableFuncSharedState> initSharedState(const TableFunctionInitInput& input) {
+static std::unique_ptr<TableFuncSharedState> initSharedState(const TableFuncInitSharedStateInput& input) {
     py::gil_scoped_acquire acquire;
     PyArrowTableScanFunctionData* bindData =
         dynamic_cast<PyArrowTableScanFunctionData*>(input.bindData);
@@ -82,10 +82,9 @@ static std::unique_ptr<TableFuncSharedState> initSharedState(const TableFunction
         bindData->arrowArrayBatches);
 }
 
-static std::unique_ptr<TableFuncLocalState> initLocalState(const TableFunctionInitInput&,
-    TableFuncSharedState* sharedState, storage::MemoryManager* /*mm*/) {
+static std::unique_ptr<TableFuncLocalState> initLocalState(const TableFuncInitLocalStateInput& input) {
     PyArrowTableScanSharedState* pyArrowShared =
-        dynamic_cast<PyArrowTableScanSharedState*>(sharedState);
+        dynamic_cast<PyArrowTableScanSharedState*>(&input.sharedState);
     return std::make_unique<PyArrowTableScanLocalState>(pyArrowShared->getNextChunk());
 }
 


### PR DESCRIPTION
# Description

- Simplify initSharedState signature.
- Remove TableFunctionCall shared state wrapper.
- Add initOutput functor and replace TableFunctionCall::initLocalState as a functor call.