### PR TITLE
Replace CountZeros implementation with one based on std::countl_zero/countr_zero

### DIFF
--- a/src/include/common/utils.h
+++ b/src/include/common/utils.h
@@ -7,6 +7,7 @@
 #include "common/assert.h"
 #include "common/numeric_utils.h"
 #include "common/types/int128_t.h"
+#include <bit>
 
 namespace kuzu {
 namespace common {
@@ -66,70 +67,15 @@ constexpr T countBits(T) {
     return sizeof(T) * bitsPerByte;
 }
 
-template<class T>
-struct CountZeros {};
-
-template<>
-struct CountZeros<uint64_t> {
-    // see here: https://en.wikipedia.org/wiki/De_Bruijn_sequence
-    static idx_t Leading(const uint64_t value_in) {
-        if (!value_in) {
-            return 64;
-        }
-
-        uint64_t value = value_in;
-
-        constexpr uint64_t index64msb[] = {0, 47, 1, 56, 48, 27, 2, 60, 57, 49, 41, 37, 28, 16, 3,
-            61, 54, 58, 35, 52, 50, 42, 21, 44, 38, 32, 29, 23, 17, 11, 4, 62, 46, 55, 26, 59, 40,
-            36, 15, 53, 34, 51, 20, 43, 31, 22, 10, 45, 25, 39, 14, 33, 19, 30, 9, 24, 13, 18, 8,
-            12, 7, 6, 5, 63};
-
-        constexpr uint64_t debruijn64msb = 0X03F79D71B4CB0A89;
-
-        value |= value >> 1;
-        value |= value >> 2;
-        value |= value >> 4;
-        value |= value >> 8;
-        value |= value >> 16;
-        value |= value >> 32;
-        auto result = 63 - index64msb[(value * debruijn64msb) >> 58];
-#ifdef __clang__
-        if constexpr (sizeof(unsigned long) == sizeof(uint64_t)) {
-            KU_ASSERT(result == static_cast<uint64_t>(__builtin_clzl(value_in)));
-        }
-#endif
-        return result;
-    }
-    static idx_t Trailing(uint64_t value_in) {
-        if (!value_in) {
-            return 64;
-        }
-        uint64_t value = value_in;
-
-        constexpr uint64_t index64lsb[] = {63, 0, 58, 1, 59, 47, 53, 2, 60, 39, 48, 27, 54, 33, 42,
-            3, 61, 51, 37, 40, 49, 18, 28, 20, 55, 30, 34, 11, 43, 14, 22, 4, 62, 57, 46, 52, 38,
-            26, 32, 41, 50, 36, 17, 19, 29, 10, 13, 21, 56, 45, 25, 31, 35, 16, 9, 12, 44, 24, 15,
-            8, 23, 7, 6, 5};
-        constexpr uint64_t debruijn64lsb = 0x07EDD5E59A4E28C2ULL;
-        auto result = index64lsb[((value & -value) * debruijn64lsb) >> 58];
-#ifdef __clang__
-        if constexpr (sizeof(unsigned long) == sizeof(uint64_t)) {
-            KU_ASSERT(result == static_cast<uint64_t>(__builtin_ctzl(value_in)));
-        }
-#endif
-        return result;
-    }
-};
-
-template<>
-struct CountZeros<uint32_t> {
-    static idx_t Leading(uint32_t value) { return CountZeros<uint64_t>::Leading(value) - 32; }
-    static idx_t Trailing(uint32_t value) { return CountZeros<uint64_t>::Trailing(value); }
+template<numeric_utils::IsIntegral T>
+struct CountZeros {
+    static constexpr idx_t Leading(T value_in) { return std::countl_zero(value_in); }
+    static constexpr idx_t Trailing(T value_in) { return std::countr_zero(value_in); }
 };
 
 template<>
 struct CountZeros<int128_t> {
-    static idx_t Leading(int128_t value) {
+    static constexpr idx_t Leading(int128_t value) {
         const uint64_t upper = static_cast<uint64_t>(value.high);
         const uint64_t lower = value.low;
 
@@ -142,7 +88,7 @@ struct CountZeros<int128_t> {
         return 128;
     }
 
-    static idx_t Trailing(int128_t value) {
+    static constexpr idx_t Trailing(int128_t value) {
         const uint64_t upper = static_cast<uint64_t>(value.high);
         const uint64_t lower = value.low;
 


### PR DESCRIPTION
Something originally mentioned in https://github.com/kuzudb/kuzu/pull/5205#discussion_r2043232438. This simplifies the code and also should make it faster.

While I'd like to use an unsigned integer constraint for this, the support for int128_t makes it weird, so I just constrained it to integers and it will have a less nice error if you try and use it on signed types.