### PR TITLE
Fix missing chrono include that prevents windows builds

### DIFF
--- a/third_party/antlr4_runtime/src/antlr4-common.h
+++ b/third_party/antlr4_runtime/src/antlr4-common.h
@@ -32,6 +32,7 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <chrono>
 
 // Defines for the Guid class and other platform dependent stuff.
 #ifdef _WIN32


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue (if applicable). Please also include
relevant motivation and context.

When  trying to build the kuzu library on Windows Server 2025 via the github actions vm's the library fails to build do to the "ProfilingATNSimulator.cpp" missing the include for the chrono library. I added it to the antlr4-common.h file as it seemed the most appropriate location to put it.

...
0.8.3-pre.22\kuzu-src\third_party\simsimd\include -external:W0 -nologo -MD -Brepro /O2 /Ob2 /DNDEBUG -std:c++20 -MD /utf-8 /EHa /Zc:inline /W0 /O2 /showIncludes /Fothird_party\antlr4_runtime\CMakeFiles\antlr4_runtime.dir\src\atn\ProfilingATNSimulator.cpp.obj /Fdthird_party\antlr4_runtime\CMakeFiles\antlr4_runtime.dir\antlr4_runtime.pdb /FS -c C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\kuzu-0.8.3-pre.22\kuzu-src\third_party\antlr4_runtime\src\atn\ProfilingATNSimulator.cpp
  C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\kuzu-0.8.3-pre.22\kuzu-src\third_party\antlr4_runtime\src\atn\ProfilingATNSimulator.cpp(38): error C2653: 'high_resolution_clock': is not a class or namespace name
  C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\kuzu-0.8.3-pre.22\kuzu-src\third_party\antlr4_runtime\src\atn\ProfilingATNSimulator.cpp(38): error C2653: 'high_resolution_clock': is not a class or namespace name

Fixes # (issue)
N/A  I couldn't find an issue for this and I needed it to work ASAP so I just fixed it without creating an issue. From looking a the 0.8.3-pre.22 version and the current main branch and the issue is still present. 
# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).