### PR TITLE
Move OutputNodeMask output GDSComputeState

### DIFF
--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -267,10 +267,10 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
     node_id_map_t<ScoreInfo> scores;
     auto edgeCompute = std::make_unique<QFTSEdgeCompute>(scores, dfs);
     auto auxiliaryState = std::make_unique<EmptyGDSAuxiliaryState>();
-    auto compState = GDSComputeState(std::move(frontierPair), std::move(edgeCompute),
-        std::move(auxiliaryState), nullptr /* outputNodeMask */);
+    auto compState =
+        GDSComputeState(std::move(frontierPair), std::move(edgeCompute), std::move(auxiliaryState));
     GDSUtils::runFrontiersUntilConvergence(input.context, compState, graph, ExtendDirection::FWD,
-        1 /* maxIters */, TERM_FREQUENCY_PROP_NAME);
+        1 /* maxIters */, nullptr /* outputNodeMask */, TERM_FREQUENCY_PROP_NAME);
 
     // Do vertex compute to calculate the score for doc with the length property.
     auto mm = clientContext->getMemoryManager();

--- a/src/function/gds/asp_destinations.cpp
+++ b/src/function/gds/asp_destinations.cpp
@@ -183,7 +183,7 @@ public:
 
 private:
     RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID, const RJBindData&,
-        processor::RecursiveExtendSharedState* sharedState) override {
+        RecursiveExtendSharedState* sharedState) override {
         auto clientContext = context->clientContext;
         auto graph = sharedState->graph.get();
         auto frontier = PathLengths::getUnvisitedFrontier(context, graph);
@@ -197,7 +197,7 @@ private:
             std::make_unique<ASPDestinationsEdgeCompute>(frontierPair.get(), multiplicities);
         auto auxiliaryState = std::make_unique<ASPDestinationsAuxiliaryState>(multiplicities);
         auto gdsState = std::make_unique<GDSComputeState>(std::move(frontierPair),
-            std::move(edgeCompute), std::move(auxiliaryState), sharedState->getOutputNodeMaskMap());
+            std::move(edgeCompute), std::move(auxiliaryState));
         return RJCompState(std::move(gdsState), std::move(outputWriter));
     }
 };

--- a/src/function/gds/asp_paths.cpp
+++ b/src/function/gds/asp_paths.cpp
@@ -76,7 +76,7 @@ public:
 
 private:
     RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID,
-        const RJBindData& bindData, processor::RecursiveExtendSharedState* sharedState) override {
+        const RJBindData& bindData, RecursiveExtendSharedState* sharedState) override {
         auto clientContext = context->clientContext;
         auto frontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
         auto bfsGraph = getBFSGraph(context, sharedState->graph.get());
@@ -89,7 +89,7 @@ private:
             std::make_unique<ASPPathsEdgeCompute>(frontierPair.get(), bfsGraph.get());
         auto auxiliaryState = std::make_unique<PathAuxiliaryState>(std::move(bfsGraph));
         auto gdsState = std::make_unique<GDSComputeState>(std::move(frontierPair),
-            std::move(edgeCompute), std::move(auxiliaryState), sharedState->getOutputNodeMaskMap());
+            std::move(edgeCompute), std::move(auxiliaryState));
         return RJCompState(std::move(gdsState), std::move(outputWriter));
     }
 };

--- a/src/function/gds/awsp_paths.cpp
+++ b/src/function/gds/awsp_paths.cpp
@@ -9,6 +9,7 @@
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
+using namespace kuzu::processor;
 
 namespace kuzu {
 namespace function {
@@ -135,8 +136,8 @@ public:
     }
 
 private:
-    RJCompState getRJCompState(processor::ExecutionContext* context, nodeID_t sourceNodeID,
-        const RJBindData& bindData, processor::RecursiveExtendSharedState* sharedState) override {
+    RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID,
+        const RJBindData& bindData, RecursiveExtendSharedState* sharedState) override {
         auto clientContext = context->clientContext;
         auto graph = sharedState->graph.get();
         auto curFrontier = PathLengths::getUnvisitedFrontier(context, graph);
@@ -151,9 +152,8 @@ private:
         visit(bindData.weightPropertyExpr->getDataType(), [&]<typename T>(T) {
             auto edgeCompute = std::make_unique<AWSPPathsEdgeCompute<T>>(*bfsGraph);
             auto auxiliaryState = std::make_unique<WSPPathsAuxiliaryState>(std::move(bfsGraph));
-            gdsState =
-                std::make_unique<GDSComputeState>(std::move(frontierPair), std::move(edgeCompute),
-                    std::move(auxiliaryState), sharedState->getOutputNodeMaskMap());
+            gdsState = std::make_unique<GDSComputeState>(std::move(frontierPair),
+                std::move(edgeCompute), std::move(auxiliaryState));
         });
         return RJCompState(std::move(gdsState), std::move(outputWriter));
     }

--- a/src/function/gds/degrees.h
+++ b/src/function/gds/degrees.h
@@ -86,7 +86,8 @@ struct DegreesUtils {
         auto auxiliaryState = std::make_unique<DegreesGDSAuxiliaryState>(degrees);
         auto computeState =
             GDSComputeState(std::move(frontierPair), std::move(ec), std::move(auxiliaryState));
-        GDSUtils::runFrontiersUntilConvergence(context, computeState, graph, direction, 1 /* maxIters */);
+        GDSUtils::runFrontiersUntilConvergence(context, computeState, graph, direction,
+            1 /* maxIters */);
     }
 };
 

