### PR TITLE
Fix windows import db path bug

### DIFF
--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -298,14 +298,3 @@ TEST_F(CApiDatabaseTest, VirtualFileSystemDeleteFilesWildcardNoRemoval) {
     // Cleanup
     std::filesystem::remove_all("/tmp/dbHome_wildcard");
 }
-
-TEST_F(CApiDatabaseTest, NHBNHN) {
-    createDBAndConn();
-    // printf(conn->query("CREATE NODE TABLE PERSON (ID INT64, PRIMARY KEY(ID));")->toString().c_str());
-    // printf(conn->query("CREATE (p:PERSON {ID: 5})")->toString().c_str());
-    // printf(conn->query("CREATE (p:PERSON {ID: 20})")->toString().c_str());
-    // printf(conn->query("CREATE (p:PERSON {ID: 15})")->toString().c_str());
-    // printf(conn->query("export database 'C:\\\\Users\\\\z473chen\\\\CLionProjects\\\\kuzu\\\\test552'")->toString().c_str());
-    printf(conn->query("import database 'C:\\\\Users\\\\z473chen\\\\CLionProjects\\\\kuzu\\\\test552'")->toString().c_str());
-    printf(conn->query("match (p:PERSON) RETURN p")->toString().c_str());
-}

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -298,3 +298,14 @@ TEST_F(CApiDatabaseTest, VirtualFileSystemDeleteFilesWildcardNoRemoval) {
     // Cleanup
     std::filesystem::remove_all("/tmp/dbHome_wildcard");
 }
+
+TEST_F(CApiDatabaseTest, NHBNHN) {
+    createDBAndConn();
+    // printf(conn->query("CREATE NODE TABLE PERSON (ID INT64, PRIMARY KEY(ID));")->toString().c_str());
+    // printf(conn->query("CREATE (p:PERSON {ID: 5})")->toString().c_str());
+    // printf(conn->query("CREATE (p:PERSON {ID: 20})")->toString().c_str());
+    // printf(conn->query("CREATE (p:PERSON {ID: 15})")->toString().c_str());
+    // printf(conn->query("export database 'C:\\\\Users\\\\z473chen\\\\CLionProjects\\\\kuzu\\\\test552'")->toString().c_str());
+    printf(conn->query("import database 'C:\\\\Users\\\\z473chen\\\\CLionProjects\\\\kuzu\\\\test552'")->toString().c_str());
+    printf(conn->query("match (p:PERSON) RETURN p")->toString().c_str());
+}


### PR DESCRIPTION
This is a temporary workaround because our parser requires input cypher queries to escape all special characters in string literal. E.g. The user input query is: 'IMPORT DATABASE 'C:\\db\\uw''. The parser removes any escaped characters and this function accepts the path parameter as 'C:\db\uw'. Then the ImportDatabase operator gives the file path to  antlr4 parser directly without escaping any special characters in the path, which causes a parser exception. However, the parser exception is not thrown properly which leads to the undefined behavior.