### PR TITLE
Fix failure limit when doing BM Evictions

### DIFF
--- a/src/storage/buffer_manager/buffer_manager.cpp
+++ b/src/storage/buffer_manager/buffer_manager.cpp
@@ -278,7 +278,7 @@ uint64_t BufferManager::evictPages() {
     // Using the eviction queue's cursor means that we fail after the same number of total attempts,
     // regardless of how many threads are trying to evict.
     auto startCursor = evictionQueue.getEvictionCursor();
-    auto failureLimit = evictionQueue.getSize() * 2;
+    auto failureLimit = evictionQueue.getCapacity() * 2;
     while (evictablePages == 0 && evictionQueue.getEvictionCursor() - startCursor < failureLimit) {
         for (auto& candidate : evictionQueue.next()) {
             auto evictionCandidate = candidate.load();


### PR DESCRIPTION
This was an annoyingly simple mistake, since the intention from the beginning (as the comment indicates) was to use the capacity of the eviction queue as the failure limit.

When doing lots of 256KB allocations the size of the eviction queue is significantly smaller than the capacity even when the buffer pool size has been reached, leading to the failure limit being exceeded before the eviction cursor has wrapped around to the beginning of the queue. And because of the two-stage mark/evict process we don't actually evict anything before failing in this situation.