### PR TITLE
Limit the max DB size for the rust tests

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -373,7 +373,7 @@ jobs:
         run: |
           make extension-release
           cd tools/rust_api
-          cargo test --profile=relwithdebinfo --locked --all-features -- --test-threads=12
+          cargo test --profile=relwithdebinfo --locked --all-features
 
       - name: Rust example
         working-directory: examples/rust
@@ -709,7 +709,7 @@ jobs:
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
           make extension-release
           cd tools/rust_api
-          cargo test --profile=relwithdebinfo --locked --all-features -- --test-threads=12
+          cargo test --profile=relwithdebinfo --locked --all-features
 
       - name: Rust test with pre-built library
         env:
@@ -967,7 +967,7 @@ jobs:
           cmake -B build/release -DBUILD_EXAMPLES=OFF
           make extension-release
           cd tools/rust_api
-          cargo test --profile=relwithdebinfo --locked --all-features -- --test-threads=12
+          cargo test --profile=relwithdebinfo --locked --all-features
 
       - name: Rust example
         working-directory: examples/rust

--- a/.github/workflows/multiplatform-build-test.yml
+++ b/.github/workflows/multiplatform-build-test.yml
@@ -130,7 +130,7 @@ jobs:
         working-directory: tools/rust_api
         run: |
           set +e
-          cargo test --release --features arrow -- --test-threads=12
+          cargo test --release --features arrow
           echo "Rust test,$?" >> ../../status.txt
 
       - name: Rust example
@@ -267,7 +267,7 @@ jobs:
           set OPENSSL_DIR=C:\Program Files\OpenSSL-Win64
           set CXXFLAGS=/std:c++20
           set CARGO_BUILD_JOBS=%NUMBER_OF_PROCESSORS%
-          cargo test --release --features arrow -- --test-threads=12
+          cargo test --release --features arrow
           echo Rust test,%ERRORLEVEL% >> status.txt
 
       - name: Rust example
@@ -414,7 +414,7 @@ jobs:
         working-directory: tools/rust_api
         run: |
           set +e
-          cargo test --release --features arrow -- --test-threads=12
+          cargo test --release --features arrow
           echo "Rust test,$?" >> ../../status.txt
 
       - name: Rust example
@@ -575,7 +575,7 @@ jobs:
         working-directory: tools/rust_api
         run: |
           set +e
-          cargo test --release --features arrow -- --test-threads=12
+          cargo test --release --features arrow
           echo "Rust test,$?" >> ../../status.txt
 
       - name: Rust example
@@ -704,7 +704,7 @@ jobs:
         continue-on-error: true
         run: |
           set +e
-          cargo test --release --features arrow -- --test-threads=12
+          cargo test --release --features arrow
           echo "Rust test,$?" >> ../../status.txt
 
       - name: Rust example

--- a/Makefile
+++ b/Makefile
@@ -178,11 +178,8 @@ ifeq ($(OS),Windows_NT)
 	set CARGO_BUILD_JOBS=$(NUM_THREADS)
 else
 	export CARGO_BUILD_JOBS=$(NUM_THREADS)
-	# Note that the number of test threads has a hard limit (unlike with ctest)
-	# since they are all run in the same process and most tests create a database
-	# (requiring mmapping 8TB of virtual memory). This quickly exhausts the process' virtual memory.
 endif
-	cd tools/rust_api && cargo test --profile=relwithdebinfo --locked --features arrow -- --test-threads=12
+	cd tools/rust_api && cargo test --profile=relwithdebinfo --locked --features arrow
 
 wasmtest:
 	mkdir -p build/wasm && cd build/wasm &&\

--- a/tools/rust_api/src/connection.rs
+++ b/tools/rust_api/src/connection.rs
@@ -210,13 +210,14 @@ impl<'a> Connection<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Connection, Database, SystemConfig, Value};
+    use crate::database::SYSTEM_CONFIG_FOR_TESTS;
+    use crate::{Connection, Database, Value};
     use anyhow::{Error, Result};
 
     #[test]
     fn test_connection_threads() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
+        let db = Database::new(temp_dir.path(), SYSTEM_CONFIG_FOR_TESTS)?;
         let mut conn = Connection::new(&db)?;
         conn.set_max_num_threads_for_exec(5);
         assert_eq!(conn.get_max_num_threads_for_exec(), 5);
