### PR TITLE
Fix unused member compile warnings

### DIFF
--- a/extension/json/src/include/reader/buffered_json_reader.h
+++ b/extension/json/src/include/reader/buffered_json_reader.h
@@ -86,7 +86,6 @@ public:
     std::mutex lock;
 
 private:
-    main::ClientContext& context;
     std::unique_ptr<JsonFileHandle> fileHandle;
     std::string fileName;
     BufferedJSONReaderOptions options;

--- a/extension/json/src/reader/buffered_json_reader.cpp
+++ b/extension/json/src/reader/buffered_json_reader.cpp
@@ -35,7 +35,7 @@ void JsonFileHandle::readAtPosition(uint8_t* pointer, uint64_t size, uint64_t po
 
 BufferedJsonReader::BufferedJsonReader(main::ClientContext& context, std::string fileName,
     BufferedJSONReaderOptions options)
-    : context{context}, fileName{std::move(fileName)}, options{options}, bufferIdx{0} {
+    : fileName{std::move(fileName)}, options{options}, bufferIdx{0} {
     auto fileInfo = context.getVFSUnsafe()->openFile(this->fileName, FileFlags::READ_ONLY);
     fileHandle = std::make_unique<JsonFileHandle>(std::move(fileInfo));
 }

--- a/extension/vector/src/include/index/hnsw_graph.h
+++ b/extension/vector/src/include/index/hnsw_graph.h
@@ -50,15 +50,13 @@ struct OnDiskEmbeddingScanState {
 
 class OnDiskEmbeddings final : public EmbeddingColumn {
 public:
-    OnDiskEmbeddings(EmbeddingTypeInfo typeInfo, storage::NodeTable& nodeTable,
-        common::column_id_t columnID);
+    OnDiskEmbeddings(EmbeddingTypeInfo typeInfo, storage::NodeTable& nodeTable);
 
     float* getEmbedding(transaction::Transaction* transaction,
         storage::NodeTableScanState& scanState, common::offset_t offset) const;
 
 private:
     storage::NodeTable& nodeTable;
-    common::column_id_t columnID;
 };
 
 struct NodeWithDistance {

--- a/extension/vector/src/include/index/hnsw_graph.h
+++ b/extension/vector/src/include/index/hnsw_graph.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <cmath>
+
 #include "index/hnsw_config.h"
 #include "processor/operator/partitioner.h"
+#include "storage/buffer_manager/memory_manager.h"
 #include "storage/local_cached_column.h"
 #include "storage/store/column_chunk_data.h"
 

--- a/extension/vector/src/index/hnsw_graph.cpp
+++ b/extension/vector/src/index/hnsw_graph.cpp
@@ -52,9 +52,8 @@ OnDiskEmbeddingScanState::OnDiskEmbeddingScanState(const transaction::Transactio
     scanState->setToTable(transaction, &nodeTable, std::move(columnIDs));
 }
 
-OnDiskEmbeddings::OnDiskEmbeddings(EmbeddingTypeInfo typeInfo, NodeTable& nodeTable,
-    common::column_id_t columnID)
-    : EmbeddingColumn{std::move(typeInfo)}, nodeTable{nodeTable}, columnID{columnID} {}
+OnDiskEmbeddings::OnDiskEmbeddings(EmbeddingTypeInfo typeInfo, NodeTable& nodeTable)
+    : EmbeddingColumn{std::move(typeInfo)}, nodeTable{nodeTable} {}
 
 float* OnDiskEmbeddings::getEmbedding(transaction::Transaction* transaction,
     NodeTableScanState& scanState, common::offset_t offset) const {

--- a/extension/vector/src/index/hnsw_index.cpp
+++ b/extension/vector/src/index/hnsw_index.cpp
@@ -285,8 +285,7 @@ OnDiskHNSWIndex::OnDiskHNSWIndex(main::ClientContext* context,
         indexColumnType.getExtraTypeInfo()->constPtrCast<common::ArrayTypeInfo>();
     EmbeddingTypeInfo indexColumnTypeInfo{extraTypeInfo->getChildType().copy(),
         extraTypeInfo->getNumElements()};
-    embeddings =
-        std::make_unique<OnDiskEmbeddings>(std::move(indexColumnTypeInfo), nodeTable, columnID);
+    embeddings = std::make_unique<OnDiskEmbeddings>(std::move(indexColumnTypeInfo), nodeTable);
     graph::GraphEntry lowerGraphEntry{{nodeTableEntry}, {lowerRelTableEntry}};
     lowerGraph = std::make_unique<graph::OnDiskGraph>(context, std::move(lowerGraphEntry));
     graph::GraphEntry upperGraphEntry{{nodeTableEntry}, {upperRelTableEntry}};

--- a/src/include/main/storage_driver.h
+++ b/src/include/main/storage_driver.h
@@ -28,7 +28,6 @@ private:
         const common::offset_t* offsets, size_t size, uint8_t* result) const;
 
 private:
-    Database* database;
     std::unique_ptr<ClientContext> clientContext;
 };
 

--- a/src/include/storage/store/chunked_node_group.h
+++ b/src/include/storage/store/chunked_node_group.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <mutex>
 
 #include "common/enums/rel_multiplicity.h"
 #include "storage/enums/residency_state.h"

--- a/src/include/storage/store/column_chunk_data.h
+++ b/src/include/storage/store/column_chunk_data.h
@@ -7,6 +7,7 @@
 #include "common/data_chunk/sel_vector.h"
 #include "common/enums/rel_multiplicity.h"
 #include "common/null_mask.h"
+#include "common/system_config.h"
 #include "common/types/types.h"
 #include "common/vector/value_vector.h"
 #include "storage/compression/compression.h"

--- a/src/include/storage/store/column_reader_writer.h
+++ b/src/include/storage/store/column_reader_writer.h
@@ -38,14 +38,12 @@ using filter_func_t = std::function<bool(common::offset_t, common::offset_t)>;
 
 struct ColumnReadWriterFactory {
     static std::unique_ptr<ColumnReadWriter> createColumnReadWriter(common::PhysicalTypeID dataType,
-        DBFileID dbFileID, FileHandle* dataFH, BufferManager* bufferManager,
-        ShadowFile* shadowFile);
+        DBFileID dbFileID, FileHandle* dataFH, ShadowFile* shadowFile);
 };
 
 class ColumnReadWriter {
 public:
-    ColumnReadWriter(DBFileID dbFileID, FileHandle* dataFH, BufferManager* bufferManager,
-        ShadowFile* shadowFile);
+    ColumnReadWriter(DBFileID dbFileID, FileHandle* dataFH, ShadowFile* shadowFile);
 
     virtual ~ColumnReadWriter() = default;
 
@@ -94,7 +92,6 @@ protected:
 private:
     DBFileID dbFileID;
     FileHandle* dataFH;
-    BufferManager* bufferManager;
     ShadowFile* shadowFile;
 };
 

--- a/src/include/storage/store/column_reader_writer.h
+++ b/src/include/storage/store/column_reader_writer.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "storage/buffer_manager/buffer_manager.h"
 #include "storage/compression/float_compression.h"
 #include "storage/db_file_id.h"
 
@@ -10,6 +9,7 @@ class Transaction;
 }
 namespace storage {
 
+class FileHandle;
 class ColumnReadWriter;
 class ShadowFile;
 struct ColumnChunkMetadata;

--- a/src/include/storage/store/csr_node_group.h
+++ b/src/include/storage/store/csr_node_group.h
@@ -3,6 +3,8 @@
 #include <array>
 #include <bitset>
 
+#include "common/constants.h"
+#include "common/system_config.h"
 #include "storage/enums/csr_node_group_scan_source.h"
 #include "storage/store/csr_chunked_node_group.h"
 #include "storage/store/node_group.h"

--- a/src/include/storage/store/in_memory_exception_chunk.h
+++ b/src/include/storage/store/in_memory_exception_chunk.h
@@ -10,6 +10,7 @@ class Transaction;
 namespace storage {
 
 class Column;
+class MemoryManager;
 class ColumnReadWriter;
 struct ColumnChunkMetadata;
 struct ChunkState;

--- a/src/main/storage_driver.cpp
+++ b/src/main/storage_driver.cpp
@@ -15,7 +15,7 @@ using namespace kuzu::catalog;
 namespace kuzu {
 namespace main {
 
-StorageDriver::StorageDriver(Database* database) : database{database} {
+StorageDriver::StorageDriver(Database* database) {
     clientContext = std::make_unique<ClientContext>(database);
 }
 

--- a/src/storage/buffer_manager/spiller.cpp
+++ b/src/storage/buffer_manager/spiller.cpp
@@ -7,6 +7,8 @@
 #include "common/exception/io.h"
 #include "common/file_system/virtual_file_system.h"
 #include "common/types/types.h"
+#include "storage/buffer_manager/buffer_manager.h"
+#include "storage/buffer_manager/memory_manager.h"
 #include "storage/file_handle.h"
 #include "storage/store/chunked_node_group.h"
 #include "storage/store/column_chunk_data.h"

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -105,9 +105,8 @@ Column::Column(std::string name, LogicalType dataType, FileHandle* dataFH, Memor
     ShadowFile* shadowFile, bool enableCompression, bool requireNullColumn)
     : name{std::move(name)}, dbFileID{DBFileID::newDataFileID()}, dataType{std::move(dataType)},
       dataFH{dataFH}, mm{mm}, shadowFile{shadowFile}, enableCompression{enableCompression},
-      columnReadWriter(
-          ColumnReadWriterFactory::createColumnReadWriter(this->dataType.getPhysicalType(),
-              dbFileID, this->dataFH, this->mm->getBufferManager(), this->shadowFile)) {
+      columnReadWriter(ColumnReadWriterFactory::createColumnReadWriter(
+          this->dataType.getPhysicalType(), dbFileID, this->dataFH, this->shadowFile)) {
     readToVectorFunc = getReadValuesToVectorFunc(this->dataType);
     readToPageFunc = ReadCompressedValuesFromPage(this->dataType);
     writeFunc = getWriteValuesFunc(this->dataType);

--- a/src/storage/store/column_chunk_data.cpp
+++ b/src/storage/store/column_chunk_data.cpp
@@ -13,6 +13,7 @@
 #include "common/types/types.h"
 #include "common/vector/value_vector.h"
 #include "expression_evaluator/expression_evaluator.h"
+#include "storage/buffer_manager/buffer_manager.h"
 #include "storage/buffer_manager/memory_manager.h"
 #include "storage/buffer_manager/spiller.h"
 #include "storage/compression/compression.h"

--- a/src/storage/store/column_reader_writer.cpp
+++ b/src/storage/store/column_reader_writer.cpp
@@ -4,6 +4,7 @@
 #include "common/utils.h"
 #include "common/vector/value_vector.h"
 #include "storage/compression/float_compression.h"
+#include "storage/file_handle.h"
 #include "storage/shadow_utils.h"
 #include "storage/storage_utils.h"
 #include "storage/store/column_chunk_data.h"

--- a/src/storage/store/column_reader_writer.cpp
+++ b/src/storage/store/column_reader_writer.cpp
@@ -75,9 +75,8 @@ class FloatColumnReadWriter;
 
 class DefaultColumnReadWriter : public ColumnReadWriter {
 public:
-    DefaultColumnReadWriter(DBFileID dbFileID, FileHandle* dataFH, BufferManager* bufferManager,
-        ShadowFile* shadowFile)
-        : ColumnReadWriter(dbFileID, dataFH, bufferManager, shadowFile) {}
+    DefaultColumnReadWriter(DBFileID dbFileID, FileHandle* dataFH, ShadowFile* shadowFile)
+        : ColumnReadWriter(dbFileID, dataFH, shadowFile) {}
 
     void readCompressedValueToPage(const transaction::Transaction* transaction,
         const ChunkState& state, common::offset_t nodeOffset, uint8_t* result,
@@ -205,11 +204,9 @@ public:
 template<std::floating_point T>
 class FloatColumnReadWriter : public ColumnReadWriter {
 public:
-    FloatColumnReadWriter(DBFileID dbFileID, FileHandle* dataFH, BufferManager* bufferManager,
-        ShadowFile* shadowFile)
-        : ColumnReadWriter(dbFileID, dataFH, bufferManager, shadowFile),
-          defaultReader(std::make_unique<DefaultColumnReadWriter>(dbFileID, dataFH, bufferManager,
-              shadowFile)) {}
+    FloatColumnReadWriter(DBFileID dbFileID, FileHandle* dataFH, ShadowFile* shadowFile)
+        : ColumnReadWriter(dbFileID, dataFH, shadowFile),
+          defaultReader(std::make_unique<DefaultColumnReadWriter>(dbFileID, dataFH, shadowFile)) {}
 
     void readCompressedValueToPage(const transaction::Transaction* transaction,
         const ChunkState& state, common::offset_t nodeOffset, uint8_t* result,
@@ -413,23 +410,19 @@ private:
 
 std::unique_ptr<ColumnReadWriter> ColumnReadWriterFactory::createColumnReadWriter(
     common::PhysicalTypeID dataType, DBFileID dbFileID, FileHandle* dataFH,
-    BufferManager* bufferManager, ShadowFile* shadowFile) {
+    ShadowFile* shadowFile) {
     switch (dataType) {
     case common::PhysicalTypeID::FLOAT:
-        return std::make_unique<FloatColumnReadWriter<float>>(dbFileID, dataFH, bufferManager,
-            shadowFile);
+        return std::make_unique<FloatColumnReadWriter<float>>(dbFileID, dataFH, shadowFile);
     case common::PhysicalTypeID::DOUBLE:
-        return std::make_unique<FloatColumnReadWriter<double>>(dbFileID, dataFH, bufferManager,
-            shadowFile);
+        return std::make_unique<FloatColumnReadWriter<double>>(dbFileID, dataFH, shadowFile);
     default:
-        return std::make_unique<DefaultColumnReadWriter>(dbFileID, dataFH, bufferManager,
-            shadowFile);
+        return std::make_unique<DefaultColumnReadWriter>(dbFileID, dataFH, shadowFile);
     }
 }
 
-ColumnReadWriter::ColumnReadWriter(DBFileID dbFileID, FileHandle* dataFH,
-    BufferManager* bufferManager, ShadowFile* shadowFile)
-    : dbFileID(dbFileID), dataFH(dataFH), bufferManager(bufferManager), shadowFile(shadowFile) {}
+ColumnReadWriter::ColumnReadWriter(DBFileID dbFileID, FileHandle* dataFH, ShadowFile* shadowFile)
+    : dbFileID(dbFileID), dataFH(dataFH), shadowFile(shadowFile) {}
 
 void ColumnReadWriter::readFromPage(const Transaction* transaction, page_idx_t pageIdx,
     const std::function<void(uint8_t*)>& readFunc) {

--- a/src/storage/store/dictionary_chunk.cpp
+++ b/src/storage/store/dictionary_chunk.cpp
@@ -1,5 +1,6 @@
 #include "storage/store/dictionary_chunk.h"
 
+#include "common/constants.h"
 #include "common/serializer/deserializer.h"
 #include "common/serializer/serializer.h"
 #include "storage/buffer_manager/memory_manager.h"

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -7,6 +7,7 @@
 #include "common/types/types.h"
 #include "main/client_context.h"
 #include "main/db_config.h"
+#include "storage/buffer_manager/memory_manager.h"
 #include "storage/local_storage/local_node_table.h"
 #include "storage/local_storage/local_storage.h"
 #include "storage/local_storage/local_table.h"

--- a/test/storage/compress_chunk_test.cpp
+++ b/test/storage/compress_chunk_test.cpp
@@ -129,7 +129,6 @@ template<std::floating_point T>
 void CompressChunkTest::testCompressChunk(const std::vector<T>& bufferToCompress,
     check_func_t checkFunc) {
     auto* mm = getMemoryManager(*database);
-    auto* bm = getBufferManager(*database);
     auto* storageManager = getStorageManager(*database);
     auto* dataFH = storageManager->getDataFH();
 
@@ -141,7 +140,7 @@ void CompressChunkTest::testCompressChunk(const std::vector<T>& bufferToCompress
         compressBuffer(bufferToCompress, alg, preScanMetadata.get(), dataFH, dataType);
 
     auto columnReader = ColumnReadWriterFactory::createColumnReadWriter(dataType.getPhysicalType(),
-        DBFileID::newDataFileID(), dataFH, bm, &storageManager->getShadowFile());
+        DBFileID::newDataFileID(), dataFH, &storageManager->getShadowFile());
 
     auto* clientContext = getClientContext(*conn);
     clientContext->getTransactionContext()->beginWriteTransaction();


### PR DESCRIPTION
# Description

My compiler was reporting some warnings regarding unused member variables, added the fixes in this PR

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).