### PR TITLE
Fix function names in show_function()

### DIFF
--- a/src/function/table/show_functions.cpp
+++ b/src/function/table/show_functions.cpp
@@ -60,7 +60,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* co
         const auto type = FunctionEntryTypeUtils::toString(entry->getType());
         for (auto& function : functionSet) {
             auto signature = function->signatureToString();
-            FunctionInfos.emplace_back(function->name, type, signature);
+            FunctionInfos.emplace_back(entry->getName(), type, signature);
         }
     }
     columnNames = TableFunction::extractYieldVariables(columnNames, input->yieldVariables);

--- a/test/test_files/function/call/call.test
+++ b/test/test_files/function/call/call.test
@@ -411,3 +411,14 @@ Binder exception: Column i does not exist in table testArray.
 Binder exception: Column id is not of the expected type ARRAY.
 -STATEMENT CALL _CACHE_ARRAY_COLUMN_LOCALLY('testArray', 'arr');
 ---- ok
+
+-CASE ShowFunctionsWithAlias
+-STATEMENT CALL SHOW_FUNCTIONS() WHERE name = 'TOLOWER' RETURN *;
+---- 1
+TOLOWER|SCALAR FUNCTION|(STRING) -> STRING
+-STATEMENT CALL SHOW_FUNCTIONS() WHERE name = 'LOWER' RETURN *;
+---- 1
+LOWER|SCALAR FUNCTION|(STRING) -> STRING
+-STATEMENT CALL SHOW_FUNCTIONS() WHERE name = 'INTERVAL' RETURN *;
+---- 1
+INTERVAL|SCALAR FUNCTION|(STRING) -> INTERVAL


### PR DESCRIPTION
Fix the function names in show_function() so it shows the function alias name instead of the original function name.
Closes #5107 
As discussed with the user who requested it, they thought that it is ok to just list aliases functions as separate functions under `show_functions`