@@ -227,7 +228,7 @@ mod tests {
     #[test]
     fn test_invalid_query() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
+        let db = Database::new(temp_dir.path(), SYSTEM_CONFIG_FOR_TESTS)?;
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")?;
         conn.query("CREATE (:Person {name: 'Alice', age: 25});")?;
@@ -250,7 +251,7 @@ Invalid input <MATCH (a:Person RETURN>: expected rule oC_SingleQuery (line: 1, o
     #[test]
     fn test_multiple_statement_query() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
+        let db = Database::new(temp_dir.path(), SYSTEM_CONFIG_FOR_TESTS)?;
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")?;
         conn.query(
@@ -263,7 +264,7 @@ Invalid input <MATCH (a:Person RETURN>: expected rule oC_SingleQuery (line: 1, o
     #[test]
     fn test_query_result() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
+        let db = Database::new(temp_dir.path(), SYSTEM_CONFIG_FOR_TESTS)?;
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT16, PRIMARY KEY(name));")?;
         conn.query("CREATE (:Person {name: 'Alice', age: 25});")?;
@@ -280,7 +281,7 @@ Invalid input <MATCH (a:Person RETURN>: expected rule oC_SingleQuery (line: 1, o
     #[test]
     fn test_params() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
+        let db = Database::new(temp_dir.path(), SYSTEM_CONFIG_FOR_TESTS)?;
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT16, PRIMARY KEY(name));")?;
         conn.query("CREATE (:Person {name: 'Alice', age: 25});")?;
@@ -298,7 +299,7 @@ Invalid input <MATCH (a:Person RETURN>: expected rule oC_SingleQuery (line: 1, o
     #[test]
     fn test_multithreaded_single_conn() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
+        let db = Database::new(temp_dir.path(), SYSTEM_CONFIG_FOR_TESTS)?;
 
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT32, PRIMARY KEY(name));")?;
@@ -330,7 +331,7 @@ Invalid input <MATCH (a:Person RETURN>: expected rule oC_SingleQuery (line: 1, o
     #[test]
     fn test_multithreaded_multiple_conn() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
+        let db = Database::new(temp_dir.path(), SYSTEM_CONFIG_FOR_TESTS)?;
 
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT32, PRIMARY KEY(name));")?;
@@ -368,7 +369,7 @@ Invalid input <MATCH (a:Person RETURN>: expected rule oC_SingleQuery (line: 1, o
             #[cfg(feature = "extension_tests")]
             fn $name() -> Result<()> {
                 let temp_dir = tempfile::tempdir()?;
-                let db = Database::new(temp_dir.path(), SystemConfig::default())?;
+                let db = Database::new(temp_dir.path(), SYSTEM_CONFIG_FOR_TESTS)?;
                 let conn = Connection::new(&db)?;
                 let directory: String = if cfg!(windows) {
                     std::env::var("KUZU_LOCAL_EXTENSIONS")?.replace("\\", "/")

--- a/tools/rust_api/src/query_result.rs
+++ b/tools/rust_api/src/query_result.rs
@@ -200,13 +200,14 @@ impl std::fmt::Display for QueryResult<'_> {
 #[cfg(test)]
 mod tests {
     use crate::connection::Connection;
-    use crate::database::{Database, SystemConfig};
+    use crate::database::Database;
+    use crate::database::SYSTEM_CONFIG_FOR_TESTS;
     use crate::logical_type::LogicalType;
 
     #[test]
     fn test_query_result_metadata() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
+        let db = Database::new(temp_dir.path(), SYSTEM_CONFIG_FOR_TESTS)?;
         let connection = Connection::new(&db)?;
 
         // Create schema.
@@ -232,7 +233,7 @@ mod tests {
     #[test]
     fn test_query_result_move() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
+        let db = Database::new(temp_dir.path(), SYSTEM_CONFIG_FOR_TESTS)?;
         let result = {
             let connection = Connection::new(&db)?;
 
@@ -258,7 +259,7 @@ mod tests {
         use arrow::array::{Int64Array, StringArray};
         let temp_dir = tempfile::tempdir()?;
         let path = temp_dir.path();
-        let db = Database::new(path, SystemConfig::default())?;
+        let db = Database::new(path, SYSTEM_CONFIG_FOR_TESTS)?;
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")?;
         conn.query("CREATE (:Person {name: 'Alice', age: 25});")?;

--- a/tools/rust_api/src/value.rs
+++ b/tools/rust_api/src/value.rs
@@ -937,10 +937,9 @@ impl From<&str> for Value {
 
 #[cfg(test)]
 mod tests {
+    use crate::database::SYSTEM_CONFIG_FOR_TESTS;
     use crate::ffi::ffi;
-    use crate::{
-        Connection, Database, InternalID, LogicalType, NodeVal, RelVal, SystemConfig, Value,
-    };
+    use crate::{Connection, Database, InternalID, LogicalType, NodeVal, RelVal, Value};
     use anyhow::Result;
     use rust_decimal_macros::dec;
     use std::collections::HashSet;
@@ -1003,7 +1002,7 @@ mod tests {
             /// Tests that passing the values through the database returns what we put in
             fn $name() -> Result<()> {
                 let temp_dir = tempfile::tempdir()?;
-                let db = Database::new(temp_dir.path(), SystemConfig::default())?;
+                let db = Database::new(temp_dir.path(), SYSTEM_CONFIG_FOR_TESTS)?;
                 let conn = Connection::new(&db)?;
                 conn.query(&format!(
                     "CREATE NODE TABLE Person(name STRING, item {}, PRIMARY KEY(name));",
@@ -1200,7 +1199,7 @@ mod tests {
     /// Tests that the list value is correctly constructed
     fn test_list_get() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
+        let db = Database::new(temp_dir.path(), SYSTEM_CONFIG_FOR_TESTS)?;
         let conn = Connection::new(&db)?;
         for result in conn.query("RETURN [\"Alice\", \"Bob\"] AS l;")? {
             assert_eq!(result.len(), 1);
@@ -1217,7 +1216,7 @@ mod tests {
     /// Test that the timestamp round-trips through kuzu's internal timestamp
     fn test_timestamp() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
+        let db = Database::new(temp_dir.path(), SYSTEM_CONFIG_FOR_TESTS)?;
         let conn = Connection::new(&db)?;
         conn.query(
             "CREATE NODE TABLE Person(name STRING, registerTime TIMESTAMP, PRIMARY KEY(name));",
@@ -1264,7 +1263,7 @@ mod tests {
     #[test]
     fn test_node() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
+        let db = Database::new(temp_dir.path(), SYSTEM_CONFIG_FOR_TESTS)?;
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")?;
         conn.query("CREATE (:Person {name: \"Alice\", age: 25});")?;
@@ -1290,7 +1289,7 @@ mod tests {
     #[test]
     fn test_recursive_rel() -> Result<()> {
         let temp_dir = tempfile::TempDir::new()?;
-        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
+        let db = Database::new(temp_dir.path(), SYSTEM_CONFIG_FOR_TESTS)?;
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")?;
         conn.query("CREATE REL TABLE knows(FROM Person TO Person);")?;
@@ -1338,7 +1337,7 @@ mod tests {
     /// Test that null values are read correctly by the API
     fn test_null() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
+        let db = Database::new(temp_dir.path(), SYSTEM_CONFIG_FOR_TESTS)?;
         let conn = Connection::new(&db)?;
         let result = conn.query("RETURN null")?.next();
         let result = &result.unwrap()[0];
@@ -1351,7 +1350,7 @@ mod tests {
     /// Tests that passing the values through the database returns what we put in
     fn test_serial() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
+        let db = Database::new(temp_dir.path(), SYSTEM_CONFIG_FOR_TESTS)?;
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(id SERIAL, name STRING, PRIMARY KEY(id));")?;
         conn.query("CREATE (:Person {name: \"Bob\"});")?;
@@ -1381,7 +1380,7 @@ mod tests {
         use std::fs::File;
         use std::io::Write;
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
+        let db = Database::new(temp_dir.path(), SYSTEM_CONFIG_FOR_TESTS)?;
         let conn = Connection::new(&db)?;
         conn.query(
             "CREATE NODE TABLE demo(a SERIAL, b UNION(num INT64, str STRING), PRIMARY KEY(a));",


### PR DESCRIPTION
Instead of limiting the number of threads by passing  to cargo test.

The performance difference is not significant; these tests are very fast anyway since they're just API tests. But it's mildly more convenient for `cargo test` to work as expected by itself.