### PR TITLE
Use correct offset to access vector index embeddings during creation

### DIFF
--- a/src/storage/index/hnsw_graph.cpp
+++ b/src/storage/index/hnsw_graph.cpp
@@ -24,7 +24,8 @@ float* InMemEmbeddings::getEmbedding(common::offset_t offset) const {
     auto [nodeGroupIdx, offsetInGroup] = StorageUtils::getNodeGroupIdxAndOffsetInChunk(offset);
     KU_ASSERT(nodeGroupIdx < data->columnChunks.size());
     const auto& listChunk = data->columnChunks[nodeGroupIdx]->cast<ListChunkData>();
-    return &listChunk.getDataColumnChunk()->getData<float>()[offsetInGroup * typeInfo.dimension];
+    return &listChunk.getDataColumnChunk()
+                ->getData<float>()[listChunk.getListStartOffset(offsetInGroup)];
 }
 
 bool InMemEmbeddings::isNull(common::offset_t offset) const {


### PR DESCRIPTION
# Description

Use the offset stored in the list entry instead of trying to directly calculate the data vector offset when trying to get the location of a vector's embeddings. This addresses the cases where there are null embeddings which don't occupy any space in the data vector (and thus prevents us from being able to correctly calculate the data vector offset from the list entry offset)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).