### PR TITLE
Fix handling of SimpleAggregate non-distinct functions mixed with distinct ones

### DIFF
--- a/test/test_files/agg/distinct_agg.test
+++ b/test/test_files/agg/distinct_agg.test
@@ -119,3 +119,6 @@ Bob|Dan
 -STATEMENT MATCH (:person), (a:person)-[t:knows*2..2]->(b:person) RETURN count(DISTINCT t);
 ---- 1
 36
+-STATEMENT MATCH (:person), (a:person)-[t:knows*2..2]->(b:person) RETURN count(*), count(DISTINCT t);
+---- 1
+288|36


### PR DESCRIPTION
Apparently we missed testing this.

Fixes #5250