--- a/src/function/gds/degrees.h
+++ b/src/function/gds/degrees.h
@@ -84,10 +84,9 @@ struct DegreesUtils {
         frontierPair->initGDS();
         auto ec = std::make_unique<DegreeEdgeCompute>(degrees);
         auto auxiliaryState = std::make_unique<DegreesGDSAuxiliaryState>(degrees);
-        auto computeState = GDSComputeState(std::move(frontierPair), std::move(ec),
-            std::move(auxiliaryState), nullptr);
-        GDSUtils::runFrontiersUntilConvergence(context, computeState, graph, direction,
-            1 /* maxIters */);
+        auto computeState =
+            GDSComputeState(std::move(frontierPair), std::move(ec), std::move(auxiliaryState));
+        GDSUtils::runFrontiersUntilConvergence(context, computeState, graph, direction, 1 /* maxIters */);
     }
 };
 

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -84,17 +84,17 @@ static void runOnGraph(ExecutionContext* context, Graph* graph, ExtendDirection 
     }
 }
 
-void GDSUtils::runFrontiersUntilConvergence(ExecutionContext* context, GDSComputeState& compState, Graph* graph,
-    ExtendDirection extendDirection, uint64_t maxIteration) {
+void GDSUtils::runFrontiersUntilConvergence(ExecutionContext* context, GDSComputeState& compState,
+    Graph* graph, ExtendDirection extendDirection, uint64_t maxIteration) {
     auto frontierPair = compState.frontierPair.get();
     while (frontierPair->continueNextIter(maxIteration)) {
         frontierPair->beginNewIteration();
         runOnGraph(context, graph, extendDirection, compState, "" /* empty */);
     }
 }
-    
-void GDSUtils::runFrontiersUntilConvergence(ExecutionContext* context, GDSComputeState& compState, Graph* graph,
-    ExtendDirection extendDirection, uint64_t maxIteration,
+
+void GDSUtils::runFrontiersUntilConvergence(ExecutionContext* context, GDSComputeState& compState,
+    Graph* graph, ExtendDirection extendDirection, uint64_t maxIteration,
     common::NodeOffsetMaskMap* outputNodeMask, const std::string& propertyToScan) {
     auto frontierPair = compState.frontierPair.get();
     compState.edgeCompute->resetSingleThreadState();

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -7,9 +7,10 @@
 #include "function/gds/gds_task.h"
 #include "graph/graph.h"
 #include "graph/graph_entry.h"
-#include "main/settings.h"
+#include <re2.h>
 
 using namespace kuzu::common;
+using namespace kuzu::catalog;
 using namespace kuzu::function;
 using namespace kuzu::processor;
 using namespace kuzu::graph;
@@ -17,24 +18,27 @@ using namespace kuzu::graph;
 namespace kuzu {
 namespace function {
 
-static uint64_t getNumThreads(processor::ExecutionContext& context) {
-    return context.clientContext->getCurrentSetting(main::ThreadsSetting::name)
-        .getValue<uint64_t>();
-}
-
-static void scheduleFrontierTask(catalog::TableCatalogEntry* fromEntry,
-    catalog::TableCatalogEntry* toEntry, catalog::TableCatalogEntry* relEntry, graph::Graph* graph,
-    ExtendDirection extendDirection, GDSComputeState& computeState,
-    processor::ExecutionContext* context, const std::string& propertyToScan) {
-    auto clientContext = context->clientContext;
-    auto transaction = clientContext->getTransaction();
+static std::shared_ptr<FrontierTask> getFrontierTask(TableCatalogEntry* fromEntry,
+    TableCatalogEntry* toEntry, TableCatalogEntry* relEntry, Graph* graph,
+    ExtendDirection extendDirection, GDSComputeState& computeState, main::ClientContext* context,
+    const std::string& propertyToScan) {
+    computeState.beginFrontierCompute(fromEntry->getTableID(), toEntry->getTableID());
     auto info = FrontierTaskInfo(fromEntry, toEntry, relEntry, graph, extendDirection,
         *computeState.edgeCompute, propertyToScan);
-    auto numThreads = getNumThreads(*context);
+    auto numThreads = context->getMaxNumThreadForExec();
     auto sharedState =
         std::make_shared<FrontierTaskSharedState>(numThreads, *computeState.frontierPair);
-    auto task = std::make_shared<FrontierTask>(numThreads, info, sharedState);
+    auto maxOffset = graph->getMaxOffset(context->getTransaction(), fromEntry->getTableID());
+    sharedState->morselDispatcher.init(maxOffset);
+    return std::make_shared<FrontierTask>(numThreads, info, sharedState);
+}
 
+static void scheduleFrontierTask(TableCatalogEntry* fromEntry, TableCatalogEntry* toEntry,
+    TableCatalogEntry* relEntry, Graph* graph, ExtendDirection extendDirection,
+    GDSComputeState& computeState, ExecutionContext* context, const std::string& propertyToScan) {
+    auto clientContext = context->clientContext;
+    auto task = getFrontierTask(fromEntry, toEntry, relEntry, graph, extendDirection, computeState,
+        clientContext, propertyToScan);
     if (computeState.frontierPair->isCurFrontierSparse()) {
         task->runSparse();
         return;
@@ -47,52 +51,60 @@ static void scheduleFrontierTask(catalog::TableCatalogEntry* fromEntry,
     // more generally decrease the number of worker threads by 1. Therefore, we instruct
     // scheduleTaskAndWaitOrError to start a new thread by passing true as the last
     // argument.
-    auto maxOffset = graph->getMaxOffset(transaction, fromEntry->getTableID());
-    sharedState->morselDispatcher.init(maxOffset);
     clientContext->getTaskScheduler()->scheduleTaskAndWaitOrError(task, context,
         true /* launchNewWorkerThread */);
 }
 
-void GDSUtils::runFrontiersUntilConvergence(processor::ExecutionContext* context,
-    GDSComputeState& compState, graph::Graph* graph, ExtendDirection extendDirection,
-    uint64_t maxIteration, const std::string& propertyToScan) {
+static void runOnGraph(ExecutionContext* context, Graph* graph, ExtendDirection extendDirection,
+    GDSComputeState& compState, const std::string& propertyToScan) {
+    for (auto info : graph->getGraphEntry()->nodeInfos) {
+        auto fromEntry = info.entry;
+        for (auto& nbrInfo : graph->getForwardNbrTableInfos(fromEntry->getTableID())) {
+            auto toEntry = nbrInfo.nodeEntry;
+            auto relEntry = nbrInfo.relEntry;
+            switch (extendDirection) {
+            case ExtendDirection::FWD: {
+                scheduleFrontierTask(fromEntry, toEntry, relEntry, graph, ExtendDirection::FWD,
+                    compState, context, propertyToScan);
+            } break;
+            case ExtendDirection::BWD: {
+                scheduleFrontierTask(toEntry, fromEntry, relEntry, graph, ExtendDirection::BWD,
+                    compState, context, propertyToScan);
+            } break;
+            case ExtendDirection::BOTH: {
+                scheduleFrontierTask(fromEntry, toEntry, relEntry, graph, ExtendDirection::FWD,
+                    compState, context, propertyToScan);
+                scheduleFrontierTask(toEntry, fromEntry, relEntry, graph, ExtendDirection::BWD,
+                    compState, context, propertyToScan);
+            } break;
+            default:
+                KU_UNREACHABLE;
+            }
+        }
+    }
+}
+
+void GDSUtils::runFrontiersUntilConvergence(ExecutionContext* context, GDSComputeState& compState, Graph* graph,
+    ExtendDirection extendDirection, uint64_t maxIteration) {
+    auto frontierPair = compState.frontierPair.get();
+    while (frontierPair->continueNextIter(maxIteration)) {
+        frontierPair->beginNewIteration();
+        runOnGraph(context, graph, extendDirection, compState, "" /* empty */);
+    }
+}
+    
+void GDSUtils::runFrontiersUntilConvergence(ExecutionContext* context, GDSComputeState& compState, Graph* graph,
+    ExtendDirection extendDirection, uint64_t maxIteration,
+    common::NodeOffsetMaskMap* outputNodeMask, const std::string& propertyToScan) {
     auto frontierPair = compState.frontierPair.get();
     compState.edgeCompute->resetSingleThreadState();
     while (frontierPair->continueNextIter(maxIteration)) {
         frontierPair->beginNewIteration();
-        if (compState.outputNodeMask != nullptr && compState.outputNodeMask->enabled() &&
-            compState.edgeCompute->terminate(*compState.outputNodeMask)) {
+        if (outputNodeMask != nullptr && outputNodeMask->enabled() &&
+            compState.edgeCompute->terminate(*outputNodeMask)) {
             break;
         }
-        for (auto info : graph->getGraphEntry()->nodeInfos) {
-            auto fromEntry = info.entry;
-            for (auto& nbrInfo : graph->getForwardNbrTableInfos(fromEntry->getTableID())) {
-                auto toEntry = nbrInfo.nodeEntry;
-                auto relEntry = nbrInfo.relEntry;
-                switch (extendDirection) {
-                case ExtendDirection::FWD: {
-                    compState.beginFrontierCompute(fromEntry->getTableID(), toEntry->getTableID());
-                    scheduleFrontierTask(fromEntry, toEntry, relEntry, graph, ExtendDirection::FWD,
-                        compState, context, propertyToScan);
-                } break;
-                case ExtendDirection::BWD: {
-                    compState.beginFrontierCompute(toEntry->getTableID(), fromEntry->getTableID());
-                    scheduleFrontierTask(toEntry, fromEntry, relEntry, graph, ExtendDirection::BWD,
-                        compState, context, propertyToScan);
-                } break;
-                case ExtendDirection::BOTH: {
-                    compState.beginFrontierCompute(fromEntry->getTableID(), toEntry->getTableID());
-                    scheduleFrontierTask(fromEntry, toEntry, relEntry, graph, ExtendDirection::FWD,
-                        compState, context, propertyToScan);
-                    compState.beginFrontierCompute(toEntry->getTableID(), fromEntry->getTableID());
-                    scheduleFrontierTask(toEntry, fromEntry, relEntry, graph, ExtendDirection::BWD,
-                        compState, context, propertyToScan);
-                } break;
-                default:
-                    KU_UNREACHABLE;
-                }
-            }
-        }
+        runOnGraph(context, graph, extendDirection, compState, propertyToScan);
     }
 }
 

--- a/src/function/gds/k_core_decomposition.cpp
+++ b/src/function/gds/k_core_decomposition.cpp
@@ -176,7 +176,7 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
     // Compute Core values
     auto removeVertexEdgeCompute = std::make_unique<RemoveVertexEdgeCompute>(degrees);
     auto computeState = GDSComputeState(std::move(frontierPair), std::move(removeVertexEdgeCompute),
-        std::move(auxiliaryState), nullptr);
+        std::move(auxiliaryState));
     auto coreValue = 0u;
     auto numNodes = graph->getNumNodes(clientContext->getTransaction());
     auto numNodesComputed = 0u;
@@ -196,8 +196,7 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
             }
             // Remove found nodes by decreasing their nbrs degree by one.
             computeState.frontierPair->initGDS();
-            GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph,
-                ExtendDirection::BOTH,
+            GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph, ExtendDirection::BOTH,
                 computeState.frontierPair->getCurrentIter() + 1 /* maxIters */);
             // Repeat until all remaining nodes has degree greater than current core.
         }

--- a/src/function/gds/k_core_decomposition.cpp
+++ b/src/function/gds/k_core_decomposition.cpp
@@ -196,7 +196,8 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
             }
             // Remove found nodes by decreasing their nbrs degree by one.
             computeState.frontierPair->initGDS();
-            GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph, ExtendDirection::BOTH,
+            GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph,
+                ExtendDirection::BOTH,
                 computeState.frontierPair->getCurrentIter() + 1 /* maxIters */);
             // Repeat until all remaining nodes has degree greater than current core.
         }

--- a/src/function/gds/page_rank.cpp
+++ b/src/function/gds/page_rank.cpp
@@ -291,7 +291,8 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
             std::make_unique<PNextUpdateEdgeCompute>(degrees, *pCurrent, *pNext);
         computeState.auxiliaryState =
             std::make_unique<PageRankAuxiliaryState>(degrees, *pCurrent, *pNext);
-        GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph, ExtendDirection::BWD, 1);
+        GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph,
+            ExtendDirection::BWD, 1);
         auto pNextUpdateVC = PNextUpdateVertexCompute(config.dampingFactor, pNextUpdateConstant,
             *pNext, sharedState->getGraphNodeMaskMap());
         GDSUtils::runVertexCompute(input.context, graph, pNextUpdateVC);

--- a/src/function/gds/page_rank.cpp
+++ b/src/function/gds/page_rank.cpp
@@ -282,7 +282,7 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
         ExtendDirection::FWD);
     auto frontierPair =
         std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier, nextFrontier);
