### PR TITLE
Add option blind/directed upper sel threshold; rename distFunc to metric

### DIFF
--- a/extension/vector/src/catalog/hnsw_index_catalog_entry.cpp
+++ b/extension/vector/src/catalog/hnsw_index_catalog_entry.cpp
@@ -50,11 +50,11 @@ std::string HNSWIndexAuxInfo::toCypher(const IndexCatalogEntry& indexEntry,
         catalog->getTableCatalogEntry(context->getTransaction(), indexEntry.getTableID());
     auto tableName = tableEntry->getName();
     auto propertyName = tableEntry->getProperty(indexEntry.getPropertyIDs()[0]).getName();
-    auto distFuncName = HNSWIndexConfig::distFuncToString(config.distFunc);
+    auto metricName = HNSWIndexConfig::metricToString(config.metric);
     cypher += common::stringFormat("CALL CREATE_HNSW_INDEX('{}', '{}', '{}', mu := {}, ml := {}, "
-                                   "pu := {}, distFunc := '{}', alpha := {}, efc := {});",
+                                   "pu := {}, metric := '{}', alpha := {}, efc := {});",
         tableName, indexEntry.getIndexName(), propertyName, config.mu, config.ml, config.pu,
-        distFuncName, config.alpha, config.efc);
+        metricName, config.alpha, config.efc);
     return cypher;
 }
 

