### PR TITLE
Fix stop threshold for BM evictions

### DIFF
--- a/src/include/storage/buffer_manager/buffer_manager.h
+++ b/src/include/storage/buffer_manager/buffer_manager.h
@@ -75,6 +75,7 @@ public:
     void clear(std::atomic<EvictionCandidate>& candidate);
 
     uint64_t getSize() const { return size; }
+    uint64_t getEvictionCursor() const { return evictionCursor; }
     uint64_t getCapacity() const { return capacity; }
 
 private:


### PR DESCRIPTION
Sets the stop threshold for eviction to be exactly twice through the eviction queue

Previously we were not only skipping counting empty slots (`EvictionQueue::next` returns what is possibly the next non-empty slot), but were not taking into account other threads evicting at the same time (the eviction cursor is shared, and if there are n threads evicting at once, it's overkill to try to check the entire queue 2n times; we just need to do it twice to make sure that any pages which were unlocked when we start are marked on the first pass and evicted on the second).

This significantly improves failure time when a large number of threads are trying to evict at the same time, and partially addresses the last issue I mentioned in #5169.