-    auto computeState = GDSComputeState(std::move(frontierPair), nullptr, nullptr, nullptr);
+    auto computeState = GDSComputeState(std::move(frontierPair), nullptr, nullptr);
     auto pNextUpdateConstant = (1 - config.dampingFactor) * ((double)1 / numNodes);
     while (currentIter < config.maxIterations) {
         computeState.frontierPair->initState();
@@ -291,8 +291,7 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
             std::make_unique<PNextUpdateEdgeCompute>(degrees, *pCurrent, *pNext);
         computeState.auxiliaryState =
             std::make_unique<PageRankAuxiliaryState>(degrees, *pCurrent, *pNext);
-        GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph,
-            ExtendDirection::BWD, 1);
+        GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph, ExtendDirection::BWD, 1);
         auto pNextUpdateVC = PNextUpdateVertexCompute(config.dampingFactor, pNextUpdateConstant,
             *pNext, sharedState->getGraphNodeMaskMap());
         GDSUtils::runVertexCompute(input.context, graph, pNextUpdateVC);

--- a/src/function/gds/ssp_destinations.cpp
+++ b/src/function/gds/ssp_destinations.cpp
@@ -95,7 +95,7 @@ public:
 
 private:
     RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID, const RJBindData&,
-        processor::RecursiveExtendSharedState* sharedState) override {
+        RecursiveExtendSharedState* sharedState) override {
         auto clientContext = context->clientContext;
         auto frontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
         auto outputWriter = std::make_unique<SSPDestinationsOutputWriter>(clientContext,
@@ -104,7 +104,7 @@ private:
         auto edgeCompute = std::make_unique<SSPDestinationsEdgeCompute>(frontierPair.get());
         auto auxiliaryState = std::make_unique<EmptyGDSAuxiliaryState>();
         auto gdsState = std::make_unique<GDSComputeState>(std::move(frontierPair),
-            std::move(edgeCompute), std::move(auxiliaryState), sharedState->getOutputNodeMaskMap());
+            std::move(edgeCompute), std::move(auxiliaryState));
         return RJCompState(std::move(gdsState), std::move(outputWriter));
     }
 };