--- a/extension/vector/src/function/create_hnsw_index.cpp
+++ b/extension/vector/src/function/create_hnsw_index.cpp
@@ -25,8 +25,8 @@ namespace vector_extension {
 CreateInMemHNSWSharedState::CreateInMemHNSWSharedState(const CreateHNSWIndexBindData& bindData)
     : SimpleTableFuncSharedState{bindData.numRows}, name{bindData.indexName},
       nodeTable{bindData.context->getStorageManager()
-              ->getTable(bindData.tableEntry->getTableID())
-              ->cast<storage::NodeTable>()},
+                    ->getTable(bindData.tableEntry->getTableID())
+                    ->cast<storage::NodeTable>()},
       numNodes{bindData.numRows}, bindData{&bindData} {
     hnswIndex = std::make_shared<InMemHNSWIndex>(bindData.context, nodeTable,
         bindData.tableEntry->getColumnID(bindData.propertyID), bindData.config.copy());

--- a/extension/vector/src/include/index/hnsw_config.h
+++ b/extension/vector/src/include/index/hnsw_config.h
@@ -6,7 +6,7 @@
 namespace kuzu {
 namespace vector_extension {
 
-enum class DistFuncType : uint8_t { Cosine = 0, L2 = 1, L2_SQUARE = 2, DotProduct = 3 };
+enum class MetricType : uint8_t { Cosine = 0, L2 = 1, L2_SQUARE = 2, DotProduct = 3 };
 
 // Max degree of the upper graph.
 struct Mu {
@@ -35,12 +35,12 @@ struct Pu {
     static void validate(double value);
 };
 
-struct DistFunc {
-    static constexpr const char* NAME = "distfunc";
+struct Metric {
+    static constexpr const char* NAME = "metric";
     static constexpr common::LogicalTypeID TYPE = common::LogicalTypeID::STRING;
-    static constexpr DistFuncType DEFAULT_VALUE = DistFuncType::Cosine;
+    static constexpr MetricType DEFAULT_VALUE = MetricType::Cosine;
 
-    static void validate(const std::string& distFuncName);
+    static void validate(const std::string& metric);
 };
 
 struct Alpha {
@@ -67,11 +67,27 @@ struct Efs {
     static void validate(int64_t value);
 };
 
+struct BlindSearchUpSelThreshold {
+    static constexpr const char* NAME = "blind_search_up_sel";
+    static constexpr common::LogicalTypeID TYPE = common::LogicalTypeID::DOUBLE;
+    static constexpr double DEFAULT_VALUE = 0.08;
+
+    static void validate(double value);
+};
+
+struct DirectedSearchUpSelThreshold {
+    static constexpr const char* NAME = "directed_search_up_sel";
+    static constexpr common::LogicalTypeID TYPE = common::LogicalTypeID::DOUBLE;
+    static constexpr double DEFAULT_VALUE = 0.4;
+
+    static void validate(double value);
+};
+
 struct HNSWIndexConfig {
     int64_t mu = Mu::DEFAULT_VALUE;
     int64_t ml = Ml::DEFAULT_VALUE;
     double pu = Pu::DEFAULT_VALUE;
-    DistFuncType distFunc = DistFunc::DEFAULT_VALUE;
+    MetricType metric = Metric::DEFAULT_VALUE;
     double alpha = Alpha::DEFAULT_VALUE;
     int64_t efc = Efc::DEFAULT_VALUE;
 
@@ -85,18 +101,20 @@ struct HNSWIndexConfig {
 
     static HNSWIndexConfig deserialize(common::Deserializer& deSer);
 
-    static std::string distFuncToString(DistFuncType distFunc);
+    static std::string metricToString(MetricType metric);
 
 private:
     HNSWIndexConfig(const HNSWIndexConfig& other)
-        : mu{other.mu}, ml{other.ml}, pu{other.pu}, distFunc{other.distFunc}, alpha{other.alpha},
+        : mu{other.mu}, ml{other.ml}, pu{other.pu}, metric{other.metric}, alpha{other.alpha},
           efc{other.efc} {}
 
-    static DistFuncType getDistFuncType(const std::string& funcName);
+    static MetricType getMetricType(const std::string& metricName);
 };
 
 struct QueryHNSWConfig {
     int64_t efs = Efs::DEFAULT_VALUE;
+    double blindSearchUpSelThreshold = BlindSearchUpSelThreshold::DEFAULT_VALUE;
+    double directedSearchUpSelThreshold = DirectedSearchUpSelThreshold::DEFAULT_VALUE;
 
     QueryHNSWConfig() = default;
 

--- a/extension/vector/src/include/index/hnsw_graph.h
+++ b/extension/vector/src/include/index/hnsw_graph.h
@@ -72,9 +72,9 @@ struct NodeWithDistance {
 struct HNSWGraphInfo {
     common::offset_t numNodes;
     EmbeddingColumn* embeddings;
-    DistFuncType distFunc;
+    MetricType distFunc;
 
-    HNSWGraphInfo(common::offset_t numNodes, EmbeddingColumn* embeddings, DistFuncType distFunc)
+    HNSWGraphInfo(common::offset_t numNodes, EmbeddingColumn* embeddings, MetricType distFunc)
         : numNodes{numNodes}, embeddings{embeddings}, distFunc{distFunc} {}
 };
 

--- a/extension/vector/src/include/index/hnsw_index.h
+++ b/extension/vector/src/include/index/hnsw_index.h
@@ -88,7 +88,7 @@ protected:
 struct InMemHNSWLayerInfo {
     common::offset_t numNodes;
     InMemEmbeddings* embeddings;
-    DistFuncType distFunc;
+    MetricType metric;
     // The degree threshold of a node that will start to trigger shrinking during insertions. Thus,
     // it is also the max degree of a node in the graph before shrinking.
     int64_t degreeThresholdToShrink;
@@ -97,10 +97,9 @@ struct InMemHNSWLayerInfo {
     double alpha;
     int64_t efc;
 
-    InMemHNSWLayerInfo(common::offset_t numNodes, InMemEmbeddings* embeddings,
-        DistFuncType distFunc, int64_t degreeThresholdToShrink, int64_t maxDegree, double alpha,
-        int64_t efc)
-        : numNodes{numNodes}, embeddings{embeddings}, distFunc{distFunc},
+    InMemHNSWLayerInfo(common::offset_t numNodes, InMemEmbeddings* embeddings, MetricType metric,
+        int64_t degreeThresholdToShrink, int64_t maxDegree, double alpha, int64_t efc)
+        : numNodes{numNodes}, embeddings{embeddings}, metric{metric},
           degreeThresholdToShrink{degreeThresholdToShrink}, maxDegree{maxDegree}, alpha{alpha},
           efc{efc} {}
 };
@@ -257,8 +256,6 @@ public:
         max_node_priority_queue_t& results) const;
 
 private:
-    static constexpr double BLIND_SEARCH_UP_SEL_THRESHOLD = 0.08;
-    static constexpr double DIRECTED_SEARCH_UP_SEL_THRESHOLD = 0.4;
     static constexpr uint64_t FILTERED_SEARCH_INITIAL_CANDIDATES = 10;
 
     common::table_id_t nodeTableID;

--- a/extension/vector/src/include/index/hnsw_index_utils.h
+++ b/extension/vector/src/include/index/hnsw_index_utils.h
@@ -28,7 +28,7 @@ struct HNSWIndexUtils {
     static void validateAutoTransaction(const main::ClientContext& context,
         const std::string& funcName);
 
-    static double computeDistance(DistFuncType funcType, const float* left, const float* right,
+    static double computeDistance(MetricType funcType, const float* left, const float* right,
         uint32_t dimension);
 
     static void validateColumnType(const catalog::TableCatalogEntry& tableEntry,

--- a/extension/vector/src/index/hnsw_index_utils.cpp
+++ b/extension/vector/src/index/hnsw_index_utils.cpp
@@ -61,22 +61,22 @@ void HNSWIndexUtils::validateColumnType(const catalog::TableCatalogEntry& tableE
     validateColumnType(type);
 }
 
-double HNSWIndexUtils::computeDistance(DistFuncType funcType, const float* left, const float* right,
+double HNSWIndexUtils::computeDistance(MetricType funcType, const float* left, const float* right,
     uint32_t dimension) {
     double distance = 0.0;
     switch (funcType) {
-    case DistFuncType::Cosine: {
+    case MetricType::Cosine: {
         simsimd_cos_f32(left, right, dimension, &distance);
     } break;
-    case DistFuncType::DotProduct: {
+    case MetricType::DotProduct: {
         simsimd_dot_f32(left, right, dimension, &distance);
     } break;
-    case DistFuncType::L2: {
+    case MetricType::L2: {
         // L2 distance is the square root of the sum of the squared differences between the two
         // vectors. Also known as the Euclidean distance.
         simsimd_l2_f32(left, right, dimension, &distance);
     } break;
-    case DistFuncType::L2_SQUARE: {
+    case MetricType::L2_SQUARE: {
         // L2 square distance is the sum of the squared differences between the two vectors.
         // Also known as the squared Euclidean distance.
         simsimd_l2sq_f32(left, right, dimension, &distance);

--- a/extension/vector/test/test_files/error.test
+++ b/extension/vector/test/test_files/error.test
@@ -57,9 +57,9 @@ Binder exception: Pu must be a double between 0 and 1.
 -STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', alpha := 0.5);
 ---- error
 Binder exception: Alpha must be a double greater than or equal to 1.
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'invalid');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'invalid');
 ---- error
-Binder exception: DistFunc must be one of COSINE, L2, L2SQ or DOTPRODUCT.
+Binder exception: Metric must be one of COSINE, L2, L2SQ or DOTPRODUCT.
 -STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec');
 ---- ok
 -STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index', CAST([0.0459,0.0439,0.0251,0.1,0.2,0.3,0.4,0.4], 'FLOAT[8]'), 10, unknown_param := 1) RETURN *;
@@ -76,7 +76,7 @@ Binder exception: Efs must be a positive integer.
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'l2');
 ---- ok
 -STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index', ['abc','def','ddd','awe','alice','bob','de','pwd'], 3) RETURN nn.id ORDER BY _distance;
 ---- error
@@ -112,3 +112,22 @@ Binder exception: Projected graph emb-graph2 either contains relationship tables
 -STATEMENT CALL QUERY_HNSW_INDEX('emb-graph3', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
 ---- error
 Binder exception: Cannot find table or projected graph named as emb-graph3.
+
+-CASE InCorrectSearchThreshold
+-STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/vector/build/libvector.kuzu_extension';
+---- ok
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
+---- ok
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', metric := 'l2');
+---- ok
+-STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index', [0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557], 3, blind_search_up_sel := 1.1) RETURN nn.id ORDER BY _distance;
+---- error
+Binder exception: Blind search upper selectivity threshold must be a double between 0 and 1.
+-STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index', [0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557], 3, directed_search_up_sel := -0.1) RETURN nn.id ORDER BY _distance;
+---- error
+Binder exception: Directed search upper selectivity threshold must be a double between 0 and 1.
+-STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index', [0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557], 3, directed_search_up_sel := 0.1, blind_search_up_sel := 0.8) RETURN nn.id ORDER BY _distance;
+---- error
+Binder exception: Blind search upper selectivity threshold is set to 0.800000, but the directed search upper selectivity threshold is set to 0.100000. The blind search upper selectivity threshold must be less than the directed search upper selectivity threshold.

--- a/extension/vector/test/test_files/filter.test
+++ b/extension/vector/test/test_files/filter.test
@@ -9,11 +9,23 @@
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'dotproduct');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'dotproduct');
 ---- ok
 -STATEMENT CALL create_projected_graph('emb-graph', {'embeddings': {'filter': 'n.id < 100'}}, []);
 ---- ok
 -STATEMENT CALL QUERY_HNSW_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
+-CHECK_ORDER
+---- 3
+58
+93
+28
+-STATEMENT CALL QUERY_HNSW_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3, directed_search_up_sel := 0.8) RETURN nn.id ORDER BY _distance;
+-CHECK_ORDER
+---- 3
+58
+93
+28
+-STATEMENT CALL QUERY_HNSW_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3, blind_search_up_sel := 0.8, directed_search_up_sel := 0.9) RETURN nn.id ORDER BY _distance;
 -CHECK_ORDER
 ---- 3
 58
@@ -33,7 +45,7 @@
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'dotproduct');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'dotproduct');
 ---- ok
 -STATEMENT CALL create_projected_graph('emb-graph', {'embeddings': {'filter': 'n.id < 50'}}, []);
 ---- ok
@@ -57,7 +69,7 @@
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'dotproduct');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'dotproduct');
 ---- ok
 -STATEMENT CALL create_projected_graph('emb-graph', {'embeddings': {'filter': 'n.id < 600'}}, []);
 ---- ok
@@ -81,7 +93,7 @@
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'l2');
 ---- ok
 -STATEMENT CALL create_projected_graph('emb-graph', {'embeddings': {'filter': 'n.id < 100'}}, []);
 ---- ok
@@ -105,7 +117,7 @@
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'l2');
 ---- ok
 -STATEMENT CALL create_projected_graph('emb-graph', {'embeddings': {'filter': 'n.id < 50'}}, []);
 ---- ok
@@ -129,7 +141,7 @@
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'l2');
 ---- ok
 -STATEMENT CALL create_projected_graph('emb-graph', {'embeddings': {'filter': 'n.id < 600'}}, []);
 ---- ok

--- a/extension/vector/test/test_files/small.test
+++ b/extension/vector/test/test_files/small.test
@@ -13,7 +13,7 @@
 ---- ok
 -STATEMENT CREATE (e:embeddings{id: 1000})
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'l2');
 ---- ok
 -STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 6) RETURN nn.id ORDER BY _distance;
 -CHECK_ORDER
@@ -33,7 +33,7 @@
 ---- ok
 -STATEMENT MATCH (e:embeddings) WHERE e.id < 995 DELETE e
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'l2');
 ---- ok
 -STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 6) RETURN nn.id ORDER BY _distance;
 -CHECK_ORDER
@@ -57,7 +57,7 @@
 ---- ok
 -STATEMENT CREATE (e:embeddings{id: 1000})
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'l2');
 ---- ok
 -STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 6) RETURN nn.id ORDER BY _distance;
 -CHECK_ORDER
@@ -75,7 +75,7 @@
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', metric := 'l2');
 ---- ok
 -STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index', [0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557], 3) RETURN nn.id ORDER BY _distance;
 -CHECK_ORDER
@@ -108,7 +108,7 @@
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', distFunc := 'dotproduct');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', metric := 'dotproduct');
 ---- ok
 -STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index', [0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557], 3) RETURN nn.id ORDER BY _distance;
 -CHECK_ORDER
