### PR TITLE
Shell table autocomplete catalog version

### DIFF
--- a/tools/shell/include/embedded_shell.h
+++ b/tools/shell/include/embedded_shell.h
@@ -82,6 +82,7 @@ private:
     uint32_t maxPrintWidth;
     std::unique_ptr<Printer> printer;
     bool stats;
+    uint64_t catalogVersion;
 };
 
 } // namespace main

--- a/tools/shell/test/test_shell_basics.py
+++ b/tools/shell/test/test_shell_basics.py
@@ -194,10 +194,6 @@ def test_comments(temp_db) -> None:
 
 
 def test_shell_auto_completion(temp_db) -> None:
-    # table auto completion only works if table exists on startup currently and
-    # due to how the shell handles tab characters, in this test we need to send 
-    # tabs without characters directly after them to avoid being processed as
-    # pasted input
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_statement("CREATE NODE TABLE coolTable(i STRING, longPropertyName STRING, autoCompleteUINT8 UIN\t")
@@ -206,14 +202,7 @@ def test_shell_auto_completion(temp_db) -> None:
     test.send_statement("\t")
     test.send_statement(", PRIMARY KEY(i));\n")
     assert test.shell_process.expect_exact(["\u2502 Table coolTable has been created. \u2502", pexpect.EOF]) == 0
-
-    # insures the previous shell test propely closed before next test
-    test = ShellTest().add_argument(temp_db)
-    test.run()
-
-    # reopen shell to load new table name
-    test = ShellTest().add_argument(temp_db)
-    test.start()
+    
     test.send_statement("ma\t")
     test.send_statement("\t")
     test.send_statement("\t")


### PR DESCRIPTION
# Description

Updated shell table autocompletion to only update when there has been a change to the catalog version. As well, allowed for autocompletion of table names added in the current session. 

Fixes #4723


# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).