--- a/src/function/gds/ssp_paths.cpp
+++ b/src/function/gds/ssp_paths.cpp
@@ -67,7 +67,7 @@ public:
 
 private:
     RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID,
-        const RJBindData& bindData, processor::RecursiveExtendSharedState* sharedState) override {
+        const RJBindData& bindData, RecursiveExtendSharedState* sharedState) override {
         auto clientContext = context->clientContext;
         auto frontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
         auto bfsGraph = getBFSGraph(context, sharedState->graph.get());
@@ -80,7 +80,7 @@ private:
             std::make_unique<SSPPathsEdgeCompute>(frontierPair.get(), bfsGraph.get());
         auto auxiliaryState = std::make_unique<PathAuxiliaryState>(std::move(bfsGraph));
         auto gdsState = std::make_unique<GDSComputeState>(std::move(frontierPair),
-            std::move(edgeCompute), std::move(auxiliaryState), sharedState->getOutputNodeMaskMap());
+            std::move(edgeCompute), std::move(auxiliaryState));
         return RJCompState(std::move(gdsState), std::move(outputWriter));
     }
 };

--- a/src/function/gds/strongly_connected_components.cpp
+++ b/src/function/gds/strongly_connected_components.cpp
@@ -248,13 +248,15 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
         computeState.frontierPair->initState();
         computeState.frontierPair->initGDS();
         GDSUtils::runVertexCompute(input.context, graph, *initializeFrontiers);