@@ -124,7 +124,7 @@
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-960-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', metric := 'l2');
 ---- ok
 -STATEMENT CALL show_tables() return *;
 ---- 1
@@ -156,7 +156,7 @@
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', metric := 'l2');
 ---- ok
 -STATEMENT CALL show_tables() return *;
 ---- 1
@@ -172,7 +172,7 @@
 ---- ok
 -STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', metric := 'l2');
 ---- ok
 -STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index', [0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557], 3) RETURN nn.id ORDER BY _distance;
 ---- 0
@@ -219,6 +219,30 @@
 0
 1
 
+-CASE MetricDotProduct
+-STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/vector/build/libvector.kuzu_extension';
+---- ok
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
+---- ok
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', metric := 'dotproduct');
+---- ok
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index2','vec', metric := 'dot_product');
+---- ok
+-STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index', [0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557], cast(3 as uint32)) RETURN nn.id ORDER BY _distance;
+-CHECK_ORDER
+---- 3
+499
+581
+58
+-STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index2', [0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557], cast(3 as uint32)) RETURN nn.id ORDER BY _distance;
+-CHECK_ORDER
+---- 3
+499
+581
+58
+
 -CASE 8DimDPImportExport
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/vector/build/libvector.kuzu_extension';
 ---- ok
