### PR TITLE
Use case insensitive map when binding query

### DIFF
--- a/src/include/binder/binder_scope.h
+++ b/src/include/binder/binder_scope.h
@@ -2,6 +2,7 @@
 
 #include "binder/expression/expression.h"
 #include "binder/expression/node_expression.h"
+#include "common/case_insensitive_map.h"
 
 namespace kuzu {
 namespace binder {
@@ -55,15 +56,15 @@ private:
 private:
     // Expressions in scope. Order should be preserved.
     expression_vector expressions;
-    std::unordered_map<std::string, common::idx_t> nameToExprIdx;
+    common::case_insensitive_map_t<common::idx_t> nameToExprIdx;
     // A node might be popped out of scope. But we may need to retain its table ID information.
     // E.g. MATCH (a:person) WITH collect(a) AS list_a UNWIND list_a AS new_a MATCH (new_a)-[]->()
     // It will be more performant if we can retain the information that new_a has label person.
-    std::unordered_map<std::string, std::vector<catalog::TableCatalogEntry*>>
+    common::case_insensitive_map_t<std::vector<catalog::TableCatalogEntry*>>
         memorizedNodeNameToEntries;
     // A node pattern may not always be bound as a node expression, e.g. in the above query,
     // (new_a) is bound as a variable rather than node expression.
-    std::unordered_map<std::string, std::shared_ptr<NodeExpression>> nodeReplacement;
+    common::case_insensitive_map_t<std::shared_ptr<NodeExpression>> nodeReplacement;
 };
 
 } // namespace binder

--- a/test/test_files/load_from/load_from.test
+++ b/test/test_files/load_from/load_from.test
@@ -168,7 +168,6 @@ Binder exception: Cannot load from file type tsv. If this file type is part of a
 1|1
 2|2
 
--CASE LoadFromErrorTest
 -LOG LoadFromIncorrectPath
 -STATEMENT LOAD FROM '${KUZU_ROOT_DIRECTORY}/dataset' (file_format='csv') RETURN *;
 ---- error
@@ -189,10 +188,14 @@ Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/npy-1d/one_dim_doub
 ---- error
 Binder exception: Cannot load from file type npyd. If this file type is part of a kuzu extension please load the extension then try again.
 
--CASE LoadFromMultipleFiles
 -STATEMENT LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson*.csv" RETURN id;
 ---- error(regex)
 Binder exception: Number of columns mismatch. Expected .+
 -STATEMENT LOAD FROM ["${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv", "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows_2.csv"] RETURN COUNT(*);
 ---- 1
 14
+
+-LOG CaseInsensitiveColumnName
+-STATEMENT LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/ldbc-1/csv/comment_0_0.csv" RETURN MIN(Length);
+---- 1
+2


### PR DESCRIPTION
# Description

Make all variable name case insensitive in cypher statement. This behavior is more consistent with other database systems.

Fixes #3916 