### PR TITLE
Fix merge

### DIFF
--- a/src/include/planner/operator/persistent/logical_merge.h
+++ b/src/include/planner/operator/persistent/logical_merge.h
@@ -16,10 +16,10 @@ public:
         : LogicalOperator{type_, std::move(child)}, existenceMark{std::move(existenceMark)},
           keys{std::move(keys)} {}
 
-    void computeFactorizedSchema() final;
-    void computeFlatSchema() final;
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
 
-    std::string getExpressionsForPrinting() const final { return {}; }
+    std::string getExpressionsForPrinting() const override { return {}; }
 
     f_group_pos_set getGroupsPosToFlatten();
 
@@ -73,6 +73,11 @@ private:
     // On Match infos
     std::vector<binder::BoundSetPropertyInfo> onMatchSetNodeInfos;
     std::vector<binder::BoundSetPropertyInfo> onMatchSetRelInfos;
+    // Key expressions used in merge hash table.
+    // If a merge clause is taking input from previous query parts
+    // E.g. UNWIND [1,1,3] AS x MERGE (n:N{id:x})
+    // Since we don't re-evaluate the existence of n for each x, we need to create n only for
+    // distinct x, i.e. 1 & 3. So there is a notion of key in MERGE.
     binder::expression_vector keys;
 };
 

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -143,11 +143,11 @@ public:
 
     // Plan subquery
     void planOptionalMatch(const binder::QueryGraphCollection& queryGraphCollection,
-        const binder::expression_vector& predicates, const binder::expression_vector& corrExprs,
+        const binder::expression_vector& predicates,
         LogicalPlan& leftPlan, std::shared_ptr<binder::BoundJoinHintNode> hint);
     // Write whether optional match succeed or not to mark.
     void planOptionalMatch(const binder::QueryGraphCollection& queryGraphCollection,
-        const binder::expression_vector& predicates, const binder::expression_vector& corrExprs,
+        const binder::expression_vector& predicates,
         std::shared_ptr<binder::Expression> mark, LogicalPlan& leftPlan,
         std::shared_ptr<binder::BoundJoinHintNode> hint);
     void planRegularMatch(const binder::QueryGraphCollection& queryGraphCollection,

--- a/src/include/processor/operator/persistent/merge.h
+++ b/src/include/processor/operator/persistent/merge.h
@@ -9,10 +9,8 @@ namespace kuzu {
 namespace processor {
 
 struct MergeInfo {
-    // std::vector<DataPos> keyPoses;
     std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> keyEvaluators;
     FactorizedTableSchema tableSchema;
-    // TODO: change me
     common::executor_info executorInfo;
     DataPos existenceMark;
 
@@ -26,9 +24,6 @@ private:
     MergeInfo(const MergeInfo& other)
         : keyEvaluators{copyVector(other.keyEvaluators)}, tableSchema{other.tableSchema.copy()},
         executorInfo {other.executorInfo}, existenceMark{other.existenceMark} {}
-    // MergeInfo copy() const {
-    //     return MergeInfo{keyPoses, tableSchema.copy(), executorInfo, existenceMark};
-    // }
 };
 
 struct MergePrintInfo final : OPPrintInfo {

--- a/src/include/processor/operator/persistent/merge.h
+++ b/src/include/processor/operator/persistent/merge.h
@@ -9,19 +9,26 @@ namespace kuzu {
 namespace processor {
 
 struct MergeInfo {
-    std::vector<DataPos> keyPoses;
+    // std::vector<DataPos> keyPoses;
+    std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> keyEvaluators;
     FactorizedTableSchema tableSchema;
+    // TODO: change me
     common::executor_info executorInfo;
     DataPos existenceMark;
 
-    MergeInfo(std::vector<DataPos> keyPoses, FactorizedTableSchema tableSchema,
-        common::executor_info executorInfo, DataPos existenceMark)
-        : keyPoses{std::move(keyPoses)}, tableSchema{std::move(tableSchema)},
+    MergeInfo(std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> keyEvaluators,
+        FactorizedTableSchema tableSchema, common::executor_info executorInfo, DataPos existenceMark)
+        : keyEvaluators{std::move(keyEvaluators)}, tableSchema{std::move(tableSchema)},
           executorInfo{std::move(executorInfo)}, existenceMark{existenceMark} {}
+    EXPLICIT_COPY_DEFAULT_MOVE(MergeInfo);
 
-    MergeInfo copy() const {
-        return MergeInfo{keyPoses, tableSchema.copy(), executorInfo, existenceMark};
-    }
+private:
+    MergeInfo(const MergeInfo& other)
+        : keyEvaluators{copyVector(other.keyEvaluators)}, tableSchema{other.tableSchema.copy()},
+        executorInfo {other.executorInfo}, existenceMark{other.existenceMark} {}
+    // MergeInfo copy() const {
+    //     return MergeInfo{keyPoses, tableSchema.copy(), executorInfo, existenceMark};
+    // }
 };
 
 struct MergePrintInfo final : OPPrintInfo {

--- a/src/include/processor/result/pattern_creation_info_table.h
+++ b/src/include/processor/result/pattern_creation_info_table.h
@@ -1,6 +1,6 @@
-#include "processor/operator/aggregate/aggregate_hash_table.h"
-
 #pragma once
+
+#include "processor/operator/aggregate/aggregate_hash_table.h"
 
 namespace kuzu {
 namespace processor {

--- a/src/planner/plan/plan_read.cpp
+++ b/src/planner/plan/plan_read.cpp
@@ -51,12 +51,7 @@ void Planner::planMatchClause(const BoundReadingClause& readingClause,
     } break;
     case MatchClauseType::OPTIONAL_MATCH: {
         for (auto& plan : plans) {
-            expression_vector corrExprs;
-            if (!plan->isEmpty()) {
-                corrExprs =
-                    getCorrelatedExprs(*queryGraphCollection, predicates, plan->getSchema());
-            }
-            planOptionalMatch(*queryGraphCollection, predicates, corrExprs, *plan,
+            planOptionalMatch(*queryGraphCollection, predicates, *plan,
                 boundMatchClause.getHint());
         }
     } break;

--- a/src/planner/plan/plan_update.cpp
+++ b/src/planner/plan/plan_update.cpp
@@ -58,20 +58,30 @@ void Planner::planInsertClause(const BoundUpdatingClause* updatingClause, Logica
 
 void Planner::planMergeClause(const BoundUpdatingClause* updatingClause, LogicalPlan& plan) {
     auto& mergeClause = updatingClause->constCast<BoundMergeClause>();
-    binder::expression_vector predicates;
+    expression_vector predicates;
     if (mergeClause.hasPredicate()) {
         predicates = mergeClause.getPredicate()->splitOnAND();
     }
-    expression_vector corrExprs;
+    // Collect merge hash keys. See LogicalMerge for details.
+    expression_vector keys;
+    for (auto& expr : mergeClause.getColumnDataExprs()) {
+        if (expr->expressionType == ExpressionType::LITERAL || expr->expressionType == ExpressionType::PARAMETER) {
+            continue;
+        }
+        keys.push_back(expr);
+    }
     if (!plan.isEmpty()) {
-        corrExprs = getCorrelatedExprs(*mergeClause.getQueryGraphCollection(), predicates,
-            plan.getSchema());
+        for (auto& node : mergeClause.getQueryGraphCollection()->getQueryNodes()) {
+            if (plan.getSchema()->isExpressionInScope(*node->getInternalID())) {
+                keys.push_back(node->getInternalID());
+            }
+        }
     }
     auto existenceMark = mergeClause.getExistenceMark();
-    planOptionalMatch(*mergeClause.getQueryGraphCollection(), predicates, corrExprs, existenceMark,
+    planOptionalMatch(*mergeClause.getQueryGraphCollection(), predicates, existenceMark,
         plan, nullptr /* hint */);
     auto merge =
-        std::make_shared<LogicalMerge>(existenceMark, std::move(corrExprs), plan.getLastOperator());
+        std::make_shared<LogicalMerge>(existenceMark, keys, plan.getLastOperator());
     if (mergeClause.hasInsertNodeInfo()) {
         for (auto& info : mergeClause.getInsertNodeInfos()) {
             merge->addInsertNodeInfo(createLogicalInsertInfo(info)->copy());

--- a/test/test_files/unwind/unwind.test
+++ b/test/test_files/unwind/unwind.test
@@ -225,3 +225,12 @@ Aida|Alice|Bob|Dan
 [5,2,1]
 [2,3]
 [15,64,74]
+
+-LOG UnwindMerge
+-STATEMENT CREATE NODE TABLE N (id INT64 PRIMARY KEY, x STRING);
+---- ok
+-STATEMENT unwind [-1,1] as t merge (a:N {id: abs(t)}) RETURN a.id;
+---- ok
+-STATEMENT MATCH (a:N) RETURN a.id
+---- 1
+1


### PR DESCRIPTION
# Description

We were using a wrong hash key in MERGE which leads to bug in the following query

```
unwind [-1,1] as t merge (a:N {id: abs(t)}) RETURN a.id;
```

I guess because we always test with constant of reference so this bug is not revealed before.

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).