### PR TITLE
Add projected graph with table droping tests

### DIFF
--- a/extension/fts/test/test_files/fts_small.test
+++ b/extension/fts/test/test_files/fts_small.test
@@ -277,7 +277,7 @@ Binder exception: Table 0_docIdx_docs does not exist.
 Catalog exception: 0_docIdx_docs does not exist in catalog.
 -STATEMENT CALL create_projected_graph('PK1', ['0_docIdx_docs'], [])
 ---- error
-Catalog exception: 0_docIdx_docs does not exist in catalog.
+Binder exception: Table 0_docIdx_docs does not exist.
 -STATEMENT RETURN nextval('0_docIdx_appears_info_ID_serial');
 ---- error
 Catalog exception: 0_docIdx_appears_info_ID_serial does not exist in catalog.

--- a/extension/vector/src/function/query_hnsw_index.cpp
+++ b/extension/vector/src/function/query_hnsw_index.cpp
@@ -17,6 +17,7 @@
 #include "planner/planner.h"
 #include "processor/execution_context.h"
 #include "storage/storage_manager.h"
+#include <function/gds/gds.h>
 
 using namespace kuzu::common;
 using namespace kuzu::binder;
@@ -27,10 +28,10 @@ namespace kuzu {
 namespace vector_extension {
 
 QueryHNSWIndexBindData::QueryHNSWIndexBindData(main::ClientContext* context,
-    expression_vector columns, BoundQueryHNSWIndexInput boundInput, QueryHNSWConfig config,
+    expression_vector columns, const BoundQueryHNSWIndexInput& boundInput, QueryHNSWConfig config,
     std::shared_ptr<NodeExpression> outputNode)
     : TableFuncBindData{std::move(columns), 1 /*maxOffset*/}, context{context},
-      boundInput{std::move(boundInput)}, config{config}, outputNode{std::move(outputNode)} {
+      boundInput{boundInput}, config{config}, outputNode{std::move(outputNode)} {
     const auto indexEntry = this->boundInput.indexEntry;
     auto& indexAuxInfo = indexEntry->getAuxInfo().cast<HNSWIndexAuxInfo>();
     indexColumnID = this->boundInput.nodeTableEntry->getColumnID(indexEntry->getPropertyIDs()[0]);
@@ -67,22 +68,22 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     const auto k = input->getLiteralVal<int64_t>(3);
 
     catalog::NodeTableCatalogEntry* nodeTableEntry = nullptr;
-    const graph::GraphEntry* graphEntry = nullptr;
+    graph::GraphEntry graphEntry;
     if (context->getCatalog()->containsTable(context->getTransaction(), tableOrGraphName)) {
         nodeTableEntry = HNSWIndexUtils::bindNodeTable(*context, tableOrGraphName, indexName,
             HNSWIndexUtils::IndexOperation::QUERY);
     } else if (context->getGraphEntrySetUnsafe().hasGraph(tableOrGraphName)) {
-        graphEntry = &context->getGraphEntrySetUnsafe().getEntry(tableOrGraphName);
-        if (graphEntry->nodeInfos.size() > 1 || !graphEntry->relInfos.empty()) {
+        graphEntry = GDSFunction::bindGraphEntry(*context, tableOrGraphName);
+        if (graphEntry.nodeInfos.size() > 1 || !graphEntry.relInfos.empty()) {
             throw BinderException{stringFormat(
                 "Projected graph {} either contains relationship tables or "
                 "multiple node tables. Projected graphs passed to QUERY_HNSW_INDEX function must "
                 "contain only nodes from a single node table and no relationship tables.",
                 tableOrGraphName)};
         }
-        nodeTableEntry = graphEntry->nodeInfos[0].entry->ptrCast<catalog::NodeTableCatalogEntry>();
+        nodeTableEntry = graphEntry.nodeInfos[0].entry->ptrCast<catalog::NodeTableCatalogEntry>();
         HNSWIndexUtils::validateIndexExistence(*context, nodeTableEntry, indexName,
-            HNSWIndexUtils::IndexOperation::QUERY);
+             HNSWIndexUtils::IndexOperation::QUERY);
     } else {
         throw BinderException{
             stringFormat("Cannot find table or projected graph named as {}.", tableOrGraphName)};
@@ -100,7 +101,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     expression_vector columns;
     columns.push_back(outputNode->getInternalID());
     columns.push_back(input->binder->createVariable("_distance", LogicalType::DOUBLE()));
-    auto boundInput = BoundQueryHNSWIndexInput{nodeTableEntry, graphEntry, indexEntry,
+    auto boundInput = BoundQueryHNSWIndexInput{nodeTableEntry, graphEntry.copy(), indexEntry,
         std::move(inputQueryExpression), static_cast<uint64_t>(k)};
     auto config = QueryHNSWConfig{input->optionalParams};
     return std::make_unique<QueryHNSWIndexBindData>(context, std::move(columns), boundInput, config,
@@ -184,9 +185,9 @@ QueryHNSWIndexSharedState::QueryHNSWIndexSharedState(const QueryHNSWIndexBindDat
     nodeTable = storageManager->getTable(bindData.boundInput.nodeTableEntry->getTableID())
                     ->ptrCast<storage::NodeTable>();
     numNodes = nodeTable->getStats(bindData.context->getTransaction()).getTableCard();
-    if (bindData.boundInput.graphEntry) {
-        KU_ASSERT(!bindData.boundInput.graphEntry->nodeInfos.empty());
-        if (bindData.boundInput.graphEntry->nodeInfos[0].predicate) {
+    if (!bindData.boundInput.graphEntry.isEmpty()) {
+        KU_ASSERT(bindData.boundInput.graphEntry.nodeInfos.size() == 1);
+        if (bindData.boundInput.graphEntry.nodeInfos[0].predicate) {
             semiMasks.addMask(bindData.boundInput.nodeTableEntry->getTableID(),
                 SemiMaskUtil::createMask(numNodes));
         }
@@ -224,9 +225,9 @@ static void getLogicalPlan(Planner* planner, const BoundReadingClause& readingCl
         auto op = std::make_shared<LogicalTableFunctionCall>(call.getTableFunc(), bindData->copy());
         // Check if there is filter predicate on the base node table. If so, we need to plan the
         // filtered search.
-        if (bindData->boundInput.graphEntry) {
-            KU_ASSERT(bindData->boundInput.graphEntry->nodeInfos.size() == 1);
-            auto& nodeInfo = bindData->boundInput.graphEntry->nodeInfos[0];
+        if (!bindData->boundInput.graphEntry.isEmpty()) {
+            KU_ASSERT(bindData->boundInput.graphEntry.nodeInfos.size() == 1);
+            auto& nodeInfo = bindData->boundInput.graphEntry.nodeInfos[0];
             if (nodeInfo.predicate) {
                 // We have filter predicate on the base node table. Should add a semi mask subplan
                 // and pass the semi mask to QueryHNSWIndexFunction to perform filtered search.

--- a/extension/vector/src/function/query_hnsw_index.cpp
+++ b/extension/vector/src/function/query_hnsw_index.cpp
@@ -83,7 +83,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
         }
         nodeTableEntry = graphEntry.nodeInfos[0].entry->ptrCast<catalog::NodeTableCatalogEntry>();
         HNSWIndexUtils::validateIndexExistence(*context, nodeTableEntry, indexName,
-             HNSWIndexUtils::IndexOperation::QUERY);
+            HNSWIndexUtils::IndexOperation::QUERY);
     } else {
         throw BinderException{
             stringFormat("Cannot find table or projected graph named as {}.", tableOrGraphName)};

--- a/extension/vector/src/include/function/hnsw_index_functions.h
+++ b/extension/vector/src/include/function/hnsw_index_functions.h
@@ -62,10 +62,19 @@ struct FinalizeHNSWSharedState final : function::SimpleTableFuncSharedState {
 
 struct BoundQueryHNSWIndexInput {
     catalog::NodeTableCatalogEntry* nodeTableEntry;
-    const graph::GraphEntry* graphEntry;
+    graph::GraphEntry graphEntry;
     catalog::IndexCatalogEntry* indexEntry;
     std::shared_ptr<binder::Expression> queryExpression;
     uint64_t k;
+
+    BoundQueryHNSWIndexInput(catalog::NodeTableCatalogEntry* nodeTableEntry,
+        graph::GraphEntry graphEntry, catalog::IndexCatalogEntry* indexEntry,
+        std::shared_ptr<binder::Expression> queryExpression, uint64_t k)
+        : nodeTableEntry{nodeTableEntry}, graphEntry{std::move(graphEntry)}, indexEntry{indexEntry},
+          queryExpression{std::move(queryExpression)}, k{k} {}
+    BoundQueryHNSWIndexInput(const BoundQueryHNSWIndexInput& rhs)
+        : nodeTableEntry{rhs.nodeTableEntry}, graphEntry{rhs.graphEntry.copy()},
+          indexEntry{rhs.indexEntry}, queryExpression{rhs.queryExpression}, k{rhs.k} {}
 };
 
 struct QueryHNSWIndexBindData final : function::TableFuncBindData {
@@ -79,7 +88,7 @@ struct QueryHNSWIndexBindData final : function::TableFuncBindData {
     std::shared_ptr<binder::NodeExpression> outputNode;
 
     QueryHNSWIndexBindData(main::ClientContext* context, binder::expression_vector columns,
-        BoundQueryHNSWIndexInput boundInput, QueryHNSWConfig config,
+        const BoundQueryHNSWIndexInput& boundInput, QueryHNSWConfig config,
         std::shared_ptr<binder::NodeExpression> outputNode);
 
     std::unique_ptr<TableFuncBindData> copy() const override {

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -75,6 +75,10 @@ bool Catalog::containsTable(const Transaction* transaction, const std::string& t
     return false;
 }
 
+bool Catalog::containsTable(const Transaction* transaction, table_id_t tableID) const {
+    return tables->getEntryOfOID(transaction, tableID) != nullptr;
+}
+
 TableCatalogEntry* Catalog::getTableCatalogEntry(const Transaction* transaction,
     table_id_t tableID) const {
     auto result = tables->getEntryOfOID(transaction, tableID);

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -82,8 +82,8 @@ GraphEntry GDSFunction::bindGraphEntry(ClientContext& context, const ParsedGraph
         validateEntryType(*nodeEntry, CatalogEntryType::NODE_TABLE_ENTRY);
         projectedNodeTableIDSet.insert(nodeEntry->getTableID());
         if (!nodeInfo.predicate.empty()) {
-            auto cypher =
-                stringFormat("MATCH (n:`{}`) RETURN n, {}", nodeEntry->getName(), nodeInfo.predicate);
+            auto cypher = stringFormat("MATCH (n:`{}`) RETURN n, {}", nodeEntry->getName(),
+                nodeInfo.predicate);
             auto columns = getResultColumns(cypher, &context);
             KU_ASSERT(columns.size() == 2);
             result.nodeInfos.emplace_back(nodeEntry, columns[0], columns[1]);

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -1,7 +1,6 @@
 #include "function/gds/gds_utils.h"
 
 #include "binder/expression/property_expression.h"
-#include "catalog/catalog.h"
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "common/task_system/task_scheduler.h"
 #include "function/gds/gds_task.h"

--- a/src/function/table/create_project_graph.cpp
+++ b/src/function/table/create_project_graph.cpp
@@ -1,10 +1,8 @@
-#include "binder/binder.h"
-#include "catalog/catalog.h"
-#include "catalog/catalog_entry/rel_table_catalog_entry.h"
 #include "common/exception/binder.h"
 #include "common/exception/runtime.h"
 #include "common/string_utils.h"
 #include "common/types/value/nested.h"
+#include "function/gds/gds.h"
 #include "function/table/bind_data.h"
 #include "function/table/standalone_call_function.h"
 #include "graph/graph_entry.h"
@@ -31,18 +29,6 @@ struct CreateProjectedGraphBindData final : TableFuncBindData {
         : TableFuncBindData{0}, graphName{std::move(graphName)}, nodeInfos{std::move(nodeInfos)},
           relInfos{std::move(relInfos)} {}
 
-    void addNodeInfo(TableCatalogEntry* entry) { nodeInfos.emplace_back(entry); }
-    void addNodeInfo(TableCatalogEntry* entry, std::shared_ptr<Expression> node,
-        std::shared_ptr<Expression> predicate) {
-        nodeInfos.emplace_back(entry, std::move(node), std::move(predicate));
-    }
-
-    void addRelInfo(TableCatalogEntry* entry) { relInfos.emplace_back(entry); }
-    void addRelInfo(TableCatalogEntry* entry, std::shared_ptr<Expression> rel,
-        std::shared_ptr<Expression> predicate) {
-        relInfos.emplace_back(entry, std::move(rel), std::move(predicate));
-    }
-
     std::unique_ptr<TableFuncBindData> copy() const override {
         return std::make_unique<CreateProjectedGraphBindData>(graphName, nodeInfos, relInfos);
     }
@@ -55,9 +41,11 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
         throw RuntimeException(
             stringFormat("Project graph {} already exists.", bindData->graphName));
     }
-    auto entry = graph::GraphEntry();
+    auto entry = graph::ParsedGraphEntry();
     entry.nodeInfos = bindData->nodeInfos;
     entry.relInfos = bindData->relInfos;
+    // bind graph entry to check if input is valid or not. Ignore bind result.
+    GDSFunction::bindGraphEntry(*input.context->clientContext, entry);
     graphEntrySet.addGraph(bindData->graphName, entry);
     return 0;
 }
@@ -70,63 +58,18 @@ static std::vector<std::string> getAsStringVector(const Value& value) {
     return result;
 }
 
-static void validateEntryType(const TableCatalogEntry& entry, CatalogEntryType type) {
-    if (entry.getType() != type) {
-        throw BinderException(stringFormat("Expect catalog entry type {} but got {}.",
-            CatalogEntryTypeUtils::toString(type),
-            CatalogEntryTypeUtils::toString(entry.getType())));
-    }
-}
-
-static void validateNodeProjected(table_id_t tableID, const table_id_set_t& projectedNodeIDSet,
-    const std::string& relName, Catalog* catalog, transaction::Transaction* transaction) {
-    if (projectedNodeIDSet.contains(tableID)) {
-        return;
-    }
-    auto entryName = catalog->getTableCatalogEntry(transaction, tableID)->getName();
-    throw BinderException(
-        stringFormat("{} is connected to {} but not projected.", entryName, relName));
-}
-
-static void validateRelSrcDstNodeAreProjected(const TableCatalogEntry& entry,
-    const table_id_set_t& projectedNodeIDSet, Catalog* catalog,
-    transaction::Transaction* transaction) {
-    auto& relEntry = entry.constCast<RelTableCatalogEntry>();
-    validateNodeProjected(relEntry.getSrcTableID(), projectedNodeIDSet, entry.getName(), catalog,
-        transaction);
-    validateNodeProjected(relEntry.getDstTableID(), projectedNodeIDSet, entry.getName(), catalog,
-        transaction);
-}
-
-static expression_pair getFilterField(Value& val, const std::string& cypherTemplate,
-    Binder* binder) {
+static std::string getPredicateStr(Value& val) {
     auto& type = val.getDataType();
     if (type.getLogicalTypeID() != LogicalTypeID::STRUCT) {
         throw BinderException(stringFormat("{} has data type {}. STRUCT was expected.",
             val.toString(), type.toString()));
     }
-    for (auto j = 0u; j < StructType::getNumFields(type); ++j) {
-        auto fieldName = StructType::getField(type, j).getName();
+    for (auto i = 0u; i < StructType::getNumFields(type); i++) {
+        auto fieldName = StructType::getField(type, i).getName();
         if (StringUtils::getUpper(fieldName) == "FILTER") {
-            auto childVal = NestedVal::getChildVal(&val, j);
+            const auto childVal = NestedVal::getChildVal(&val, i);
             childVal->validateType(LogicalTypeID::STRING);
-            auto predicateStr = childVal->getValue<std::string>();
-            std::string statementStr;
-            if (!predicateStr.empty()) {
-                statementStr = stringFormat(cypherTemplate + ", {}", predicateStr);
-            } else {
-                statementStr = cypherTemplate;
-            }
-            auto parsedStatements = parser::Parser::parseQuery(statementStr);
-            KU_ASSERT(parsedStatements.size() == 1);
-            auto boundStatement = binder->bind(*parsedStatements[0]);
-            auto columns = boundStatement->getStatementResult()->getColumns();
-            if (columns.size() == 1) {
-                return {columns[0], nullptr};
-            } else {
-                KU_ASSERT(columns.size() == 2);
-                return {columns[0], columns[1]};
-            }
+            return childVal->getValue<std::string>();
         } else {
             throw BinderException(stringFormat(
                 "Unrecognized configuration {}. Supported configuration is 'filter'.", fieldName));
@@ -135,72 +78,37 @@ static expression_pair getFilterField(Value& val, const std::string& cypherTempl
     return {};
 }
 
-static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* context,
+static std::vector<GraphEntryTableInfo> extractGraphEntryTableInfos(const Value& value) {
+    std::vector<GraphEntryTableInfo> infos;
+    switch (value.getDataType().getLogicalTypeID()) {
+    case LogicalTypeID::LIST: {
+        for (auto name : getAsStringVector(value)) {
+            infos.emplace_back(name, "" /* empty predicate */);
+        }
+    } break;
+    case LogicalTypeID::STRUCT: {
+        for (auto i = 0u; i < StructType::getNumFields(value.getDataType()); ++i) {
+            auto& field = StructType::getField(value.getDataType(), i);
+            infos.emplace_back(field.getName(),
+                getPredicateStr(*NestedVal::getChildVal(&value, i)));
+        }
+    } break;
+    default:
+        throw BinderException(
+            stringFormat("Input argument {} has data type {}. STRUCT or LIST was expected.",
+                value.toString(), value.getDataType().toString()));
+    }
+    return infos;
+}
+
+static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext*,
     const TableFuncBindInput* input) {
-    auto catalog = context->getCatalog();
-    auto transaction = context->getTransaction();
-    // Bind graph name
     auto graphName = input->getLiteralVal<std::string>(0);
     auto bindData = std::make_unique<CreateProjectedGraphBindData>(graphName);
-    // Bind node table
     auto argNode = input->getValue(1);
-    common::table_id_set_t nodeTableIDSet;
-    switch (argNode.getDataType().getLogicalTypeID()) {
-    case LogicalTypeID::LIST: {
-        for (auto& name : getAsStringVector(argNode)) {
-            auto entry = catalog->getTableCatalogEntry(transaction, name, false /* useInternal */);
-            validateEntryType(*entry, CatalogEntryType::NODE_TABLE_ENTRY);
-            bindData->addNodeInfo(entry);
-            nodeTableIDSet.insert(entry->getTableID());
-        }
-    } break;
-    case LogicalTypeID::STRUCT: {
-        for (auto i = 0u; i < StructType::getNumFields(argNode.getDataType()); ++i) {
-            auto& field = StructType::getField(argNode.getDataType(), i);
-            auto entry = catalog->getTableCatalogEntry(transaction, field.getName(),
-                false /* useInternal */);
-            validateEntryType(*entry, CatalogEntryType::NODE_TABLE_ENTRY);
-            auto matchPattern = stringFormat("MATCH (n:{}) ", entry->getName());
-            auto [node, predicate] = getFilterField(*NestedVal::getChildVal(&argNode, i),
-                matchPattern + " RETURN n", input->binder);
-            bindData->addNodeInfo(entry, node, predicate);
-            nodeTableIDSet.insert(entry->getTableID());
-        }
-    } break;
-    default:
-        throw BinderException(
-            stringFormat("Input argument {} has data type {}. STRUCT or LIST was expected.",
-                argNode.toString(), argNode.getDataType().toString()));
-    }
-    // Bind rel table
+    bindData->nodeInfos = extractGraphEntryTableInfos(argNode);
     auto argRel = input->getValue(2);
-    switch (argRel.getDataType().getLogicalTypeID()) {
-    case LogicalTypeID::LIST: {
-        for (auto& name : getAsStringVector(argRel)) {
-            auto entry = catalog->getTableCatalogEntry(transaction, name, false /* useInternal */);
-            validateEntryType(*entry, CatalogEntryType::REL_TABLE_ENTRY);
-            validateRelSrcDstNodeAreProjected(*entry, nodeTableIDSet, catalog, transaction);
-            bindData->addRelInfo(entry);
-        }
-    } break;
-    case LogicalTypeID::STRUCT: {
-        for (auto i = 0u; i < StructType::getNumFields(argRel.getDataType()); ++i) {
-            auto& field = StructType::getField(argRel.getDataType(), i);
-            auto entry = catalog->getTableCatalogEntry(transaction, field.getName(),
-                false /* useInternal */);
-            validateEntryType(*entry, CatalogEntryType::REL_TABLE_ENTRY);
-            validateRelSrcDstNodeAreProjected(*entry, nodeTableIDSet, catalog, transaction);
-            auto matchPattern = stringFormat("MATCH ()-[r:{}]->() ", entry->getName());
-            auto [rel, predicate] = getFilterField(*NestedVal::getChildVal(&argRel, i),
-                matchPattern + " RETURN r", input->binder);
-            bindData->addRelInfo(entry, rel, predicate);
-        }
-    } break;
-    default:
-        throw BinderException(
-            stringFormat("Input argument {} has data type {}. STRUCT or LIST was expected.",
-                argRel.toString(), argRel.getDataType().toString()));
-    }
+    bindData->relInfos = extractGraphEntryTableInfos(argRel);
     return bindData;
 }
 

--- a/src/graph/graph_entry.cpp
+++ b/src/graph/graph_entry.cpp
@@ -10,11 +10,6 @@ using namespace kuzu::catalog;
 namespace kuzu {
 namespace graph {
 
-void GraphEntryTableInfo::setPredicate(std::shared_ptr<Expression> predicate_) {
-    KU_ASSERT(predicate == nullptr);
-    predicate = std::move(predicate_);
-}
-
 GraphEntry::GraphEntry(std::vector<TableCatalogEntry*> nodeEntries,
     std::vector<TableCatalogEntry*> relEntries) {
     for (auto& entry : nodeEntries) {
@@ -57,7 +52,7 @@ std::vector<TableCatalogEntry*> GraphEntry::getRelEntries() const {
     return result;
 }
 
-const GraphEntryTableInfo& GraphEntry::getRelInfo(table_id_t tableID) const {
+const BoundGraphEntryTableInfo& GraphEntry::getRelInfo(table_id_t tableID) const {
     for (auto& info : relInfos) {
         if (info.entry->getTableID() == tableID) {
             return info;
@@ -70,7 +65,8 @@ const GraphEntryTableInfo& GraphEntry::getRelInfo(table_id_t tableID) const {
 
 void GraphEntry::setRelPredicate(std::shared_ptr<Expression> predicate) {
     for (auto& info : relInfos) {
-        info.setPredicate(predicate);
+        KU_ASSERT(info.predicate == nullptr);
+        info.predicate = predicate;
     }
 }
 

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -59,6 +59,8 @@ public:
     // Check if table entry exists.
     bool containsTable(const transaction::Transaction* transaction, const std::string& tableName,
         bool useInternal = true) const;
+    bool containsTable(const transaction::Transaction* transaction,
+        common::table_id_t tableID) const;
     // Get table entry with name.
     TableCatalogEntry* getTableCatalogEntry(const transaction::Transaction* transaction,
         const std::string& tableName, bool useInternal = true) const;

--- a/src/include/function/gds/gds.h
+++ b/src/include/function/gds/gds.h
@@ -62,6 +62,8 @@ class KUZU_API GDSFunction {
 
 public:
     static graph::GraphEntry bindGraphEntry(main::ClientContext& context, const std::string& name);
+    static graph::GraphEntry bindGraphEntry(main::ClientContext& context,
+        const graph::ParsedGraphEntry& parsedGraphEntry);
     static std::shared_ptr<binder::Expression> bindNodeOutput(const TableFuncBindInput& bindInput,
         const std::vector<catalog::TableCatalogEntry*>& nodeEntries);
     static std::string bindColumnName(const parser::YieldVariable& yieldVariable,

--- a/src/include/graph/graph_entry.h
+++ b/src/include/graph/graph_entry.h
@@ -14,39 +14,51 @@ class Schema;
 }
 namespace graph {
 
-struct KUZU_API GraphEntryTableInfo {
+struct GraphEntryTableInfo {
+    std::string tableName;
+    std::string predicate;
+
+    GraphEntryTableInfo(std::string tableName, std::string predicate)
+        : tableName{std::move(tableName)}, predicate{std::move(predicate)} {}
+};
+
+struct ParsedGraphEntry {
+    std::vector<GraphEntryTableInfo> nodeInfos;
+    std::vector<GraphEntryTableInfo> relInfos;
+};
+
+struct BoundGraphEntryTableInfo {
     catalog::TableCatalogEntry* entry;
 
     std::shared_ptr<binder::Expression> nodeOrRel;
     std::shared_ptr<binder::Expression> predicate;
 
-    explicit GraphEntryTableInfo(catalog::TableCatalogEntry* entry)
-        : entry{entry}, predicate{nullptr} {}
-    GraphEntryTableInfo(catalog::TableCatalogEntry* entry,
+    explicit BoundGraphEntryTableInfo(catalog::TableCatalogEntry* entry) : entry{entry} {}
+    BoundGraphEntryTableInfo(catalog::TableCatalogEntry* entry,
         std::shared_ptr<binder::Expression> nodeOrRel,
         std::shared_ptr<binder::Expression> predicate)
         : entry{entry}, nodeOrRel{std::move(nodeOrRel)}, predicate{std::move(predicate)} {}
-
-    void setPredicate(std::shared_ptr<binder::Expression> predicate_);
 };
 
 // Organize projected graph similar to CatalogEntry. When we want to share projected graph across
 // statements, we need to migrate this class to catalog (or client context).
 struct KUZU_API GraphEntry {
-    std::vector<GraphEntryTableInfo> nodeInfos;
-    std::vector<GraphEntryTableInfo> relInfos;
+    std::vector<BoundGraphEntryTableInfo> nodeInfos;
+    std::vector<BoundGraphEntryTableInfo> relInfos;
 
     GraphEntry() = default;
     GraphEntry(std::vector<catalog::TableCatalogEntry*> nodeEntries,
         std::vector<catalog::TableCatalogEntry*> relEntries);
     EXPLICIT_COPY_DEFAULT_MOVE(GraphEntry);
 
+    bool isEmpty() const { return nodeInfos.empty() && relInfos.empty(); }
+
     std::vector<common::table_id_t> getNodeTableIDs() const;
     std::vector<common::table_id_t> getRelTableIDs() const;
     std::vector<catalog::TableCatalogEntry*> getNodeEntries() const;
     std::vector<catalog::TableCatalogEntry*> getRelEntries() const;
 
-    const GraphEntryTableInfo& getRelInfo(common::table_id_t tableID) const;
+    const BoundGraphEntryTableInfo& getRelInfo(common::table_id_t tableID) const;
 
     void setRelPredicate(std::shared_ptr<binder::Expression> predicate);
 
@@ -57,17 +69,17 @@ private:
 class GraphEntrySet {
 public:
     bool hasGraph(const std::string& name) const { return nameToEntry.contains(name); }
-    const GraphEntry& getEntry(const std::string& name) const {
+    const ParsedGraphEntry& getEntry(const std::string& name) const {
         KU_ASSERT(hasGraph(name));
         return nameToEntry.at(name);
     }
-    void addGraph(const std::string& name, const GraphEntry& entry) {
-        nameToEntry.insert({name, entry.copy()});
+    void addGraph(const std::string& name, const ParsedGraphEntry& entry) {
+        nameToEntry.insert({name, entry});
     }
     void dropGraph(const std::string& name) { nameToEntry.erase(name); }
 
 private:
-    std::unordered_map<std::string, GraphEntry> nameToEntry;
+    std::unordered_map<std::string, ParsedGraphEntry> nameToEntry;
 };
 
 } // namespace graph

--- a/test/test_files/function/gds/special_projected_graph.test
+++ b/test/test_files/function/gds/special_projected_graph.test
@@ -64,3 +64,10 @@ Binder exception: Cannot find property dummy for r.
 -STATEMENT CALL create_projected_graph('err', ['person'], {'knows': {'filter': 'r.comments > date("1999-01-01")'}});
 ---- error
 Binder exception: Type Mismatch: Cannot compare types STRING[] and DATE
+-STATEMENT CALL create_projected_graph('G', ['person'], ['knows']);
+---- ok
+-STATEMENT DROP TABLE knows;
+---- ok
+-STATEMENT CALL weakly_connected_component('G') RETURN node.ID, group_id;
+---- error
+Catalog exception: knows does not exist in catalog.


### PR DESCRIPTION
# Description

Throw proper error message if any table from projected graph is dropped afterwards. We now store a string version when creating projected graph and on-the-fly bind it for any gds/vector index query.