### PR TITLE
Allow WAL replaying on some corrupted WAL files (e.g. after DB was killed)

### DIFF
--- a/src/include/binder/expression/expression.h
+++ b/src/include/binder/expression/expression.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include "common/assert.h"
 #include "common/cast.h"

--- a/src/storage/wal/wal_record.cpp
+++ b/src/storage/wal/wal_record.cpp
@@ -128,7 +128,7 @@ std::unique_ptr<CreateCatalogEntryRecord> CreateCatalogEntryRecord::deserialize(
     Deserializer& deserializer) {
     auto retVal = std::make_unique<CreateCatalogEntryRecord>();
     retVal->ownedCatalogEntry = catalog::CatalogEntry::deserialize(deserializer);
-    idx_t vectorSize;
+    idx_t vectorSize = 0;
     deserializer.deserializeValue(vectorSize);
     for (auto i = 0u; i < vectorSize; ++i) {
         retVal->ownedChildrenEntries.push_back(catalog::CatalogEntry::deserialize(deserializer));

--- a/src/storage/wal_replayer.cpp
+++ b/src/storage/wal_replayer.cpp
@@ -45,9 +45,20 @@ void WALReplayer::replay() const {
     }
     try {
         Deserializer deserializer(std::make_unique<BufferedFileReader>(std::move(fileInfo)));
+        RUNTIME_CHECK(bool nextRecordShouldBeRollback = false);
         while (!deserializer.finished()) {
+            // If an exception occurs while deserializing we will stop replaying
             auto walRecord = WALRecord::deserialize(deserializer, clientContext);
-            replayWALRecord(*walRecord);
+            KU_ASSERT(
+                !nextRecordShouldBeRollback || walRecord->type == WALRecordType::ROLLBACK_RECORD);
+            try {
+                replayWALRecord(*walRecord);
+                RUNTIME_CHECK(nextRecordShouldBeRollback = false);
+            } catch (const Exception& e) {
+                // exception while replaying a WAL record
+                // stop executing the current query, the next record should be a rollback record
+                RUNTIME_CHECK(nextRecordShouldBeRollback = true);
+            }
         }
         if (clientContext.getTransactionContext()->hasActiveTransaction()) {
             // Handle the case that either the last transaction is not committed or the wal file is

--- a/src/storage/wal_replayer.cpp
+++ b/src/storage/wal_replayer.cpp
@@ -62,8 +62,6 @@ void WALReplayer::replay() const {
             // under this case.
             clientContext.getTransactionContext()->rollback();
         }
-        throw RuntimeException(
-            stringFormat("Failed to replay wal record from WAL file. Error: {}", e.what()));
     }
 }
 

--- a/tools/python_api/test/test_wal.py
+++ b/tools/python_api/test/test_wal.py
@@ -1,0 +1,36 @@
+import subprocess
+import sys
+import time
+from pathlib import Path
+from textwrap import dedent
+
+import kuzu
+
+
+def run_query_in_new_process(tmp_path: Path, build_dir: Path):
+    code = dedent(
+        f"""
+        import sys
+        sys.path.append(r"{build_dir!s}")
+
+        import kuzu
+        db = kuzu.Database(r"{tmp_path!s}")
+        print(r"{tmp_path!s}")
+
+        conn = kuzu.Connection(db)
+        conn.execute("CREATE NODE TABLE tab (id INT64, PRIMARY KEY (id));")
+        conn.execute("UNWIND RANGE(1,100000) AS x UNWIND RANGE(1, 100000) AS y CREATE (:tab {{id: x * 100000 + y}});")
+        """
+    )
+    return subprocess.Popen([sys.executable, "-c", code])
+
+
+# Kill the database while it's in the middle of executing a long persistent query
+# When we reload the database it should
+def test_replay_after_kill(tmp_path: Path, build_dir: Path) -> None:
+    proc = run_query_in_new_process(tmp_path, build_dir)
+    time.sleep(5)
+    proc.kill()
+    proc.wait(5)
+    with kuzu.Database(tmp_path) as db:
+        pass

--- a/tools/python_api/test/test_wal.py
+++ b/tools/python_api/test/test_wal.py
@@ -32,6 +32,7 @@ def test_replay_after_kill(tmp_path: Path, build_dir: Path) -> None:
     proc.kill()
     proc.wait(5)
     with kuzu.Database(tmp_path) as db, kuzu.Connection(db) as conn:
+        # previously committed queries should be valid after replaying WAL
         result = conn.execute("CALL show_tables() RETURN *")
         assert result.has_next()
         assert result.get_next()[1] == "tab"

--- a/tools/python_api/test/test_wal.py
+++ b/tools/python_api/test/test_wal.py
@@ -56,6 +56,7 @@ def test_replay_with_exception(tmp_path: Path, build_dir: Path) -> None:
     for i in range(10):
         try:
             conn.execute(f"CREATE (:tab {{id: {i // 2}}})")
+            assert i % 2 == 0
         except:
             assert i % 2 == 1
     conn.execute("UNWIND RANGE(1,100000) AS x UNWIND RANGE(1, 100000) AS y CREATE (:tab {id: x * 100000 + y});")

--- a/tools/python_api/test/test_wal.py
+++ b/tools/python_api/test/test_wal.py
@@ -31,7 +31,7 @@ def run_query_then_kill(tmp_path: Path, build_dir: Path, queries: str):
 
 
 # Kill the database while it's in the middle of executing a long persistent query
-# When we reload the database it should
+# When we reload the database we will replay from the WAL (which will be incomplete)
 def test_replay_after_kill(tmp_path: Path, build_dir: Path) -> None:
     queries = dedent("""
     conn = kuzu.Connection(db)

--- a/tools/python_api/test/test_wal.py
+++ b/tools/python_api/test/test_wal.py
@@ -7,34 +7,65 @@ from textwrap import dedent
 import kuzu
 
 
-def run_query_in_new_process(tmp_path: Path, build_dir: Path):
-    code = dedent(
-        f"""
+def run_query_in_new_process(tmp_path: Path, build_dir: Path, queries: str):
+    code = (
+        dedent(
+            f"""
         import sys
         sys.path.append(r"{build_dir!s}")
 
         import kuzu
         db = kuzu.Database(r"{tmp_path!s}")
-
-        conn = kuzu.Connection(db)
-        conn.execute("CREATE NODE TABLE tab (id INT64, PRIMARY KEY (id));")
-        conn.execute("UNWIND RANGE(1,100000) AS x UNWIND RANGE(1, 100000) AS y CREATE (:tab {{id: x * 100000 + y}});")
         """
+        )
+        + queries
     )
     return subprocess.Popen([sys.executable, "-c", code])
+
+
+def run_query_then_kill(tmp_path: Path, build_dir: Path, queries: str):
+    proc = run_query_in_new_process(tmp_path, build_dir, queries)
+    time.sleep(5)
+    proc.kill()
+    proc.wait(5)
 
 
 # Kill the database while it's in the middle of executing a long persistent query
 # When we reload the database it should
 def test_replay_after_kill(tmp_path: Path, build_dir: Path) -> None:
-    proc = run_query_in_new_process(tmp_path, build_dir)
-    time.sleep(5)
-    proc.kill()
-    proc.wait(5)
+    queries = dedent("""
+    conn = kuzu.Connection(db)
+    conn.execute("CREATE NODE TABLE tab (id INT64, PRIMARY KEY (id));")
+    conn.execute("UNWIND RANGE(1,100000) AS x UNWIND RANGE(1, 100000) AS y CREATE (:tab {id: x * 100000 + y});")
+    """)
+    run_query_then_kill(tmp_path, build_dir, queries)
     with kuzu.Database(tmp_path) as db, kuzu.Connection(db) as conn:
         # previously committed queries should be valid after replaying WAL
         result = conn.execute("CALL show_tables() RETURN *")
         assert result.has_next()
         assert result.get_next()[1] == "tab"
+        assert not result.has_next()
+        result.close()
+
+
+def test_replay_with_exception(tmp_path: Path, build_dir: Path) -> None:
+    queries = dedent("""
+    conn = kuzu.Connection(db)
+    conn.execute("CREATE NODE TABLE tab (id INT64, PRIMARY KEY (id));")
+    # some of these queries will throw exceptions
+    for i in range(10):
+        try:
+            conn.execute(f"CREATE (:tab {{id: {i // 2}}})")
+        except:
+            assert i % 2 == 1
+    conn.execute("UNWIND RANGE(1,100000) AS x UNWIND RANGE(1, 100000) AS y CREATE (:tab {id: x * 100000 + y});")
+    """)
+    run_query_then_kill(tmp_path, build_dir, queries)
+    with kuzu.Database(tmp_path) as db, kuzu.Connection(db) as conn:
+        # previously committed queries should be valid after replaying WAL
+        result = conn.execute("match (t:tab) where t.id <= 5 return t.id")
+        assert result.get_num_tuples() == 5
+        for i in range(5):
+            assert result.get_next()[0] == i
         assert not result.has_next()
         result.close()


### PR DESCRIPTION
# Description

After a kuzu process is killed, the WAL may be in an incomplete state. This PR stops an error from being reported if we are replaying an incomplete WAL. Instead the replaying logic will be:
```
for each WAL record:
  record = WAL::deserializeRecord() // if this throws stop replaying
  WAL::replayRecord(record) // if this throws we continue replaying as the next record should be a rollback
```

Fixes https://github.com/kuzudb/kuzu/issues/5016

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).