### PR TITLE
Remove a few tools subdirectory for clang tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -35,5 +35,5 @@ Checks:
   performance-move-const-arg,
 
 HeaderFilterRegex:
-  src/include|tools/benchmark/include|tools/nodejs_api/src_cpp/include|tools/python_api/src_cpp/include|tools/rust_api/include|tools/shell/include|extension/[a-zA-Z0-9]*/src/include
+  tools/shell/include|extension/[a-zA-Z0-9]*/src/include
 WarningsAsErrors: "*"

--- a/.clang-tidy-analyzer
+++ b/.clang-tidy-analyzer
@@ -6,5 +6,5 @@ Checks:
   -clang-analyzer-cplusplus.NewDeleteLeaks,
 
 HeaderFilterRegex:
-  src/include|tools/benchmark/include|tools/nodejs_api/src_cpp/include|tools/python_api/src_cpp/include|tools/rust_api/include|tools/shell/include|extension/[a-zA-Z0-9]*/src/include
+  tools/shell/include|extension/[a-zA-Z0-9]*/src/include
 WarningsAsErrors: "*"

--- a/Makefile
+++ b/Makefile
@@ -249,11 +249,11 @@ shell-test:
 # parallelism.
 tidy: | allconfig java_native_header
 	run-clang-tidy -p build/release -quiet -j $(NUM_THREADS) \
-		"^$(realpath src)|$(realpath extension)/(?!fts/third_party/snowball/)|$(realpath tools)/(?!shell/linenoise.cpp)"
+		"^$(realpath src)|$(realpath extension)/(?!fts/third_party/snowball/)|$(realpath tools)/shell/(?!linenoise\.cpp)"
 
 tidy-analyzer: | allconfig java_native_header
 	run-clang-tidy -config-file .clang-tidy-analyzer -p build/release -quiet -j $(NUM_THREADS) \
-		"^$(realpath src)|$(realpath extension)/(?!fts/third_party/snowball/)|$(realpath tools)/(?!shell/linenoise.cpp)"
+		"^$(realpath src)|$(realpath extension)/(?!fts/third_party/snowball/)|$(realpath tools)/shell/(?!linenoise\.cpp)"
 
 clangd-diagnostics: | allconfig java_native_header
 	find src -name *.h -or -name *.cpp | xargs \


### PR DESCRIPTION
# Description

Clang tidy checks are running extremely slow (>1h) recently. Try if removing a few tools sub-directory can help.