### PR TITLE
Fix concurrency issue in building hnsw

### DIFF
--- a/extension/vector/src/include/index/hnsw_graph.h
+++ b/extension/vector/src/include/index/hnsw_graph.h
@@ -117,14 +117,14 @@ public:
         csrLengths[nodeOffset].store(length);
     }
     // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const function.
+    // Note: when the incremented csr length hits maxDegree, this function will block until there is
+    // a shrink happening.
     uint16_t incrementCSRLength(common::offset_t nodeOffset) {
         KU_ASSERT(nodeOffset < numNodes);
         while (true) {
             auto val = csrLengths[nodeOffset].load();
             if (val < maxDegree && csrLengths[nodeOffset].compare_exchange_strong(val, val + 1)) {
-                if (val < maxDegree) {
-                    return val;
-                }
+                return val;
             }
         }
     }

--- a/extension/vector/src/index/hnsw_index.cpp
+++ b/extension/vector/src/index/hnsw_index.cpp
@@ -79,13 +79,13 @@ common::offset_t InMemHNSWLayer::searchNN(common::offset_t node, common::offset_
 
 // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const function.
 void InMemHNSWLayer::insertRel(common::offset_t srcNode, common::offset_t dstNode) {
-    const auto currentLen = graph->incrementCSRLength(srcNode);
-    if (currentLen >= info.degreeThresholdToShrink) {
+    auto currentLen = graph->incrementCSRLength(srcNode);
+    while (currentLen >= info.degreeThresholdToShrink - 1) {
         shrinkForNode(info, graph.get(), srcNode, currentLen);
-    } else {
-        KU_ASSERT(srcNode < info.numNodes);
-        graph->setDstNode(srcNode * info.degreeThresholdToShrink + currentLen, dstNode);
+        currentLen = graph->incrementCSRLength(srcNode);
     }
+    KU_ASSERT(srcNode < info.numNodes);
+    graph->setDstNode(srcNode * info.degreeThresholdToShrink + currentLen, dstNode);
 }
 
 static void processEntryNodeInKNNSearch(const float* queryVector, const float* entryVector,
@@ -186,7 +186,7 @@ void InMemHNSWLayer::shrinkForNode(const InMemHNSWLayerInfo& info, InMemHNSWGrap
             const auto startCSROffset = nodeOffset * info.degreeThresholdToShrink;
             graph->setDstNode(startCSROffset + newSize++, nbrs[i].nodeOffset);
         }
-        if (newSize >= info.maxDegree) {
+        if (newSize == info.maxDegree) {
             break;
         }
     }

--- a/extension/vector/src/index/hnsw_index.cpp
+++ b/extension/vector/src/index/hnsw_index.cpp
@@ -80,12 +80,11 @@ common::offset_t InMemHNSWLayer::searchNN(common::offset_t node, common::offset_
 // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const function.
 void InMemHNSWLayer::insertRel(common::offset_t srcNode, common::offset_t dstNode) {
     auto currentLen = graph->incrementCSRLength(srcNode);
-    while (currentLen >= info.degreeThresholdToShrink - 1) {
-        shrinkForNode(info, graph.get(), srcNode, currentLen);
-        currentLen = graph->incrementCSRLength(srcNode);
-    }
     KU_ASSERT(srcNode < info.numNodes);
     graph->setDstNode(srcNode * info.degreeThresholdToShrink + currentLen, dstNode);
+    if (currentLen == info.degreeThresholdToShrink - 1) {
+        shrinkForNode(info, graph.get(), srcNode, currentLen);
+    }
 }
 
 static void processEntryNodeInKNNSearch(const float* queryVector, const float* entryVector,


### PR DESCRIPTION
# Description

Fix the concurrency issue when increment csr length concurrently leading to the set csrLength >maxDegree (`incrementCSRLength`), also potentially there could be cases where multiple threads shrinking the same node at the same time.