-        GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph, ExtendDirection::FWD, MAX_ITERATION);
+        GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph,
+            ExtendDirection::FWD, MAX_ITERATION);
 
         // Bwd colors.
         computeState.frontierPair->initState();
         computeState.frontierPair->initGDS();
         GDSUtils::runVertexCompute(input.context, graph, *initializeFrontiers);
-        GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph, ExtendDirection::BWD, MAX_ITERATION);
+        GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph,
+            ExtendDirection::BWD, MAX_ITERATION);
 
         // Find new SCC IDs and exit if all IDs have been found.
         computationState.reset();

--- a/src/function/gds/strongly_connected_components.cpp
+++ b/src/function/gds/strongly_connected_components.cpp
@@ -237,7 +237,7 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
     auto computeColors = std::make_unique<SccComputeColors>(computationState);
     auto auxiliaryState = std::make_unique<EmptyGDSAuxiliaryState>();
     auto computeState = GDSComputeState(std::move(frontierPair), std::move(computeColors),
-        std::move(auxiliaryState), nullptr);
+        std::move(auxiliaryState));
     auto initializeFrontiers =
         std::make_unique<SccInitializeFrontiers>(*computeState.frontierPair, computationState);
 
@@ -248,15 +248,13 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
         computeState.frontierPair->initState();
         computeState.frontierPair->initGDS();
         GDSUtils::runVertexCompute(input.context, graph, *initializeFrontiers);
-        GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph,
-            ExtendDirection::FWD, MAX_ITERATION);
+        GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph, ExtendDirection::FWD, MAX_ITERATION);
 
         // Bwd colors.
         computeState.frontierPair->initState();
         computeState.frontierPair->initGDS();
         GDSUtils::runVertexCompute(input.context, graph, *initializeFrontiers);
