### PR TITLE
Error when default expression type doesn't match

### DIFF
--- a/src/binder/bind/bind_ddl.cpp
+++ b/src/binder/bind/bind_ddl.cpp
@@ -401,7 +401,7 @@ std::unique_ptr<BoundStatement> Binder::bindAddProperty(const Statement& stateme
     auto defaultExpr =
         resolvePropertyDefault(extraInfo->defaultValue.get(), type, tableName, propertyName);
     auto boundDefault = expressionBinder.bindExpression(*defaultExpr);
-    boundDefault = expressionBinder.implicitCast(boundDefault, type);
+    boundDefault = expressionBinder.implicitCastIfNecessary(boundDefault, type);
     if (ConstantExpressionVisitor::needFold(*boundDefault)) {
         boundDefault = expressionBinder.foldExpression(boundDefault);
     }

--- a/test/test_files/ddl/ddl.test
+++ b/test/test_files/ddl/ddl.test
@@ -1,3 +1,4 @@
+
 -DATASET CSV tinysnb
 --
 
@@ -556,3 +557,13 @@ Table A altered.
 
 -STATEMENT CREATE NODE TABLE TEST_KEYWORD(YIELD STRING, PRIMARY KEY(YIELD))
 ---- ok
+
+-STATEMENT CREATE NODE TABLE default_val_type(val INT64 default 'wrong type', PRIMARY KEY(val))
+---- error
+Binder exception: Expression wrong type has data type STRING but expected INT64. Implicit cast is not supported.
+-STATEMENT CREATE NODE TABLE default_val_type(val INT64 default upper('abc'), PRIMARY KEY(val))
+---- error
+Binder exception: Expression UPPER(abc) has data type STRING but expected INT64. Implicit cast is not supported.
+-STATEMENT CREATE NODE TABLE default_val_type(val INT64, val1 INT64[3] default 'ABC', PRIMARY KEY(val))
+---- error
+Binder exception: Expression ABC has data type STRING but expected INT64[3]. Implicit cast is not supported.

--- a/test/test_files/function/gds/basic.test
+++ b/test/test_files/function/gds/basic.test
@@ -38,6 +38,15 @@ PKWO|{{'table': 'person'},{'table': 'organisation'}}|{{'table': 'knows'},{'table
 PK|{{'table': 'person'}}|{{'table': 'knows'}}
 multipleTableWithFilter|{{'table': 'person','predicate': 'n.age > 35'},{'table': 'organisation','predicate': 'n.ID > 2'}}|{{'table': 'knows','predicate': 'size(r.comments) > 5'}}
 withFilter|{{'table': 'person','predicate': 'n.age > 35'}}|{{'table': 'knows','predicate': 'size(r.comments) > 5'}}
+-STATEMENT CALL create_projected_graph('emptygraph', [], [])
+---- ok
+-STATEMENT CALL SHOW_PROJECTED_GRAPH() RETURN *;
+---- 5
+PKWO|{{'table': 'person'},{'table': 'organisation'}}|{{'table': 'knows'},{'table': 'workAt'}}
+PK|{{'table': 'person'}}|{{'table': 'knows'}}
+multipleTableWithFilter|{{'table': 'person','predicate': 'n.age > 35'},{'table': 'organisation','predicate': 'n.ID > 2'}}|{{'table': 'knows','predicate': 'size(r.comments) > 5'}}
+withFilter|{{'table': 'person','predicate': 'n.age > 35'}}|{{'table': 'knows','predicate': 'size(r.comments) > 5'}}
+emptygraph||
 -STATEMENT CALL drop_projected_graph('dummy')
 ---- error
 Runtime exception: Project graph dummy does not exists.


### PR DESCRIPTION
Throw an exception when the default expression type doesn't match the type declared in DDL.
Fixes `show_projected_graph` when the projected graph is empty