### PR TITLE
Implement dynamic sparse/dense frontier switch for recursive joins

### DIFF
--- a/extension/fts/src/function/create_fts_index.cpp
+++ b/extension/fts/src/function/create_fts_index.cpp
@@ -268,7 +268,7 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
     graph::OnDiskGraph graph(context.clientContext, std::move(entry));
     auto sharedState = LenComputeSharedState{};
     LenCompute lenCompute{&sharedState};
-    GDSUtils::runVertexCompute(&context, &graph, lenCompute,
+    GDSUtils::runVertexCompute(&context, GDSDensityState::DENSE, &graph, lenCompute,
         std::vector<std::string>{InternalCreateFTSFunction::DOC_LEN_PROP_NAME});
     auto numDocs = sharedState.numDocs.load();
     auto avgDocLen = numDocs == 0 ? 0 : static_cast<double>(sharedState.totalLen.load()) / numDocs;

--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -244,7 +244,7 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
     auto currentFrontier = DenseFrontier::getUnvisitedFrontier(input.context, graph);
     auto nextFrontier = DenseFrontier::getUnvisitedFrontier(input.context, graph);
     auto frontierPair =
-        std::make_unique<DenseSparseDynamicFrontierPair>(currentFrontier, nextFrontier);
+        std::make_unique<DenseSparseDynamicFrontierPair>(std::move(currentFrontier), std::move(nextFrontier));
     auto termsTableID = termsEntry.getTableID();
     initFrontier(*frontierPair, termsTableID, dfs);
     auto storageManager = clientContext->getStorageManager();
@@ -276,7 +276,7 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
             }
         }
     } else {
-        GDSUtils::runVertexCompute(input.context, graph, *vc, docsEntry, vertexPropertiesToScan);
+        GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph, *vc, docsEntry, vertexPropertiesToScan);
     }
     sharedState->factorizedTablePool.mergeLocalTables();
     return 0;

--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -243,8 +243,8 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
     // vertex compute.
     auto currentFrontier = DenseFrontier::getUnvisitedFrontier(input.context, graph);
     auto nextFrontier = DenseFrontier::getUnvisitedFrontier(input.context, graph);
-    auto frontierPair =
-        std::make_unique<DenseSparseDynamicFrontierPair>(std::move(currentFrontier), std::move(nextFrontier));
+    auto frontierPair = std::make_unique<DenseSparseDynamicFrontierPair>(std::move(currentFrontier),
+        std::move(nextFrontier));
     auto termsTableID = termsEntry.getTableID();
     initFrontier(*frontierPair, termsTableID, dfs);
     auto storageManager = clientContext->getStorageManager();
@@ -276,7 +276,8 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
             }
         }
     } else {
-        GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph, *vc, docsEntry, vertexPropertiesToScan);
+        GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph, *vc, docsEntry,
+            vertexPropertiesToScan);
     }
     sharedState->factorizedTablePool.mergeLocalTables();
     return 0;