-        GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph,
-            ExtendDirection::BWD, MAX_ITERATION);
+        GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph, ExtendDirection::BWD, MAX_ITERATION);
 
         // Find new SCC IDs and exit if all IDs have been found.
         computationState.reset();

--- a/src/function/gds/variable_length_path.cpp
+++ b/src/function/gds/variable_length_path.cpp
@@ -115,7 +115,7 @@ private:
             std::make_unique<VarLenJoinsEdgeCompute>(frontierPair.get(), bfsGraph.get());
         auto auxiliaryState = std::make_unique<PathAuxiliaryState>(std::move(bfsGraph));
         auto gdsState = std::make_unique<GDSComputeState>(std::move(frontierPair),
-            std::move(edgeCompute), std::move(auxiliaryState), sharedState->getOutputNodeMaskMap());
+            std::move(edgeCompute), std::move(auxiliaryState));
         return RJCompState(std::move(gdsState), std::move(outputWriter));
     }
 };

--- a/src/function/gds/weakly_connected_components.cpp
+++ b/src/function/gds/weakly_connected_components.cpp
@@ -167,7 +167,8 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
         sharedState, componentIDs);
     auto computeState =
         GDSComputeState(std::move(frontierPair), std::move(edgeCompute), std::move(auxiliaryState));
-    GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph, ExtendDirection::BOTH, MAX_ITERATION);
+    GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph,
+        ExtendDirection::BOTH, MAX_ITERATION);
     GDSUtils::runVertexCompute(input.context, graph, *vertexCompute);
     sharedState->factorizedTablePool.mergeLocalTables();
     return 0;

--- a/src/function/gds/weakly_connected_components.cpp
+++ b/src/function/gds/weakly_connected_components.cpp
@@ -165,10 +165,9 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
     auto edgeCompute = std::make_unique<WCCEdgeCompute>(*auxiliaryState);
     auto vertexCompute = std::make_unique<WCCVertexCompute>(clientContext->getMemoryManager(),
         sharedState, componentIDs);
-    auto computeState = GDSComputeState(std::move(frontierPair), std::move(edgeCompute),
-        std::move(auxiliaryState), nullptr);
-    GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph,
-        ExtendDirection::BOTH, MAX_ITERATION);
+    auto computeState =
+        GDSComputeState(std::move(frontierPair), std::move(edgeCompute), std::move(auxiliaryState));
+    GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph, ExtendDirection::BOTH, MAX_ITERATION);
     GDSUtils::runVertexCompute(input.context, graph, *vertexCompute);
     sharedState->factorizedTablePool.mergeLocalTables();
     return 0;

--- a/src/function/gds/wsp_destinations.cpp
+++ b/src/function/gds/wsp_destinations.cpp
@@ -7,6 +7,7 @@
 using namespace kuzu::binder;
 using namespace kuzu::common;
 using namespace kuzu::storage;
+using namespace kuzu::processor;
 
 namespace kuzu {
 namespace function {
@@ -147,8 +148,8 @@ public:
     }
 
 private:
-    RJCompState getRJCompState(processor::ExecutionContext* context, nodeID_t sourceNodeID,
-        const RJBindData& bindData, processor::RecursiveExtendSharedState* sharedState) override {
+    RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID,
+        const RJBindData& bindData, RecursiveExtendSharedState* sharedState) override {
         auto clientContext = context->clientContext;
         auto graph = sharedState->graph.get();
         auto curFrontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
@@ -164,9 +165,8 @@ private:
         std::unique_ptr<GDSComputeState> gdsState;
         visit(bindData.weightPropertyExpr->getDataType(), [&]<typename T>(T) {
             auto edgeCompute = std::make_unique<WSPDestinationsEdgeCompute<T>>(costs);
-            gdsState =
-                std::make_unique<GDSComputeState>(std::move(frontierPair), std::move(edgeCompute),
-                    std::move(auxiliaryState), sharedState->getOutputNodeMaskMap());
+            gdsState = std::make_unique<GDSComputeState>(std::move(frontierPair),
+                std::move(edgeCompute), std::move(auxiliaryState));
         });
         return RJCompState(std::move(gdsState), std::move(outputWriter));
     }

--- a/src/function/gds/wsp_paths.cpp
+++ b/src/function/gds/wsp_paths.cpp
@@ -112,8 +112,8 @@ public:
     }
 
 private:
-    RJCompState getRJCompState(processor::ExecutionContext* context, nodeID_t sourceNodeID,
-        const RJBindData& bindData, processor::RecursiveExtendSharedState* sharedState) override {
+    RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID,
+        const RJBindData& bindData, RecursiveExtendSharedState* sharedState) override {
         auto clientContext = context->clientContext;
         auto graph = sharedState->graph.get();
         auto curFrontier = PathLengths::getUnvisitedFrontier(context, graph);
@@ -128,9 +128,8 @@ private:
         visit(bindData.weightPropertyExpr->getDataType(), [&]<typename T>(T) {
             auto edgeCompute = std::make_unique<WSPPathsEdgeCompute<T>>(*bfsGraph);
             auto auxiliaryState = std::make_unique<WSPPathsAuxiliaryState>(std::move(bfsGraph));
-            gdsState =
-                std::make_unique<GDSComputeState>(std::move(frontierPair), std::move(edgeCompute),
-                    std::move(auxiliaryState), sharedState->getOutputNodeMaskMap());
+            gdsState = std::make_unique<GDSComputeState>(std::move(frontierPair),
+                std::move(edgeCompute), std::move(auxiliaryState));
         });
         return RJCompState(std::move(gdsState), std::move(outputWriter));
     }

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -135,14 +135,14 @@ public:
         return nodeMaxOffsetMap;
     }
 