@@ -226,7 +250,7 @@
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', distFunc := 'dotproduct');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', metric := 'dotproduct');
 ---- ok
 -STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index', [0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557], cast(3 as uint32)) RETURN nn.id ORDER BY _distance;
 -CHECK_ORDER
@@ -268,7 +292,7 @@ Binder exception: _e_hnsw_index_LOWER already exists in catalog.
 93
 -STATEMENT CALL SHOW_INDEXES() RETURN *
 ---- 1
-embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', mu := 30, ml := 60, pu := 0.050000, distFunc := 'dotproduct', alpha := 1.100000, efc := 200);
+embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', mu := 30, ml := 60, pu := 0.050000, metric := 'dotproduct', alpha := 1.100000, efc := 200);
 
 -CASE ShowIndexes
 -SKIP_IN_MEM
@@ -276,11 +300,11 @@ embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_HNSW_INDEX('embeddings', 'e_
 ---- ok
 -STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'l2');
 ---- ok
 -STATEMENT CALL SHOW_INDEXES() RETURN *
 ---- 1
-embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', mu := 30, ml := 60, pu := 0.050000, distFunc := 'l2', alpha := 1.100000, efc := 200);
+embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', mu := 30, ml := 60, pu := 0.050000, metric := 'l2', alpha := 1.100000, efc := 200);
 -RELOADDB
 -STATEMENT CALL SHOW_INDEXES() RETURN *
 ---- 1
