### PR TITLE
Fix dropping table with fts and vector indexes

### DIFF
--- a/extension/fts/test/test_files/basic.test
+++ b/extension/fts/test/test_files/basic.test
@@ -291,17 +291,14 @@ twelve
 ---- ok
 -STATEMENT CREATE (b:Documents {title: 'title4', text: 'test drive', quantity: 6});
 ---- ok
-
 -STATEMENT CALL CREATE_FTS_INDEX('Documents', 'documents_index', ['text'], stemmer := 'english');
 ---- ok
-
 -STATEMENT CALL QUERY_FTS_INDEX('Documents', 'documents_index', 'test-case', conjunctive := true) RETURN node.title;
 ---- 4
 title1
 title1
 title2
 title3
-
 -STATEMENT CALL QUERY_FTS_INDEX('Documents', 'documents_index', 'test-case', conjunctive := true) RETURN node.quantity;
 ---- 4
 1
@@ -321,3 +318,36 @@ Extension: fts has been installed from repo: http://localhost/extension/repo/.
 ---- 2
 The Quantum World
 Learning Machines
+
+-CASE DropTableWithIndex
+-STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension';
+---- ok
+-STATEMENT CREATE NODE TABLE Documents (ID SERIAL, title STRING, text STRING, quantity INT64, PRIMARY KEY (ID));
+---- ok
+-STATEMENT CREATE (b:Documents {title: 'title1', text: 'test.case', quantity: 1});
+---- ok
+-STATEMENT CREATE (b:Documents {title: 'title1', text: 'test.case', quantity: 2});
+---- ok
+-STATEMENT CREATE (b:Documents {title: 'title2', text: 'test-drive', quantity: 3});
+---- ok
+-STATEMENT CREATE (b:Documents {title: 'title2', text: 'test case', quantity: 4});
+---- ok
+-STATEMENT CREATE (b:Documents {title: 'title3', text: 'test.case', quantity: 5});
+---- ok
+-STATEMENT CREATE (b:Documents {title: 'title4', text: 'test drive', quantity: 6});
+---- ok
+-STATEMENT CALL CREATE_FTS_INDEX('Documents', 'documents_index', ['text'], stemmer := 'english');
+---- ok
+-STATEMENT CALL QUERY_FTS_INDEX('Documents', 'documents_index', 'test-case', conjunctive := true) RETURN node.title;
+---- 4
+title1
+title1
+title2
+title3
+-STATEMENT DROP TABLE Documents;
+---- error
+Binder exception: Cannot delete node table Documents because it is referenced by index documents_index.
+-STATEMENT CALL DROP_FTS_INDEX('Documents', 'documents_index');
+---- ok
+-STATEMENT DROP TABLE Documents;
+---- ok

--- a/extension/fts/test/test_files/error.test
+++ b/extension/fts/test/test_files/error.test
@@ -108,60 +108,38 @@ Roma
 
 
 -CASE DropTableWithIndexes
-
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
 ---- ok
 -STATEMENT CREATE NODE TABLE STUDENT (ID INT64, name string, age INT64, note string, PRIMARY KEY(ID))
 ---- ok
-
 -STATEMENT CALL CREATE_FTS_INDEX('STUDENT', 'sIdx1', ['name'])
 ---- ok
-
 -STATEMENT CALL CREATE_FTS_INDEX('STUDENT', 'sIdx2', ['name', 'note'])
 ---- ok
-
 -STATEMENT CALL QUERY_FTS_INDEX('STUDENT', 'sIdx1', 'test') RETURN *
 ---- 0
-
 -STATEMENT CALL QUERY_FTS_INDEX('STUDENT', 'sIdx2', 'test') RETURN *
 ---- 0
-
 -STATEMENT ALTER TABLE STUDENT DROP name;
 ---- error
 Binder exception: Cannot drop property name in table STUDENT because it is used in one or more indexes. Please remove the associated indexes before attempting to drop this property.
-
 -STATEMENT CALL DROP_FTS_INDEX('STUDENT', 'sIdx1')
 ---- ok