-    uint16_t getMaskValueFromCurFrontier(common::offset_t offset) {
+    uint16_t getMaskValueFromCurFrontier(common::offset_t offset) const {
         return curFrontier[offset].load(std::memory_order_relaxed);
     }
-    uint16_t getMaskValueFromNextFrontier(common::offset_t offset) {
+    uint16_t getMaskValueFromNextFrontier(common::offset_t offset) const {
         return nextFrontier[offset].load(std::memory_order_relaxed);
     }
 
-    bool isActive(common::offset_t offset) { return curFrontier[offset] == curIter - 1; }
+    bool isActive(common::offset_t offset) const { return curFrontier[offset] == curIter - 1; }
 
     void setActive(std::span<const common::nodeID_t> nodeIDs) {
         for (const auto nodeID : nodeIDs) {
@@ -164,6 +164,7 @@ public:
     void pinCurFrontierTableID(common::table_id_t tableID) { curFrontier = getMaskData(tableID); }
     void pinNextFrontierTableID(common::table_id_t tableID) { nextFrontier = getMaskData(tableID); }
 
+    static std::shared_ptr<PathLengths> getUninitializedFrontier();
     // Init frontier to UNVISITED
     static std::shared_ptr<PathLengths> getUnvisitedFrontier(processor::ExecutionContext* context,
         graph::Graph* graph);
@@ -218,7 +219,6 @@ class KUZU_API FrontierPair {
 public:
     FrontierPair(std::shared_ptr<PathLengths> curFrontier,
         std::shared_ptr<PathLengths> nextFrontier);
-
     virtual ~FrontierPair() = default;
 
     void setActiveNodesForNextIter() { hasActiveNodesForNextIter_.store(true); }

--- a/src/include/function/gds/gds_state.h
+++ b/src/include/function/gds/gds_state.h
@@ -7,18 +7,14 @@ namespace kuzu {
 namespace function {
 
 struct GDSComputeState {
-    std::unique_ptr<function::FrontierPair> frontierPair = nullptr;
-    std::unique_ptr<function::EdgeCompute> edgeCompute = nullptr;
-    std::unique_ptr<function::GDSAuxiliaryState> auxiliaryState = nullptr;
+    std::unique_ptr<FrontierPair> frontierPair = nullptr;
+    std::unique_ptr<EdgeCompute> edgeCompute = nullptr;
+    std::unique_ptr<GDSAuxiliaryState> auxiliaryState = nullptr;
 
-    common::NodeOffsetMaskMap* outputNodeMask = nullptr;
-
-    GDSComputeState(std::unique_ptr<function::FrontierPair> frontierPair,
-        std::unique_ptr<function::EdgeCompute> edgeCompute,
-        std::unique_ptr<function::GDSAuxiliaryState> auxiliaryState,
-        common::NodeOffsetMaskMap* outputNodeMask)
+    GDSComputeState(std::unique_ptr<FrontierPair> frontierPair,
+        std::unique_ptr<EdgeCompute> edgeCompute, std::unique_ptr<GDSAuxiliaryState> auxiliaryState)
         : frontierPair{std::move(frontierPair)}, edgeCompute{std::move(edgeCompute)},
-          auxiliaryState{std::move(auxiliaryState)}, outputNodeMask{outputNodeMask} {}
+          auxiliaryState{std::move(auxiliaryState)} {}
 
     void initSource(common::nodeID_t sourceNodeID) const;
     // When performing computations on multi-label graphs, it is beneficial to fix a single

--- a/src/include/function/gds/gds_task.h
+++ b/src/include/function/gds/gds_task.h
@@ -44,7 +44,7 @@ class FrontierTask : public common::Task {
 public:
     FrontierTask(uint64_t maxNumThreads, const FrontierTaskInfo& info,
         std::shared_ptr<FrontierTaskSharedState> sharedState)
-        : common::Task{maxNumThreads}, info{info}, sharedState{std::move(sharedState)} {}
+        : Task{maxNumThreads}, info{info}, sharedState{std::move(sharedState)} {}
 
     void run() override;
 

--- a/src/include/function/gds/gds_utils.h
+++ b/src/include/function/gds/gds_utils.h
@@ -9,9 +9,12 @@ namespace function {
 
 class KUZU_API GDSUtils {
 public:
-    static void runFrontiersUntilConvergence(processor::ExecutionContext* context,
-        GDSComputeState& rjCompState, graph::Graph* graph, common::ExtendDirection extendDirection,
-        uint64_t maxIteration, const std::string& propertyToScan = "");
+    static void runFrontiersUntilConvergence(processor::ExecutionContext* context, GDSComputeState& compState,
+        graph::Graph* graph, common::ExtendDirection extendDirection, uint64_t maxIteration);
+    // Run edge compute with output node mask for early termination
+    static void runFrontiersUntilConvergence(processor::ExecutionContext* context, GDSComputeState& compState,
+        graph::Graph* graph, common::ExtendDirection extendDirection, uint64_t maxIteration,
+        common::NodeOffsetMaskMap* outputNodeMask, const std::string& propertyToScan = "");
     // Run vertex compute without property scan
     static void runVertexCompute(processor::ExecutionContext* context, graph::Graph* graph,
         VertexCompute& vc);

--- a/src/include/function/gds/gds_utils.h
+++ b/src/include/function/gds/gds_utils.h
@@ -9,12 +9,14 @@ namespace function {
 
 class KUZU_API GDSUtils {
 public:
-    static void runFrontiersUntilConvergence(processor::ExecutionContext* context, GDSComputeState& compState,
-        graph::Graph* graph, common::ExtendDirection extendDirection, uint64_t maxIteration);
+    static void runFrontiersUntilConvergence(processor::ExecutionContext* context,
+        GDSComputeState& compState, graph::Graph* graph, common::ExtendDirection extendDirection,
+        uint64_t maxIteration);
     // Run edge compute with output node mask for early termination
-    static void runFrontiersUntilConvergence(processor::ExecutionContext* context, GDSComputeState& compState,
-        graph::Graph* graph, common::ExtendDirection extendDirection, uint64_t maxIteration,
-        common::NodeOffsetMaskMap* outputNodeMask, const std::string& propertyToScan = "");
+    static void runFrontiersUntilConvergence(processor::ExecutionContext* context,
+        GDSComputeState& compState, graph::Graph* graph, common::ExtendDirection extendDirection,
+        uint64_t maxIteration, common::NodeOffsetMaskMap* outputNodeMask,
+        const std::string& propertyToScan = "");
     // Run vertex compute without property scan
     static void runVertexCompute(processor::ExecutionContext* context, graph::Graph* graph,
         VertexCompute& vc);

--- a/src/processor/operator/recursive_extend.cpp
+++ b/src/processor/operator/recursive_extend.cpp
@@ -96,8 +96,9 @@ void RecursiveExtend::executeInternal(ExecutionContext* context) {
                 propertyName =
                     bindData.weightPropertyExpr->ptrCast<PropertyExpression>()->getPropertyName();
             }
-            GDSUtils::runFrontiersUntilConvergence(context, *gdsComputeState, graph, bindData.extendDirection,
-                bindData.upperBound, sharedState->getOutputNodeMaskMap(), propertyName);
+            GDSUtils::runFrontiersUntilConvergence(context, *gdsComputeState, graph,
+                bindData.extendDirection, bindData.upperBound, sharedState->getOutputNodeMaskMap(),
+                propertyName);
             auto vertexCompute =
                 std::make_unique<RJVertexCompute>(clientContext->getMemoryManager(),
                     sharedState.get(), rjCompState.outputWriter->copy());

--- a/src/processor/operator/recursive_extend.cpp
+++ b/src/processor/operator/recursive_extend.cpp
@@ -96,8 +96,8 @@ void RecursiveExtend::executeInternal(ExecutionContext* context) {
                 propertyName =
                     bindData.weightPropertyExpr->ptrCast<PropertyExpression>()->getPropertyName();
             }
-            GDSUtils::runFrontiersUntilConvergence(context, *gdsComputeState, graph,
-                bindData.extendDirection, bindData.upperBound, propertyName);
+            GDSUtils::runFrontiersUntilConvergence(context, *gdsComputeState, graph, bindData.extendDirection,
+                bindData.upperBound, sharedState->getOutputNodeMaskMap(), propertyName);
             auto vertexCompute =
                 std::make_unique<RJVertexCompute>(clientContext->getMemoryManager(),
                     sharedState.get(), rjCompState.outputWriter->copy());


### PR DESCRIPTION
# Description

See title. OutputNodeMask by definition is not a state and thus should not be stored in GDSComputeState. 

I'm currently differentiating interfaces between GDS and RecursiveJoin because GDS does not have an outputNodeMask. We can unify them alternatively. I don't have a strong opinion at this point.