### PR TITLE
Hash Aggregate memory fix

### DIFF
--- a/src/include/function/aggregate/base_count.h
+++ b/src/include/function/aggregate/base_count.h
@@ -19,7 +19,7 @@ struct BaseCountFunction {
 
     static std::unique_ptr<AggregateState> initialize() {
         auto state = std::make_unique<CountState>();
-        state->isNull = false;
+        state->isValid = true;
         return state;
     }
 

--- a/src/include/function/aggregate/sum.h
+++ b/src/include/function/aggregate/sum.h
@@ -40,9 +40,9 @@ struct SumFunction {
         uint32_t pos, uint64_t multiplicity) {
         INPUT_TYPE val = input->getValue<INPUT_TYPE>(pos);
         for (auto j = 0u; j < multiplicity; ++j) {
-            if (state->isNull) {
+            if (!state->isValid) {
                 state->sum = val;
-                state->isNull = false;
+                state->isValid = true;
             } else {
                 Add::operation(state->sum, val, state->sum);
             }
@@ -52,13 +52,13 @@ struct SumFunction {
     static void combine(uint8_t* state_, uint8_t* otherState_,
         storage::MemoryManager* /*memoryManager*/) {
         auto* otherState = reinterpret_cast<SumState<RESULT_TYPE>*>(otherState_);
-        if (otherState->isNull) {
+        if (!otherState->isValid) {
             return;
         }
         auto* state = reinterpret_cast<SumState<RESULT_TYPE>*>(state_);
-        if (state->isNull) {
+        if (!state->isValid) {
             state->sum = otherState->sum;
-            state->isNull = false;
+            state->isValid = true;
         } else {
             Add::operation(state->sum, otherState->sum, state->sum);
         }

--- a/src/include/function/aggregate_function.h
+++ b/src/include/function/aggregate_function.h
@@ -14,7 +14,8 @@ struct AggregateState {
     virtual void moveResultToVector(common::ValueVector* outputVector, uint64_t pos) = 0;
     virtual ~AggregateState() = default;
 
-    bool isNull = true;
+    // Default to false so that zeroed memory will not be considered valid
+    bool isValid = false;
 };
 
 using param_rewrite_function_t = std::function<void(binder::expression_vector&)>;

--- a/src/include/processor/operator/aggregate/hash_aggregate.h
+++ b/src/include/processor/operator/aggregate/hash_aggregate.h
@@ -48,22 +48,22 @@ public:
         std::span<AggregateInfo> aggregateInfos, std::vector<common::LogicalType> keyTypes,
         std::vector<common::LogicalType> payloadTypes);
 
-    void appendTuples(const FactorizedTable& factorizedTable, ft_col_offset_t hashOffset) override {
+    void moveTuples(const FactorizedTable& factorizedTable, ft_col_offset_t hashOffset) override {
         auto numBytesPerTuple = factorizedTable.getTableSchema()->getNumBytesPerTuple();
         for (ft_tuple_idx_t tupleIdx = 0; tupleIdx < factorizedTable.getNumTuples(); tupleIdx++) {
             auto tuple = factorizedTable.getTuple(tupleIdx);
             auto hash = *reinterpret_cast<common::hash_t*>(tuple + hashOffset);
             auto& partition =
                 globalPartitions[(hash >> shiftForPartitioning) % globalPartitions.size()];
-            partition.queue->appendTuple(std::span(tuple, numBytesPerTuple));
+            partition.queue->moveTuple(std::span(tuple, numBytesPerTuple));
         }
     }
 
-    void appendDistinctTuple(size_t distinctFuncIndex, std::span<uint8_t> tuple,
+    void moveDistinctTuple(size_t distinctFuncIndex, std::span<uint8_t> tuple,
         common::hash_t hash) override {
         auto& partition =
             globalPartitions[(hash >> shiftForPartitioning) % globalPartitions.size()];
-        partition.distinctTableQueues[distinctFuncIndex]->appendTuple(tuple);
+        partition.distinctTableQueues[distinctFuncIndex]->moveTuple(tuple);
     }
 
     void appendOverflow(common::InMemOverflowBuffer&& overflowBuffer) override {

--- a/src/include/processor/operator/aggregate/simple_aggregate.h
+++ b/src/include/processor/operator/aggregate/simple_aggregate.h
@@ -58,9 +58,9 @@ protected:
         SimpleAggregatePartitioningData(SimpleAggregateSharedState* sharedState, size_t functionIdx)
             : sharedState{sharedState}, functionIdx{functionIdx} {}
 
-        void appendTuples(const FactorizedTable& factorizedTable,
+        void moveTuples(const FactorizedTable& factorizedTable,
             ft_col_offset_t hashOffset) override;
-        void appendDistinctTuple(size_t, std::span<uint8_t>, common::hash_t) override;
+        void moveDistinctTuple(size_t, std::span<uint8_t>, common::hash_t) override;
         void appendOverflow(common::InMemOverflowBuffer&& overflowBuffer) override;
 
     private:

--- a/src/include/processor/result/factorized_table.h
+++ b/src/include/processor/result/factorized_table.h
@@ -84,6 +84,7 @@ class KUZU_API FactorizedTable {
 
 public:
     FactorizedTable(storage::MemoryManager* memoryManager, FactorizedTableSchema tableSchema);
+    virtual ~FactorizedTable() = default;
 
     void append(const std::vector<common::ValueVector*>& vectors);
 
@@ -229,7 +230,7 @@ private:
     void readFlatCol(uint8_t** tuplesToRead, ft_col_idx_t colIdx, common::ValueVector& vector,
         uint64_t numTuplesToRead) const;
 
-private:
+protected:
     storage::MemoryManager* memoryManager;
     // Table Schema. Keeping track of factorization structure.
     FactorizedTableSchema tableSchema;

--- a/src/processor/operator/aggregate/base_aggregate_scan.cpp
+++ b/src/processor/operator/aggregate/base_aggregate_scan.cpp
@@ -16,8 +16,8 @@ void BaseAggregateScan::initLocalStateInternal(ResultSet* resultSet,
 
 void BaseAggregateScan::writeAggregateResultToVector(ValueVector& vector, uint64_t pos,
     AggregateState* aggregateState) {
-    vector.setNull(pos, aggregateState->isNull);
-    if (!aggregateState->isNull) {
+    vector.setNull(pos, !aggregateState->isValid);
+    if (aggregateState->isValid) {
         aggregateState->moveResultToVector(&vector, pos);
     }
 }

--- a/test/test_files/agg/hash_leak.test
+++ b/test/test_files/agg/hash_leak.test
@@ -1,0 +1,42 @@
+-DATASET CSV empty
+
+--
+# Tests that buffer manager exceptions during aggregation do not leak memory (meant to be run with the leak sanitizer)
+-CASE LargeAggregateLeakTest
+-STATEMENT CREATE NODE TABLE vertex(ID STRING, PRIMARY KEY(ID));
+---- ok
+-STATEMENT UNWIND range(1, 100000) AS i CREATE (a:vertex {ID: i});
+---- ok
+-STATEMENT MATCH (a:vertex) RETURN a.ID, MIN("very loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong string");
+---- error
+Buffer manager exception: Unable to allocate memory! The buffer pool is full and no memory could be freed!
+-STATEMENT MATCH (a:vertex) RETURN a.ID, MIN("very loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong string");
+---- error
+Buffer manager exception: Unable to allocate memory! The buffer pool is full and no memory could be freed!
+-STATEMENT MATCH (a:vertex) RETURN a.ID, MIN("very loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong string");
+---- error
+Buffer manager exception: Unable to allocate memory! The buffer pool is full and no memory could be freed!
+-STATEMENT MATCH (a:vertex) RETURN a.ID, MIN("very loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong string");
+---- error
+Buffer manager exception: Unable to allocate memory! The buffer pool is full and no memory could be freed!
+-STATEMENT MATCH (a:vertex) RETURN a.ID, MIN("very loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong string");
+---- error
+Buffer manager exception: Unable to allocate memory! The buffer pool is full and no memory could be freed!
+-STATEMENT MATCH (a:vertex) RETURN a.ID, MIN("very loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong string");
+---- error
+Buffer manager exception: Unable to allocate memory! The buffer pool is full and no memory could be freed!
+-STATEMENT MATCH (a:vertex) RETURN a.ID, MIN("very loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong string");
+---- error
+Buffer manager exception: Unable to allocate memory! The buffer pool is full and no memory could be freed!
+-STATEMENT MATCH (a:vertex) RETURN a.ID, MIN("very loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong string");
+---- error
+Buffer manager exception: Unable to allocate memory! The buffer pool is full and no memory could be freed!
+-STATEMENT MATCH (a:vertex) RETURN a.ID, MIN("very loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong string");
+---- error
+Buffer manager exception: Unable to allocate memory! The buffer pool is full and no memory could be freed!
+-STATEMENT MATCH (a:vertex) RETURN a.ID, MIN("very loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong string");
+---- error
+Buffer manager exception: Unable to allocate memory! The buffer pool is full and no memory could be freed!
+-STATEMENT MATCH (a:vertex) RETURN MIN(a.ID);
+---- 1
+1


### PR DESCRIPTION
When the hash aggregate operator using the `MIN`/`MAX` functions on strings fails (and also distinct simple aggregate) we are leaking memory since the `AggregateState` objects are being stored as raw data in the FactorizedTable and don't get their destructor called automatically when the FactorizedTable is destroyed (`MinMaxAggregateState` stores a `std::unique_ptr<InMemOverflowBuffer>`).
I've added an AggregateFactorizedTable class with a custom destructor that will call the destructors on all the AggregateState objects it holds.

I had to flip the polarity of the `AggregateState::isNull` field (renaming it to `isValid`) since zeroed memory that was never initialized would have invalid vtable pointers (causing a segfault when the destructor is called), but isNull would be false, and it's easier to have `isNull` become `isValid` and default to invalid and check isValid before trying to call the destructor, than it is to check if the vtable pointer is valid (I'm not sure if there's a good way of doing that).

Also note that the values when being moved from one table to another need to be cleared so that they don't get double-freed, which I've done with a memset in `HashTableQueue::appendTuple` (since each copy of the AggregateState stores a copy of the `std::unique_ptr`; storing it as raw data removes the usual ways of guaranteeing that the unique_ptr is unique). I also renamed appendTuple to moveTuple to better indicate that it's modifying the source data.