### PR TITLE
Try to reproduce copy error in wasm

### DIFF
--- a/test/test_files/issue/try_mnist.test
+++ b/test/test_files/issue/try_mnist.test
@@ -1,4 +1,4 @@
--DATASET parquet mnist
+-DATASET PARQUET mnist
 -BUFFER_POOL_SIZE 1342177280
 --
 

--- a/test/test_files/try_mnist.test
+++ b/test/test_files/try_mnist.test
@@ -1,0 +1,8 @@
+-DATASET parquet mnist
+-BUFFER_POOL_SIZE 1342177280
+--
+
+-CASE Test
+-STATEMENT MATCH (t:tbl) RETURN COUNT(*);
+---- 1
+60000


### PR DESCRIPTION
Draft to see if the copy error of parquet with array in WASM can be reduced in CI.