--- a/src/function/gds/CMakeLists.txt
+++ b/src/function/gds/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(kuzu_function_algorithm
         asp_paths.cpp
         awsp_paths.cpp
         bfs_graph.cpp
+        frontier_morsel.cpp
         gds.cpp
         gds_frontier.cpp
         gds_state.cpp

--- a/src/function/gds/asp_destinations.cpp
+++ b/src/function/gds/asp_destinations.cpp
@@ -1,3 +1,5 @@
+#include <unistd.h>
+
 #include "binder/expression/node_expression.h"
 #include "function/gds/gds_function_collection.h"
 #include "function/gds/rec_joins.h"
@@ -12,90 +14,214 @@ using namespace kuzu::graph;
 namespace kuzu {
 namespace function {
 
+using multiplicity_t = uint64_t;
+
 class Multiplicities {
 public:
-    Multiplicities(const std::unordered_map<table_id_t, uint64_t>& maxOffsetMap,
-        storage::MemoryManager* mm) {
+    virtual ~Multiplicities() = default;
+
+    virtual void pinTableID(table_id_t tableID) = 0;
+
+    virtual void increaseMultiplicity(offset_t offset, multiplicity_t multiplicity) = 0;
+
+    virtual multiplicity_t getMultiplicity(offset_t offset) = 0;
+};
+
+class SparseMultiplicitiesReference final : public Multiplicities {
+public:
+    explicit SparseMultiplicitiesReference(GDSSpareObjectManager<multiplicity_t>& spareObjects)
+        : spareObjects{spareObjects} {}
+
+    void pinTableID(table_id_t tableID) override { curData = spareObjects.getData(tableID); }
+
+    void increaseMultiplicity(offset_t offset, multiplicity_t multiplicity) override {
+        KU_ASSERT(curData);
+        if (curData->contains(offset)) {
+            curData->at(offset) += multiplicity;
+        } else {
+            curData->insert({offset, multiplicity});
+        }
+    }
+
+    multiplicity_t getMultiplicity(offset_t offset) override {
+        KU_ASSERT(curData);
+        if (curData->contains(offset)) {
+            return curData->at(offset);
+        }
+        return 0;
+    }
+
+private:
+    GDSSpareObjectManager<multiplicity_t>& spareObjects;
+    std::unordered_map<offset_t, multiplicity_t>* curData = nullptr;
+};
+
+class DenseMultiplicitiesReference final : public Multiplicities {
+public:
+    explicit DenseMultiplicitiesReference(
+        GDSDenseObjectManager<std::atomic<multiplicity_t>>& denseObjects)
+        : denseObjects(denseObjects) {}
+
+    void pinTableID(table_id_t tableID) override { curData = denseObjects.getData(tableID); }
+
+    void increaseMultiplicity(offset_t offset, multiplicity_t multiplicity) override {
+        KU_ASSERT(curData);
+        curData[offset].fetch_add(multiplicity);
+    }
+
+    multiplicity_t getMultiplicity(offset_t offset) override {
+        KU_ASSERT(curData);
+        return curData[offset].load(std::memory_order_relaxed);
+    }
+
+private:
+    GDSDenseObjectManager<std::atomic<multiplicity_t>>& denseObjects;
+    std::atomic<multiplicity_t>* curData = nullptr;
+};
+
+class MultiplicitiesPair {
+public:
+    explicit MultiplicitiesPair(const table_id_map_t<offset_t>& maxOffsetMap)
+        : maxOffsetMap{maxOffsetMap}, densityState{GDSDensityState::SPARSE},
+          sparseObjects{maxOffsetMap} {
+        curSparseMultiplicities = std::make_unique<SparseMultiplicitiesReference>(sparseObjects);
+        nextSparseMultiplicities = std::make_unique<SparseMultiplicitiesReference>(sparseObjects);
+        denseObjects = GDSDenseObjectManager<std::atomic<multiplicity_t>>();
+        curDenseMultiplicities = std::make_unique<DenseMultiplicitiesReference>(denseObjects);
+        nextDenseMultiplicities = std::make_unique<DenseMultiplicitiesReference>(denseObjects);
+    }
+
+    void pinCurTableID(table_id_t tableID) {
+        switch (densityState) {
+        case GDSDensityState::SPARSE: {
+            curSparseMultiplicities->pinTableID(tableID);
+            curMultiplicities = curSparseMultiplicities.get();
+        } break;
+        case GDSDensityState::DENSE: {
+            curDenseMultiplicities->pinTableID(tableID);
+            curMultiplicities = curDenseMultiplicities.get();
+        } break;
+        default:
+            KU_UNREACHABLE;
+        }
+    }
+
+    void pinNextTableID(table_id_t tableID) {
+        switch (densityState) {
+        case GDSDensityState::SPARSE: {
+            nextSparseMultiplicities->pinTableID(tableID);
+            nextMultiplicities = nextSparseMultiplicities.get();
+        } break;
+        case GDSDensityState::DENSE: {
+            nextDenseMultiplicities->pinTableID(tableID);
+            nextMultiplicities = nextDenseMultiplicities.get();
+        } break;
+        default:
+            KU_UNREACHABLE;
+        }
+    }
+
+    void increaseNextMultiplicity(offset_t offset, multiplicity_t multiplicity) {
+        nextMultiplicities->increaseMultiplicity(offset, multiplicity);
+    }
+
+    multiplicity_t getCurrentMultiplicity(offset_t offset) const {
+        return curMultiplicities->getMultiplicity(offset);
+    }
+    Multiplicities* getCurrentMultiplicities() { return curMultiplicities; }
+
+    void switchToDense(ExecutionContext* context) {
+        KU_ASSERT(densityState == GDSDensityState::SPARSE);
+        densityState = GDSDensityState::DENSE;
         for (auto& [tableID, maxOffset] : maxOffsetMap) {
-            multiplicityArray.allocate(tableID, maxOffset, mm);
-            // Question to Trevor: Do I need to use atomics? If so, why?
-            auto data = multiplicityArray.getData(tableID);
-            for (uint64_t i = 0; i < maxOffset; ++i) {
+            denseObjects.allocate(tableID, maxOffset, context->clientContext->getMemoryManager());
+            auto data = denseObjects.getData(tableID);
+            for (auto i = 0u; i < maxOffset; i++) {
                 data[i].store(0);
+            }
+        }
+        for (auto& [tableID, map] : sparseObjects.getData()) {
+            auto data = denseObjects.getData(tableID);
+            for (auto& [offset, multiplicity] : map) {
+                data[offset].store(multiplicity);
             }
         }
     }
 
-    void incrementTargetMultiplicity(offset_t offset, uint64_t multiplicity) {
-        curTargetMultiplicities[offset].fetch_add(multiplicity);
-    }
-
-    uint64_t getBoundMultiplicity(offset_t nodeOffset) {
-        return curBoundMultiplicities[nodeOffset].load(std::memory_order_relaxed);
-    }
-
-    uint64_t getTargetMultiplicity(offset_t nodeOffset) {
-        return curTargetMultiplicities[nodeOffset].load(std::memory_order_relaxed);
-    }
-
-    void pinBoundTable(table_id_t tableID) {
-        curBoundMultiplicities = multiplicityArray.getData(tableID);
-    }
-
-    void pinTargetTable(table_id_t tableID) {
-        curTargetMultiplicities = multiplicityArray.getData(tableID);
-    }
-
 private:
-    ObjectArraysMap<std::atomic<uint64_t>> multiplicityArray;
-    // curTargetMultiplicities is the multiplicities of the current table that will be updated in a
-    // particular rel table extension.
-    std::atomic<uint64_t>* curTargetMultiplicities = nullptr;
-    // curBoundMultiplicities is the multiplicities of the table "from which" an extension is
-    // being made.
-    std::atomic<uint64_t>* curBoundMultiplicities = nullptr;
+    table_id_map_t<offset_t> maxOffsetMap;
+    GDSDensityState densityState;
+    GDSSpareObjectManager<multiplicity_t> sparseObjects;
+    std::unique_ptr<SparseMultiplicitiesReference> curSparseMultiplicities;
+    std::unique_ptr<SparseMultiplicitiesReference> nextSparseMultiplicities;
+    GDSDenseObjectManager<std::atomic<multiplicity_t>> denseObjects;
+    std::unique_ptr<DenseMultiplicitiesReference> curDenseMultiplicities;
+    std::unique_ptr<DenseMultiplicitiesReference> nextDenseMultiplicities;
+
+    Multiplicities* curMultiplicities = nullptr;
+    Multiplicities* nextMultiplicities = nullptr;
 };
 
 class ASPDestinationsAuxiliaryState : public GDSAuxiliaryState {
 public:
-    explicit ASPDestinationsAuxiliaryState(std::shared_ptr<Multiplicities> multiplicities)
-        : multiplicities{std::move(multiplicities)} {}
+    explicit ASPDestinationsAuxiliaryState(std::unique_ptr<MultiplicitiesPair> multiplicitiesPair)
+        : multiplicitiesPair{std::move(multiplicitiesPair)} {}
 
-    void initSource(common::nodeID_t source) override {
-        multiplicities->pinTargetTable(source.tableID);
-        multiplicities->incrementTargetMultiplicity(source.offset, 1);
+    MultiplicitiesPair* getMultiplicitiesPair() const { return multiplicitiesPair.get(); }
+
+    void initSource(nodeID_t source) override {
+        multiplicitiesPair->pinNextTableID(source.tableID);
+        multiplicitiesPair->increaseNextMultiplicity(source.offset, 1);
     }
 
-    void beginFrontierCompute(common::table_id_t fromTableID,
-        common::table_id_t toTableID) override {
-        multiplicities->pinBoundTable(fromTableID);
-        multiplicities->pinTargetTable(toTableID);
+    void beginFrontierCompute(table_id_t curTableID, table_id_t nextTableID) override {
+        multiplicitiesPair->pinCurTableID(curTableID);
+        multiplicitiesPair->pinNextTableID(nextTableID);
+    }
+
+    void switchToDense(ExecutionContext* context, Graph*) override {
+        multiplicitiesPair->switchToDense(context);
     }
 
 private:
-    std::shared_ptr<Multiplicities> multiplicities;
+    std::unique_ptr<MultiplicitiesPair> multiplicitiesPair;
 };
 
 class ASPDestinationsOutputWriter : public RJOutputWriter {
 public:
     ASPDestinationsOutputWriter(main::ClientContext* context, NodeOffsetMaskMap* outputNodeMask,
-        nodeID_t sourceNodeID, std::shared_ptr<PathLengths> pathLengths,
-        std::shared_ptr<Multiplicities> multiplicities)
-        : RJOutputWriter{context, outputNodeMask, sourceNodeID},
-          pathLengths{std::move(pathLengths)}, multiplicities{std::move(multiplicities)} {
+        nodeID_t sourceNodeID, Frontier* frontier, Multiplicities* multiplicities)
+        : RJOutputWriter{context, outputNodeMask, sourceNodeID}, frontier{frontier},
+          multiplicities{multiplicities} {
         lengthVector = createVector(LogicalType::UINT16());
     }
 
-    void beginWritingOutputsInternal(common::table_id_t tableID) override {
-        pathLengths->pinCurFrontierTableID(tableID);
-        multiplicities->pinTargetTable(tableID);
+    void beginWritingInternal(table_id_t tableID) override {
+        frontier->pinTableID(tableID);
+        multiplicities->pinTableID(tableID);
+    }
+
+    void write(FactorizedTable& fTable, table_id_t tableID, LimitCounter* counter) override {
+        auto& sparseFrontier = frontier->cast<SparseFrontier>();
+        for (auto [offset, _] : sparseFrontier.getCurrentData()) {
+            write(fTable, {offset, tableID}, counter);
+        }
     }
 
     void write(FactorizedTable& fTable, nodeID_t dstNodeID, LimitCounter* counter) override {
-        auto length = pathLengths->getMaskValueFromCurFrontier(dstNodeID.offset);
+        if (!inOutputNodeMask(dstNodeID.offset)) { // Skip dst if it not is in scope.
+            return;
+        }
+        if (dstNodeID == sourceNodeID_) { // Skip writing source node.
+            return;
+        }
+        auto iter = frontier->getIteration(dstNodeID.offset);
+        if (iter == FRONTIER_UNVISITED) { // Skip if dst is not visited.
+            return;
+        }
         dstNodeIDVector->setValue<nodeID_t>(0, dstNodeID);
-        lengthVector->setValue<uint16_t>(0, length);
-        auto multiplicity = multiplicities->getTargetMultiplicity(dstNodeID.offset);
+        lengthVector->setValue<uint16_t>(0, iter);
+        auto multiplicity = multiplicities->getMultiplicity(dstNodeID.offset);
         for (auto i = 0u; i < multiplicity; ++i) {
             fTable.append(vectors);
         }
@@ -105,47 +231,40 @@ public:
     }
 
     std::unique_ptr<RJOutputWriter> copy() override {
-        return std::make_unique<ASPDestinationsOutputWriter>(context, outputNodeMask, sourceNodeID,
-            pathLengths, multiplicities);
-    }
-
-private:
-    bool skipInternal(nodeID_t dstNodeID) const override {
-        return dstNodeID == sourceNodeID ||
-               pathLengths->getMaskValueFromCurFrontier(dstNodeID.offset) == PathLengths::UNVISITED;
+        return std::make_unique<ASPDestinationsOutputWriter>(context, outputNodeMask, sourceNodeID_,
+            frontier, multiplicities);
     }
 
 private:
     std::unique_ptr<ValueVector> lengthVector;
-    std::shared_ptr<PathLengths> pathLengths;
-    std::shared_ptr<Multiplicities> multiplicities;
+    Frontier* frontier;
+    Multiplicities* multiplicities;
 };
 
 class ASPDestinationsEdgeCompute : public SPEdgeCompute {
 public:
-    ASPDestinationsEdgeCompute(SinglePathLengthsFrontierPair* frontierPair,
-        std::shared_ptr<Multiplicities> multiplicities)
-        : SPEdgeCompute{frontierPair}, multiplicities{std::move(multiplicities)} {};
+    ASPDestinationsEdgeCompute(SPFrontierPair* frontierPair, MultiplicitiesPair* multiplicitiesPair)
+        : SPEdgeCompute{frontierPair}, multiplicitiesPair{multiplicitiesPair} {};
 
     std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, NbrScanState::Chunk& resultChunk,
         bool) override {
         std::vector<nodeID_t> activeNodes;
         resultChunk.forEach([&](auto nbrNodeID, auto /*edgeID*/) {
-            auto nbrVal =
-                frontierPair->getPathLengths()->getMaskValueFromNextFrontier(nbrNodeID.offset);
+            auto nbrVal = frontierPair->getNextFrontierValue(nbrNodeID.offset);
             // We should update the nbrID's multiplicity in 2 cases: 1) if nbrID is being visited
             // for the first time, i.e., when its value in the pathLengths frontier is
-            // PathLengths::UNVISITED. Or 2) if nbrID has already been visited but in this
+            // FRONTIER_UNVISITED. Or 2) if nbrID has already been visited but in this
             // iteration, so it's value is curIter + 1.
             auto shouldUpdate =
-                nbrVal == PathLengths::UNVISITED || nbrVal == frontierPair->getCurrentIter();
+                nbrVal == FRONTIER_UNVISITED || nbrVal == frontierPair->getCurrentIter();
             if (shouldUpdate) {
-                // Note: This is safe because curNodeID is in the current frontier, so its
+                // This is safe because boundNodeID is in the current frontier, so its
                 // shortest paths multiplicity is guaranteed to not change in the current iteration.
-                multiplicities->incrementTargetMultiplicity(nbrNodeID.offset,
-                    multiplicities->getBoundMultiplicity(boundNodeID.offset));
+                auto boundMultiplicity =
+                    multiplicitiesPair->getCurrentMultiplicity(boundNodeID.offset);
+                multiplicitiesPair->increaseNextMultiplicity(nbrNodeID.offset, boundMultiplicity);
             }
-            if (nbrVal == PathLengths::UNVISITED) {
+            if (nbrVal == FRONTIER_UNVISITED) {
                 activeNodes.push_back(nbrNodeID);
             }
         });
@@ -153,18 +272,14 @@ public:
     }
 
     std::unique_ptr<EdgeCompute> copy() override {
-        return std::make_unique<ASPDestinationsEdgeCompute>(frontierPair, multiplicities);
+        return std::make_unique<ASPDestinationsEdgeCompute>(frontierPair, multiplicitiesPair);
     }
 
 private:
-    std::shared_ptr<Multiplicities> multiplicities;
+    MultiplicitiesPair* multiplicitiesPair;
 };
 
-/**
- * Algorithm for parallel all shortest paths computation, so all shortest paths from a source to
- * is returned for each destination. If paths are not returned, multiplicities indicate the
- * number of paths to each destination.
- */
+// All shortest path algorithm. Only destinations are tracked (reachability query).
 class AllSPDestinationsAlgorithm final : public RJAlgorithm {
 public:
     std::string getFunctionName() const override { return AllSPDestinationsFunction::name; }
@@ -182,23 +297,31 @@ public:
     }
 
 private:
-    RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID, const RJBindData&,
+    std::unique_ptr<GDSComputeState> getComputeState(ExecutionContext* context, const RJBindData&,
         RecursiveExtendSharedState* sharedState) override {
         auto clientContext = context->clientContext;
         auto graph = sharedState->graph.get();
-        auto frontier = PathLengths::getUnvisitedFrontier(context, graph);
-        auto mm = clientContext->getMemoryManager();
-        auto multiplicities = std::make_shared<Multiplicities>(
-            graph->getMaxOffsetMap(clientContext->getTransaction()), mm);
-        auto outputWriter = std::make_unique<ASPDestinationsOutputWriter>(clientContext,
+        auto multiplicitiesPair = std::make_unique<MultiplicitiesPair>(
+            graph->getMaxOffsetMap(clientContext->getTransaction()));
+        auto frontier = DenseFrontier::getUnvisitedFrontier(context, graph);
+        auto frontierPair = std::make_unique<SPFrontierPair>(frontier);
+        auto edgeCompute = std::make_unique<ASPDestinationsEdgeCompute>(frontierPair.get(),
+            multiplicitiesPair.get());
+        auto auxiliaryState =
+            std::make_unique<ASPDestinationsAuxiliaryState>(std::move(multiplicitiesPair));
+        return std::make_unique<GDSComputeState>(std::move(frontierPair), std::move(edgeCompute),
+            std::move(auxiliaryState));
+    }
+
+    std::unique_ptr<RJOutputWriter> getOutputWriter(ExecutionContext* context, const RJBindData&,
+        GDSComputeState& computeState, nodeID_t sourceNodeID,
+        RecursiveExtendSharedState* sharedState) override {
+        auto frontier = computeState.frontierPair->ptrCast<SPFrontierPair>()->getFrontier();
+        auto multiplicities = computeState.auxiliaryState->ptrCast<ASPDestinationsAuxiliaryState>()
+                                  ->getMultiplicitiesPair()
+                                  ->getCurrentMultiplicities();
+        return std::make_unique<ASPDestinationsOutputWriter>(context->clientContext,
             sharedState->getOutputNodeMaskMap(), sourceNodeID, frontier, multiplicities);
-        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(frontier);
-        auto edgeCompute =
-            std::make_unique<ASPDestinationsEdgeCompute>(frontierPair.get(), multiplicities);
-        auto auxiliaryState = std::make_unique<ASPDestinationsAuxiliaryState>(multiplicities);
-        auto gdsState = std::make_unique<GDSComputeState>(std::move(frontierPair),
-            std::move(edgeCompute), std::move(auxiliaryState));
-        return RJCompState(std::move(gdsState), std::move(outputWriter));
     }
 };
 

--- a/src/function/gds/asp_destinations.cpp
+++ b/src/function/gds/asp_destinations.cpp
@@ -1,5 +1,3 @@
-#include <unistd.h>
-
 #include "binder/expression/node_expression.h"
 #include "function/gds/gds_function_collection.h"
 #include "function/gds/rec_joins.h"
@@ -304,7 +302,7 @@ private:
         auto multiplicitiesPair = std::make_unique<MultiplicitiesPair>(
             graph->getMaxOffsetMap(clientContext->getTransaction()));
         auto frontier = DenseFrontier::getUnvisitedFrontier(context, graph);
-        auto frontierPair = std::make_unique<SPFrontierPair>(frontier);
+        auto frontierPair = std::make_unique<SPFrontierPair>(std::move(frontier));
         auto edgeCompute = std::make_unique<ASPDestinationsEdgeCompute>(frontierPair.get(),
             multiplicitiesPair.get());
         auto auxiliaryState =

--- a/src/function/gds/asp_paths.cpp
+++ b/src/function/gds/asp_paths.cpp
@@ -80,7 +80,7 @@ private:
         auto clientContext = context->clientContext;
         auto denseFrontier =
             DenseFrontier::getUninitializedFrontier(context, sharedState->graph.get());
-        auto frontierPair = std::make_unique<SPFrontierPair>(denseFrontier);
+        auto frontierPair = std::make_unique<SPFrontierPair>(std::move(denseFrontier));
         auto bfsGraph = std::make_unique<BFSGraphManager>(
             sharedState->graph->getMaxOffsetMap(clientContext->getTransaction()),
             clientContext->getMemoryManager());

--- a/src/function/gds/asp_paths.cpp
+++ b/src/function/gds/asp_paths.cpp
@@ -13,31 +13,30 @@ namespace function {
 
 class ASPPathsEdgeCompute : public SPEdgeCompute {
 public:
-    ASPPathsEdgeCompute(SinglePathLengthsFrontierPair* frontiersPair, BFSGraph* bfsGraph)
-        : SPEdgeCompute{frontiersPair}, bfsGraph{bfsGraph} {
-        block = bfsGraph->addNewBlock();
+    ASPPathsEdgeCompute(SPFrontierPair* frontiersPair, BFSGraphManager* bfsGraphManager)
+        : SPEdgeCompute{frontiersPair}, bfsGraphManager{bfsGraphManager} {
+        block = bfsGraphManager->getCurrentGraph()->addNewBlock();
     }
 
     std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, graph::NbrScanState::Chunk& resultChunk,
         bool fwdEdge) override {
         std::vector<nodeID_t> activeNodes;
         resultChunk.forEach([&](auto nbrNodeID, auto edgeID) {
-            auto nbrLen =
-                frontierPair->getPathLengths()->getMaskValueFromNextFrontier(nbrNodeID.offset);
+            auto iter = frontierPair->getNextFrontierValue(nbrNodeID.offset);
             // We should update in 2 cases: 1) if nbrID is being visited
             // for the first time, i.e., when its value in the pathLengths frontier is
             // PathLengths::UNVISITED. Or 2) if nbrID has already been visited but in this
             // iteration, so it's value is curIter + 1.
             auto shouldUpdate =
-                nbrLen == PathLengths::UNVISITED || nbrLen == frontierPair->getCurrentIter();
+                iter == FRONTIER_UNVISITED || iter == frontierPair->getCurrentIter();
             if (shouldUpdate) {
                 if (!block->hasSpace()) {
-                    block = bfsGraph->addNewBlock();
+                    block = bfsGraphManager->getCurrentGraph()->addNewBlock();
                 }
-                bfsGraph->addParent(frontierPair->getCurrentIter(), boundNodeID, edgeID, nbrNodeID,
-                    fwdEdge, block);
+                bfsGraphManager->getCurrentGraph()->addParent(frontierPair->getCurrentIter(),
+                    boundNodeID, edgeID, nbrNodeID, fwdEdge, block);
             }
-            if (nbrLen == PathLengths::UNVISITED) {
+            if (iter == FRONTIER_UNVISITED) {
                 activeNodes.push_back(nbrNodeID);
             }
         });
@@ -45,14 +44,15 @@ public:
     }
 
     std::unique_ptr<EdgeCompute> copy() override {
-        return std::make_unique<ASPPathsEdgeCompute>(frontierPair, bfsGraph);
+        return std::make_unique<ASPPathsEdgeCompute>(frontierPair, bfsGraphManager);
     }
 
 private:
-    BFSGraph* bfsGraph;
+    BFSGraphManager* bfsGraphManager;
     ObjectBlock<ParentList>* block = nullptr;
 };
 
+// All shortest path algorithm. Paths are tracked.
 class AllSPPathsAlgorithm final : public RJAlgorithm {
 public:
     std::string getFunctionName() const override { return AllSPPathsFunction::name; }
@@ -75,22 +75,32 @@ public:
     }
 
 private:
-    RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID,
-        const RJBindData& bindData, RecursiveExtendSharedState* sharedState) override {
+    std::unique_ptr<GDSComputeState> getComputeState(ExecutionContext* context, const RJBindData&,
+        RecursiveExtendSharedState* sharedState) override {
         auto clientContext = context->clientContext;
-        auto frontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
-        auto bfsGraph = getBFSGraph(context, sharedState->graph.get());
-        auto writerInfo = bindData.getPathWriterInfo();
-        writerInfo.pathNodeMask = sharedState->getPathNodeMaskMap();
-        auto outputWriter = std::make_unique<SPPathsOutputWriter>(clientContext,
-            sharedState->getOutputNodeMaskMap(), sourceNodeID, writerInfo, *bfsGraph);
-        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(frontier);
+        auto denseFrontier =
+            DenseFrontier::getUninitializedFrontier(context, sharedState->graph.get());
+        auto frontierPair = std::make_unique<SPFrontierPair>(denseFrontier);
+        auto bfsGraph = std::make_unique<BFSGraphManager>(
+            sharedState->graph->getMaxOffsetMap(clientContext->getTransaction()),
+            clientContext->getMemoryManager());
         auto edgeCompute =
             std::make_unique<ASPPathsEdgeCompute>(frontierPair.get(), bfsGraph.get());
         auto auxiliaryState = std::make_unique<PathAuxiliaryState>(std::move(bfsGraph));
-        auto gdsState = std::make_unique<GDSComputeState>(std::move(frontierPair),
-            std::move(edgeCompute), std::move(auxiliaryState));
-        return RJCompState(std::move(gdsState), std::move(outputWriter));
+        return std::make_unique<GDSComputeState>(std::move(frontierPair), std::move(edgeCompute),
+            std::move(auxiliaryState));
+    }
+
+    std::unique_ptr<RJOutputWriter> getOutputWriter(ExecutionContext* context,
+        const RJBindData& bindData, GDSComputeState& computeState, nodeID_t sourceNodeID,
+        RecursiveExtendSharedState* sharedState) override {
+        auto bfsGraph = computeState.auxiliaryState->ptrCast<PathAuxiliaryState>()
+                            ->getBFSGraphManager()
+                            ->getCurrentGraph();
+        auto writerInfo = bindData.getPathWriterInfo();
+        writerInfo.pathNodeMask = sharedState->getPathNodeMaskMap();
+        return std::make_unique<SPPathsOutputWriter>(context->clientContext,
+            sharedState->getOutputNodeMaskMap(), sourceNodeID, writerInfo, *bfsGraph);
     }
 };
 

--- a/src/function/gds/awsp_paths.cpp
+++ b/src/function/gds/awsp_paths.cpp
@@ -144,7 +144,7 @@ private:
         auto curDenseFrontier = DenseFrontier::getUninitializedFrontier(context, graph);
         auto nextDenseFrontier = DenseFrontier::getUninitializedFrontier(context, graph);
         auto frontierPair =
-            std::make_unique<DenseSparseDynamicFrontierPair>(curDenseFrontier, nextDenseFrontier);
+            std::make_unique<DenseSparseDynamicFrontierPair>(std::move(curDenseFrontier), std::move(nextDenseFrontier));
         auto bfsGraph = std::make_unique<BFSGraphManager>(
             sharedState->graph->getMaxOffsetMap(clientContext->getTransaction()),
             clientContext->getMemoryManager());

--- a/src/function/gds/awsp_paths.cpp
+++ b/src/function/gds/awsp_paths.cpp
@@ -143,8 +143,8 @@ private:
         auto graph = sharedState->graph.get();
         auto curDenseFrontier = DenseFrontier::getUninitializedFrontier(context, graph);
         auto nextDenseFrontier = DenseFrontier::getUninitializedFrontier(context, graph);
-        auto frontierPair =
-            std::make_unique<DenseSparseDynamicFrontierPair>(std::move(curDenseFrontier), std::move(nextDenseFrontier));
+        auto frontierPair = std::make_unique<DenseSparseDynamicFrontierPair>(
+            std::move(curDenseFrontier), std::move(nextDenseFrontier));
         auto bfsGraph = std::make_unique<BFSGraphManager>(
             sharedState->graph->getMaxOffsetMap(clientContext->getTransaction()),
             clientContext->getMemoryManager());

--- a/src/function/gds/bfs_graph.cpp
+++ b/src/function/gds/bfs_graph.cpp
@@ -48,7 +48,7 @@ void DenseBFSGraph::init(ExecutionContext* context, Graph* graph) {
         denseObjects.allocate(tableID, maxOffset, context->clientContext->getMemoryManager());
     }
     auto vc = std::make_unique<BFSGraphInitVertexCompute>(*this);
-    GDSUtils::runVertexCompute(context, graph, *vc);
+    GDSUtils::runVertexCompute(context, GDSDensityState::DENSE, graph, *vc);
 }
 
 void DenseBFSGraph::pinTableID(table_id_t tableID) {

--- a/src/function/gds/bfs_graph.cpp
+++ b/src/function/gds/bfs_graph.cpp
@@ -1,13 +1,18 @@
 #include "function/gds/bfs_graph.h"
 
+#include "function/gds/gds_utils.h"
+#include "processor/execution_context.h"
+
 using namespace kuzu::common;
+using namespace kuzu::graph;
+using namespace kuzu::processor;
 
 namespace kuzu {
 namespace function {
 
 static constexpr uint64_t BFS_GRAPH_BLOCK_SIZE = (std::uint64_t)1 << 19;
 
-ObjectBlock<ParentList>* BFSGraph::addNewBlock() {
+ObjectBlock<ParentList>* BaseBFSGraph::addNewBlock() {
     std::unique_lock lck{mtx};
     auto memBlock = mm->allocateBuffer(false /* init to 0 */, BFS_GRAPH_BLOCK_SIZE);
     blocks.push_back(
@@ -15,25 +20,65 @@ ObjectBlock<ParentList>* BFSGraph::addNewBlock() {
     return blocks[blocks.size() - 1].get();
 }
 
-void BFSGraph::addParent(uint16_t iter, nodeID_t boundNodeID, relID_t edgeID, nodeID_t nbrNodeID,
-    bool fwdEdge, ObjectBlock<ParentList>* block) {
+class BFSGraphInitVertexCompute : public VertexCompute {
+public:
+    explicit BFSGraphInitVertexCompute(DenseBFSGraph& bfsGraph) : bfsGraph{bfsGraph} {}
+
+    bool beginOnTable(table_id_t tableID) override {
+        bfsGraph.pinTableID(tableID);
+        return true;
+    }
+
+    void vertexCompute(offset_t startOffset, offset_t endOffset, table_id_t) override {
+        for (auto i = startOffset; i < endOffset; ++i) {
+            bfsGraph.curData[i].store(nullptr);
+        }
+    }
+
+    std::unique_ptr<VertexCompute> copy() override {
+        return std::make_unique<BFSGraphInitVertexCompute>(bfsGraph);
+    }
+
+private:
+    DenseBFSGraph& bfsGraph;
+};
+
+void DenseBFSGraph::init(ExecutionContext* context, Graph* graph) {
+    for (auto& [tableID, maxOffset] : maxOffsetMap) {
+        denseObjects.allocate(tableID, maxOffset, context->clientContext->getMemoryManager());
+    }
+    auto vc = std::make_unique<BFSGraphInitVertexCompute>(*this);
+    GDSUtils::runVertexCompute(context, graph, *vc);
+}
+
+void DenseBFSGraph::pinTableID(table_id_t tableID) {
+    curData = denseObjects.getData(tableID);
+}
+
+static ParentList* reserveParent(nodeID_t boundNodeID, relID_t edgeID, bool fwdEdge,
+    ObjectBlock<ParentList>* block) {
     auto parent = block->reserveNext();
     parent->setNbrInfo(boundNodeID, edgeID, fwdEdge);
+    return parent;
+}
+
+void DenseBFSGraph::addParent(uint16_t iter, nodeID_t boundNodeID, relID_t edgeID,
+    nodeID_t nbrNodeID, bool fwdEdge, ObjectBlock<ParentList>* block) {
+    auto parent = reserveParent(boundNodeID, edgeID, fwdEdge, block);
     parent->setIter(iter);
     // Since by default the parentPtr of each node is nullptr, that's what we start with.
     ParentList* expected = nullptr;
-    while (!currParentPtrs[nbrNodeID.offset].compare_exchange_strong(expected, parent))
+    while (!curData[nbrNodeID.offset].compare_exchange_strong(expected, parent))
         ;
     parent->setNextPtr(expected);
 }
 
-void BFSGraph::addSingleParent(uint16_t iter, nodeID_t boundNodeID, relID_t edgeID,
+void DenseBFSGraph::addSingleParent(uint16_t iter, nodeID_t boundNodeID, relID_t edgeID,
     nodeID_t nbrNodeID, bool fwdEdge, ObjectBlock<ParentList>* block) {
-    auto parent = block->reserveNext();
-    parent->setNbrInfo(boundNodeID, edgeID, fwdEdge);
+    auto parent = reserveParent(boundNodeID, edgeID, fwdEdge, block);
     parent->setIter(iter);
     ParentList* expected = nullptr;
-    if (currParentPtrs[nbrNodeID.offset].compare_exchange_strong(expected, parent)) {
+    if (curData[nbrNodeID.offset].compare_exchange_strong(expected, parent)) {
         parent->setNextPtr(expected);
     } else {
         // Other thread has added the parent. Do NOT add parent and revert reserved slot.
@@ -45,14 +90,38 @@ static double getCost(ParentList* parentList) {
     return parentList == nullptr ? std::numeric_limits<double>::max() : parentList->getCost();
 }
 
-bool BFSGraph::tryAddSingleParentWithWeight(nodeID_t boundNodeID, relID_t edgeID,
+bool DenseBFSGraph::tryAddParentWithWeight(nodeID_t boundNodeID, relID_t edgeID, nodeID_t nbrNodeID,
+    bool fwdEdge, double weight, ObjectBlock<ParentList>* block) {
+    ParentList* expected = getParentListHead(nbrNodeID.offset);
+    auto parent = reserveParent(boundNodeID, edgeID, fwdEdge, block);
+    parent->setCost(getParentListHead(boundNodeID)->getCost() + weight);
+    while (true) {
+        if (parent->getCost() < getCost(expected)) {
+            // New parent has smaller cost, erase all existing parents and add new parent.
+            if (curData[nbrNodeID.offset].compare_exchange_strong(expected, parent)) {
+                parent->setNextPtr(nullptr);
+                return true;
+            }
+        } else if (parent->getCost() == getCost(expected)) {
+            // New parent has the same cost, append new parent as after existing parents.
+            if (curData[nbrNodeID.offset].compare_exchange_strong(expected, parent)) {
+                parent->setNextPtr(expected);
+                return true;
+            }
+        } else {
+            block->revertLast();
+            return false;
+        }
+    }
+}
+
+bool DenseBFSGraph::tryAddSingleParentWithWeight(nodeID_t boundNodeID, relID_t edgeID,
     nodeID_t nbrNodeID, bool fwdEdge, double weight, ObjectBlock<ParentList>* block) {
     ParentList* expected = getParentListHead(nbrNodeID.offset);
-    auto parent = block->reserveNext();
-    parent->setNbrInfo(boundNodeID, edgeID, fwdEdge);
-    parent->setCost(getParentListHead(boundNodeID.offset)->getCost() + weight);
+    auto parent = reserveParent(boundNodeID, edgeID, fwdEdge, block);
+    parent->setCost(getParentListHead(boundNodeID)->getCost() + weight);
     while (parent->getCost() < getCost(expected)) {
-        if (currParentPtrs[nbrNodeID.offset].compare_exchange_strong(expected, parent)) {
+        if (curData[nbrNodeID.offset].compare_exchange_strong(expected, parent)) {
             // Since each node can have one parent, set next ptr to nullptr.
             parent->setNextPtr(nullptr);
             return true;
@@ -63,30 +132,139 @@ bool BFSGraph::tryAddSingleParentWithWeight(nodeID_t boundNodeID, relID_t edgeID
     return false;
 }
 
-bool BFSGraph::tryAddParentWithWeight(nodeID_t boundNodeID, relID_t edgeID, nodeID_t nbrNodeID,
-    bool fwdEdge, double weight, ObjectBlock<ParentList>* block) {
-    ParentList* expected = getParentListHead(nbrNodeID.offset);
-    auto parent = block->reserveNext();
-    parent->setNbrInfo(boundNodeID, edgeID, fwdEdge);
-    parent->setCost(getParentListHead(boundNodeID.offset)->getCost() + weight);
-    while (true) {
-        if (parent->getCost() < getCost(expected)) {
-            // New parent has smaller cost, erase all existing parents and add new parent.
-            if (currParentPtrs[nbrNodeID.offset].compare_exchange_strong(expected, parent)) {
-                parent->setNextPtr(nullptr);
-                return true;
-            }
-        } else if (parent->getCost() == getCost(expected)) {
-            // New parent has the same cost, append new parent as after existing parents.
-            if (currParentPtrs[nbrNodeID.offset].compare_exchange_strong(expected, parent)) {
-                parent->setNextPtr(expected);
-                return true;
-            }
+ParentList* DenseBFSGraph::getParentListHead(offset_t offset) {
+    KU_ASSERT(curData);
+    return curData[offset].load(std::memory_order_relaxed);
+}
+
+ParentList* DenseBFSGraph::getParentListHead(nodeID_t nodeID) {
+    return denseObjects.getData(nodeID.tableID)[nodeID.offset].load(std::memory_order_relaxed);
+}
+
+void DenseBFSGraph::setParentList(offset_t offset, ParentList* parentList) {
+    KU_ASSERT(curData && getParentListHead(offset) == nullptr);
+    curData[offset].store(parentList, std::memory_order_relaxed);
+}
+
+void SparseBFSGraph::pinTableID(table_id_t tableID) {
+    curData = sparseObjects.getData(tableID);
+}
+
+void SparseBFSGraph::addParent(uint16_t iter, nodeID_t boundNodeID, relID_t edgeID,
+    nodeID_t nbrNodeID, bool fwdEdge, ObjectBlock<ParentList>* block) {
+    auto parent = reserveParent(boundNodeID, edgeID, fwdEdge, block);
+    parent->setIter(iter);
+    if (curData->contains(nbrNodeID.offset)) {
+        parent->setNextPtr(curData->at(nbrNodeID.offset));
+        curData->at(nbrNodeID.offset) = parent;
+    } else {
+        parent->setNextPtr(nullptr);
+        curData->insert({nbrNodeID.offset, parent});
+    }
+}
+
+void SparseBFSGraph::addSingleParent(uint16_t iter, nodeID_t boundNodeID, relID_t edgeID,
+    nodeID_t nbrNodeID, bool fwdEdge, ObjectBlock<ParentList>* block) {
+    if (curData->contains(nbrNodeID.offset)) {
+        return;
+    }
+    auto parent = reserveParent(boundNodeID, edgeID, fwdEdge, block);
+    parent->setIter(iter);
+    parent->setNextPtr(nullptr);
+    curData->insert({nbrNodeID.offset, parent});
+}
+
+bool SparseBFSGraph::tryAddParentWithWeight(nodeID_t boundNodeID, relID_t edgeID,
+    nodeID_t nbrNodeID, bool fwdEdge, double weight, ObjectBlock<ParentList>* block) {
+    auto nbrCost = getCost(getParentListHead(nbrNodeID.offset));
+    auto newCost = getParentListHead(boundNodeID)->getCost() + weight;
+    if (newCost < nbrCost) {
+        auto parent = reserveParent(boundNodeID, edgeID, fwdEdge, block);
+        parent->setCost(newCost);
+        parent->setNextPtr(nullptr);
+        curData->erase(nbrNodeID.offset);
+        curData->insert({nbrNodeID.offset, parent});
+        return true;
+    }
+    if (newCost == nbrCost) {
+        auto parent = reserveParent(boundNodeID, edgeID, fwdEdge, block);
+        parent->setCost(newCost);
+        if (curData->contains(nbrNodeID.offset)) {
+            parent->setNextPtr(curData->at(nbrNodeID.offset));
+            curData->erase(nbrNodeID.offset);
         } else {
-            block->revertLast();
+            parent->setNextPtr(nullptr);
+        }
+        curData->insert({nbrNodeID.offset, parent});
+        return true;
+    }
+    return false;
+}
+
+bool SparseBFSGraph::tryAddSingleParentWithWeight(nodeID_t boundNodeID, relID_t edgeID,
+    nodeID_t nbrNodeID, bool fwdEdge, double weight, ObjectBlock<ParentList>* block) {
+    auto nbrCost = getCost(getParentListHead(nbrNodeID.offset));
+    auto newCost = getParentListHead(boundNodeID)->getCost() + weight;
+    if (newCost < nbrCost) {
+        auto parent = reserveParent(boundNodeID, edgeID, fwdEdge, block);
+        parent->setCost(newCost);
+        parent->setNextPtr(nullptr);
+        curData->erase(nbrNodeID.offset);
+        curData->insert({nbrNodeID.offset, parent});
+        return true;
+    }
+    if (newCost == nbrCost) {
+        if (curData->contains(nbrNodeID.offset)) {
             return false;
         }
+        auto parent = reserveParent(boundNodeID, edgeID, fwdEdge, block);
+        parent->setCost(newCost);
+        parent->setNextPtr(nullptr);
+        curData->insert({nbrNodeID.offset, parent});
     }
+    return false;
+}
+
+ParentList* SparseBFSGraph::getParentListHead(offset_t offset) {
+    KU_ASSERT(curData);
+    if (!curData->contains(offset)) {
+        return nullptr;
+    }
+    return curData->at(offset);
+}
+
+ParentList* SparseBFSGraph::getParentListHead(nodeID_t nodeID) {
+    auto data = sparseObjects.getData(nodeID.tableID);
+    if (!data->contains(nodeID.offset)) {
+        return nullptr;
+    }
+    return data->at(nodeID.offset);
+}
+
+void SparseBFSGraph::setParentList(offset_t offset, ParentList* parentList) {
+    KU_ASSERT(!curData->contains(offset));
+    curData->insert({offset, parentList});
+}
+
+BFSGraphManager::BFSGraphManager(table_id_map_t<offset_t> maxOffsetMap,
+    storage::MemoryManager* mm) {
+    denseBFSGraph = std::make_unique<DenseBFSGraph>(mm, maxOffsetMap);
+    sparseBFSGraph = std::make_unique<SparseBFSGraph>(mm, maxOffsetMap);
+    curGraph = sparseBFSGraph.get();
+}
+
+void BFSGraphManager::switchToDense(ExecutionContext* context, Graph* graph) {
+    KU_ASSERT(state == GDSDensityState::SPARSE);
+    state = GDSDensityState::DENSE;
+    denseBFSGraph->init(context, graph);
+    denseBFSGraph->blocks = std::move(sparseBFSGraph->blocks);
+    for (auto& [tableID, map] : sparseBFSGraph->sparseObjects.getData()) {
+        denseBFSGraph->pinTableID(tableID);
+        for (auto& [offset, ptr] : map) {
+            denseBFSGraph->setParentList(offset, ptr);
+        }
+    }
+    curGraph = denseBFSGraph.get();
 }
 
 } // namespace function

--- a/src/function/gds/degrees.h
+++ b/src/function/gds/degrees.h
@@ -81,7 +81,8 @@ struct DegreesUtils {
         common::NodeOffsetMaskMap* nodeOffsetMaskMap, Degrees* degrees, ExtendDirection direction) {
         auto currentFrontier = DenseFrontier::getUnvisitedFrontier(context, graph);
         auto nextFrontier = DenseFrontier::getVisitedFrontier(context, graph, nodeOffsetMaskMap);
-        auto frontierPair = std::make_unique<DenseFrontierPair>(std::move(currentFrontier), std::move(nextFrontier));
+        auto frontierPair = std::make_unique<DenseFrontierPair>(std::move(currentFrontier),
+            std::move(nextFrontier));
         frontierPair->setActiveNodesForNextIter();
         auto ec = std::make_unique<DegreeEdgeCompute>(degrees);
         auto auxiliaryState = std::make_unique<DegreesGDSAuxiliaryState>(degrees);

--- a/src/function/gds/degrees.h
+++ b/src/function/gds/degrees.h
@@ -81,7 +81,7 @@ struct DegreesUtils {
         common::NodeOffsetMaskMap* nodeOffsetMaskMap, Degrees* degrees, ExtendDirection direction) {
         auto currentFrontier = DenseFrontier::getUnvisitedFrontier(context, graph);
         auto nextFrontier = DenseFrontier::getVisitedFrontier(context, graph, nodeOffsetMaskMap);
-        auto frontierPair = std::make_unique<DenseFrontierPair>(currentFrontier, nextFrontier);
+        auto frontierPair = std::make_unique<DenseFrontierPair>(std::move(currentFrontier), std::move(nextFrontier));
         frontierPair->setActiveNodesForNextIter();
         auto ec = std::make_unique<DegreeEdgeCompute>(degrees);
         auto auxiliaryState = std::make_unique<DegreesGDSAuxiliaryState>(degrees);

--- a/src/function/gds/frontier_morsel.cpp
+++ b/src/function/gds/frontier_morsel.cpp
@@ -1,0 +1,35 @@
+#include "function/gds/frontier_morsel.h"
+
+using namespace kuzu::common;
+
+namespace kuzu {
+namespace function {
+
+FrontierMorselDispatcher::FrontierMorselDispatcher(uint64_t maxThreads)
+    : maxOffset{INVALID_OFFSET}, maxThreads{maxThreads}, morselSize(UINT64_MAX) {
+    nextOffset.store(INVALID_OFFSET);
+}
+
+void FrontierMorselDispatcher::init(offset_t _maxOffset) {
+    maxOffset = _maxOffset;
+    nextOffset.store(0u);
+    // Frontier size calculation: The ideal scenario is to have k^2 many morsels where k
+    // the number of maximum threads that could be working on this frontier. However, if
+    // that is too small then we default to MIN_FRONTIER_MORSEL_SIZE.
+    auto idealMorselSize =
+        maxOffset / std::max(MIN_NUMBER_OF_FRONTIER_MORSELS, maxThreads * maxThreads);
+    morselSize = std::max(MIN_FRONTIER_MORSEL_SIZE, idealMorselSize);
+}
+
+bool FrontierMorselDispatcher::getNextRangeMorsel(FrontierMorsel& frontierMorsel) {
+    auto beginOffset = nextOffset.fetch_add(morselSize, std::memory_order_acq_rel);
+    if (beginOffset >= maxOffset) {
+        return false;
+    }
+    auto endOffset = beginOffset + morselSize > maxOffset ? maxOffset : beginOffset + morselSize;
+    frontierMorsel.init(beginOffset, endOffset);
+    return true;
+}
+
+} // namespace function
+} // namespace kuzu

--- a/src/function/gds/gds_state.cpp
+++ b/src/function/gds/gds_state.cpp
@@ -4,7 +4,9 @@ namespace kuzu {
 namespace function {
 
 void GDSComputeState::initSource(common::nodeID_t sourceNodeID) const {
-    frontierPair->initSource(sourceNodeID);
+    frontierPair->pinNextFrontier(sourceNodeID.tableID);
+    frontierPair->addNodeToNextFrontier(sourceNodeID);
+    frontierPair->setActiveNodesForNextIter();
     auxiliaryState->initSource(sourceNodeID);
 }
 
@@ -12,6 +14,12 @@ void GDSComputeState::beginFrontierCompute(common::table_id_t currTableID,
     common::table_id_t nextTableID) const {
     frontierPair->beginFrontierComputeBetweenTables(currTableID, nextTableID);
     auxiliaryState->beginFrontierCompute(currTableID, nextTableID);
+}
+
+void GDSComputeState::switchToDense(processor::ExecutionContext* context,
+    graph::Graph* graph) const {
+    frontierPair->switchToDense(context, graph);
+    auxiliaryState->switchToDense(context, graph);
 }
 
 } // namespace function

--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -1,6 +1,7 @@
 #include "function/gds/gds_task.h"
 
 #include "catalog/catalog_entry/table_catalog_entry.h"
+#include "function/gds/frontier_morsel.h"
 #include "graph/graph.h"
 
 using namespace kuzu::common;
@@ -8,35 +9,24 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace function {
 
-static uint64_t runEdgeCompute(nodeID_t sourceNodeID, graph::NbrScanState::Chunk& nbrChunk,
-    EdgeCompute& ec, FrontierPair& frontierPair, bool isFwd, SparseFrontier& localFrontier) {
-    auto activeNodes = ec.edgeCompute(sourceNodeID, nbrChunk, isFwd);
-    frontierPair.addNodesToNextDenseFrontier(activeNodes);
-    localFrontier.addNodes(activeNodes);
-    localFrontier.checkSampleSize();
-    return nbrChunk.size();
-}
-
 void FrontierTask::run() {
     FrontierMorsel morsel;
     auto numActiveNodes = 0u;
     auto graph = info.graph;
     auto scanState = graph->prepareRelScan(info.relEntry, info.nbrEntry, info.propertyToScan);
-    auto localEc = info.edgeCompute.copy();
-    SparseFrontier localFrontier;
-    localFrontier.pinTableID(info.nbrEntry->getTableID());
-    auto& curFrontier = sharedState->frontierPair.getCurDenseFrontier();
+    auto ec = info.edgeCompute.copy();
     switch (info.direction) {
     case ExtendDirection::FWD: {
         while (sharedState->morselDispatcher.getNextRangeMorsel(morsel)) {
             for (auto offset = morsel.getBeginOffset(); offset < morsel.getEndOffset(); ++offset) {
-                if (!curFrontier.isActive(offset)) {
+                if (!sharedState->frontierPair.isActiveOnCurrentFrontier(offset)) {
                     continue;
                 }
                 nodeID_t nodeID = {offset, info.boundEntry->getTableID()};
                 for (auto chunk : graph->scanFwd(nodeID, *scanState)) {
-                    numActiveNodes += runEdgeCompute(nodeID, chunk, *localEc,
-                        sharedState->frontierPair, true, localFrontier);
+                    auto activeNodes = ec->edgeCompute(nodeID, chunk, true);
+                    sharedState->frontierPair.addNodesToNextFrontier(activeNodes);
+                    numActiveNodes += activeNodes.size();
                 }
             }
         }
@@ -44,13 +34,14 @@ void FrontierTask::run() {
     case ExtendDirection::BWD: {
         while (sharedState->morselDispatcher.getNextRangeMorsel(morsel)) {
             for (auto offset = morsel.getBeginOffset(); offset < morsel.getEndOffset(); ++offset) {
-                if (!curFrontier.isActive(offset)) {
+                if (!sharedState->frontierPair.isActiveOnCurrentFrontier(offset)) {
                     continue;
                 }
                 nodeID_t nodeID = {offset, info.boundEntry->getTableID()};
                 for (auto chunk : graph->scanBwd(nodeID, *scanState)) {
-                    numActiveNodes += runEdgeCompute(nodeID, chunk, *localEc,
-                        sharedState->frontierPair, false, localFrontier);
+                    auto activeNodes = ec->edgeCompute(nodeID, chunk, false);
+                    sharedState->frontierPair.addNodesToNextFrontier(activeNodes);
+                    numActiveNodes += activeNodes.size();
                 }
             }
         }
@@ -60,7 +51,6 @@ void FrontierTask::run() {
     }
     if (numActiveNodes) {
         sharedState->frontierPair.setActiveNodesForNextIter();
-        sharedState->frontierPair.mergeLocalFrontier(localFrontier);
     }
 }
 
@@ -68,26 +58,25 @@ void FrontierTask::runSparse() {
     auto numActiveNodes = 0u;
     auto graph = info.graph;
     auto scanState = graph->prepareRelScan(info.relEntry, info.nbrEntry, info.propertyToScan);
-    auto localEc = info.edgeCompute.copy();
-    SparseFrontier localFrontier;
-    localFrontier.pinTableID(info.nbrEntry->getTableID());
-    auto& curFrontier = sharedState->frontierPair.getCurSparseFrontier();
+    auto ec = info.edgeCompute.copy();
     switch (info.direction) {
     case ExtendDirection::FWD: {
-        for (auto& offset : curFrontier.getOffsetSet()) {
-            auto nodeID = nodeID_t{offset, curFrontier.getTableID()};
+        for (const auto offset : sharedState->frontierPair.getActiveNodesOnCurrentFrontier()) {
+            auto nodeID = nodeID_t{offset, info.boundEntry->getTableID()};
             for (auto chunk : graph->scanFwd(nodeID, *scanState)) {
-                numActiveNodes += runEdgeCompute(nodeID, chunk, *localEc, sharedState->frontierPair,
-                    true, localFrontier);
+                auto activeNodes = ec->edgeCompute(nodeID, chunk, true);
+                sharedState->frontierPair.addNodesToNextFrontier(activeNodes);
+                numActiveNodes += activeNodes.size();
             }
         }
     } break;
     case ExtendDirection::BWD: {
-        for (auto& offset : curFrontier.getOffsetSet()) {
-            auto nodeID = nodeID_t{offset, curFrontier.getTableID()};
+        for (auto& offset : sharedState->frontierPair.getActiveNodesOnCurrentFrontier()) {
+            auto nodeID = nodeID_t{offset, info.boundEntry->getTableID()};
             for (auto chunk : graph->scanBwd(nodeID, *scanState)) {
-                numActiveNodes += runEdgeCompute(nodeID, chunk, *localEc, sharedState->frontierPair,
-                    false, localFrontier);
+                auto activeNodes = ec->edgeCompute(nodeID, chunk, false);
+                sharedState->frontierPair.addNodesToNextFrontier(activeNodes);
+                numActiveNodes += activeNodes.size();
             }
         }
     } break;
@@ -96,7 +85,6 @@ void FrontierTask::runSparse() {
     }
     if (numActiveNodes) {
         sharedState->frontierPair.setActiveNodesForNextIter();
-        sharedState->frontierPair.mergeLocalFrontier(localFrontier);
     }
 }
 

--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -114,6 +114,5 @@ void VertexComputeTask::runSparse() {
     localVc->vertexCompute(info.tableEntry->getTableID());
 }
 
-
 } // namespace function
 } // namespace kuzu

--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -108,5 +108,12 @@ void VertexComputeTask::run() {
     }
 }
 
+void VertexComputeTask::runSparse() {
+    KU_ASSERT(!info.hasPropertiesToScan());
+    auto localVc = info.vc.copy();
+    localVc->vertexCompute(info.tableEntry->getTableID());
+}
+
+
 } // namespace function
 } // namespace kuzu

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -131,8 +131,8 @@ static void runVertexComputeInternal(TableCatalogEntry* currentEntry, GDSDensity
         true /* launchNewWorkerThread */);
 }
 
-void GDSUtils::runVertexCompute(ExecutionContext* context, GDSDensityState densityState, Graph* graph,
-    VertexCompute& vc, std::vector<std::string> propertiesToScan) {
+void GDSUtils::runVertexCompute(ExecutionContext* context, GDSDensityState densityState,
+    Graph* graph, VertexCompute& vc, std::vector<std::string> propertiesToScan) {
     auto maxThreads = context->clientContext->getMaxNumThreadForExec();
     auto sharedState = std::make_shared<VertexComputeTaskSharedState>(maxThreads);
     for (auto& nodeInfo : graph->getGraphEntry()->nodeInfos) {
@@ -146,12 +146,14 @@ void GDSUtils::runVertexCompute(ExecutionContext* context, GDSDensityState densi
     }
 }
 
-void GDSUtils::runVertexCompute(ExecutionContext* context, GDSDensityState densityState, Graph* graph, VertexCompute& vc) {
+void GDSUtils::runVertexCompute(ExecutionContext* context, GDSDensityState densityState,
+    Graph* graph, VertexCompute& vc) {
     runVertexCompute(context, densityState, graph, vc, std::vector<std::string>{});
 }
 
-void GDSUtils::runVertexCompute(ExecutionContext* context, GDSDensityState densityState, Graph* graph, VertexCompute& vc,
-    TableCatalogEntry* entry, std::vector<std::string> propertiesToScan) {
+void GDSUtils::runVertexCompute(ExecutionContext* context, GDSDensityState densityState,
+    Graph* graph, VertexCompute& vc, TableCatalogEntry* entry,
+    std::vector<std::string> propertiesToScan) {
     auto maxThreads = context->clientContext->getMaxNumThreadForExec();
     auto info = VertexComputeTaskInfo(vc, graph, entry, propertiesToScan);
     auto sharedState = std::make_shared<VertexComputeTaskSharedState>(maxThreads);

--- a/src/function/gds/k_core_decomposition.cpp
+++ b/src/function/gds/k_core_decomposition.cpp
@@ -174,7 +174,8 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
         DenseFrontier::getUnvisitedFrontier(input.context, sharedState->graph.get());
     auto nextFrontier =
         DenseFrontier::getUnvisitedFrontier(input.context, sharedState->graph.get());
-    auto frontierPair = std::make_unique<DenseFrontierPair>(std::move(currentFrontier), std::move(nextFrontier));
+    auto frontierPair =
+        std::make_unique<DenseFrontierPair>(std::move(currentFrontier), std::move(nextFrontier));
     // Compute Core values
     auto removeVertexEdgeCompute = std::make_unique<RemoveVertexEdgeCompute>(degrees);
     auto computeState = GDSComputeState(std::move(frontierPair), std::move(removeVertexEdgeCompute),
@@ -191,7 +192,8 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
             auto vc = DegreeLessThanCoreVertexCompute(degrees, coreValues,
                 computeState.frontierPair.get(), coreValue, numActiveNodes,
                 sharedState->getGraphNodeMaskMap());
-            GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, sharedState->graph.get(), vc);
+            GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE,
+                sharedState->graph.get(), vc);
             numNodesComputed += numActiveNodes.load();
             if (numActiveNodes.load() == 0) {
                 break;

--- a/src/function/gds/k_core_decomposition.cpp
+++ b/src/function/gds/k_core_decomposition.cpp
@@ -174,7 +174,7 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
         DenseFrontier::getUnvisitedFrontier(input.context, sharedState->graph.get());
     auto nextFrontier =
         DenseFrontier::getUnvisitedFrontier(input.context, sharedState->graph.get());
-    auto frontierPair = std::make_unique<DenseFrontierPair>(currentFrontier, nextFrontier);
+    auto frontierPair = std::make_unique<DenseFrontierPair>(std::move(currentFrontier), std::move(nextFrontier));
     // Compute Core values
     auto removeVertexEdgeCompute = std::make_unique<RemoveVertexEdgeCompute>(degrees);
     auto computeState = GDSComputeState(std::move(frontierPair), std::move(removeVertexEdgeCompute),
@@ -191,7 +191,7 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
             auto vc = DegreeLessThanCoreVertexCompute(degrees, coreValues,
                 computeState.frontierPair.get(), coreValue, numActiveNodes,
                 sharedState->getGraphNodeMaskMap());
-            GDSUtils::runVertexCompute(input.context, sharedState->graph.get(), vc);
+            GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, sharedState->graph.get(), vc);
             numNodesComputed += numActiveNodes.load();
             if (numActiveNodes.load() == 0) {
                 break;
@@ -208,7 +208,7 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
     // Write output
     auto vertexCompute =
         KCoreResultVertexCompute(clientContext->getMemoryManager(), sharedState, coreValues);
-    GDSUtils::runVertexCompute(input.context, graph, vertexCompute);
+    GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph, vertexCompute);
     sharedState->factorizedTablePool.mergeLocalTables();
     return 0;
 }

--- a/src/function/gds/output_writer.cpp
+++ b/src/function/gds/output_writer.cpp
@@ -1,6 +1,7 @@
 #include "common/exception/interrupt.h"
 #include "function/gds/rj_output_writer.h"
 #include "main/client_context.h"
+#include <function/gds/gds_frontier.h>
 
 using namespace kuzu::common;
 using namespace kuzu::processor;
@@ -8,29 +9,29 @@ using namespace kuzu::processor;
 namespace kuzu {
 namespace function {
 
-RJOutputWriter::RJOutputWriter(main::ClientContext* context,
-    common::NodeOffsetMaskMap* outputNodeMask, nodeID_t sourceNodeID)
-    : context{context}, outputNodeMask{outputNodeMask}, sourceNodeID{sourceNodeID} {
+RJOutputWriter::RJOutputWriter(main::ClientContext* context, NodeOffsetMaskMap* outputNodeMask,
+    nodeID_t sourceNodeID)
+    : context{context}, outputNodeMask{outputNodeMask}, sourceNodeID_{sourceNodeID} {
     srcNodeIDVector = createVector(LogicalType::INTERNAL_ID());
     dstNodeIDVector = createVector(LogicalType::INTERNAL_ID());
     srcNodeIDVector->setValue<nodeID_t>(0, sourceNodeID);
 }
 
-void RJOutputWriter::beginWritingOutputs(table_id_t tableID) {
+void RJOutputWriter::pinOutputNodeMask(table_id_t tableID) {
     if (outputNodeMask != nullptr) {
         outputNodeMask->pin(tableID);
     }
-    beginWritingOutputsInternal(tableID);
 }
 
-bool RJOutputWriter::skip(nodeID_t dstNodeID) const {
-    if (outputNodeMask != nullptr && outputNodeMask->hasPinnedMask()) {
-        auto mask = outputNodeMask->getPinnedMask();
-        if (mask->isEnabled() && !mask->isMasked(dstNodeID.offset)) {
-            return true;
-        }
+bool RJOutputWriter::inOutputNodeMask(common::offset_t offset) {
+    if (outputNodeMask == nullptr) { // No mask
+        return true;
     }
-    return skipInternal(dstNodeID);
+    auto mask = outputNodeMask->getPinnedMask();
+    if (!mask->isEnabled()) { // No mask
+        return true;
+    }
+    return mask->isMasked(offset);
 }
 
 std::unique_ptr<ValueVector> RJOutputWriter::createVector(const LogicalType& type) {
@@ -41,8 +42,8 @@ std::unique_ptr<ValueVector> RJOutputWriter::createVector(const LogicalType& typ
 }
 
 PathsOutputWriter::PathsOutputWriter(main::ClientContext* context,
-    common::NodeOffsetMaskMap* outputNodeMask, nodeID_t sourceNodeID, PathsOutputWriterInfo info,
-    BFSGraph& bfsGraph)
+    NodeOffsetMaskMap* outputNodeMask, nodeID_t sourceNodeID, PathsOutputWriterInfo info,
+    BaseBFSGraph& bfsGraph)
     : RJOutputWriter{context, outputNodeMask, sourceNodeID}, info{info}, bfsGraph{bfsGraph} {
     lengthVector = createVector(LogicalType::UINT16());
     if (info.writeEdgeDirection) {
@@ -65,26 +66,40 @@ static ParentList* getTop(const std::vector<ParentList*>& path) {
     return path[path.size() - 1];
 }
 
-void PathsOutputWriter::write(processor::FactorizedTable& fTable, nodeID_t dstNodeID,
-    LimitCounter* counter) {
+void PathsOutputWriter::write(FactorizedTable& fTable, table_id_t tableID, LimitCounter* counter) {
+    auto& sparseGraph = bfsGraph.cast<SparseBFSGraph>();
+    for (auto& [offset, _] : sparseGraph.getCurrentData()) {
+        write(fTable, {offset, tableID}, counter);
+    }
+    if (info.lowerBound == 0 && sourceNodeID_.tableID == tableID) {
+        write(fTable, sourceNodeID_, counter);
+    }
+}
+
+void PathsOutputWriter::write(FactorizedTable& fTable, nodeID_t dstNodeID, LimitCounter* counter) {
+    if (!inOutputNodeMask(dstNodeID.offset)) {
+        return;
+    }
     dstNodeIDVector->setValue<nodeID_t>(0, dstNodeID);
-    auto firstParent = findFirstParent(dstNodeID.offset);
-    if (firstParent == nullptr) {
-        if (sourceNodeID == dstNodeID && info.lowerBound == 0) {
-            // We still output a path from src to src if required path length is 0.
-            // This case should only run for variable length joins.
-            writePath({});
-            fTable.append(vectors);
-            // No need to check against limit number since this is the first output.
-            updateCounterAndTerminate(counter);
-        }
-        return;
-    }
-    if (!info.hasNodeMask() && info.semantic == PathSemantic::WALK) {
-        dfsFast(firstParent, fTable, counter);
-        return;
-    }
-    dfsSlow(firstParent, fTable, counter);
+    writeInternal(fTable, dstNodeID, counter);
+
+    // auto firstParent = findFirstParent(dstNodeID.offset);
+    // if (firstParent == nullptr) {
+    //     if (sourceNodeID_ == dstNodeID && info.lowerBound == 0) {
+    //         // We still output a path from src to src if required path length is 0.
+    //         // This case should only run for variable length joins.
+    //         writePath({});
+    //         fTable.append(vectors);
+    //         // No need to check against limit number since this is the first output.
+    //         updateCounterAndTerminate(counter);
+    //     }
+    //     return;
+    // }
+    // if (!info.hasNodeMask() && info.semantic == PathSemantic::WALK) {
+    //     dfsFast(firstParent, fTable, counter);
+    //     return;
+    // }
+    // dfsSlow(firstParent, fTable, counter);
 }
 
 void PathsOutputWriter::dfsFast(ParentList* firstParent, FactorizedTable& fTable,
@@ -125,8 +140,8 @@ void PathsOutputWriter::dfsFast(ParentList* firstParent, FactorizedTable& fTable
     }
 }
 
-void PathsOutputWriter::dfsSlow(kuzu::function::ParentList* firstParent,
-    processor::FactorizedTable& fTable, LimitCounter* counter) {
+void PathsOutputWriter::dfsSlow(ParentList* firstParent, FactorizedTable& fTable,
+    LimitCounter* counter) {
     std::vector<ParentList*> curPath;
     curPath.push_back(firstParent);
     auto backtracking = false;
@@ -376,6 +391,31 @@ void PathsOutputWriter::addEdge(relID_t edgeID, bool fwdEdge, sel_t pos) const {
 
 void PathsOutputWriter::addNode(nodeID_t nodeID, sel_t pos) const {
     ListVector::getDataVector(pathNodeIDsVector.get())->setValue(pos, nodeID);
+}
+
+void SPPathsOutputWriter::writeInternal(FactorizedTable& fTable, nodeID_t dstNodeID,
+    LimitCounter* counter) {
+    auto firstParent = findFirstParent(dstNodeID.offset);
+    if (firstParent == nullptr) {
+        // if (sourceNodeID_ == dstNodeID && info.lowerBound == 0) {
+        //     // We still output a path from src to src if required path length is 0.
+        //     // This case should only run for variable length joins.
+        //     writePath({});
+        //     fTable.append(vectors);
+        //     // No need to check against limit number since this is the first output.
+        //     updateCounterAndTerminate(counter);
+        // }
+        return;
+    }
+    if (dstNodeID == sourceNodeID_) { // Avoid writing source
+        KU_ASSERT(firstParent->getIter() == FRONTIER_INITIAL_VISITED);
+        return;
+    }
+    if (!info.hasNodeMask() && info.semantic == PathSemantic::WALK) {
+        dfsFast(firstParent, fTable, counter);
+        return;
+    }
+    dfsSlow(firstParent, fTable, counter);
 }
 
 } // namespace function

--- a/src/function/gds/output_writer.cpp
+++ b/src/function/gds/output_writer.cpp
@@ -82,24 +82,6 @@ void PathsOutputWriter::write(FactorizedTable& fTable, nodeID_t dstNodeID, Limit
     }
     dstNodeIDVector->setValue<nodeID_t>(0, dstNodeID);
     writeInternal(fTable, dstNodeID, counter);
-
-    // auto firstParent = findFirstParent(dstNodeID.offset);
-    // if (firstParent == nullptr) {
-    //     if (sourceNodeID_ == dstNodeID && info.lowerBound == 0) {
-    //         // We still output a path from src to src if required path length is 0.
-    //         // This case should only run for variable length joins.
-    //         writePath({});
-    //         fTable.append(vectors);
-    //         // No need to check against limit number since this is the first output.
-    //         updateCounterAndTerminate(counter);
-    //     }
-    //     return;
-    // }
-    // if (!info.hasNodeMask() && info.semantic == PathSemantic::WALK) {
-    //     dfsFast(firstParent, fTable, counter);
-    //     return;
-    // }
-    // dfsSlow(firstParent, fTable, counter);
 }
 
 void PathsOutputWriter::dfsFast(ParentList* firstParent, FactorizedTable& fTable,
@@ -397,14 +379,6 @@ void SPPathsOutputWriter::writeInternal(FactorizedTable& fTable, nodeID_t dstNod
     LimitCounter* counter) {
     auto firstParent = findFirstParent(dstNodeID.offset);
     if (firstParent == nullptr) {
-        // if (sourceNodeID_ == dstNodeID && info.lowerBound == 0) {
-        //     // We still output a path from src to src if required path length is 0.
-        //     // This case should only run for variable length joins.
-        //     writePath({});
-        //     fTable.append(vectors);
-        //     // No need to check against limit number since this is the first output.
-        //     updateCounterAndTerminate(counter);
-        // }
         return;
     }
     if (dstNodeID == sourceNodeID_) { // Avoid writing source

--- a/src/function/gds/page_rank.cpp
+++ b/src/function/gds/page_rank.cpp
@@ -19,16 +19,16 @@ namespace kuzu {
 namespace function {
 
 struct PageRankOptionalParams {
-    std::shared_ptr<binder::Expression> dampingFactor;
-    std::shared_ptr<binder::Expression> maxIteration;
-    std::shared_ptr<binder::Expression> tolerance;
+    std::shared_ptr<Expression> dampingFactor;
+    std::shared_ptr<Expression> maxIteration;
+    std::shared_ptr<Expression> tolerance;
 
-    explicit PageRankOptionalParams(const binder::expression_vector& optionalParams);
+    explicit PageRankOptionalParams(const expression_vector& optionalParams);
 
     PageRankConfig getConfig() const;
 };
 
-PageRankOptionalParams::PageRankOptionalParams(const binder::expression_vector& optionalParams) {
+PageRankOptionalParams::PageRankOptionalParams(const expression_vector& optionalParams) {
     for (auto& optionalParam : optionalParams) {
         auto paramName = StringUtils::getLower(optionalParam->getAlias());
         if (paramName == DampingFactor::NAME) {
@@ -64,8 +64,8 @@ PageRankConfig PageRankOptionalParams::getConfig() const {
 struct PageRankBindData final : public GDSBindData {
     PageRankOptionalParams optionalParams;
 
-    PageRankBindData(binder::expression_vector columns, graph::GraphEntry graphEntry,
-        std::shared_ptr<binder::Expression> nodeOutput, PageRankOptionalParams optionalParams)
+    PageRankBindData(expression_vector columns, graph::GraphEntry graphEntry,
+        std::shared_ptr<Expression> nodeOutput, PageRankOptionalParams optionalParams)
         : GDSBindData{std::move(columns), std::move(graphEntry), std::move(nodeOutput)},
           optionalParams{std::move(optionalParams)} {}
     PageRankBindData(const PageRankBindData& other)
@@ -111,7 +111,7 @@ public:
 
 private:
     std::atomic<double>* values = nullptr;
-    ObjectArraysMap<std::atomic<double>> valueMap;
+    GDSDenseObjectManager<std::atomic<double>> valueMap;
 };
 
 class PageRankAuxiliaryState : public GDSAuxiliaryState {
@@ -124,6 +124,8 @@ public:
         pCurrent.pinTable(toTableID);
         pNext.pinTable(fromTableID);
     }
+
+    void switchToDense(ExecutionContext*, Graph*) override {}
 
 private:
     Degrees& degrees;
@@ -274,25 +276,24 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
     auto config = pageRankBindData->getConfig();
     auto currentIter = 1u;
     auto currentFrontier =
-        PathLengths::getVisitedFrontier(input.context, graph, sharedState->getGraphNodeMaskMap());
+        DenseFrontier::getVisitedFrontier(input.context, graph, sharedState->getGraphNodeMaskMap());
     auto nextFrontier =
-        PathLengths::getVisitedFrontier(input.context, graph, sharedState->getGraphNodeMaskMap());
+        DenseFrontier::getVisitedFrontier(input.context, graph, sharedState->getGraphNodeMaskMap());
     auto degrees = Degrees(maxOffsetMap, clientContext->getMemoryManager());
     DegreesUtils::computeDegree(input.context, graph, sharedState->getGraphNodeMaskMap(), &degrees,
         ExtendDirection::FWD);
-    auto frontierPair =
-        std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier, nextFrontier);
+    auto frontierPair = std::make_unique<DenseFrontierPair>(currentFrontier, nextFrontier);
     auto computeState = GDSComputeState(std::move(frontierPair), nullptr, nullptr);
     auto pNextUpdateConstant = (1 - config.dampingFactor) * ((double)1 / numNodes);
     while (currentIter < config.maxIterations) {
-        computeState.frontierPair->initState();
-        computeState.frontierPair->initGDS();
+        computeState.frontierPair->resetCurrentIter();
+        computeState.frontierPair->setActiveNodesForNextIter();
         computeState.edgeCompute =
             std::make_unique<PNextUpdateEdgeCompute>(degrees, *pCurrent, *pNext);
         computeState.auxiliaryState =
             std::make_unique<PageRankAuxiliaryState>(degrees, *pCurrent, *pNext);
-        GDSUtils::runFrontiersUntilConvergence(input.context, computeState, graph,
-            ExtendDirection::BWD, 1);
+        GDSUtils::runAlgorithmEdgeCompute(input.context, computeState, graph, ExtendDirection::BWD,
+            1);
         auto pNextUpdateVC = PNextUpdateVertexCompute(config.dampingFactor, pNextUpdateConstant,
             *pNext, sharedState->getGraphNodeMaskMap());
         GDSUtils::runVertexCompute(input.context, graph, pNextUpdateVC);

--- a/src/function/gds/page_rank.cpp
+++ b/src/function/gds/page_rank.cpp
@@ -282,7 +282,8 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
     auto degrees = Degrees(maxOffsetMap, clientContext->getMemoryManager());
     DegreesUtils::computeDegree(input.context, graph, sharedState->getGraphNodeMaskMap(), &degrees,
         ExtendDirection::FWD);
-    auto frontierPair = std::make_unique<DenseFrontierPair>(std::move(currentFrontier), std::move(nextFrontier));
+    auto frontierPair =
+        std::make_unique<DenseFrontierPair>(std::move(currentFrontier), std::move(nextFrontier));
     auto computeState = GDSComputeState(std::move(frontierPair), nullptr, nullptr);
     auto pNextUpdateConstant = (1 - config.dampingFactor) * ((double)1 / numNodes);
     while (currentIter < config.maxIterations) {

--- a/src/function/gds/rec_joins.cpp
+++ b/src/function/gds/rec_joins.cpp
@@ -1,11 +1,5 @@
 #include "function/gds/rec_joins.h"
 
-#include "function/gds/gds_utils.h"
-#include "processor/execution_context.h"
-
-using namespace kuzu::binder;
-using namespace kuzu::common;
-
 namespace kuzu {
 namespace function {
 
@@ -32,19 +26,9 @@ PathsOutputWriterInfo RJBindData::getPathWriterInfo() const {
     info.semantic = semantic;
     info.lowerBound = lowerBound;
     info.flipPath = flipPath;
-    info.writeEdgeDirection = writePath && extendDirection == ExtendDirection::BOTH;
+    info.writeEdgeDirection = writePath && extendDirection == common::ExtendDirection::BOTH;
     info.writePath = writePath;
     return info;
-}
-
-std::unique_ptr<BFSGraph> RJAlgorithm::getBFSGraph(processor::ExecutionContext* context,
-    graph::Graph* graph) {
-    auto tx = context->clientContext->getTransaction();
-    auto mm = context->clientContext->getMemoryManager();
-    auto bfsGraph = std::make_unique<BFSGraph>(graph->getMaxOffsetMap(tx), mm);
-    auto vc = std::make_unique<BFSGraphInitVertexCompute>(*bfsGraph);
-    GDSUtils::runVertexCompute(context, graph, *vc);
-    return bfsGraph;
 }
 
 } // namespace function

--- a/src/function/gds/ssp_destinations.cpp
+++ b/src/function/gds/ssp_destinations.cpp
@@ -104,7 +104,7 @@ private:
         RecursiveExtendSharedState* sharedState) override {
         auto graph = sharedState->graph.get();
         auto denseFrontier = DenseFrontier::getUninitializedFrontier(context, graph);
-        auto frontierPair = std::make_unique<SPFrontierPair>(denseFrontier);
+        auto frontierPair = std::make_unique<SPFrontierPair>(std::move(denseFrontier));
         auto edgeCompute = std::make_unique<SSPDestinationsEdgeCompute>(frontierPair.get());
         auto auxiliaryState = std::make_unique<EmptyGDSAuxiliaryState>();
         return std::make_unique<GDSComputeState>(std::move(frontierPair), std::move(edgeCompute),

--- a/src/function/gds/ssp_destinations.cpp
+++ b/src/function/gds/ssp_destinations.cpp
@@ -1,3 +1,5 @@
+#include <unistd.h>
+
 #include "binder/expression/node_expression.h"
 #include "function/gds/gds_function_collection.h"
 #include "function/gds/rec_joins.h"
@@ -6,27 +8,42 @@
 using namespace kuzu::binder;
 using namespace kuzu::common;
 using namespace kuzu::processor;
+using namespace kuzu::graph;
+using namespace kuzu::main;
 
 namespace kuzu {
 namespace function {
 
 class SSPDestinationsOutputWriter : public RJOutputWriter {
 public:
-    SSPDestinationsOutputWriter(main::ClientContext* context, NodeOffsetMaskMap* outputNodeMask,
-        nodeID_t sourceNodeID, std::shared_ptr<PathLengths> pathLengths)
-        : RJOutputWriter{context, outputNodeMask, sourceNodeID},
-          pathLengths{std::move(pathLengths)} {
+    SSPDestinationsOutputWriter(ClientContext* context, NodeOffsetMaskMap* outputNodeMask,
+        nodeID_t sourceNodeID, Frontier* frontier)
+        : RJOutputWriter{context, outputNodeMask, sourceNodeID}, frontier{frontier} {
         lengthVector = createVector(LogicalType::UINT16());
     }
 
-    void beginWritingOutputsInternal(common::table_id_t tableID) override {
-        pathLengths->pinCurFrontierTableID(tableID);
+    void beginWritingInternal(table_id_t tableID) override { frontier->pinTableID(tableID); }
+
+    void write(FactorizedTable& fTable, table_id_t tableID, LimitCounter* counter) override {
+        auto& sparseFrontier = frontier->cast<SparseFrontier>();
+        for (auto [offset, _] : sparseFrontier.getCurrentData()) {
+            write(fTable, {offset, tableID}, counter);
+        }
     }
 
     void write(FactorizedTable& fTable, nodeID_t dstNodeID, LimitCounter* counter) override {
-        auto length = pathLengths->getMaskValueFromCurFrontier(dstNodeID.offset);
+        if (!inOutputNodeMask(dstNodeID.offset)) { // Skip dst if it not is in scope.
+            return;
+        }
+        if (sourceNodeID_ == dstNodeID) { // Skip writing source node.
+            return;
+        }
+        auto iter = frontier->getIteration(dstNodeID.offset);
+        if (iter == FRONTIER_UNVISITED) { // Skip if dst is not visited.
+            return;
+        }
         dstNodeIDVector->setValue<nodeID_t>(0, dstNodeID);
-        lengthVector->setValue<uint16_t>(0, length);
+        lengthVector->setValue<uint16_t>(0, iter);
         fTable.append(vectors);
         if (counter != nullptr) {
             counter->increase(1);
@@ -34,32 +51,25 @@ public:
     }
 
     std::unique_ptr<RJOutputWriter> copy() override {
-        return std::make_unique<SSPDestinationsOutputWriter>(context, outputNodeMask, sourceNodeID,
-            pathLengths);
+        return std::make_unique<SSPDestinationsOutputWriter>(context, outputNodeMask, sourceNodeID_,
+            frontier);
     }
 
 private:
-    bool skipInternal(nodeID_t dstNodeID) const override {
-        return dstNodeID == sourceNodeID ||
-               pathLengths->getMaskValueFromCurFrontier(dstNodeID.offset) == PathLengths::UNVISITED;
-    }
-
-private:
+    Frontier* frontier;
     std::unique_ptr<ValueVector> lengthVector;
-    std::shared_ptr<PathLengths> pathLengths;
 };
 
 class SSPDestinationsEdgeCompute : public SPEdgeCompute {
 public:
-    explicit SSPDestinationsEdgeCompute(SinglePathLengthsFrontierPair* frontierPair)
+    explicit SSPDestinationsEdgeCompute(SPFrontierPair* frontierPair)
         : SPEdgeCompute{frontierPair} {};
 
-    std::vector<nodeID_t> edgeCompute(nodeID_t, graph::NbrScanState::Chunk& resultChunk,
-        bool) override {
+    std::vector<nodeID_t> edgeCompute(nodeID_t, NbrScanState::Chunk& resultChunk, bool) override {
         std::vector<nodeID_t> activeNodes;
         resultChunk.forEach([&](auto nbrNode, auto) {
-            if (frontierPair->getPathLengths()->getMaskValueFromNextFrontier(nbrNode.offset) ==
-                PathLengths::UNVISITED) {
+            auto iter = frontierPair->getNextFrontierValue(nbrNode.offset);
+            if (iter == FRONTIER_UNVISITED) {
                 activeNodes.push_back(nbrNode);
             }
         });
@@ -71,12 +81,8 @@ public:
     }
 };
 
-/**
- * Algorithm for parallel single shortest path computation, i.e., assumes Distinct semantics, so
- * one arbitrary shortest path is returned for each destination. If paths are not returned,
- * multiplicities of each destination is ignored (e.g., if there are 3 paths to a destination d,
- * d is returned only once).
- */
+// Single shortest path algorithm. Only destinations are tracked (reachability query).
+// If there are multiple path to a destination. Only one of the path is tracked.
 class SingleSPDestinationsAlgorithm : public RJAlgorithm {
 public:
     std::string getFunctionName() const override { return SingleSPDestinationsFunction::name; }
@@ -94,18 +100,23 @@ public:
     }
 
 private:
-    RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID, const RJBindData&,
+    std::unique_ptr<GDSComputeState> getComputeState(ExecutionContext* context, const RJBindData&,
         RecursiveExtendSharedState* sharedState) override {
-        auto clientContext = context->clientContext;
-        auto frontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
-        auto outputWriter = std::make_unique<SSPDestinationsOutputWriter>(clientContext,
-            sharedState->getOutputNodeMaskMap(), sourceNodeID, frontier);
-        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(frontier);
+        auto graph = sharedState->graph.get();
+        auto denseFrontier = DenseFrontier::getUninitializedFrontier(context, graph);
+        auto frontierPair = std::make_unique<SPFrontierPair>(denseFrontier);
         auto edgeCompute = std::make_unique<SSPDestinationsEdgeCompute>(frontierPair.get());
         auto auxiliaryState = std::make_unique<EmptyGDSAuxiliaryState>();
-        auto gdsState = std::make_unique<GDSComputeState>(std::move(frontierPair),
-            std::move(edgeCompute), std::move(auxiliaryState));
-        return RJCompState(std::move(gdsState), std::move(outputWriter));
+        return std::make_unique<GDSComputeState>(std::move(frontierPair), std::move(edgeCompute),
+            std::move(auxiliaryState));
+    }
+
+    std::unique_ptr<RJOutputWriter> getOutputWriter(ExecutionContext* context, const RJBindData&,
+        GDSComputeState& computeState, nodeID_t sourceNodeID,
+        RecursiveExtendSharedState* sharedState) override {
+        auto frontier = computeState.frontierPair->ptrCast<SPFrontierPair>()->getFrontier();
+        return std::make_unique<SSPDestinationsOutputWriter>(context->clientContext,
+            sharedState->getOutputNodeMaskMap(), sourceNodeID, frontier);
     }
 };
 

--- a/src/function/gds/ssp_destinations.cpp
+++ b/src/function/gds/ssp_destinations.cpp
@@ -1,5 +1,3 @@
-#include <unistd.h>
-
 #include "binder/expression/node_expression.h"
 #include "function/gds/gds_function_collection.h"
 #include "function/gds/rec_joins.h"

--- a/src/function/gds/ssp_paths.cpp
+++ b/src/function/gds/ssp_paths.cpp
@@ -72,7 +72,7 @@ private:
         RecursiveExtendSharedState* sharedState) override {
         auto clientContext = context->clientContext;
         auto frontier = DenseFrontier::getUninitializedFrontier(context, sharedState->graph.get());
-        auto frontierPair = std::make_unique<SPFrontierPair>(frontier);
+        auto frontierPair = std::make_unique<SPFrontierPair>(std::move(frontier));
         auto bfsGraph = std::make_unique<BFSGraphManager>(
             sharedState->graph->getMaxOffsetMap(clientContext->getTransaction()),
             clientContext->getMemoryManager());

--- a/src/function/gds/strongly_connected_components.cpp
+++ b/src/function/gds/strongly_connected_components.cpp
@@ -232,7 +232,8 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
     // TODO(sdht): refactor when a better FrontierPair API is available.
     currentFrontier->pinTableID(tableId);
     nextFrontier->pinTableID(tableId);
-    auto frontierPair = std::make_unique<DenseFrontierPair>(std::move(currentFrontier), std::move(nextFrontier));
+    auto frontierPair =
+        std::make_unique<DenseFrontierPair>(std::move(currentFrontier), std::move(nextFrontier));
     auto initializeFrontiers =
         std::make_unique<SccInitializeFrontiers>(*frontierPair, computationState);
     auto setNewSccIds = std::make_unique<SccFindNewSccIds>(computationState);
@@ -247,14 +248,16 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
         // Fwd colors.
         computeState.frontierPair->resetCurrentIter();
         computeState.frontierPair->setActiveNodesForNextIter();
-        GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph, *initializeFrontiers);
+        GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph,
+            *initializeFrontiers);
         GDSUtils::runAlgorithmEdgeCompute(input.context, computeState, graph, ExtendDirection::FWD,
             MAX_ITERATION);
 
         // Bwd colors.
         computeState.frontierPair->resetCurrentIter();
         computeState.frontierPair->setActiveNodesForNextIter();
-        GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph, *initializeFrontiers);
+        GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph,
+            *initializeFrontiers);
         GDSUtils::runAlgorithmEdgeCompute(input.context, computeState, graph, ExtendDirection::BWD,
             MAX_ITERATION);
 

--- a/src/function/gds/strongly_connected_components_kosaraju.cpp
+++ b/src/function/gds/strongly_connected_components_kosaraju.cpp
@@ -49,7 +49,7 @@ public:
 
 private:
     offset_t* componentIDs = nullptr;
-    ObjectArraysMap<offset_t> componentIDsMap;
+    GDSDenseObjectManager<offset_t> componentIDsMap;
 };
 
 class SCCCompute {

--- a/src/function/gds/strongly_connected_components_kosaraju.cpp
+++ b/src/function/gds/strongly_connected_components_kosaraju.cpp
@@ -24,8 +24,8 @@ static constexpr offset_t NOT_VISITED = numeric_limits<offset_t>::max() - 2;
 class SCCState {
 public:
     SCCState(const offset_t tableID, const offset_t numNodes, MemoryManager* mm) {
-        componentIDsMap.allocate(tableID, numNodes, mm);
-        componentIDs = componentIDsMap.getData(tableID);
+        denseObjects.allocate(tableID, numNodes, mm);
+        componentIDs = denseObjects.getData(tableID);
         for (auto i = 0u; i < numNodes; ++i) {
             componentIDs[i] = NOT_VISITED;
         }
@@ -49,7 +49,7 @@ public:
 
 private:
     offset_t* componentIDs = nullptr;
-    GDSDenseObjectManager<offset_t> componentIDsMap;
+    GDSDenseObjectManager<offset_t> denseObjects;
 };
 
 class SCCCompute {
@@ -168,7 +168,7 @@ static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&)
     edgeCompute->compute(tableID, maxOffset);
 
     auto vertexCompute = make_unique<SCCVertexCompute>(mm, sharedState, sccState);
-    GDSUtils::runVertexCompute(input.context, graph, *vertexCompute);
+    GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph, *vertexCompute);
 
     sharedState->factorizedTablePool.mergeLocalTables();
     return 0;

--- a/src/function/gds/variable_length_path.cpp
+++ b/src/function/gds/variable_length_path.cpp
@@ -121,8 +121,8 @@ private:
             DenseFrontier::getUninitializedFrontier(context, sharedState->graph.get());
         auto nextDenseFrontier =
             DenseFrontier::getUninitializedFrontier(context, sharedState->graph.get());
-        auto frontierPair = std::make_unique<DenseSparseDynamicFrontierPair>(currentDenseFrontier,
-            nextDenseFrontier);
+        auto frontierPair = std::make_unique<DenseSparseDynamicFrontierPair>(std::move(currentDenseFrontier),
+            std::move(nextDenseFrontier));
         auto edgeCompute =
             std::make_unique<VarLenJoinsEdgeCompute>(frontierPair.get(), bfsGraph.get());
         auto auxiliaryState = std::make_unique<PathAuxiliaryState>(std::move(bfsGraph));

--- a/src/function/gds/variable_length_path.cpp
+++ b/src/function/gds/variable_length_path.cpp
@@ -14,38 +14,46 @@ namespace function {
 
 class VarLenPathsOutputWriter final : public PathsOutputWriter {
 public:
-    VarLenPathsOutputWriter(main::ClientContext* context, common::NodeOffsetMaskMap* outputNodeMask,
-        common::nodeID_t sourceNodeID, PathsOutputWriterInfo info, BFSGraph& bfsGraph)
+    VarLenPathsOutputWriter(main::ClientContext* context, NodeOffsetMaskMap* outputNodeMask,
+        nodeID_t sourceNodeID, PathsOutputWriterInfo info, BaseBFSGraph& bfsGraph)
         : PathsOutputWriter{context, outputNodeMask, sourceNodeID, info, bfsGraph} {}
 
-    bool skipInternal(common::nodeID_t dstNodeID) const override {
-        auto head = bfsGraph.getParentListHead(dstNodeID.offset);
-        // For variable lengths joins, we skip a destination node d in the following conditions:
-        //    (i) if no path has reached d from the source, except when the lower bound is 0.
-        //    (ii) the longest path that has reached d, which is stored in the iter value of the
-        //    firstParent is smaller than the lower bound.
-        // We also do not output any results if a destination node has not been reached.
-        if (nullptr == head) {
-            return info.lowerBound > 0;
-        } else {
-            return head->getIter() < info.lowerBound;
+    void writeInternal(FactorizedTable& fTable, nodeID_t dstNodeID,
+        LimitCounter* counter) override {
+        auto firstParent = findFirstParent(dstNodeID.offset);
+        if (firstParent == nullptr) {
+            if (sourceNodeID_ == dstNodeID && info.lowerBound == 0) {
+                // We still output a path from src to src if required path length is 0.
+                // e.g. MATCH (a)-[e*0..]->
+                // "a" needs to be in the output
+                writePath({});
+                fTable.append(vectors);
+                updateCounterAndTerminate(counter);
+            }
+            return;
         }
+        if (firstParent->getIter() < info.lowerBound) { // Skip if lower bound is not met.
+            return;
+        }
+        if (!info.hasNodeMask() && info.semantic == PathSemantic::WALK) {
+            dfsFast(firstParent, fTable, counter);
+            return;
+        }
+        dfsSlow(firstParent, fTable, counter);
     }
 
     std::unique_ptr<RJOutputWriter> copy() override {
-        return std::make_unique<VarLenPathsOutputWriter>(context, outputNodeMask, sourceNodeID,
+        return std::make_unique<VarLenPathsOutputWriter>(context, outputNodeMask, sourceNodeID_,
             info, bfsGraph);
     }
 };
 
-struct VarLenJoinsEdgeCompute : public EdgeCompute {
-    DoublePathLengthsFrontierPair* frontierPair;
-    BFSGraph* bfsGraph;
-    ObjectBlock<ParentList>* block = nullptr;
-
-    VarLenJoinsEdgeCompute(DoublePathLengthsFrontierPair* frontierPair, BFSGraph* bfsGraph)
-        : frontierPair{frontierPair}, bfsGraph{bfsGraph} {
-        block = bfsGraph->addNewBlock();
+class VarLenJoinsEdgeCompute : public EdgeCompute {
+public:
+    VarLenJoinsEdgeCompute(DenseSparseDynamicFrontierPair* frontierPair,
+        BFSGraphManager* bfsGraphManager)
+        : frontierPair{frontierPair}, bfsGraphManager{bfsGraphManager} {
+        block = bfsGraphManager->getCurrentGraph()->addNewBlock();
     };
 
     std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, graph::NbrScanState::Chunk& chunk,
@@ -54,18 +62,23 @@ struct VarLenJoinsEdgeCompute : public EdgeCompute {
         chunk.forEach([&](auto nbrNodeID, auto edgeID) {
             // We should always update the nbrID in variable length joins
             if (!block->hasSpace()) {
-                block = bfsGraph->addNewBlock();
+                block = bfsGraphManager->getCurrentGraph()->addNewBlock();
             }
-            bfsGraph->addParent(frontierPair->getCurrentIter(), boundNodeID, edgeID, nbrNodeID,
-                fwdEdge, block);
+            bfsGraphManager->getCurrentGraph()->addParent(frontierPair->getCurrentIter(),
+                boundNodeID, edgeID, nbrNodeID, fwdEdge, block);
             activeNodes.push_back(nbrNodeID);
         });
         return activeNodes;
     }
 
     std::unique_ptr<EdgeCompute> copy() override {
-        return std::make_unique<VarLenJoinsEdgeCompute>(frontierPair, bfsGraph);
+        return std::make_unique<VarLenJoinsEdgeCompute>(frontierPair, bfsGraphManager);
     }
+
+private:
+    DenseSparseDynamicFrontierPair* frontierPair;
+    BFSGraphManager* bfsGraphManager;
+    ObjectBlock<ParentList>* block = nullptr;
 };
 
 /**
@@ -78,7 +91,7 @@ public:
     std::string getFunctionName() const override { return VarLenJoinsFunction::name; }
 
     // return srcNodeID, dstNodeID, length, [direction, pathNodeIDs, pathEdgeIDs] (if track path)
-    binder::expression_vector getResultColumns(const RJBindData& bindData) const override {
+    expression_vector getResultColumns(const RJBindData& bindData) const override {
         expression_vector columns;
         columns.push_back(bindData.nodeInput->constCast<NodeExpression>().getInternalID());
         columns.push_back(bindData.nodeOutput->constCast<NodeExpression>().getInternalID());
@@ -98,25 +111,35 @@ public:
     }
 
 private:
-    RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID,
-        const RJBindData& bindData, processor::RecursiveExtendSharedState* sharedState) override {
+    std::unique_ptr<GDSComputeState> getComputeState(ExecutionContext* context, const RJBindData&,
+        RecursiveExtendSharedState* sharedState) override {
         auto clientContext = context->clientContext;
-        auto frontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
-        auto bfsGraph = getBFSGraph(context, sharedState->graph.get());
-        auto writerInfo = bindData.getPathWriterInfo();
-        writerInfo.pathNodeMask = sharedState->getPathNodeMaskMap();
-        auto outputWriter = std::make_unique<VarLenPathsOutputWriter>(clientContext,
-            sharedState->getOutputNodeMaskMap(), sourceNodeID, writerInfo, *bfsGraph);
-        auto currentFrontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
-        auto nextFrontier = PathLengths::getUnvisitedFrontier(context, sharedState->graph.get());
-        auto frontierPair =
-            std::make_unique<DoublePathLengthsFrontierPair>(currentFrontier, nextFrontier);
+        auto bfsGraph = std::make_unique<BFSGraphManager>(
+            sharedState->graph->getMaxOffsetMap(clientContext->getTransaction()),
+            clientContext->getMemoryManager());
+        auto currentDenseFrontier =
+            DenseFrontier::getUninitializedFrontier(context, sharedState->graph.get());
+        auto nextDenseFrontier =
+            DenseFrontier::getUninitializedFrontier(context, sharedState->graph.get());
+        auto frontierPair = std::make_unique<DenseSparseDynamicFrontierPair>(currentDenseFrontier,
+            nextDenseFrontier);
         auto edgeCompute =
             std::make_unique<VarLenJoinsEdgeCompute>(frontierPair.get(), bfsGraph.get());
         auto auxiliaryState = std::make_unique<PathAuxiliaryState>(std::move(bfsGraph));
-        auto gdsState = std::make_unique<GDSComputeState>(std::move(frontierPair),
-            std::move(edgeCompute), std::move(auxiliaryState));
-        return RJCompState(std::move(gdsState), std::move(outputWriter));
+        return std::make_unique<GDSComputeState>(std::move(frontierPair), std::move(edgeCompute),
+            std::move(auxiliaryState));
+    }
+
+    std::unique_ptr<RJOutputWriter> getOutputWriter(ExecutionContext* context,
+        const RJBindData& bindData, GDSComputeState& computeState, common::nodeID_t sourceNodeID,
+        processor::RecursiveExtendSharedState* sharedState) override {
+        auto bfsGraph = computeState.auxiliaryState->ptrCast<PathAuxiliaryState>()
+                            ->getBFSGraphManager()
+                            ->getCurrentGraph();
+        auto writerInfo = bindData.getPathWriterInfo();
+        writerInfo.pathNodeMask = sharedState->getPathNodeMaskMap();
+        return std::make_unique<VarLenPathsOutputWriter>(context->clientContext,
+            sharedState->getOutputNodeMaskMap(), sourceNodeID, writerInfo, *bfsGraph);
     }
 };
 

--- a/src/function/gds/variable_length_path.cpp
+++ b/src/function/gds/variable_length_path.cpp
@@ -121,8 +121,8 @@ private:
             DenseFrontier::getUninitializedFrontier(context, sharedState->graph.get());
         auto nextDenseFrontier =
             DenseFrontier::getUninitializedFrontier(context, sharedState->graph.get());
-        auto frontierPair = std::make_unique<DenseSparseDynamicFrontierPair>(std::move(currentDenseFrontier),
-            std::move(nextDenseFrontier));
+        auto frontierPair = std::make_unique<DenseSparseDynamicFrontierPair>(
+            std::move(currentDenseFrontier), std::move(nextDenseFrontier));
         auto edgeCompute =
             std::make_unique<VarLenJoinsEdgeCompute>(frontierPair.get(), bfsGraph.get());
         auto auxiliaryState = std::make_unique<PathAuxiliaryState>(std::move(bfsGraph));

--- a/src/function/gds/weakly_connected_components.cpp
+++ b/src/function/gds/weakly_connected_components.cpp
@@ -154,7 +154,7 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
     auto currentFrontier = DenseFrontier::getUnvisitedFrontier(input.context, graph);
     auto nextFrontier =
         DenseFrontier::getVisitedFrontier(input.context, graph, sharedState->getGraphNodeMaskMap());
-    auto frontierPair = std::make_unique<DenseFrontierPair>(currentFrontier, nextFrontier);
+    auto frontierPair = std::make_unique<DenseFrontierPair>(std::move(currentFrontier), std::move(nextFrontier));
     frontierPair->setActiveNodesForNextIter();
     auto maxOffsetMap = graph->getMaxOffsetMap(clientContext->getTransaction());
     auto offsetManager = OffsetManager(maxOffsetMap);
@@ -168,7 +168,7 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
         GDSComputeState(std::move(frontierPair), std::move(edgeCompute), std::move(auxiliaryState));
     GDSUtils::runAlgorithmEdgeCompute(input.context, computeState, graph, ExtendDirection::BOTH,
         MAX_ITERATION);
-    GDSUtils::runVertexCompute(input.context, graph, *vertexCompute);
+    GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph, *vertexCompute);
     sharedState->factorizedTablePool.mergeLocalTables();
     return 0;
 }

--- a/src/function/gds/weakly_connected_components.cpp
+++ b/src/function/gds/weakly_connected_components.cpp
@@ -154,7 +154,8 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
     auto currentFrontier = DenseFrontier::getUnvisitedFrontier(input.context, graph);
     auto nextFrontier =
         DenseFrontier::getVisitedFrontier(input.context, graph, sharedState->getGraphNodeMaskMap());
-    auto frontierPair = std::make_unique<DenseFrontierPair>(std::move(currentFrontier), std::move(nextFrontier));
+    auto frontierPair =
+        std::make_unique<DenseFrontierPair>(std::move(currentFrontier), std::move(nextFrontier));
     frontierPair->setActiveNodesForNextIter();
     auto maxOffsetMap = graph->getMaxOffsetMap(clientContext->getTransaction());
     auto offsetManager = OffsetManager(maxOffsetMap);

--- a/src/function/gds/wsp_destinations.cpp
+++ b/src/function/gds/wsp_destinations.cpp
@@ -169,7 +169,7 @@ private:
         auto curDenseFrontier = DenseFrontier::getUninitializedFrontier(context, graph);
         auto nextDenseFrontier = DenseFrontier::getUninitializedFrontier(context, graph);
         auto frontierPair =
-            std::make_unique<DenseSparseDynamicFrontierPair>(curDenseFrontier, nextDenseFrontier);
+            std::make_unique<DenseSparseDynamicFrontierPair>(std::move(curDenseFrontier), std::move(nextDenseFrontier));
         auto costs =
             std::make_shared<Costs>(graph->getMaxOffsetMap(clientContext->getTransaction()),
                 clientContext->getMemoryManager());

--- a/src/function/gds/wsp_destinations.cpp
+++ b/src/function/gds/wsp_destinations.cpp
@@ -168,8 +168,8 @@ private:
         auto graph = sharedState->graph.get();
         auto curDenseFrontier = DenseFrontier::getUninitializedFrontier(context, graph);
         auto nextDenseFrontier = DenseFrontier::getUninitializedFrontier(context, graph);
-        auto frontierPair =
-            std::make_unique<DenseSparseDynamicFrontierPair>(std::move(curDenseFrontier), std::move(nextDenseFrontier));
+        auto frontierPair = std::make_unique<DenseSparseDynamicFrontierPair>(
+            std::move(curDenseFrontier), std::move(nextDenseFrontier));
         auto costs =
             std::make_shared<Costs>(graph->getMaxOffsetMap(clientContext->getTransaction()),
                 clientContext->getMemoryManager());

--- a/src/function/gds/wsp_paths.cpp
+++ b/src/function/gds/wsp_paths.cpp
@@ -63,9 +63,6 @@ public:
         if (parent == nullptr) { // Skip if dst is not visited.
             return;
         }
-        // if (parent->getCost() == std::numeric_limits<double>::max()) {
-        //     return;
-        // }
         costVector->setValue<double>(0, parent->getCost());
         std::vector<ParentList*> curPath;
         curPath.push_back(parent);
@@ -83,15 +80,6 @@ public:
         return std::make_unique<WSPPathsOutputWriter>(context, outputNodeMask, sourceNodeID_, info,
             bfsGraph);
     }
-
-private:
-    // bool skipInternal(nodeID_t dstNodeID) const override {
-    //     if (dstNodeID == sourceNodeID) {
-    //         return true;
-    //     }
-    //     auto parent = bfsGraph.getParentListHead(dstNodeID.offset);
-    //     return parent == nullptr || parent->getCost() == std::numeric_limits<double>::max();
-    // }
 
 private:
     std::unique_ptr<ValueVector> costVector;
@@ -128,7 +116,7 @@ private:
         auto curDenseFrontier = DenseFrontier::getUninitializedFrontier(context, graph);
         auto nextDenseFrontier = DenseFrontier::getUninitializedFrontier(context, graph);
         auto frontierPair =
-            std::make_unique<DenseSparseDynamicFrontierPair>(curDenseFrontier, nextDenseFrontier);
+            std::make_unique<DenseSparseDynamicFrontierPair>(std::move(curDenseFrontier), std::move(nextDenseFrontier));
         auto bfsGraph = std::make_unique<BFSGraphManager>(
             sharedState->graph->getMaxOffsetMap(clientContext->getTransaction()),
             clientContext->getMemoryManager());

--- a/src/function/gds/wsp_paths.cpp
+++ b/src/function/gds/wsp_paths.cpp
@@ -115,8 +115,8 @@ private:
         auto graph = sharedState->graph.get();
         auto curDenseFrontier = DenseFrontier::getUninitializedFrontier(context, graph);
         auto nextDenseFrontier = DenseFrontier::getUninitializedFrontier(context, graph);
-        auto frontierPair =
-            std::make_unique<DenseSparseDynamicFrontierPair>(std::move(curDenseFrontier), std::move(nextDenseFrontier));
+        auto frontierPair = std::make_unique<DenseSparseDynamicFrontierPair>(
+            std::move(curDenseFrontier), std::move(nextDenseFrontier));
         auto bfsGraph = std::make_unique<BFSGraphManager>(
             sharedState->graph->getMaxOffsetMap(clientContext->getTransaction()),
             clientContext->getMemoryManager());

--- a/src/function/gds/wsp_paths.cpp
+++ b/src/function/gds/wsp_paths.cpp
@@ -17,8 +17,9 @@ namespace function {
 template<typename T>
 class WSPPathsEdgeCompute : public EdgeCompute {
 public:
-    explicit WSPPathsEdgeCompute(BFSGraph& bfsGraph) : bfsGraph{bfsGraph} {
-        block = bfsGraph.addNewBlock();
+    explicit WSPPathsEdgeCompute(BFSGraphManager* bfsGraphManager)
+        : bfsGraphManager{bfsGraphManager} {
+        block = bfsGraphManager->getCurrentGraph()->addNewBlock();
     }
 
     std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, graph::NbrScanState::Chunk& chunk,
@@ -26,10 +27,10 @@ public:
         std::vector<nodeID_t> result;
         chunk.forEach<T>([&](auto nbrNodeID, auto edgeID, auto weight) {
             if (!block->hasSpace()) {
-                block = bfsGraph.addNewBlock();
+                block = bfsGraphManager->getCurrentGraph()->addNewBlock();
             }
-            if (bfsGraph.tryAddSingleParentWithWeight(boundNodeID, edgeID, nbrNodeID, fwdEdge,
-                    (double)weight, block)) {
+            if (bfsGraphManager->getCurrentGraph()->tryAddSingleParentWithWeight(boundNodeID,
+                    edgeID, nbrNodeID, fwdEdge, (double)weight, block)) {
                 result.push_back(nbrNodeID);
             }
         });
@@ -37,26 +38,34 @@ public:
     }
 
     std::unique_ptr<EdgeCompute> copy() override {
-        return std::make_unique<WSPPathsEdgeCompute<T>>(bfsGraph);
+        return std::make_unique<WSPPathsEdgeCompute<T>>(bfsGraphManager);
     }
 
 private:
-    BFSGraph& bfsGraph;
+    BFSGraphManager* bfsGraphManager;
     ObjectBlock<ParentList>* block = nullptr;
 };
 
 class WSPPathsOutputWriter : public PathsOutputWriter {
 public:
-    WSPPathsOutputWriter(main::ClientContext* context, common::NodeOffsetMaskMap* outputNodeMask,
-        common::nodeID_t sourceNodeID, PathsOutputWriterInfo info, BFSGraph& bfsGraph)
+    WSPPathsOutputWriter(main::ClientContext* context, NodeOffsetMaskMap* outputNodeMask,
+        nodeID_t sourceNodeID, PathsOutputWriterInfo info, BaseBFSGraph& bfsGraph)
         : PathsOutputWriter{context, outputNodeMask, sourceNodeID, info, bfsGraph} {
         costVector = createVector(LogicalType::DOUBLE());
     }
 
-    void write(processor::FactorizedTable& fTable, common::nodeID_t dstNodeID,
+    void writeInternal(FactorizedTable& fTable, nodeID_t dstNodeID,
         LimitCounter* counter) override {
-        dstNodeIDVector->setValue<nodeID_t>(0, dstNodeID);
+        if (dstNodeID == sourceNodeID_) { // Skip writing source node.
+            return;
+        }
         auto parent = bfsGraph.getParentListHead(dstNodeID.offset);
+        if (parent == nullptr) { // Skip if dst is not visited.
+            return;
+        }
+        // if (parent->getCost() == std::numeric_limits<double>::max()) {
+        //     return;
+        // }
         costVector->setValue<double>(0, parent->getCost());
         std::vector<ParentList*> curPath;
         curPath.push_back(parent);
@@ -71,18 +80,18 @@ public:
     }
 
     std::unique_ptr<RJOutputWriter> copy() override {
-        return std::make_unique<WSPPathsOutputWriter>(context, outputNodeMask, sourceNodeID, info,
+        return std::make_unique<WSPPathsOutputWriter>(context, outputNodeMask, sourceNodeID_, info,
             bfsGraph);
     }
 
 private:
-    bool skipInternal(nodeID_t dstNodeID) const override {
-        if (dstNodeID == sourceNodeID) {
-            return true;
-        }
-        auto parent = bfsGraph.getParentListHead(dstNodeID.offset);
-        return parent == nullptr || parent->getCost() == std::numeric_limits<double>::max();
-    }
+    // bool skipInternal(nodeID_t dstNodeID) const override {
+    //     if (dstNodeID == sourceNodeID) {
+    //         return true;
+    //     }
+    //     auto parent = bfsGraph.getParentListHead(dstNodeID.offset);
+    //     return parent == nullptr || parent->getCost() == std::numeric_limits<double>::max();
+    // }
 
 private:
     std::unique_ptr<ValueVector> costVector;
@@ -112,26 +121,36 @@ public:
     }
 
 private:
-    RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID,
+    std::unique_ptr<GDSComputeState> getComputeState(ExecutionContext* context,
         const RJBindData& bindData, RecursiveExtendSharedState* sharedState) override {
         auto clientContext = context->clientContext;
         auto graph = sharedState->graph.get();
-        auto curFrontier = PathLengths::getUnvisitedFrontier(context, graph);
-        auto nextFrontier = PathLengths::getUnvisitedFrontier(context, graph);
+        auto curDenseFrontier = DenseFrontier::getUninitializedFrontier(context, graph);
+        auto nextDenseFrontier = DenseFrontier::getUninitializedFrontier(context, graph);
         auto frontierPair =
-            std::make_unique<DoublePathLengthsFrontierPair>(curFrontier, nextFrontier);
-        auto bfsGraph = getBFSGraph(context, graph);
-        auto writerInfo = bindData.getPathWriterInfo();
-        auto outputWriter = std::make_unique<WSPPathsOutputWriter>(clientContext,
-            sharedState->getOutputNodeMaskMap(), sourceNodeID, writerInfo, *bfsGraph);
+            std::make_unique<DenseSparseDynamicFrontierPair>(curDenseFrontier, nextDenseFrontier);
+        auto bfsGraph = std::make_unique<BFSGraphManager>(
+            sharedState->graph->getMaxOffsetMap(clientContext->getTransaction()),
+            clientContext->getMemoryManager());
         std::unique_ptr<GDSComputeState> gdsState;
         visit(bindData.weightPropertyExpr->getDataType(), [&]<typename T>(T) {
-            auto edgeCompute = std::make_unique<WSPPathsEdgeCompute<T>>(*bfsGraph);
+            auto edgeCompute = std::make_unique<WSPPathsEdgeCompute<T>>(bfsGraph.get());
             auto auxiliaryState = std::make_unique<WSPPathsAuxiliaryState>(std::move(bfsGraph));
             gdsState = std::make_unique<GDSComputeState>(std::move(frontierPair),
                 std::move(edgeCompute), std::move(auxiliaryState));
         });
-        return RJCompState(std::move(gdsState), std::move(outputWriter));
+        return gdsState;
+    }
+
+    std::unique_ptr<RJOutputWriter> getOutputWriter(ExecutionContext* context,
+        const RJBindData& bindData, GDSComputeState& computeState, nodeID_t sourceNodeID,
+        RecursiveExtendSharedState* sharedState) override {
+        auto bfsGraph = computeState.auxiliaryState->ptrCast<WSPPathsAuxiliaryState>()
+                            ->getBFSGraphManager()
+                            ->getCurrentGraph();
+        auto writerInfo = bindData.getPathWriterInfo();
+        return std::make_unique<WSPPathsOutputWriter>(context->clientContext,
+            sharedState->getOutputNodeMaskMap(), sourceNodeID, writerInfo, *bfsGraph);
     }
 };
 

--- a/src/include/function/gds/auxiliary_state/gds_auxilary_state.h
+++ b/src/include/function/gds/auxiliary_state/gds_auxilary_state.h
@@ -4,6 +4,14 @@
 #include "common/types/types.h"
 
 namespace kuzu {
+namespace graph {
+class Graph;
+}
+
+namespace processor {
+struct ExecutionContext;
+}
+
 namespace function {
 
 // Maintain algorithm specific data structures
@@ -19,6 +27,8 @@ public:
     virtual void beginFrontierCompute(common::table_id_t fromTableID,
         common::table_id_t toTableID) = 0;
 
+    virtual void switchToDense(processor::ExecutionContext* context, graph::Graph* graph) = 0;
+
     template<class TARGET>
     TARGET* ptrCast() {
         return common::ku_dynamic_cast<TARGET*>(this);
@@ -30,6 +40,8 @@ public:
     EmptyGDSAuxiliaryState() = default;
 
     void beginFrontierCompute(common::table_id_t, common::table_id_t) override {}
+
+    void switchToDense(processor::ExecutionContext*, graph::Graph*) override {}
 };
 
 } // namespace function

--- a/src/include/function/gds/compute.h
+++ b/src/include/function/gds/compute.h
@@ -50,6 +50,9 @@ public:
     // the function on each node in a graph.
     virtual void vertexCompute(const graph::VertexScanState::Chunk&) {}
     virtual void vertexCompute(common::offset_t, common::offset_t, common::table_id_t) {}
+    // This function assumes the number of nodes is small (sparse) and morsel driven parallelism
+    // is not necessary. It should not be used in parallel computations.
+    virtual void vertexCompute(common::table_id_t) {}
 
     virtual std::unique_ptr<VertexCompute> copy() = 0;
 };

--- a/src/include/function/gds/density_state.h
+++ b/src/include/function/gds/density_state.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstdint>
+
+namespace kuzu {
+namespace function {
+
+enum class GDSDensityState : uint8_t {
+    SPARSE = 0,
+    DENSE = 1,
+};
+
+}
+} // namespace kuzu

--- a/src/include/function/gds/frontier_morsel.h
+++ b/src/include/function/gds/frontier_morsel.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <atomic>
+
+#include "common/types/types.h"
+
+namespace kuzu {
+namespace function {
+
+class FrontierMorsel {
+public:
+    FrontierMorsel() = default;
+
+    common::offset_t getBeginOffset() const { return beginOffset; }
+    common::offset_t getEndOffset() const { return endOffset; }
+
+    void init(common::offset_t beginOffset_, common::offset_t endOffset_) {
+        beginOffset = beginOffset_;
+        endOffset = endOffset_;
+    }
+
+private:
+    common::offset_t beginOffset = common::INVALID_OFFSET;
+    common::offset_t endOffset = common::INVALID_OFFSET;
+};
+
+class KUZU_API FrontierMorselDispatcher {
+    static constexpr uint64_t MIN_FRONTIER_MORSEL_SIZE = 512;
+    // Note: MIN_NUMBER_OF_FRONTIER_MORSELS is the minimum number of morsels we aim to have but we
+    // can have fewer than this. See the beginFrontierComputeBetweenTables to see the actual
+    // morselSize computation for details.
+    static constexpr uint64_t MIN_NUMBER_OF_FRONTIER_MORSELS = 128;
+
+public:
+    explicit FrontierMorselDispatcher(uint64_t maxThreads);
+
+    void init(common::offset_t _maxOffset);
+
+    bool getNextRangeMorsel(FrontierMorsel& frontierMorsel);
+
+private:
+    common::offset_t maxOffset;
+    std::atomic<common::offset_t> nextOffset;
+    uint64_t maxThreads;
+    uint64_t morselSize;
+};
+
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/gds/gds_state.h
+++ b/src/include/function/gds/gds_state.h
@@ -28,6 +28,9 @@ struct GDSComputeState {
     // RJOutputs, to possibly avoid them doing lookups of S and T-related data structures,
     // e.g., maps, internally.
     void beginFrontierCompute(common::table_id_t currTableID, common::table_id_t nextTableID) const;
+
+    // Switch all data structures (frontierPair & auxiliaryState) to dense version.
+    void switchToDense(processor::ExecutionContext* context, graph::Graph* graph) const;
 };
 
 } // namespace function

--- a/src/include/function/gds/gds_task.h
+++ b/src/include/function/gds/gds_task.h
@@ -90,6 +90,8 @@ public:
 
     void run() override;
 
+    void runSparse();
+
 private:
     VertexComputeTaskInfo info;
     std::shared_ptr<VertexComputeTaskSharedState> sharedState;

--- a/src/include/function/gds/gds_task.h
+++ b/src/include/function/gds/gds_task.h
@@ -4,6 +4,7 @@
 
 #include "common/enums/extend_direction.h"
 #include "common/task_system/task.h"
+#include "frontier_morsel.h"
 #include "function/gds/gds_frontier.h"
 #include "graph/graph.h"
 

--- a/src/include/function/gds/gds_utils.h
+++ b/src/include/function/gds/gds_utils.h
@@ -9,14 +9,20 @@ namespace function {
 
 class KUZU_API GDSUtils {
 public:
-    static void runFrontiersUntilConvergence(processor::ExecutionContext* context,
+    static void runAlgorithmEdgeCompute(processor::ExecutionContext* context,
         GDSComputeState& compState, graph::Graph* graph, common::ExtendDirection extendDirection,
         uint64_t maxIteration);
-    // Run edge compute with output node mask for early termination
-    static void runFrontiersUntilConvergence(processor::ExecutionContext* context,
+
+    static void runFTSEdgeCompute(processor::ExecutionContext* context, GDSComputeState& compState,
+        graph::Graph* graph, common::ExtendDirection extendDirection,
+        const std::string& propertyToScan);
+
+    // Run edge compute for recursive join. TODO continue comment
+    static void runRecursiveJoinEdgeCompute(processor::ExecutionContext* context,
         GDSComputeState& compState, graph::Graph* graph, common::ExtendDirection extendDirection,
         uint64_t maxIteration, common::NodeOffsetMaskMap* outputNodeMask,
         const std::string& propertyToScan = "");
+
     // Run vertex compute without property scan
     static void runVertexCompute(processor::ExecutionContext* context, graph::Graph* graph,
         VertexCompute& vc);
@@ -27,8 +33,7 @@ public:
     static void runVertexCompute(processor::ExecutionContext* context, graph::Graph* graph,
         VertexCompute& vc, catalog::TableCatalogEntry* entry,
         std::vector<std::string> propertiesToScan);
-    static void runVertexComputeSparse(SparseFrontier& sparseFrontier, graph::Graph* graph,
-        VertexCompute& vc);
+    static void runVertexComputeSparse(graph::Graph* graph, VertexCompute& vc);
 };
 
 } // namespace function

--- a/src/include/function/gds/gds_utils.h
+++ b/src/include/function/gds/gds_utils.h
@@ -9,31 +9,30 @@ namespace function {
 
 class KUZU_API GDSUtils {
 public:
+    // Run edge compute for graph algorithms
     static void runAlgorithmEdgeCompute(processor::ExecutionContext* context,
         GDSComputeState& compState, graph::Graph* graph, common::ExtendDirection extendDirection,
         uint64_t maxIteration);
-
+    // Run edge compute for full text search
     static void runFTSEdgeCompute(processor::ExecutionContext* context, GDSComputeState& compState,
         graph::Graph* graph, common::ExtendDirection extendDirection,
         const std::string& propertyToScan);
-
-    // Run edge compute for recursive join. TODO continue comment
+    // Run edge compute for recursive join.
     static void runRecursiveJoinEdgeCompute(processor::ExecutionContext* context,
         GDSComputeState& compState, graph::Graph* graph, common::ExtendDirection extendDirection,
         uint64_t maxIteration, common::NodeOffsetMaskMap* outputNodeMask,
         const std::string& propertyToScan = "");
 
     // Run vertex compute without property scan
-    static void runVertexCompute(processor::ExecutionContext* context, graph::Graph* graph,
-        VertexCompute& vc);
+    static void runVertexCompute(processor::ExecutionContext* context, GDSDensityState densityState,
+        graph::Graph* graph, VertexCompute& vc);
     // Run vertex compute with property scan
-    static void runVertexCompute(processor::ExecutionContext* context, graph::Graph* graph,
-        VertexCompute& vc, std::vector<std::string> propertiesToScan);
+    static void runVertexCompute(processor::ExecutionContext* context, GDSDensityState densityState,
+        graph::Graph* graph, VertexCompute& vc, std::vector<std::string> propertiesToScan);
     // Run vertex compute on specific table with property scan
-    static void runVertexCompute(processor::ExecutionContext* context, graph::Graph* graph,
-        VertexCompute& vc, catalog::TableCatalogEntry* entry,
+    static void runVertexCompute(processor::ExecutionContext* context, GDSDensityState densityState,
+        graph::Graph* graph, VertexCompute& vc, catalog::TableCatalogEntry* entry,
         std::vector<std::string> propertiesToScan);
-    static void runVertexComputeSparse(graph::Graph* graph, VertexCompute& vc);
 };
 
 } // namespace function

--- a/src/include/function/gds/rec_joins.h
+++ b/src/include/function/gds/rec_joins.h
@@ -41,30 +41,20 @@ struct RJBindData {
     PathsOutputWriterInfo getPathWriterInfo() const;
 };
 
-struct RJCompState {
-    std::unique_ptr<GDSComputeState> gdsComputeState;
-    std::unique_ptr<RJOutputWriter> outputWriter;
-
-    RJCompState(std::unique_ptr<GDSComputeState> gdsComputeState,
-        std::unique_ptr<RJOutputWriter> writer)
-        : gdsComputeState{std::move(gdsComputeState)}, outputWriter{std::move(writer)} {}
-};
-
 class RJAlgorithm {
 public:
     virtual ~RJAlgorithm() = default;
 
     virtual std::string getFunctionName() const = 0;
     virtual binder::expression_vector getResultColumns(const RJBindData& bindData) const = 0;
-    virtual RJCompState getRJCompState(processor::ExecutionContext* context,
-        common::nodeID_t sourceNodeID, const RJBindData& bindData,
+
+    virtual std::unique_ptr<GDSComputeState> getComputeState(processor::ExecutionContext* context,
+        const RJBindData& bindData, processor::RecursiveExtendSharedState* sharedState) = 0;
+    virtual std::unique_ptr<RJOutputWriter> getOutputWriter(processor::ExecutionContext* context,
+        const RJBindData& bindData, GDSComputeState& computeState, common::nodeID_t sourceNodeID,
         processor::RecursiveExtendSharedState* sharedState) = 0;
 
     virtual std::unique_ptr<RJAlgorithm> copy() const = 0;
-
-protected:
-    std::unique_ptr<BFSGraph> getBFSGraph(processor::ExecutionContext* context,
-        graph::Graph* graph);
 };
 
 } // namespace function

--- a/src/processor/operator/recursive_extend.cpp
+++ b/src/processor/operator/recursive_extend.cpp
@@ -111,8 +111,10 @@ void RecursiveExtend::executeInternal(ExecutionContext* context) {
             auto writer = function->getOutputWriter(context, bindData, *computeState, sourceNodeID,
                 sharedState.get());
             auto vertexCompute = std::make_unique<RJVertexCompute>(
-                clientContext->getMemoryManager(), sharedState.get(), writer->copy(), bindData.nodeOutput->constCast<NodeExpression>().getTableIDsSet());
-            GDSUtils::runVertexCompute(context, computeState->frontierPair->getState(), graph, *vertexCompute);
+                clientContext->getMemoryManager(), sharedState.get(), writer->copy(),
+                bindData.nodeOutput->constCast<NodeExpression>().getTableIDsSet());
+            GDSUtils::runVertexCompute(context, computeState->frontierPair->getState(), graph,
+                *vertexCompute);
         };
         auto maxOffset = graph->getMaxOffset(clientContext->getTransaction(), tableID);
         if (inputNodeMaskMap && inputNodeMaskMap->getOffsetMask(tableID)->isEnabled()) {

--- a/src/processor/operator/recursive_extend.cpp
+++ b/src/processor/operator/recursive_extend.cpp
@@ -112,16 +112,7 @@ void RecursiveExtend::executeInternal(ExecutionContext* context) {
                 sharedState.get());
             auto vertexCompute = std::make_unique<RJVertexCompute>(
                 clientContext->getMemoryManager(), sharedState.get(), writer->copy(), bindData.nodeOutput->constCast<NodeExpression>().getTableIDsSet());
-            switch (computeState->frontierPair->getState()) {
-            case GDSDensityState::DENSE: {
-                GDSUtils::runVertexCompute(context, graph, *vertexCompute);
-            } break;
-            case GDSDensityState::SPARSE: {
-                GDSUtils::runVertexComputeSparse(graph, *vertexCompute);
-            } break;
-            default:
-                KU_UNREACHABLE;
-            }
+            GDSUtils::runVertexCompute(context, computeState->frontierPair->getState(), graph, *vertexCompute);
         };
         auto maxOffset = graph->getMaxOffset(clientContext->getTransaction(), tableID);
         if (inputNodeMaskMap && inputNodeMaskMap->getOffsetMask(tableID)->isEnabled()) {

--- a/test/test_files/function/gds/basic.test
+++ b/test/test_files/function/gds/basic.test
@@ -19,6 +19,7 @@ Alice|12
 Bob|12
 Carol|12
 Dan|12
+
 -STATEMENT CALL SHOW_PROJECTED_GRAPHS() RETURN *;
 ---- 2
 PKWO|{{'table': 'person'},{'table': 'organisation'}}|{{'table': 'knows'},{'table': 'workAt'}}
@@ -74,6 +75,7 @@ Dan|42
 Alice|Bob|1
 Alice|Carol|1
 Alice|Dan|1
+
 -STATEMENT MATCH (a:person)-[e:knows|:workAt* SHORTEST 1..2]->(b:person:organisation) WHERE a.ID = 0 RETURN a.fName, b.fName, b.name, length(e);
 ---- 5
 Alice|Bob||1

--- a/test/test_files/function/gds/rec_joins_small.test
+++ b/test/test_files/function/gds/rec_joins_small.test
@@ -10,7 +10,6 @@
 --
 
 -CASE GDSSmall
-
 -LOG RJLimitPushDown
 -STATEMENT MATCH p = (a:person1)-[e:knows11*2..2]->(b:person1) HINT (a JOIN e) JOIN b WITH b LIMIT 1 RETURN COUNT(*);
 ---- 1

--- a/test/test_files/function/gds/weighted_shortest.test
+++ b/test/test_files/function/gds/weighted_shortest.test
@@ -29,6 +29,7 @@ F|160.000000|[A,B,D,E,F]|[50,40,30,40]
         RETURN a.ID, b.ID, e_weight
 ---- error
 Binder exception: INT128 weight type is not supported for weighted shortest path.
+
 -LOG WSP-INT64
 -STATEMENT MATCH p = (a)-[e* WSHORTEST(cost1) ]->(b)
         RETURN a.ID, b.ID, e_weight


### PR DESCRIPTION
# Description

Implement sparse frontier. The incentive is to avoid costly allocation of dense data structures when the database size is large. The sparse frontier will adaptively converted itself to dense frontier when the frontier becomes large.

Some preliminary test result.

For LDBC100 comment- reply-of-comment.

```
MATCH (c:Comment)-[]->(d) WHERE c.ID = 8796093023595 RETURN d.*;
```
Takes about  7ms.

While its recursive version on master
```
MATCH (c:Comment)-[*1..1]->(d) WHERE c.ID = 8796093023595 RETURN d.*;
```
Takes about 300ms

This PR brings it back down to 7ms.


Note: I'm using a very small threshold for sparse frontier for now because all test cases are small. Once add more CI tests, the threshold needs to be made larger.

- [ ] Increase frontier threshold and add CI test for different threshold
- [ ] Add read/write interface to GDSSparse/DenseObjectManager