### PR TITLE
Make the scan of relID optional for GDS algorithms

### DIFF
--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -455,7 +455,7 @@ std::shared_ptr<RelExpression> Binder::createRecursiveQueryRel(const parser::Rel
         bindData->directionExpr =
             createInvisibleVariable("pathEdgeDirections", LogicalType::LIST(LogicalType::BOOL()));
     }
-    // Bind weighted path related experssions.
+    // Bind weighted path related expressions.
     if (QueryRelTypeUtils::isWeighted(queryRel->getRelType())) {
         auto propertyExpr = expressionBinder.bindNodeOrRelPropertyExpression(*rel,
             recursivePatternInfo->weightPropertyName);

--- a/src/function/gds/asp_destinations.cpp
+++ b/src/function/gds/asp_destinations.cpp
@@ -247,7 +247,8 @@ public:
     std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, NbrScanState::Chunk& resultChunk,
         bool) override {
         std::vector<nodeID_t> activeNodes;
-        resultChunk.forEach([&](auto nbrNodeID, auto /*edgeID*/) {
+        resultChunk.forEach([&](auto neighbors, auto, auto i) {
+            auto nbrNodeID = neighbors[i];
             auto nbrVal = frontierPair->getNextFrontierValue(nbrNodeID.offset);
             // We should update the nbrID's multiplicity in 2 cases: 1) if nbrID is being visited
             // for the first time, i.e., when its value in the pathLengths frontier is

--- a/src/function/gds/asp_paths.cpp
+++ b/src/function/gds/asp_paths.cpp
@@ -21,7 +21,8 @@ public:
     std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, graph::NbrScanState::Chunk& resultChunk,
         bool fwdEdge) override {
         std::vector<nodeID_t> activeNodes;
-        resultChunk.forEach([&](auto nbrNodeID, auto edgeID) {
+        resultChunk.forEach([&](auto neighbors, auto propertyVectors, auto i) {
+            auto nbrNodeID = neighbors[i];
             auto iter = frontierPair->getNextFrontierValue(nbrNodeID.offset);
             // We should update in 2 cases: 1) if nbrID is being visited
             // for the first time, i.e., when its value in the pathLengths frontier is
@@ -33,6 +34,7 @@ public:
                 if (!block->hasSpace()) {
                     block = bfsGraphManager->getCurrentGraph()->addNewBlock();
                 }
+                auto edgeID = propertyVectors[0]->template getValue<nodeID_t>(i);
                 bfsGraphManager->getCurrentGraph()->addParent(frontierPair->getCurrentIter(),
                     boundNodeID, edgeID, nbrNodeID, fwdEdge, block);
             }

--- a/src/function/gds/awsp_paths.cpp
+++ b/src/function/gds/awsp_paths.cpp
@@ -25,13 +25,16 @@ public:
     std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, graph::NbrScanState::Chunk& chunk,
         bool fwdEdge) override {
         std::vector<nodeID_t> result;
-        chunk.forEach<T>([&](auto nbrNodeID, auto edgeID, auto weight) {
+        chunk.forEach([&](auto neighbors, auto propertyVectors, auto i) {
+            auto nbrNodeID = neighbors[i];
+            auto edgeID = propertyVectors[0]->template getValue<relID_t>(i);
+            auto weight = propertyVectors[1]->template getValue<T>(i);
             checkWeight(weight);
             if (!block->hasSpace()) {
                 block = bfsGraphManager->getCurrentGraph()->addNewBlock();
             }
             if (bfsGraphManager->getCurrentGraph()->tryAddParentWithWeight(boundNodeID, edgeID,
-                    nbrNodeID, fwdEdge, (double)weight, block)) {
+                    nbrNodeID, fwdEdge, static_cast<double>(weight), block)) {
                 result.push_back(nbrNodeID);
             }
         });

--- a/src/function/gds/degrees.h
+++ b/src/function/gds/degrees.h
@@ -78,7 +78,7 @@ private:
 
 struct DegreesUtils {
     static void computeDegree(processor::ExecutionContext* context, graph::Graph* graph,
-        common::NodeOffsetMaskMap* nodeOffsetMaskMap, Degrees* degrees, ExtendDirection direction) {
+        NodeOffsetMaskMap* nodeOffsetMaskMap, Degrees* degrees, ExtendDirection direction) {
         auto currentFrontier = DenseFrontier::getUnvisitedFrontier(context, graph);
         auto nextFrontier = DenseFrontier::getVisitedFrontier(context, graph, nodeOffsetMaskMap);
         auto frontierPair = std::make_unique<DenseFrontierPair>(std::move(currentFrontier),

--- a/src/function/gds/gds_task.cpp
+++ b/src/function/gds/gds_task.cpp
@@ -13,7 +13,7 @@ void FrontierTask::run() {
     FrontierMorsel morsel;
     auto numActiveNodes = 0u;
     auto graph = info.graph;
-    auto scanState = graph->prepareRelScan(info.relEntry, info.nbrEntry, info.propertyToScan);
+    auto scanState = graph->prepareRelScan(info.relEntry, info.nbrEntry, info.propertiesToScan);
     auto ec = info.edgeCompute.copy();
     switch (info.direction) {
     case ExtendDirection::FWD: {
@@ -57,7 +57,7 @@ void FrontierTask::run() {
 void FrontierTask::runSparse() {
     auto numActiveNodes = 0u;
     auto graph = info.graph;
-    auto scanState = graph->prepareRelScan(info.relEntry, info.nbrEntry, info.propertyToScan);
+    auto scanState = graph->prepareRelScan(info.relEntry, info.nbrEntry, info.propertiesToScan);
     auto ec = info.edgeCompute.copy();
     switch (info.direction) {
     case ExtendDirection::FWD: {

--- a/src/function/gds/k_core_decomposition.cpp
+++ b/src/function/gds/k_core_decomposition.cpp
@@ -69,8 +69,11 @@ class RemoveVertexEdgeCompute : public EdgeCompute {
 public:
     explicit RemoveVertexEdgeCompute(Degrees& degrees) : degrees{degrees} {}
 
-    std::vector<nodeID_t> edgeCompute(nodeID_t, graph::NbrScanState::Chunk& chunk, bool) override {
-        chunk.forEach([&](auto nbrNodeID, auto) { degrees.decreaseDegreeByOne(nbrNodeID.offset); });
+    std::vector<nodeID_t> edgeCompute(nodeID_t, NbrScanState::Chunk& chunk, bool) override {
+        chunk.forEach([&](auto neighbors, auto, auto i) {
+            auto nbrNodeID = neighbors[i];
+            degrees.decreaseDegreeByOne(nbrNodeID.offset);
+        });
         return {};
     }
 

--- a/src/function/gds/page_rank.cpp
+++ b/src/function/gds/page_rank.cpp
@@ -38,8 +38,7 @@ PageRankOptionalParams::PageRankOptionalParams(const expression_vector& optional
         } else if (paramName == Tolerance::NAME) {
             tolerance = optionalParam;
         } else {
-            throw common::BinderException{
-                "Unknown optional parameter: " + optionalParam->getAlias()};
+            throw BinderException{"Unknown optional parameter: " + optionalParam->getAlias()};
         }
     }
 }
@@ -143,7 +142,8 @@ public:
         bool) override {
         if (chunk.size() > 0) {
             double valToAdd = 0;
-            chunk.forEach([&](auto nbrNodeID, auto) {
+            chunk.forEach([&](auto neighbors, auto, auto i) {
+                auto nbrNodeID = neighbors[i];
                 valToAdd +=
                     pCurrent.getValue(nbrNodeID.offset) / degrees.getValue(nbrNodeID.offset);
             });
@@ -170,7 +170,7 @@ public:
         : GDSVertexCompute{nodeMask}, dampingFactor{dampingFactor}, constant{constant},
           pNext{pNext} {}
 
-    void beginOnTableInternal(common::table_id_t tableID) override { pNext.pinTable(tableID); }
+    void beginOnTableInternal(table_id_t tableID) override { pNext.pinTable(tableID); }
 
     void vertexCompute(offset_t startOffset, offset_t endOffset, table_id_t) override {
         for (auto i = startOffset; i < endOffset; ++i) {
@@ -261,7 +261,7 @@ private:
     std::unique_ptr<ValueVector> rankVector;
 };
 
-static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
+static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
     auto clientContext = input.context->clientContext;
     auto transaction = clientContext->getTransaction();
     auto sharedState = input.sharedState->ptrCast<GDSFuncSharedState>();

--- a/src/function/gds/ssp_destinations.cpp
+++ b/src/function/gds/ssp_destinations.cpp
@@ -65,7 +65,8 @@ public:
 
     std::vector<nodeID_t> edgeCompute(nodeID_t, NbrScanState::Chunk& resultChunk, bool) override {
         std::vector<nodeID_t> activeNodes;
-        resultChunk.forEach([&](auto nbrNode, auto) {
+        resultChunk.forEach([&](auto neighbors, auto, auto i) {
+            auto nbrNode = neighbors[i];
             auto iter = frontierPair->getNextFrontierValue(nbrNode.offset);
             if (iter == FRONTIER_UNVISITED) {
                 activeNodes.push_back(nbrNode);

--- a/src/function/gds/ssp_paths.cpp
+++ b/src/function/gds/ssp_paths.cpp
@@ -21,12 +21,14 @@ public:
     std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, graph::NbrScanState::Chunk& resultChunk,
         bool isFwd) override {
         std::vector<nodeID_t> activeNodes;
-        resultChunk.forEach([&](auto nbrNodeID, auto edgeID) {
+        resultChunk.forEach([&](auto neighbors, auto propertyVectors, auto i) {
+            auto nbrNodeID = neighbors[i];
             auto iter = frontierPair->getNextFrontierValue(nbrNodeID.offset);
             if (iter == FRONTIER_UNVISITED) {
                 if (!block->hasSpace()) {
                     block = bfsGraphManager->getCurrentGraph()->addNewBlock();
                 }
+                auto edgeID = propertyVectors[0]->template getValue<nodeID_t>(i);
                 bfsGraphManager->getCurrentGraph()->addSingleParent(frontierPair->getCurrentIter(),
                     boundNodeID, edgeID, nbrNodeID, isFwd, block);
                 activeNodes.push_back(nbrNodeID);

--- a/src/function/gds/strongly_connected_components.cpp
+++ b/src/function/gds/strongly_connected_components.cpp
@@ -165,7 +165,8 @@ public:
     std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, graph::NbrScanState::Chunk& chunk,
         bool) override {
         std::vector<nodeID_t> result;
-        chunk.forEach([&](auto nbrNodeID, auto) {
+        chunk.forEach([&](auto neighbors, auto, auto i) {
+            auto nbrNodeID = neighbors[i];
             if (!componentIDs.hasValidComponentID(nbrNodeID.offset) &&
                 colorsPair.update(boundNodeID.offset, nbrNodeID.offset)) {
                 result.push_back(nbrNodeID);

--- a/src/function/gds/variable_length_path.cpp
+++ b/src/function/gds/variable_length_path.cpp
@@ -59,8 +59,10 @@ public:
     std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, graph::NbrScanState::Chunk& chunk,
         bool fwdEdge) override {
         std::vector<nodeID_t> activeNodes;
-        chunk.forEach([&](auto nbrNodeID, auto edgeID) {
+        chunk.forEach([&](auto neighbors, auto propertyVectors, auto i) {
             // We should always update the nbrID in variable length joins
+            auto nbrNodeID = neighbors[i];
+            auto edgeID = propertyVectors[0]->template getValue<relID_t>(i);
             if (!block->hasSpace()) {
                 block = bfsGraphManager->getCurrentGraph()->addNewBlock();
             }

--- a/src/function/gds/weakly_connected_components.cpp
+++ b/src/function/gds/weakly_connected_components.cpp
@@ -34,10 +34,11 @@ public:
     explicit WCCEdgeCompute(ComponentIDsPair& componentIDsPair)
         : componentIDsPair{componentIDsPair} {}
 
-    std::vector<common::nodeID_t> edgeCompute(common::nodeID_t boundNodeID,
-        graph::NbrScanState::Chunk& chunk, bool) override {
-        std::vector<common::nodeID_t> result;
-        chunk.forEach([&](auto nbrNodeID, auto) {
+    std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, NbrScanState::Chunk& chunk,
+        bool) override {
+        std::vector<nodeID_t> result;
+        chunk.forEach([&](auto neighbors, auto, auto i) {
+            auto nbrNodeID = neighbors[i];
             if (componentIDsPair.update(boundNodeID.offset, nbrNodeID.offset)) {
                 result.push_back(nbrNodeID);
             }
@@ -98,8 +99,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
 
 function_set WeaklyConnectedComponentsFunction::getFunctionSet() {
     function_set result;
-    auto func = std::make_unique<TableFunction>(WeaklyConnectedComponentsFunction::name,
-        std::vector<LogicalTypeID>{LogicalTypeID::ANY});
+    auto func = std::make_unique<TableFunction>(name, std::vector{LogicalTypeID::ANY});
     func->bindFunc = bindFunc;
     func->tableFunc = tableFunc;
     func->initSharedStateFunc = GDSFunction::initSharedState;

--- a/src/function/gds/wsp_destinations.cpp
+++ b/src/function/gds/wsp_destinations.cpp
@@ -62,9 +62,11 @@ public:
     std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, graph::NbrScanState::Chunk& chunk,
         bool) override {
         std::vector<nodeID_t> result;
-        chunk.forEach<T>([&](auto nbrNodeID, auto /* edgeID */, auto weight) {
+        chunk.forEach([&](auto neighbors, auto propertyVectors, auto i) {
+            auto nbrNodeID = neighbors[i];
+            auto weight = propertyVectors[0]->template getValue<T>(i);
             checkWeight(weight);
-            if (costs->update(boundNodeID.offset, nbrNodeID.offset, (double)weight)) {
+            if (costs->update(boundNodeID.offset, nbrNodeID.offset, static_cast<double>(weight))) {
                 result.push_back(nbrNodeID);
             }
         });

--- a/src/function/gds/wsp_paths.cpp
+++ b/src/function/gds/wsp_paths.cpp
@@ -25,13 +25,16 @@ public:
     std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, graph::NbrScanState::Chunk& chunk,
         bool fwdEdge) override {
         std::vector<nodeID_t> result;
-        chunk.forEach<T>([&](auto nbrNodeID, auto edgeID, auto weight) {
+        chunk.forEach([&](auto neighbors, auto propertyVectors, auto i) {
+            auto nbrNodeID = neighbors[i];
+            auto edgeID = propertyVectors[0]->template getValue<relID_t>(i);
+            auto weight = propertyVectors[1]->template getValue<T>(i);
             checkWeight(weight);
             if (!block->hasSpace()) {
                 block = bfsGraphManager->getCurrentGraph()->addNewBlock();
             }
             if (bfsGraphManager->getCurrentGraph()->tryAddSingleParentWithWeight(boundNodeID,
-                    edgeID, nbrNodeID, fwdEdge, (double)weight, block)) {
+                    edgeID, nbrNodeID, fwdEdge, static_cast<double>(weight), block)) {
                 result.push_back(nbrNodeID);
             }
         });

--- a/src/graph/graph.cpp
+++ b/src/graph/graph.cpp
@@ -1,7 +1,5 @@
 #include "graph/graph.h"
 
-#include <utility>
-
 #include "common/system_config.h"
 
 namespace kuzu::graph {

--- a/src/graph/graph.cpp
+++ b/src/graph/graph.cpp
@@ -1,14 +1,14 @@
 #include "graph/graph.h"
 
+#include <utility>
+
 #include "common/system_config.h"
 
 namespace kuzu::graph {
 NbrScanState::Chunk::Chunk(std::span<const common::nodeID_t> nbrNodes,
-    std::span<const common::relID_t> edges, common::SelectionVector& selVector,
-    const common::ValueVector* propertyVector)
-    : nbrNodes{nbrNodes}, edges{edges}, selVector{selVector}, propertyVector{propertyVector} {
+    common::SelectionVector& selVector, std::vector<common::ValueVector*> propertyVectors)
+    : nbrNodes{nbrNodes}, selVector{selVector}, propertyVectors{std::move(propertyVectors)} {
     KU_ASSERT(nbrNodes.size() == common::DEFAULT_VECTOR_CAPACITY);
-    KU_ASSERT(edges.size() == common::DEFAULT_VECTOR_CAPACITY);
 }
 
 VertexScanState::Chunk::Chunk(std::span<const common::nodeID_t> nodeIDs,

--- a/src/include/function/gds/gds_task.h
+++ b/src/include/function/gds/gds_task.h
@@ -18,18 +18,19 @@ struct FrontierTaskInfo {
     graph::Graph* graph;
     common::ExtendDirection direction;
     EdgeCompute& edgeCompute;
-    std::string propertyToScan;
+    std::vector<std::string> propertiesToScan;
 
     FrontierTaskInfo(catalog::TableCatalogEntry* boundEntry, catalog::TableCatalogEntry* nbrEntry,
         catalog::TableCatalogEntry* relEntry, graph::Graph* graph,
-        common::ExtendDirection direction, EdgeCompute& edgeCompute, std::string propertyToScan)
+        common::ExtendDirection direction, EdgeCompute& edgeCompute,
+        std::vector<std::string> propertiesToScan)
         : boundEntry{boundEntry}, nbrEntry{nbrEntry}, relEntry{relEntry}, graph{graph},
           direction{direction}, edgeCompute{edgeCompute},
-          propertyToScan{std::move(propertyToScan)} {}
+          propertiesToScan{std::move(propertiesToScan)} {}
     FrontierTaskInfo(const FrontierTaskInfo& other)
         : boundEntry{other.boundEntry}, nbrEntry{other.nbrEntry}, relEntry{other.relEntry},
           graph{other.graph}, direction{other.direction}, edgeCompute{other.edgeCompute},
-          propertyToScan{other.propertyToScan} {}
+          propertiesToScan{other.propertiesToScan} {}
 };
 
 struct FrontierTaskSharedState {

--- a/src/include/function/gds/gds_utils.h
+++ b/src/include/function/gds/gds_utils.h
@@ -16,23 +16,23 @@ public:
     // Run edge compute for full text search
     static void runFTSEdgeCompute(processor::ExecutionContext* context, GDSComputeState& compState,
         graph::Graph* graph, common::ExtendDirection extendDirection,
-        const std::string& propertyToScan);
+        const std::vector<std::string>& propertiesToScan);
     // Run edge compute for recursive join.
     static void runRecursiveJoinEdgeCompute(processor::ExecutionContext* context,
         GDSComputeState& compState, graph::Graph* graph, common::ExtendDirection extendDirection,
         uint64_t maxIteration, common::NodeOffsetMaskMap* outputNodeMask,
-        const std::string& propertyToScan = "");
+        const std::vector<std::string>& propertiesToScan);
 
     // Run vertex compute without property scan
     static void runVertexCompute(processor::ExecutionContext* context, GDSDensityState densityState,
         graph::Graph* graph, VertexCompute& vc);
     // Run vertex compute with property scan
     static void runVertexCompute(processor::ExecutionContext* context, GDSDensityState densityState,
-        graph::Graph* graph, VertexCompute& vc, std::vector<std::string> propertiesToScan);
+        graph::Graph* graph, VertexCompute& vc, const std::vector<std::string>& propertiesToScan);
     // Run vertex compute on specific table with property scan
     static void runVertexCompute(processor::ExecutionContext* context, GDSDensityState densityState,
         graph::Graph* graph, VertexCompute& vc, catalog::TableCatalogEntry* entry,
-        std::vector<std::string> propertiesToScan);
+        const std::vector<std::string>& propertiesToScan);
 };
 
 } // namespace function

--- a/src/include/graph/graph.h
+++ b/src/include/graph/graph.h
@@ -33,6 +33,7 @@ public:
     struct Chunk {
         friend class NbrScanState;
 
+        EXPLICIT_COPY_METHOD(Chunk);
         // Any neighbour for which the given function returns false
         // will be omitted from future iterations
         // Used in GDSTask/EdgeCompute for updating the frontier
@@ -50,6 +51,10 @@ public:
     private:
         Chunk(std::span<const common::nodeID_t> nbrNodes, common::SelectionVector& selVector,
             std::vector<common::ValueVector*> propertyVectors);
+
+        Chunk(const Chunk& other) noexcept
+            : nbrNodes{other.nbrNodes}, selVector{other.selVector},
+              propertyVectors{other.propertyVectors} {}
 
     private:
         std::span<const common::nodeID_t> nbrNodes;


### PR DESCRIPTION
# Description

Under quite a few cases, relID is not needed for computation while we still scan from rel tables. This PR makes the scan of relID optional and configured per algorithm.

Performance comparison between this branch and master on WCC and K-Core are as follows. This is done on a Mac mini with m4 pro chip, 64GB RAM and 1TB SSD.
| Algorithm | Master - cold (ms) | Master - warm (ms) | This branch - cold (ms) | This branch - warm (ms) |
| ---------- | ------------------ | -------------------- | ----------------------- | ------------------------- |
| WCC          | 140.5                       | 92.6                           |  87.1                                | 75.6                                    |
| K-CORE     | 9612.7                     | 9241.8                       | 7168.3                            | 6278.9                                |

The performance different on PageRank is not visible.

TODO:
- [ ] Get rid of the hard coding when accessing rel property vectors inside each algorithm.