@@ -289,4 +313,4 @@ embeddings|e_hnsw_index|HNSW|[vec]|False|
 ---- ok
 -STATEMENT CALL SHOW_INDEXES() RETURN *
 ---- 1
-embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', mu := 30, ml := 60, pu := 0.050000, distFunc := 'l2', alpha := 1.100000, efc := 200);
+embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', mu := 30, ml := 60, pu := 0.050000, metric := 'l2', alpha := 1.100000, efc := 200);

--- a/extension/vector/test/test_files/transaction.test
+++ b/extension/vector/test/test_files/transaction.test
@@ -9,7 +9,7 @@
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', metric := 'l2');
 ---- ok
 -STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index',CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
 -CHECK_ORDER
@@ -36,7 +36,7 @@
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', metric := 'l2');
 ---- error
 Binder exception: CREATE_HNSW_INDEX is only supported in auto transaction mode.
 # -STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index',CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
@@ -55,7 +55,7 @@ Binder exception: CREATE_HNSW_INDEX is only supported in auto transaction mode.
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', metric := 'l2');
 ---- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
@@ -75,7 +75,7 @@ Binder exception: CREATE_HNSW_INDEX is only supported in auto transaction mode.
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', metric := 'l2');
 ---- error
 Binder exception: CREATE_HNSW_INDEX is only supported in auto transaction mode.
 # -STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index',CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
