### PR TITLE
Zero new memory after resizing ColumnChunkData

### DIFF
--- a/src/storage/store/column_chunk_data.cpp
+++ b/src/storage/store/column_chunk_data.cpp
@@ -464,6 +464,7 @@ void ColumnChunkData::resize(uint64_t newCapacity) {
         auto bufferSize = getBufferSize();
         auto resizedBufferData = resizedBuffer->getBuffer().data();
         memcpy(resizedBufferData, buffer->getBuffer().data(), bufferSize);
+        memset(resizedBufferData + bufferSize, 0, numBytesAfterResize - bufferSize);
         buffer = std::move(resizedBuffer);
     }
     if (nullData) {


### PR DESCRIPTION
From #5050; uninitialized memory ends up being used for statistics in the relationship data. I suspect there may also be an issue in `RelBatchInsert::appendNodeGroup`, since if I understand that correctly it should be filling in both the data and the gaps; so this shouldn't matter. But regardless I think the behaviour of resize should match the default behaviour of the constructor of initializing the data to zero.