### PR TITLE
Fix size of chunks in RelBatchInsert

### DIFF
--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -174,16 +174,15 @@ void RelBatchInsert::populateCSRHeaderAndRowIdx(InMemChunkedNodeGroupCollection&
     populateCSRLengths(csrHeader, numNodes, partition, relInfo.boundNodeOffsetColumnID);
     checkRelMultiplicityConstraint(csrHeader, startNodeOffset, relInfo);
     const auto rightCSROffsetOfRegions = csrHeader.populateStartCSROffsetsFromLength(leaveGaps);
-    // Resize csr data column chunks.
-    const auto csrChunkCapacity = rightCSROffsetOfRegions.back() + 1;
-    localState.chunkedGroup->resizeChunks(csrChunkCapacity);
-    localState.chunkedGroup->resetToAllNull();
     for (auto& chunkedGroup : partition.getChunkedGroups()) {
         auto& offsetChunk = chunkedGroup->getColumnChunk(relInfo.boundNodeOffsetColumnID);
         // We reuse bound node offset column to store row idx for each rel in the node group.
         setRowIdxFromCSROffsets(offsetChunk.getData(), csrHeader.offset->getData());
     }
     csrHeader.finalizeCSRRegionEndOffsets(rightCSROffsetOfRegions);
+    // Resize csr data column chunks.
+    localState.chunkedGroup->resizeChunks(csrHeader.getEndCSROffset(numNodes - 1));
+    localState.chunkedGroup->resetToAllNull();
     KU_ASSERT(csrHeader.sanityCheck());
 }
 


### PR DESCRIPTION
In RelBatchInsert, the size of the in-memory local chunked group is being set before the end offset is adjusted in     `csrHeader.finalizeCSRRegionEndOffsets(rightCSROffsetOfRegions);`, leading to the chunk being larger than necessary (with memory that prior to #5082 was uninitialised).

As far as I can tell this isn't affecting what gets written to disk, just what's in-memory (at least in the examples I was looking at).