### PR TITLE
Throw exception when extension rewrite functions called in a multi-statement query

### DIFF
--- a/extension/fts/test/test_files/error.test
+++ b/extension/fts/test/test_files/error.test
@@ -179,3 +179,13 @@ Catalog exception: function QUERY_FTS_INDEX is not defined. This function exists
 -STATEMENT CALL DROP_FTS_INDEX('STUDENT', 'sIdx')
 ---- error
 Catalog exception: function DROP_FTS_INDEX is not defined. This function exists in the FTS extension. You can install and load the extension by running 'INSTALL FTS; LOAD EXTENSION FTS;'.
+
+-CASE CreateFTSSingleStatement
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension";CALL CREATE_FTS_INDEX('person', 'personIdx', ['fName']);
+---- error
+Parser exception: CREATE_FTS_INDEX must be called in a query which doesn't have other statements.
+
+-CASE CreateFTSSingleStatement
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension";CALL DROP_FTS_INDEX('STUDENT', 'sIdx');
+---- error
+Parser exception: DROP_FTS_INDEX must be called in a query which doesn't have other statements.

--- a/src/include/parser/visitor/standalone_call_rewriter.h
+++ b/src/include/parser/visitor/standalone_call_rewriter.h
@@ -8,7 +8,7 @@ namespace parser {
 class StandaloneCallRewriter final : public StatementVisitor {
 public:
     explicit StandaloneCallRewriter(main::ClientContext* context, bool allowRewrite)
-        : StatementVisitor{}, rewriteQuery{}, context{context}, allowRewrite{allowRewrite} {}
+        : StatementVisitor{}, rewriteQuery{}, context{context}, singleStatement{allowRewrite} {}
 
     std::string getRewriteQuery(const Statement& statement);
 
@@ -18,7 +18,7 @@ private:
 private:
     std::string rewriteQuery;
     main::ClientContext* context;
-    bool allowRewrite;
+    bool singleStatement;
 };
 
 } // namespace parser

--- a/src/include/parser/visitor/standalone_call_rewriter.h
+++ b/src/include/parser/visitor/standalone_call_rewriter.h
@@ -7,8 +7,8 @@ namespace parser {
 
 class StandaloneCallRewriter final : public StatementVisitor {
 public:
-    explicit StandaloneCallRewriter(main::ClientContext* context)
-        : StatementVisitor{}, rewriteQuery{}, context{context} {}
+    explicit StandaloneCallRewriter(main::ClientContext* context, bool allowRewrite)
+        : StatementVisitor{}, rewriteQuery{}, context{context}, allowRewrite{allowRewrite} {}
 
     std::string getRewriteQuery(const Statement& statement);
 
@@ -18,6 +18,7 @@ private:
 private:
     std::string rewriteQuery;
     main::ClientContext* context;
+    bool allowRewrite;
 };
 
 } // namespace parser

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -420,7 +420,7 @@ std::vector<std::shared_ptr<Statement>> ClientContext::parseQuery(std::string_vi
     auto parsedStatements = Parser::parseQuery(query);
     parserTimer.stop();
     const auto avgParsingTime = parserTimer.getElapsedTimeMS() / parsedStatements.size() / 1.0;
-    StandaloneCallRewriter standaloneCallAnalyzer{this};
+    StandaloneCallRewriter standaloneCallAnalyzer{this, parsedStatements.size() == 1};
     for (auto i = 0u; i < parsedStatements.size(); i++) {
         auto rewriteQuery = standaloneCallAnalyzer.getRewriteQuery(*parsedStatements[i]);
         if (rewriteQuery.empty()) {

--- a/src/parser/visitor/standalone_call_rewriter.cpp
+++ b/src/parser/visitor/standalone_call_rewriter.cpp
@@ -2,6 +2,7 @@
 
 #include "binder/binder.h"
 #include "binder/bound_standalone_call_function.h"
+#include "catalog/catalog.h"
 #include "common/exception/parser.h"
 #include "main/client_context.h"
 #include "parser/expression/parsed_function_expression.h"
@@ -17,16 +18,17 @@ std::string StandaloneCallRewriter::getRewriteQuery(const Statement& statement) 
 
 void StandaloneCallRewriter::visitStandaloneCallFunction(const Statement& statement) {
     auto& standaloneCallFunc = statement.constCast<StandaloneCallFunction>();
-    if (!allowRewrite) {
-        throw common::ParserException{
-            standaloneCallFunc.getFunctionExpression()
-                ->constPtrCast<parser::ParsedFunctionExpression>()
-                ->getFunctionName() +
-            " must be called in a query which doesn't have other statements."};
-    }
     main::ClientContext::TransactionHelper::runFuncInTransaction(
         *context->getTransactionContext(),
         [&]() -> void {
+            auto funcName = standaloneCallFunc.getFunctionExpression()
+                                ->constPtrCast<parser::ParsedFunctionExpression>()
+                                ->getFunctionName();
+            if (!context->getCatalog()->containsFunction(context->getTransaction(), funcName) &&
+                !singleStatement) {
+                throw common::ParserException{
+                    funcName + " must be called in a query which doesn't have other statements."};
+            }
             binder::Binder binder{context};
             const auto boundStatement = binder.bind(standaloneCallFunc);
             auto& boundStandaloneCall =

--- a/src/parser/visitor/standalone_call_rewriter.cpp
+++ b/src/parser/visitor/standalone_call_rewriter.cpp
@@ -2,7 +2,9 @@
 
 #include "binder/binder.h"
 #include "binder/bound_standalone_call_function.h"
+#include "common/exception/parser.h"
 #include "main/client_context.h"
+#include "parser/expression/parsed_function_expression.h"
 #include "parser/standalone_call_function.h"
 
 namespace kuzu {
@@ -15,6 +17,13 @@ std::string StandaloneCallRewriter::getRewriteQuery(const Statement& statement) 
 
 void StandaloneCallRewriter::visitStandaloneCallFunction(const Statement& statement) {
     auto& standaloneCallFunc = statement.constCast<StandaloneCallFunction>();
+    if (!allowRewrite) {
+        throw common::ParserException{
+            standaloneCallFunc.getFunctionExpression()
+                ->constPtrCast<parser::ParsedFunctionExpression>()
+                ->getFunctionName() +
+            " must be called in a query which doesn't have other statements."};
+    }
     main::ClientContext::TransactionHelper::runFuncInTransaction(
         *context->getTransactionContext(),
         [&]() -> void {


### PR DESCRIPTION
Throws exception when extension rewrite functions called in a multi-statement query.
e.g. `load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension";CALL DROP_FTS_INDEX('STUDENT', 'sIdx');` will trigger an exception.
Closes #5066 