-
 -STATEMENT ALTER TABLE STUDENT DROP note;
 ---- error
 Binder exception: Cannot drop property note in table STUDENT because it is used in one or more indexes. Please remove the associated indexes before attempting to drop this property.
-
 -STATEMENT ALTER TABLE STUDENT ADD length int64;
 ---- ok
-
 -STATEMENT ALTER TABLE STUDENT DROP age;
 ---- ok
-
 -STATEMENT DROP TABLE STUDENT
----- ok
-
--STATEMENT CALL QUERY_FTS_INDEX('STUDENT', 'sIdx1', 'test') RETURN *
 ---- error
-Binder exception: Table STUDENT does not exist.
-
--STATEMENT CREATE NODE TABLE STUDENT (ID INT64, name string, age INT64, note string, PRIMARY KEY(ID))
----- ok
-
+Binder exception: Cannot delete node table STUDENT because it is referenced by index sIdx2.
 -STATEMENT CALL QUERY_FTS_INDEX('STUDENT', 'sIdx1', 'test') RETURN *
 ---- error
 Binder exception: Table STUDENT doesn't have an index with name sIdx1.
-
 -STATEMENT CALL QUERY_FTS_INDEX('STUDENT', 'sIdx2', 'test') RETURN *
----- error
-Binder exception: Table STUDENT doesn't have an index with name sIdx2.
-
-
+---- ok
 
 -CASE ExtensionNotLoaded
 

--- a/extension/vector/test/test_files/error.test
+++ b/extension/vector/test/test_files/error.test
@@ -131,3 +131,35 @@ Binder exception: Directed search upper selectivity threshold must be a double b
 -STATEMENT CALL QUERY_VECTOR_INDEX('embeddings', 'e_hnsw_index', [0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557], 3, directed_search_up_sel := 0.1, blind_search_up_sel := 0.8) RETURN nn.id ORDER BY distance;
 ---- error
 Binder exception: Blind search upper selectivity threshold is set to 0.800000, but the directed search upper selectivity threshold is set to 0.100000. The blind search upper selectivity threshold must be less than the directed search upper selectivity threshold.
+
+-CASE DropTableWithIndex
+-STATEMENT LOAD '${KUZU_ROOT_DIRECTORY}/extension/vector/build/libvector.kuzu_extension';
+---- ok
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT CALL CREATE_VECTOR_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'l2');
+---- ok
+-STATEMENT CALL SHOW_INDEXES() RETURN *
+---- 1
+embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_VECTOR_INDEX('embeddings', 'e_hnsw_index', 'vec', mu := 30, ml := 60, pu := 0.050000, metric := 'l2', alpha := 1.100000, efc := 200);
+-STATEMENT DROP TABLE embeddings;
+---- error
+Binder exception: Cannot delete node table embeddings because it is referenced by index e_hnsw_index.
+-STATEMENT CALL DROP_VECTOR_INDEX('embeddings', 'e_hnsw_index');
+---- ok
+-STATEMENT DROP TABLE embeddings;
+---- ok
+
+-CASE DropColumnWithIndex
+-STATEMENT LOAD '${KUZU_ROOT_DIRECTORY}/extension/vector/build/libvector.kuzu_extension';
+---- ok
+-STATEMENT CREATE NODE TABLE embeddings (id int64, vec FLOAT[8], PRIMARY KEY (id));
+---- ok
+-STATEMENT CALL CREATE_VECTOR_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'l2');
+---- ok
+-STATEMENT CALL SHOW_INDEXES() RETURN *
+---- 1
+embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_VECTOR_INDEX('embeddings', 'e_hnsw_index', 'vec', mu := 30, ml := 60, pu := 0.050000, metric := 'l2', alpha := 1.100000, efc := 200);
+-STATEMENT ALTER TABLE embeddings DROP vec;
+---- error
+Binder exception: Cannot drop property vec in table embeddings because it is used in one or more indexes. Please remove the associated indexes before attempting to drop this property.


### PR DESCRIPTION
# Description

Throw an error when users want to drop a node table with indexes.