@@ -102,7 +102,7 @@ Binder exception: CREATE_HNSW_INDEX is only supported in auto transaction mode.
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', metric := 'l2');
 ---- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
@@ -125,7 +125,7 @@ Binder exception: CREATE_HNSW_INDEX is only supported in auto transaction mode.
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', metric := 'l2');
 ---- error
 Binder exception: CREATE_HNSW_INDEX is only supported in auto transaction mode.
 # -STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index',CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
@@ -146,7 +146,7 @@ Binder exception: CREATE_HNSW_INDEX is only supported in auto transaction mode.
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', metric := 'l2');
 ---- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
@@ -156,7 +156,7 @@ Binder exception: CREATE_HNSW_INDEX is only supported in auto transaction mode.
 ---- ok
 -STATEMENT CALL show_indexes() RETURN *;
 ---- 1
-embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', mu := 30, ml := 60, pu := 0.050000, distFunc := 'l2', alpha := 1.100000, efc := 200);
+embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', mu := 30, ml := 60, pu := 0.050000, metric := 'l2', alpha := 1.100000, efc := 200);
 
 -CASE CreateHNSWRollbackRecovery
 -SKIP_IN_MEM
@@ -168,7 +168,7 @@ embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_HNSW_INDEX('embeddings', 'e_
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', metric := 'l2');
 ---- error
 Binder exception: CREATE_HNSW_INDEX is only supported in auto transaction mode.
 # -STATEMENT CALL QUERY_HNSW_INDEX('embeddings', 'e_hnsw_index',CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3) RETURN nn.id ORDER BY _distance;
@@ -193,7 +193,7 @@ Binder exception: CREATE_HNSW_INDEX is only supported in auto transaction mode.
 ---- ok
 -STATEMENT COPY embeddings FROM "${KUZU_ROOT_DIRECTORY}/dataset/embeddings/embeddings-8-1k.csv" (deLim=',');
 ---- ok
--STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', distFunc := 'l2');
+-STATEMENT CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index','vec', metric := 'l2');
 ---- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
@@ -203,10 +203,10 @@ Binder exception: CREATE_HNSW_INDEX is only supported in auto transaction mode.
 ---- ok
 -STATEMENT CALL show_indexes() RETURN *;
 ---- 1
-embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', mu := 30, ml := 60, pu := 0.050000, distFunc := 'l2', alpha := 1.100000, efc := 200);
+embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', mu := 30, ml := 60, pu := 0.050000, metric := 'l2', alpha := 1.100000, efc := 200);
 -RELOADDB
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/vector/build/libvector.kuzu_extension';
 ---- ok
 -STATEMENT CALL show_indexes() RETURN *;
 ---- 1
-embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', mu := 30, ml := 60, pu := 0.050000, distFunc := 'l2', alpha := 1.100000, efc := 200);
+embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_HNSW_INDEX('embeddings', 'e_hnsw_index', 'vec', mu := 30, ml := 60, pu := 0.050000, metric := 'l2', alpha := 1.100000, efc := 200);


### PR DESCRIPTION
# Description

Allow users to config upper selectivity threshold for blind and directed searches in the query_hnsw_index function.
Renamed the option `distFunc` to `metric`.