### PR TITLE
Remove enabled check from semi mask

### DIFF
--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -99,7 +99,7 @@ void GDSUtils::runFrontiersUntilConvergence(ExecutionContext* context, GDSComput
     compState.edgeCompute->resetSingleThreadState();
     while (frontierPair->continueNextIter(maxIteration)) {
         frontierPair->beginNewIteration();
-        if (outputNodeMask != nullptr && outputNodeMask->enabled() &&
+        if (outputNodeMask != nullptr &&
             compState.edgeCompute->terminate(*outputNodeMask)) {
             break;
         }

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -99,8 +99,7 @@ void GDSUtils::runFrontiersUntilConvergence(ExecutionContext* context, GDSComput
     compState.edgeCompute->resetSingleThreadState();
     while (frontierPair->continueNextIter(maxIteration)) {
         frontierPair->beginNewIteration();
-        if (outputNodeMask != nullptr &&
-            compState.edgeCompute->terminate(*outputNodeMask)) {
+        if (outputNodeMask != nullptr && compState.edgeCompute->terminate(*outputNodeMask)) {
             break;
         }
         runOnGraph(context, graph, extendDirection, compState, propertyToScan);

--- a/src/function/table/table_function.cpp
+++ b/src/function/table/table_function.cpp
@@ -36,7 +36,7 @@ std::unique_ptr<TableFuncLocalState> TableFunction::initEmptyLocalState(
 }
 
 std::unique_ptr<TableFuncSharedState> TableFunction::initEmptySharedState(
-    const kuzu::function::TableFuncInitSharedStateInput& /*input*/) {
+    const TableFuncInitSharedStateInput& /*input*/) {
     return std::make_unique<TableFuncSharedState>();
 }
 
@@ -88,15 +88,15 @@ void TableFunction::getLogicalPlan(planner::Planner* planner,
     }
 }
 
-std::unique_ptr<processor::PhysicalOperator> TableFunction::getPhysicalPlan(
-    processor::PlanMapper* planMapper, const planner::LogicalOperator* logicalOp) {
-    std::vector<processor::DataPos> outPosV;
-    auto& call = logicalOp->constCast<planner::LogicalTableFunctionCall>();
+std::unique_ptr<PhysicalOperator> TableFunction::getPhysicalPlan(
+    PlanMapper* planMapper, const LogicalOperator* logicalOp) {
+    std::vector<DataPos> outPosV;
+    auto& call = logicalOp->constCast<LogicalTableFunctionCall>();
     auto outSchema = call.getSchema();
     for (auto& expr : call.getBindData()->columns) {
         outPosV.emplace_back(planMapper->getDataPos(*expr, *outSchema));
     }
-    auto info = processor::TableFunctionCallInfo();
+    auto info = TableFunctionCallInfo();
     info.function = call.getTableFunc();
     info.bindData = call.getBindData()->copy();
     info.outPosV = outPosV;
@@ -110,9 +110,9 @@ std::unique_ptr<processor::PhysicalOperator> TableFunction::getPhysicalPlan(
             logicalSemiMasker->addTarget(logicalOp);
         }
     }
-    auto printInfo = std::make_unique<processor::TableFunctionCallPrintInfo>(
+    auto printInfo = std::make_unique<TableFunctionCallPrintInfo>(
         call.getTableFunc().name, call.getBindData()->columns);
-    return std::make_unique<processor::TableFunctionCall>(std::move(info), sharedState,
+    return std::make_unique<TableFunctionCall>(std::move(info), sharedState,
         planMapper->getOperatorID(), std::move(printInfo));
 }
 

--- a/src/function/table/table_function.cpp
+++ b/src/function/table/table_function.cpp
@@ -88,8 +88,8 @@ void TableFunction::getLogicalPlan(planner::Planner* planner,
     }
 }
 
-std::unique_ptr<PhysicalOperator> TableFunction::getPhysicalPlan(
-    PlanMapper* planMapper, const LogicalOperator* logicalOp) {
+std::unique_ptr<PhysicalOperator> TableFunction::getPhysicalPlan(PlanMapper* planMapper,
+    const LogicalOperator* logicalOp) {
     std::vector<DataPos> outPosV;
     auto& call = logicalOp->constCast<LogicalTableFunctionCall>();
     auto outSchema = call.getSchema();
@@ -110,8 +110,8 @@ std::unique_ptr<PhysicalOperator> TableFunction::getPhysicalPlan(
             logicalSemiMasker->addTarget(logicalOp);
         }
     }
-    auto printInfo = std::make_unique<TableFunctionCallPrintInfo>(
-        call.getTableFunc().name, call.getBindData()->columns);
+    auto printInfo = std::make_unique<TableFunctionCallPrintInfo>(call.getTableFunc().name,
+        call.getBindData()->columns);
     return std::make_unique<TableFunctionCall>(std::move(info), sharedState,
         planMapper->getOperatorID(), std::move(printInfo));
 }

--- a/src/include/common/mask.h
+++ b/src/include/common/mask.h
@@ -40,10 +40,7 @@ struct SemiMaskUtil {
 
 class NodeOffsetMaskMap {
 public:
-    NodeOffsetMaskMap() : enabled_{false} {}
-
-    void enable() { enabled_ = true; }
-    bool enabled() const { return enabled_; }
+    NodeOffsetMaskMap() = default;
 
     offset_t getNumMaskedNode() const;
 
@@ -88,8 +85,6 @@ public:
 private:
     table_id_map_t<std::unique_ptr<SemiMask>> maskMap;
     SemiMask* pinnedMask = nullptr;
-    // If mask map is enabled, then some nodes might be masked.
-    bool enabled_;
 };
 
 } // namespace common

--- a/src/include/planner/operator/extend/logical_recursive_extend.h
+++ b/src/include/planner/operator/extend/logical_recursive_extend.h
@@ -11,11 +11,9 @@ class LogicalRecursiveExtend final : public LogicalOperator {
 
 public:
     LogicalRecursiveExtend(std::unique_ptr<function::RJAlgorithm> function,
-        function::RJBindData bindData, binder::expression_vector resultColumns,
-        common::table_id_set_t nbrTableIDSet)
+        const function::RJBindData& bindData, binder::expression_vector resultColumns)
         : LogicalOperator{operatorType_}, function{std::move(function)}, bindData{bindData},
-          resultColumns{std::move(resultColumns)}, nbrTableIDSet{std::move(nbrTableIDSet)},
-          limitNum{common::INVALID_LIMIT} {}
+          resultColumns{std::move(resultColumns)}, limitNum{common::INVALID_LIMIT} {}
 
     void computeFlatSchema() override;
     void computeFactorizedSchema() override;
@@ -29,11 +27,14 @@ public:
     void setResultColumns(binder::expression_vector exprs) { resultColumns = std::move(exprs); }
     binder::expression_vector getResultColumns() const { return resultColumns; }
 
-    bool hasNbrTableIDSet() const { return !nbrTableIDSet.empty(); }
-    common::table_id_set_t getNbrTableIDSet() const { return nbrTableIDSet; }
-
     void setLimitNum(common::offset_t num) { limitNum = num; }
     common::offset_t getLimitNum() const { return limitNum; }
+
+    bool hasInputNodeMask() const { return hasInputNodeMask_; }
+    void setInputNodeMask() { hasInputNodeMask_ = true; }
+
+    bool hasOutputNodeMask() const { return hasOutputNodeMask_; }
+    void setOutputNodeMask() { hasOutputNodeMask_ = true; }
 
     bool hasNodePredicate() const { return !children.empty(); }
     std::shared_ptr<LogicalOperator> getNodeMaskRoot() const {
@@ -46,8 +47,11 @@ public:
     std::string getExpressionsForPrinting() const override { return function->getFunctionName(); }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return std::make_unique<LogicalRecursiveExtend>(function->copy(), bindData, resultColumns,
-            nbrTableIDSet);
+        auto result = std::make_unique<LogicalRecursiveExtend>(function->copy(), bindData, resultColumns);
+        result->limitNum = limitNum;
+        result->hasInputNodeMask_ = hasInputNodeMask_;
+        result->hasOutputNodeMask_ = hasOutputNodeMask_;
+        return result;
     }
 
 private:
@@ -55,8 +59,10 @@ private:
     function::RJBindData bindData;
     binder::expression_vector resultColumns;
 
-    common::table_id_set_t nbrTableIDSet;
     common::offset_t limitNum; // TODO: remove this once recursive extend is pipelined.
+
+    bool hasInputNodeMask_ = false;
+    bool hasOutputNodeMask_ = false;
 };
 
 } // namespace planner

--- a/src/include/planner/operator/extend/logical_recursive_extend.h
+++ b/src/include/planner/operator/extend/logical_recursive_extend.h
@@ -47,7 +47,8 @@ public:
     std::string getExpressionsForPrinting() const override { return function->getFunctionName(); }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        auto result = std::make_unique<LogicalRecursiveExtend>(function->copy(), bindData, resultColumns);
+        auto result =
+            std::make_unique<LogicalRecursiveExtend>(function->copy(), bindData, resultColumns);
         result->limitNum = limitNum;
         result->hasInputNodeMask_ = hasInputNodeMask_;
         result->hasOutputNodeMask_ = hasOutputNodeMask_;

--- a/src/include/planner/operator/sip/logical_semi_masker.h
+++ b/src/include/planner/operator/sip/logical_semi_masker.h
@@ -61,18 +61,11 @@ class LogicalSemiMasker final : public LogicalOperator {
     static constexpr LogicalOperatorType type_ = LogicalOperatorType::SEMI_MASKER;
 
 public:
-    // Constructor that does not specify operators accepting semi masks. Later stage there must be
-    // logics filling "targetOps" field.
     LogicalSemiMasker(SemiMaskKeyType keyType, SemiMaskTargetType targetType,
         std::shared_ptr<binder::Expression> key, std::vector<common::table_id_t> nodeTableIDs,
-        std::shared_ptr<LogicalOperator> child)
-        : LogicalSemiMasker{keyType, targetType, std::move(key), std::move(nodeTableIDs),
-              std::vector<const LogicalOperator*>{}, std::move(child)} {}
-    LogicalSemiMasker(SemiMaskKeyType keyType, SemiMaskTargetType targetType,
-        std::shared_ptr<binder::Expression> key, std::vector<common::table_id_t> nodeTableIDs,
-        std::vector<const LogicalOperator*> ops, std::shared_ptr<LogicalOperator> child)
+         std::shared_ptr<LogicalOperator> child)
         : LogicalOperator{type_, std::move(child)}, keyType{keyType}, targetType{targetType},
-          key{std::move(key)}, nodeTableIDs{std::move(nodeTableIDs)}, targetOps{std::move(ops)} {}
+          key{std::move(key)}, nodeTableIDs{std::move(nodeTableIDs)}  {}
 
     void computeFactorizedSchema() override { copyChildSchema(0); }
     void computeFlatSchema() override { copyChildSchema(0); }

--- a/src/include/planner/operator/sip/logical_semi_masker.h
+++ b/src/include/planner/operator/sip/logical_semi_masker.h
@@ -63,9 +63,9 @@ class LogicalSemiMasker final : public LogicalOperator {
 public:
     LogicalSemiMasker(SemiMaskKeyType keyType, SemiMaskTargetType targetType,
         std::shared_ptr<binder::Expression> key, std::vector<common::table_id_t> nodeTableIDs,
-         std::shared_ptr<LogicalOperator> child)
+        std::shared_ptr<LogicalOperator> child)
         : LogicalOperator{type_, std::move(child)}, keyType{keyType}, targetType{targetType},
-          key{std::move(key)}, nodeTableIDs{std::move(nodeTableIDs)}  {}
+          key{std::move(key)}, nodeTableIDs{std::move(nodeTableIDs)} {}
 
     void computeFactorizedSchema() override { copyChildSchema(0); }
     void computeFlatSchema() override { copyChildSchema(0); }

--- a/src/include/processor/operator/recursive_extend_shared_state.h
+++ b/src/include/processor/operator/recursive_extend_shared_state.h
@@ -23,16 +23,12 @@ struct RecursiveExtendSharedState {
     void setInputNodeMask(std::unique_ptr<common::NodeOffsetMaskMap> maskMap) {
         inputNodeMask = std::move(maskMap);
     }
-    common::NodeOffsetMaskMap* getInputNodeMaskMap() const {
-        return inputNodeMask.get();
-    }
+    common::NodeOffsetMaskMap* getInputNodeMaskMap() const { return inputNodeMask.get(); }
 
     void setOutputNodeMask(std::unique_ptr<common::NodeOffsetMaskMap> maskMap) {
         outputNodeMask = std::move(maskMap);
     }
-    common::NodeOffsetMaskMap* getOutputNodeMaskMap() const {
-        return outputNodeMask.get();
-    }
+    common::NodeOffsetMaskMap* getOutputNodeMaskMap() const { return outputNodeMask.get(); }
 
     void setPathNodeMask(std::unique_ptr<common::NodeOffsetMaskMap> maskMap) {
         pathNodeMask = std::move(maskMap);

--- a/src/include/processor/operator/recursive_extend_shared_state.h
+++ b/src/include/processor/operator/recursive_extend_shared_state.h
@@ -23,14 +23,16 @@ struct RecursiveExtendSharedState {
     void setInputNodeMask(std::unique_ptr<common::NodeOffsetMaskMap> maskMap) {
         inputNodeMask = std::move(maskMap);
     }
-    void enableInputNodeMask() { inputNodeMask->enable(); }
-    common::NodeOffsetMaskMap* getInputNodeMaskMap() const { return inputNodeMask.get(); }
+    common::NodeOffsetMaskMap* getInputNodeMaskMap() const {
+        return inputNodeMask.get();
+    }
 
     void setOutputNodeMask(std::unique_ptr<common::NodeOffsetMaskMap> maskMap) {
         outputNodeMask = std::move(maskMap);
     }
-    void enableOutputNodeMask() { outputNodeMask->enable(); }
-    common::NodeOffsetMaskMap* getOutputNodeMaskMap() const { return outputNodeMask.get(); }
+    common::NodeOffsetMaskMap* getOutputNodeMaskMap() const {
+        return outputNodeMask.get();
+    }
 
     void setPathNodeMask(std::unique_ptr<common::NodeOffsetMaskMap> maskMap) {
         pathNodeMask = std::move(maskMap);
@@ -39,14 +41,6 @@ struct RecursiveExtendSharedState {
 
     bool exceedLimit() const { return !(counter == nullptr) && counter->exceedLimit(); }
 
-    void setNbrTableIDSet(common::table_id_set_t set) { nbrTableIDSet = std::move(set); }
-    bool inNbrTableIDs(common::table_id_t tableID) const {
-        if (nbrTableIDSet.empty()) {
-            return true;
-        }
-        return nbrTableIDSet.contains(tableID);
-    }
-
 public:
     FactorizedTablePool factorizedTablePool;
 
@@ -54,7 +48,6 @@ private:
     std::unique_ptr<common::NodeOffsetMaskMap> inputNodeMask = nullptr;
     std::unique_ptr<common::NodeOffsetMaskMap> outputNodeMask = nullptr;
     std::unique_ptr<common::NodeOffsetMaskMap> pathNodeMask = nullptr;
-    common::table_id_set_t nbrTableIDSet;
 };
 
 } // namespace processor

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -237,9 +237,7 @@ public:
     static FactorizedTableSchema createFlatFTableSchema(
         const binder::expression_vector& expressions, const planner::Schema& schema);
     std::unique_ptr<common::SemiMask> createSemiMask(common::table_id_t tableID) const;
-    // std::unique_ptr<common::NodeOffsetMaskMap> createNodeOffsetMaskMap(
-    //     const binder::Expression& expr) const;
-
+    
 public:
     ExecutionContext* executionContext;
     main::ClientContext* clientContext;

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -237,11 +237,11 @@ public:
     static FactorizedTableSchema createFlatFTableSchema(
         const binder::expression_vector& expressions, const planner::Schema& schema);
     std::unique_ptr<common::SemiMask> createSemiMask(common::table_id_t tableID) const;
-    std::unique_ptr<common::NodeOffsetMaskMap> createNodeOffsetMaskMap(
-        const binder::Expression& expr) const;
+    // std::unique_ptr<common::NodeOffsetMaskMap> createNodeOffsetMaskMap(
+    //     const binder::Expression& expr) const;
 
 public:
-    processor::ExecutionContext* executionContext;
+    ExecutionContext* executionContext;
     main::ClientContext* clientContext;
     std::unordered_map<const planner::LogicalOperator*, PhysicalOperator*> logicalOpToPhysicalOpMap;
 

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -237,7 +237,7 @@ public:
     static FactorizedTableSchema createFlatFTableSchema(
         const binder::expression_vector& expressions, const planner::Schema& schema);
     std::unique_ptr<common::SemiMask> createSemiMask(common::table_id_t tableID) const;
-    
+
 public:
     ExecutionContext* executionContext;
     main::ClientContext* clientContext;

--- a/src/optimizer/acc_hash_join_optimizer.cpp
+++ b/src/optimizer/acc_hash_join_optimizer.cpp
@@ -173,8 +173,8 @@ static std::vector<LogicalOperator*> getScanNodeCandidates(const Expression& nod
     return result;
 }
 
-static std::vector<LogicalOperator*> getRecursiveExtendInputNodeCandidates(
-    const Expression& nodeID, LogicalOperator* root) {
+static std::vector<LogicalOperator*> getRecursiveExtendInputNodeCandidates(const Expression& nodeID,
+    LogicalOperator* root) {
     std::vector<LogicalOperator*> result;
     auto collector = LogicalRecursiveExtendCollector();
     collector.collect(root);

--- a/src/optimizer/acc_hash_join_optimizer.cpp
+++ b/src/optimizer/acc_hash_join_optimizer.cpp
@@ -72,7 +72,7 @@ static bool sameTableIDs(const std::unordered_set<table_id_t>& set,
     return true;
 }
 
-static bool haveSameTableIDs(const std::vector<const LogicalOperator*>& ops,
+static bool haveSameTableIDs(const std::vector<LogicalOperator*>& ops,
     SemiMaskTargetType targetType) {
     std::unordered_set<table_id_t> tableIDSet;
     for (auto id : getTableIDs(ops[0], targetType)) {
@@ -86,7 +86,7 @@ static bool haveSameTableIDs(const std::vector<const LogicalOperator*>& ops,
     return true;
 }
 
-static bool haveSameType(const std::vector<const LogicalOperator*>& ops) {
+static bool haveSameType(const std::vector<LogicalOperator*>& ops) {
     for (auto i = 0u; i < ops.size(); ++i) {
         if (ops[i]->getOperatorType() != ops[0]->getOperatorType()) {
             return false;
@@ -95,7 +95,7 @@ static bool haveSameType(const std::vector<const LogicalOperator*>& ops) {
     return true;
 }
 
-bool sanityCheckCandidates(const std::vector<const LogicalOperator*>& ops,
+bool sanityCheckCandidates(const std::vector<LogicalOperator*>& ops,
     SemiMaskTargetType targetType) {
     KU_ASSERT(!ops.empty());
     if (!haveSameType(ops)) {
@@ -109,10 +109,13 @@ bool sanityCheckCandidates(const std::vector<const LogicalOperator*>& ops,
 
 static std::shared_ptr<LogicalSemiMasker> appendSemiMasker(SemiMaskKeyType keyType,
     SemiMaskTargetType targetType, std::shared_ptr<Expression> key,
-    std::vector<const LogicalOperator*> candidates, std::shared_ptr<LogicalOperator> child) {
+    std::vector<LogicalOperator*> candidates, std::shared_ptr<LogicalOperator> child) {
     auto tableIDs = getTableIDs(candidates[0], targetType);
     auto semiMasker =
-        std::make_shared<LogicalSemiMasker>(keyType, targetType, key, tableIDs, candidates, child);
+        std::make_shared<LogicalSemiMasker>(keyType, targetType, key, tableIDs, child);
+    for (auto candidate : candidates) {
+        semiMasker->addTarget(candidate);
+    }
     semiMasker->computeFlatSchema();
     return semiMasker;
 }
@@ -152,9 +155,9 @@ static bool isProbeSideQualified(LogicalOperator* probeRoot) {
 
 // Find all ScanNodeIDs under root which scans parameter nodeID. Note that there might be
 // multiple ScanNodeIDs matches because both node and rel table scans will trigger scanNodeIDs.
-static std::vector<const LogicalOperator*> getScanNodeCandidates(const Expression& nodeID,
+static std::vector<LogicalOperator*> getScanNodeCandidates(const Expression& nodeID,
     LogicalOperator* root) {
-    std::vector<const LogicalOperator*> result;
+    std::vector<LogicalOperator*> result;
     auto collector = LogicalScanNodeTableCollector();
     collector.collect(root);
     for (auto& op : collector.getOperators()) {
@@ -170,9 +173,9 @@ static std::vector<const LogicalOperator*> getScanNodeCandidates(const Expressio
     return result;
 }
 
-static std::vector<const LogicalOperator*> getRecursiveExtendInputNodeCandidates(
+static std::vector<LogicalOperator*> getRecursiveExtendInputNodeCandidates(
     const Expression& nodeID, LogicalOperator* root) {
-    std::vector<const LogicalOperator*> result;
+    std::vector<LogicalOperator*> result;
     auto collector = LogicalRecursiveExtendCollector();
     collector.collect(root);
     for (auto& op : collector.getOperators()) {
@@ -185,9 +188,9 @@ static std::vector<const LogicalOperator*> getRecursiveExtendInputNodeCandidates
     return result;
 }
 
-static std::vector<const LogicalOperator*> getRecursiveExtendOutputNodeCandidates(
+static std::vector<LogicalOperator*> getRecursiveExtendOutputNodeCandidates(
     const Expression& nodeID, LogicalOperator* root) {
-    std::vector<const LogicalOperator*> result;
+    std::vector<LogicalOperator*> result;
     auto collector = LogicalRecursiveExtendCollector();
     collector.collect(root);
     for (auto& op : collector.getOperators()) {
@@ -207,6 +210,9 @@ static std::shared_ptr<LogicalOperator> tryApplySemiMask(std::shared_ptr<Express
     auto recursiveExtendInputNodeCandidates =
         getRecursiveExtendInputNodeCandidates(*nodeID, toRoot);
     if (!recursiveExtendInputNodeCandidates.empty()) {
+        for (auto& op : recursiveExtendInputNodeCandidates) {
+            op->cast<LogicalRecursiveExtend>().setInputNodeMask();
+        }
         auto targetType = SemiMaskTargetType::RECURSIVE_EXTEND_INPUT_NODE;
         KU_ASSERT(sanityCheckCandidates(recursiveExtendInputNodeCandidates, targetType));
         return appendSemiMasker(SemiMaskKeyType::NODE, targetType, std::move(nodeID),
@@ -214,6 +220,9 @@ static std::shared_ptr<LogicalOperator> tryApplySemiMask(std::shared_ptr<Express
     }
     auto recursiveExtendNodeCandidates = getRecursiveExtendOutputNodeCandidates(*nodeID, toRoot);
     if (!recursiveExtendNodeCandidates.empty()) {
+        for (auto& op : recursiveExtendNodeCandidates) {
+            op->cast<LogicalRecursiveExtend>().setOutputNodeMask();
+        }
         auto targetType = SemiMaskTargetType::RECURSIVE_EXTEND_OUTPUT_NODE;
         KU_ASSERT(sanityCheckCandidates(recursiveExtendNodeCandidates, targetType));
         return appendSemiMasker(SemiMaskKeyType::NODE, targetType, std::move(nodeID),
@@ -330,7 +339,7 @@ void HashJoinSIPOptimizer::visitIntersect(LogicalOperator* op) {
     auto probeRoot = intersect.getChild(0);
     auto hasSemiMaskApplied = false;
     for (auto& nodeID : intersect.getKeyNodeIDs()) {
-        std::vector<const LogicalOperator*> ops;
+        std::vector<LogicalOperator*> ops;
         for (auto i = 1u; i < intersect.getNumChildren(); ++i) {
             auto buildRoot = intersect.getChild(i);
             for (auto& op_ : getScanNodeCandidates(*nodeID, buildRoot.get())) {
@@ -367,7 +376,7 @@ void HashJoinSIPOptimizer::visitPathPropertyProbe(LogicalOperator* op) {
     }
     auto recursiveRel = pathPropertyProbe.getRel();
     auto nodeID = recursiveRel->getRecursiveInfo()->node->getInternalID();
-    std::vector<const LogicalOperator*> opsToApplySemiMask;
+    std::vector<LogicalOperator*> opsToApplySemiMask;
     if (pathPropertyProbe.getNodeChild() != nullptr) {
         auto child = pathPropertyProbe.getNodeChild().get();
         for (auto op_ : getScanNodeCandidates(*nodeID, child)) {

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -118,24 +118,9 @@ void Planner::appendRecursiveExtend(const std::shared_ptr<NodeExpression>& bound
             *recursiveInfo->node, recursiveInfo->nodePredicate);
         nodeMaskRoot = p.getLastOperator();
     }
-    // E.g. Given schema person-knows->person & person-knows->animal
-    // And query MATCH (a:person:animal)-[e*]->(b:person)
-    // The destination node b after GDS will contain both person & animal label. We need to prune
-    // the animal out.
-    common::table_id_set_t nbrTableIDSet;
-    auto targetNbrTableIDSet = nbrNode->getTableIDsSet();
-    auto recursiveNbrTableIDSet = recursiveInfo->node->getTableIDsSet();
-    for (auto& tableID : recursiveNbrTableIDSet) {
-        if (targetNbrTableIDSet.contains(tableID)) {
-            nbrTableIDSet.insert(tableID);
-        }
-    }
-    if (nbrTableIDSet.size() >= recursiveNbrTableIDSet.size()) {
-        nbrTableIDSet.clear(); // No need to prune nbr table id.
-    }
     auto probePlan = LogicalPlan();
     auto recursiveExtend = std::make_shared<LogicalRecursiveExtend>(recursiveInfo->function->copy(),
-        *recursiveInfo->bindData, resultColumns, nbrTableIDSet);
+        *recursiveInfo->bindData, resultColumns);
     if (nodeMaskRoot != nullptr) {
         recursiveExtend->addChild(nodeMaskRoot);
     }

--- a/src/processor/map/map_recursive_extend.cpp
+++ b/src/processor/map/map_recursive_extend.cpp
@@ -1,9 +1,9 @@
+#include "binder/expression/node_expression.h"
 #include "graph/on_disk_graph.h"
 #include "planner/operator/extend/logical_recursive_extend.h"
 #include "planner/operator/sip/logical_semi_masker.h"
 #include "processor/operator/recursive_extend.h"
 #include "processor/plan_mapper.h"
-#include "binder/expression/node_expression.h"
 
 using namespace kuzu::planner;
 using namespace kuzu::graph;
@@ -13,7 +13,8 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace processor {
 
-std::unique_ptr<NodeOffsetMaskMap> createNodeOffsetMaskMap(const Expression& expr, PlanMapper* mapper) {
+std::unique_ptr<NodeOffsetMaskMap> createNodeOffsetMaskMap(const Expression& expr,
+    PlanMapper* mapper) {
     auto& node = expr.constCast<NodeExpression>();
     auto maskMap = std::make_unique<NodeOffsetMaskMap>();
     for (auto tableID : node.getTableIDs()) {

--- a/src/processor/map/map_semi_masker.cpp
+++ b/src/processor/map/map_semi_masker.cpp
@@ -64,21 +64,22 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapSemiMasker(
         } break;
         case PhysicalOperatorType::RECURSIVE_EXTEND: {
             auto sharedState = physicalOp->ptrCast<RecursiveExtend>()->getSharedState();
+            NodeOffsetMaskMap* maskMap = nullptr;
             switch (semiMasker.getTargetType()) {
             case SemiMaskTargetType::RECURSIVE_EXTEND_INPUT_NODE: {
-                initMask(masksPerTable, sharedState->getInputNodeMaskMap()->getMasks());
-                sharedState->enableInputNodeMask();
+                maskMap = sharedState->getInputNodeMaskMap();
             } break;
             case SemiMaskTargetType::RECURSIVE_EXTEND_OUTPUT_NODE: {
-                initMask(masksPerTable, sharedState->getOutputNodeMaskMap()->getMasks());
-                sharedState->enableOutputNodeMask();
+                maskMap = sharedState->getOutputNodeMaskMap();
             } break;
             case SemiMaskTargetType::RECURSIVE_EXTEND_PATH_NODE: {
-                initMask(masksPerTable, sharedState->getPathNodeMaskMap()->getMasks());
+                maskMap = sharedState->getPathNodeMaskMap();
             } break;
             default:
                 KU_UNREACHABLE;
             }
+            KU_ASSERT(maskMap != nullptr);
+            initMask(masksPerTable, maskMap->getMasks());
         } break;
         default:
             KU_UNREACHABLE;

--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -1,6 +1,6 @@
 #include "processor/plan_mapper.h"
 
-#include "binder/expression/node_expression.h"
+
 #include "planner/operator/sip/logical_semi_masker.h"
 #include "processor/operator/profile.h"
 #include "storage/storage_manager.h"
@@ -211,16 +211,6 @@ FactorizedTableSchema PlanMapper::createFlatFTableSchema(const expression_vector
 std::unique_ptr<SemiMask> PlanMapper::createSemiMask(table_id_t tableID) const {
     auto table = clientContext->getStorageManager()->getTable(tableID)->ptrCast<NodeTable>();
     return SemiMaskUtil::createMask(table->getNumTotalRows(clientContext->getTransaction()));
-}
-
-std::unique_ptr<NodeOffsetMaskMap> PlanMapper::createNodeOffsetMaskMap(
-    const Expression& expr) const {
-    auto& node = expr.constCast<NodeExpression>();
-    auto maskMap = std::make_unique<NodeOffsetMaskMap>();
-    for (auto tableID : node.getTableIDs()) {
-        maskMap->addMask(tableID, createSemiMask(tableID));
-    }
-    return maskMap;
 }
 
 LogicalSemiMasker* PlanMapper::findSemiMaskerInPlan(LogicalOperator* logicalOperator) {

--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -1,6 +1,5 @@
 #include "processor/plan_mapper.h"
 
-
 #include "planner/operator/sip/logical_semi_masker.h"
 #include "processor/operator/profile.h"
 #include "storage/storage_manager.h"

--- a/src/processor/operator/recursive_extend.cpp
+++ b/src/processor/operator/recursive_extend.cpp
@@ -6,7 +6,7 @@
 #include "function/gds/compute.h"
 #include "function/gds/gds_utils.h"
 #include "processor/execution_context.h"
-#include <binder/expression/node_expression.h>
+#include "binder/expression/node_expression.h"
 
 using namespace kuzu::common;
 using namespace kuzu::binder;

--- a/src/processor/operator/recursive_extend.cpp
+++ b/src/processor/operator/recursive_extend.cpp
@@ -21,7 +21,8 @@ class RJVertexCompute : public VertexCompute {
 public:
     RJVertexCompute(storage::MemoryManager* mm, RecursiveExtendSharedState* sharedState,
         std::unique_ptr<RJOutputWriter> writer, table_id_set_t nbrTableIDSet)
-        : mm{mm}, sharedState{sharedState}, writer{std::move(writer)}, nbrTableIDSet{std::move(nbrTableIDSet)} {
+        : mm{mm}, sharedState{sharedState}, writer{std::move(writer)},
+          nbrTableIDSet{std::move(nbrTableIDSet)} {
         localFT = sharedState->factorizedTablePool.claimLocalTable(mm);
     }
     ~RJVertexCompute() override { sharedState->factorizedTablePool.returnLocalTable(localFT); }
@@ -82,7 +83,7 @@ void RecursiveExtend::executeInternal(ExecutionContext* context) {
         }
     }
     offset_t completedNumNodes = 0;
-    auto inputNodeTableIDSet =  bindData.nodeInput->constCast<NodeExpression>().getTableIDsSet();
+    auto inputNodeTableIDSet = bindData.nodeInput->constCast<NodeExpression>().getTableIDsSet();
     for (auto& tableID : graph->getNodeTableIDs()) {
         // Input node table IDs could be different from graph node table IDs, e.g.
         // Given schema, student-knows->student, teacher-knows->teacher
@@ -110,7 +111,8 @@ void RecursiveExtend::executeInternal(ExecutionContext* context) {
                 propertyName);
             auto vertexCompute =
                 std::make_unique<RJVertexCompute>(clientContext->getMemoryManager(),
-                    sharedState.get(), rjCompState.outputWriter->copy(), bindData.nodeOutput->constCast<NodeExpression>().getTableIDsSet());
+                    sharedState.get(), rjCompState.outputWriter->copy(),
+                    bindData.nodeOutput->constCast<NodeExpression>().getTableIDsSet());
             auto frontierPair = gdsComputeState->frontierPair.get();
             auto& candidates = frontierPair->getVertexComputeCandidates();
             candidates.mergeSparseFrontier(frontierPair->getNextSparseFrontier());
@@ -122,7 +124,8 @@ void RecursiveExtend::executeInternal(ExecutionContext* context) {
         };
         auto maxOffset = graph->getMaxOffset(clientContext->getTransaction(), tableID);
         if (inputNodeMaskMap && inputNodeMaskMap->getOffsetMask(tableID)->isEnabled()) {
-            for (const auto& offset : inputNodeMaskMap->getOffsetMask(tableID)->range(0, maxOffset)) {
+            for (const auto& offset :
+                inputNodeMaskMap->getOffsetMask(tableID)->range(0, maxOffset)) {
                 calcFunc(offset);
                 clientContext->getProgressBar()->updateProgress(context->queryID,
                     getRJProgress(totalNumNodes, completedNumNodes++));

--- a/src/processor/operator/recursive_extend.cpp
+++ b/src/processor/operator/recursive_extend.cpp
@@ -6,6 +6,7 @@
 #include "function/gds/compute.h"
 #include "function/gds/gds_utils.h"
 #include "processor/execution_context.h"
+#include <binder/expression/node_expression.h>
 
 using namespace kuzu::common;
 using namespace kuzu::binder;
@@ -19,14 +20,16 @@ namespace processor {
 class RJVertexCompute : public VertexCompute {
 public:
     RJVertexCompute(storage::MemoryManager* mm, RecursiveExtendSharedState* sharedState,
-        std::unique_ptr<RJOutputWriter> writer)
-        : mm{mm}, sharedState{sharedState}, writer{std::move(writer)} {
+        std::unique_ptr<RJOutputWriter> writer, table_id_set_t nbrTableIDSet)
+        : mm{mm}, sharedState{sharedState}, writer{std::move(writer)}, nbrTableIDSet{std::move(nbrTableIDSet)} {
         localFT = sharedState->factorizedTablePool.claimLocalTable(mm);
     }
     ~RJVertexCompute() override { sharedState->factorizedTablePool.returnLocalTable(localFT); }
 
     bool beginOnTable(table_id_t tableID) override {
-        if (!sharedState->inNbrTableIDs(tableID)) {
+        // Nbr node table IDs might be different from graph node table IDs
+        // See comment below in RecursiveExtend::executeInternal.
+        if (!nbrTableIDSet.contains(tableID)) {
             return false;
         }
         writer->beginWritingOutputs(tableID);
@@ -47,7 +50,7 @@ public:
     }
 
     std::unique_ptr<VertexCompute> copy() override {
-        return std::make_unique<RJVertexCompute>(mm, sharedState, writer->copy());
+        return std::make_unique<RJVertexCompute>(mm, sharedState, writer->copy(), nbrTableIDSet);
     }
 
 private:
@@ -56,6 +59,7 @@ private:
     RecursiveExtendSharedState* sharedState;
     FactorizedTable* localFT;
     std::unique_ptr<RJOutputWriter> writer;
+    table_id_set_t nbrTableIDSet;
 };
 
 static double getRJProgress(offset_t totalNumNodes, offset_t completedNumNodes) {
@@ -70,7 +74,7 @@ void RecursiveExtend::executeInternal(ExecutionContext* context) {
     auto graph = sharedState->graph.get();
     auto inputNodeMaskMap = sharedState->getInputNodeMaskMap();
     offset_t totalNumNodes = 0;
-    if (inputNodeMaskMap->enabled()) {
+    if (inputNodeMaskMap != nullptr) {
         totalNumNodes = inputNodeMaskMap->getNumMaskedNode();
     } else {
         for (auto& tableID : graph->getNodeTableIDs()) {
@@ -78,8 +82,13 @@ void RecursiveExtend::executeInternal(ExecutionContext* context) {
         }
     }
     offset_t completedNumNodes = 0;
+    auto inputNodeTableIDSet =  bindData.nodeInput->constCast<NodeExpression>().getTableIDsSet();
     for (auto& tableID : graph->getNodeTableIDs()) {
-        if (!inputNodeMaskMap->containsTableID(tableID)) {
+        // Input node table IDs could be different from graph node table IDs, e.g.
+        // Given schema, student-knows->student, teacher-knows->teacher
+        // MATCH (a:student)-[e*knows]->(b:student)
+        // the graph node table IDs will include both student and teacher.
+        if (!inputNodeTableIDSet.contains(tableID)) {
             continue;
         }
         auto calcFunc = [tableID, graph, context, clientContext, this](offset_t offset) {
@@ -101,7 +110,7 @@ void RecursiveExtend::executeInternal(ExecutionContext* context) {
                 propertyName);
             auto vertexCompute =
                 std::make_unique<RJVertexCompute>(clientContext->getMemoryManager(),
-                    sharedState.get(), rjCompState.outputWriter->copy());
+                    sharedState.get(), rjCompState.outputWriter->copy(), bindData.nodeOutput->constCast<NodeExpression>().getTableIDsSet());
             auto frontierPair = gdsComputeState->frontierPair.get();
             auto& candidates = frontierPair->getVertexComputeCandidates();
             candidates.mergeSparseFrontier(frontierPair->getNextSparseFrontier());
@@ -112,9 +121,8 @@ void RecursiveExtend::executeInternal(ExecutionContext* context) {
             }
         };
         auto maxOffset = graph->getMaxOffset(clientContext->getTransaction(), tableID);
-        auto mask = inputNodeMaskMap->getOffsetMask(tableID);
-        if (mask->isEnabled()) {
-            for (const auto& offset : mask->range(0, maxOffset)) {
+        if (inputNodeMaskMap && inputNodeMaskMap->getOffsetMask(tableID)->isEnabled()) {
+            for (const auto& offset : inputNodeMaskMap->getOffsetMask(tableID)->range(0, maxOffset)) {
                 calcFunc(offset);
                 clientContext->getProgressBar()->updateProgress(context->queryID,
                     getRJProgress(totalNumNodes, completedNumNodes++));

--- a/src/processor/operator/recursive_extend.cpp
+++ b/src/processor/operator/recursive_extend.cpp
@@ -1,12 +1,12 @@
 #include "processor/operator/recursive_extend.h"
 
+#include "binder/expression/node_expression.h"
 #include "binder/expression/property_expression.h"
 #include "common/exception/interrupt.h"
 #include "common/task_system/progress_bar.h"
 #include "function/gds/compute.h"
 #include "function/gds/gds_utils.h"
 #include "processor/execution_context.h"
-#include "binder/expression/node_expression.h"
 
 using namespace kuzu::common;
 using namespace kuzu::binder;


### PR DESCRIPTION
# Description

The convention is to use nullptr to represent a mask is enabled or not. So this PR removes the enable interface from NodeOffsetMask

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).