### PR TITLE
Fix array size

### DIFF
--- a/src/function/list/size_function.cpp
+++ b/src/function/list/size_function.cpp
@@ -27,6 +27,14 @@ function_set SizeFunction::getFunctionSet() {
         ScalarFunction::UnaryExecFunction<list_entry_t, int64_t, ListLen>);
     listFunc->bindFunc = sizeBindFunc;
     result.push_back(std::move(listFunc));
+    // size(array)
+    auto arrayFunc = std::make_unique<ScalarFunction>(name,
+        std::vector<LogicalTypeID>{
+            LogicalTypeID::ARRAY,
+        },
+        LogicalTypeID::INT64, ScalarFunction::UnaryExecFunction<list_entry_t, int64_t, ListLen>);
+    arrayFunc->bindFunc = sizeBindFunc;
+    result.push_back(std::move(arrayFunc));
     // size(map)
     auto mapFunc = std::make_unique<ScalarFunction>(name,
         std::vector<LogicalTypeID>{LogicalTypeID::MAP}, LogicalTypeID::INT64,

--- a/test/test_files/function/array.test
+++ b/test/test_files/function/array.test
@@ -148,3 +148,8 @@ Binder exception: ARRAY_COSINE_SIMILARITY requires argument type to be FLOAT[] o
 31.220000
 38.160000
 51.230000
+
+-LOG ArraySize
+-STATEMENT RETURN SIZE(CAST([3,5,6] AS INT64[3]))
+---- 1
+3

--- a/test/test_files/path/path.test
+++ b/test/test_files/path/path.test
@@ -102,17 +102,20 @@
 ---- error
 Binder exception: Cannot match a built-in function for given function SIZE(NODE). Supported inputs are
 (LIST) -> INT64
+(ARRAY) -> INT64
 (MAP) -> INT64
 (STRING) -> INT64
 -STATEMENT MATCH p = (a:person)-[e:knows*1..2]->(b:person) RETURN size(p)
 ---- error
 Binder exception: Cannot match a built-in function for given function SIZE(RECURSIVE_REL). Supported inputs are
 (LIST) -> INT64
+(ARRAY) -> INT64
 (MAP) -> INT64
 (STRING) -> INT64
 -STATEMENT MATCH p = (a:person)-[e:knows]->(b:person) RETURN size(e)
 ---- error
 Binder exception: Cannot match a built-in function for given function SIZE(REL). Supported inputs are
 (LIST) -> INT64
+(ARRAY) -> INT64
 (MAP) -> INT64
 (STRING) -> INT64


### PR DESCRIPTION
This PR fixes an array size bug in master:
Master:
```
kuzu> RETURN SIZE(CAST([3,5,6] AS INT64[3]));
┌──────────────────────────────────────────────────────────┐
│ SIZE(CAST(CAST(LIST_CREATION(3,5,6), INT64[3]), STRING)) │
│ INT64                                                    │
├──────────────────────────────────────────────────────────┤
│ 7                                                        │
└──────────────────────────────────────────────────────────┘
(1 tuple)
(1 column)
Time: 19.39ms (compiling), 1.16ms (executing)
```
This leads to incorrect result when we apply the size() filter on projected graph. #5123 
