### PR TITLE
Validate projected graph argument type

### DIFF
--- a/src/function/table/create_project_graph.cpp
+++ b/src/function/table/create_project_graph.cpp
@@ -53,7 +53,9 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
 static std::vector<std::string> getAsStringVector(const Value& value) {
     std::vector<std::string> result;
     for (auto i = 0u; i < NestedVal::getChildrenSize(&value); ++i) {
-        result.push_back(NestedVal::getChildVal(&value, i)->getValue<std::string>());
+        auto childVal = NestedVal::getChildVal(&value, i);
+        childVal->validateType(LogicalTypeID::STRING);
+        result.push_back(childVal->getValue<std::string>());
     }
     return result;
 }

--- a/test/test_files/function/gds/special_projected_graph.test
+++ b/test/test_files/function/gds/special_projected_graph.test
@@ -64,6 +64,9 @@ Binder exception: Cannot find property dummy for r.
 -STATEMENT CALL create_projected_graph('err', ['person'], {'knows': {'filter': 'r.comments > date("1999-01-01")'}});
 ---- error
 Binder exception: Type Mismatch: Cannot compare types STRING[] and DATE
+-STATEMENT CALL create_projected_graph('err', [{'person':{'filter': 'n.ID>0'}}, {'organisation':{'filter': 'n.ID>0'}}], []);
+---- error
+Binder exception: {organisation: {filter: n.ID>0}} has data type STRUCT(organisation STRUCT(filter STRING)) but STRING was expected.
 -STATEMENT CALL create_projected_graph('G', ['person'], ['knows']);
 ---- ok
 -STATEMENT DROP TABLE knows;


### PR DESCRIPTION
# Description

See title. 

```
 CALL CREATE_PROJECTED_GRAPH(
          'filtered_test',   // Name of the projected graph
          [{'Book': {'filter': 'n.published_year > 2010'}},   // Projected node table Book with a filter on published_year. `n` is a place_holder here to reference the node table.
          {'test': {'filter': 'n.id > 2010'}}],
          []   // No relationship tables can be projected.
      );
```
as described in #5123. The input is either `LIST[STRING]` if no filtered in needed. Or `STRUCT` where filter is specified as value for each table.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).