### PR TITLE
rust: tie result lifetime to the database

### DIFF
--- a/tools/rust_api/src/connection.rs
+++ b/tools/rust_api/src/connection.rs
@@ -172,7 +172,7 @@ impl<'a> Connection<'a> {
         &self,
         prepared_statement: &mut PreparedStatement,
         params: Vec<(&str, Value)>,
-    ) -> Result<QueryResult, Error> {
+    ) -> Result<QueryResult<'a>, Error> {
         // Passing and converting Values in a collection across the ffi boundary is difficult
         // (std::vector cannot be constructed from rust, Vec cannot contain opaque C++ types)
         // So we create an opaque parameter pack and copy the parameters into it one by one


### PR DESCRIPTION
The result's lifetime current is implicitly attached to `&self` which could be a local `conn` variable in a function. We want to tie the lifetime to the more general `db` instead.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).