### PR TITLE
Fix rust extensions in testing and document how other binaries can use them

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -365,11 +365,15 @@ jobs:
       CMAKE_BUILD_PARALLEL_LEVEL: 32
       CC: gcc
       CXX: g++
+      KUZU_LOCAL_EXTENSIONS: ${{ github.workspace }}/extension
     steps:
       - uses: actions/checkout@v4
 
       - name: Rust test
-        run: make rusttest
+        run: |
+          make extension-release
+          cd tools/rust_api
+          cargo test --profile=relwithdebinfo --locked --all-features -- --test-threads=12
 
       - name: Rust example
         working-directory: examples/rust
@@ -699,9 +703,13 @@ jobs:
 
       - name: Rust test
         shell: cmd
+        env:
+          KUZU_LOCAL_EXTENSIONS: ${{ github.workspace }}/extension
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-          make rusttest
+          make extension-release
+          cd tools/rust_api
+          cargo test --profile=relwithdebinfo --locked --all-features -- --test-threads=12
 
       - name: Rust test with pre-built library
         env:
@@ -951,10 +959,15 @@ jobs:
           make javatest
 
       - name: Rust test
+        env:
+          KUZU_LOCAL_EXTENSIONS: ${{ github.workspace }}/extension
         run: |
           ulimit -n 10240
           source /Users/runner/.cargo/env
-          make rusttest
+          cmake -B build/release -DBUILD_EXAMPLES=OFF
+          make extension-release
+          cd tools/rust_api
+          cargo test --profile=relwithdebinfo --locked --all-features -- --test-threads=12
 
       - name: Rust example
         working-directory: examples/rust

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ else
 	# since they are all run in the same process and most tests create a database
 	# (requiring mmapping 8TB of virtual memory). This quickly exhausts the process' virtual memory.
 endif
-	cd tools/rust_api && cargo test --profile=relwithdebinfo --locked --all-features -- --test-threads=12
+	cd tools/rust_api && cargo test --profile=relwithdebinfo --locked --features arrow -- --test-threads=12
 
 wasmtest:
 	mkdir -p build/wasm && cd build/wasm &&\

--- a/examples/rust/build.rs
+++ b/examples/rust/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    // Only needed for using extensions
+    println!("cargo:rustc-link-arg=-rdynamic");
+}

--- a/tools/rust_api/Cargo.toml
+++ b/tools/rust_api/Cargo.toml
@@ -47,6 +47,7 @@ rust_decimal_macros = "1.35"
 [features]
 default = []
 arrow = ["dep:arrow"]
+extension_tests = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tools/rust_api/build.rs
+++ b/tools/rust_api/build.rs
@@ -14,6 +14,10 @@ fn get_target() -> String {
 }
 
 fn link_libraries() {
+    // This also needs to be set by any crates using it if they want to use extensions
+    if !cfg!(windows) && link_mode() == "static" {
+        println!("cargo:rustc-link-arg=-rdynamic");
+    }
     if cfg!(windows) && link_mode() == "dylib" {
         println!("cargo:rustc-link-lib=dylib=kuzu_shared");
     } else if link_mode() == "dylib" {

--- a/tools/rust_api/src/lib.rs
+++ b/tools/rust_api/src/lib.rs
@@ -30,6 +30,21 @@
 //! - `KUZU_SHARED`: If set, link dynamically instead of statically
 //! - `KUZU_INCLUDE_DIR`: Directory of kuzu's headers
 //! - `KUZU_LIBRARY_DIR`: Directory containing kuzu's pre-built libraries.
+//!
+//! ## Using Extensions
+//! By default, binaries created using this library will not work with kuzu's
+//! [extensions](https://docs.kuzudb.com/extensions/) (except on Windows/MSVC, where the linker works differently).
+//!
+//! If you want to use extensions in binaries (binary crates or tests) using this
+//! library, you will need to add the following (or a similar command; see
+//! [build-scripts](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-arg))
+//! to your build.rs (or create one) so that the binary
+//! produced acts like a library that the extension can link with. Not doing this will produce
+//! undefined symbol errors when the extension is loaded:
+//!
+//! ```ignore
+//! println!("cargo:rustc-link-arg=-rdynamic");
+//! ```
 
 pub use connection::{Connection, PreparedStatement};
 pub use database::{Database, SystemConfig};


### PR DESCRIPTION
Draft at the moment since I suspect this won't work on all platforms.

It might be a good idea to also add features for bundling the different extensions, as that will probably be more reliable (though the build process may also be complicated, e.g. for the ones which require duckdb (presumably we can make use of the libduckdb-sys crate)).
