### PR TITLE
Improve parallel scc, handle filtered multi-label graph

### DIFF
--- a/src/function/gds/CMakeLists.txt
+++ b/src/function/gds/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(kuzu_function_algorithm
         asp_paths.cpp
         awsp_paths.cpp
         bfs_graph.cpp
+        component_ids.cpp
         frontier_morsel.cpp
         gds.cpp
         gds_frontier.cpp

--- a/src/function/gds/component_ids.cpp
+++ b/src/function/gds/component_ids.cpp
@@ -1,0 +1,74 @@
+#include "component_ids.h"
+
+using namespace kuzu::common;
+
+namespace kuzu {
+namespace function {
+
+OffsetManager::OffsetManager(const table_id_map_t<offset_t>& maxOffsetMap) {
+     std::vector<table_id_t> tableIDVector;
+     for (auto [tableID, maxOffset] : maxOffsetMap) {
+         tableIDVector.push_back(tableID);
+     }
+     std::sort(tableIDVector.begin(), tableIDVector.end());
+     auto offset = 0u;
+     for (auto tableID : tableIDVector) {
+         tableIDToStartOffset.insert({tableID, offset});
+         offset += maxOffsetMap.at(tableID);
+     }
+}
+
+ComponentIDs ComponentIDs::getSequenceComponentIDs(
+    const table_id_map_t<offset_t>& maxOffsetMap,
+    const OffsetManager& offsetManager, storage::MemoryManager* mm) {
+    auto result = ComponentIDs();
+    for (auto [tableID, maxOffset] : maxOffsetMap) {
+        result.denseObjects.allocate(tableID, maxOffset, mm);
+        result.pinTableID(tableID);
+        auto startOffset = offsetManager.getStartOffset(tableID);
+        for (auto i = 0u; i < maxOffset; i++) {
+            result.setComponentID(i, startOffset + i);
+        }
+    }
+    return result;
+}
+
+ComponentIDs ComponentIDs::getUnvisitedComponentIDs(
+    const table_id_map_t<offset_t>& maxOffsetMap, storage::MemoryManager* mm) {
+    auto result = ComponentIDs();
+    for (auto [tableID, maxOffset] : maxOffsetMap) {
+        result.denseObjects.allocate(tableID, maxOffset, mm);
+        result.pinTableID(tableID);
+        for (auto i = 0u; i < maxOffset; i++) {
+            result.setComponentID(i, INVALID_COMPONENT_ID);
+        }
+    }
+    return result;
+}
+
+
+bool ComponentIDsPair::update(offset_t boundOffset, offset_t nbrOffset) {
+    auto boundValue = curData[boundOffset].load(std::memory_order_relaxed);
+    auto tmp = nextData[nbrOffset].load(std::memory_order_relaxed);
+    while (tmp > boundValue) {
+        if (nextData[nbrOffset].compare_exchange_strong(tmp, boundValue)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void ComponentIDsOutputVertexCompute::vertexCompute(offset_t startOffset, offset_t endOffset, table_id_t tableID) {
+    for (auto i = startOffset; i < endOffset; ++i) {
+        if (skip(i)) {
+            continue;
+        }
+        auto nodeID = nodeID_t{i, tableID};
+        nodeIDVector->setValue<nodeID_t>(0, nodeID);
+        componentIDVector->setValue<uint64_t>(0, componentIDs.getComponentID(i));
+        localFT->append(vectors);
+    }
+}
+
+}
+}

--- a/src/function/gds/component_ids.cpp
+++ b/src/function/gds/component_ids.cpp
@@ -6,20 +6,19 @@ namespace kuzu {
 namespace function {
 
 OffsetManager::OffsetManager(const table_id_map_t<offset_t>& maxOffsetMap) {
-     std::vector<table_id_t> tableIDVector;
-     for (auto [tableID, maxOffset] : maxOffsetMap) {
-         tableIDVector.push_back(tableID);
-     }
-     std::sort(tableIDVector.begin(), tableIDVector.end());
-     auto offset = 0u;
-     for (auto tableID : tableIDVector) {
-         tableIDToStartOffset.insert({tableID, offset});
-         offset += maxOffsetMap.at(tableID);
-     }
+    std::vector<table_id_t> tableIDVector;
+    for (auto [tableID, maxOffset] : maxOffsetMap) {
+        tableIDVector.push_back(tableID);
+    }
+    std::sort(tableIDVector.begin(), tableIDVector.end());
+    auto offset = 0u;
+    for (auto tableID : tableIDVector) {
+        tableIDToStartOffset.insert({tableID, offset});
+        offset += maxOffsetMap.at(tableID);
+    }
 }
 
-ComponentIDs ComponentIDs::getSequenceComponentIDs(
-    const table_id_map_t<offset_t>& maxOffsetMap,
+ComponentIDs ComponentIDs::getSequenceComponentIDs(const table_id_map_t<offset_t>& maxOffsetMap,
     const OffsetManager& offsetManager, storage::MemoryManager* mm) {
     auto result = ComponentIDs();
     for (auto [tableID, maxOffset] : maxOffsetMap) {
@@ -33,8 +32,8 @@ ComponentIDs ComponentIDs::getSequenceComponentIDs(
     return result;
 }
 
-ComponentIDs ComponentIDs::getUnvisitedComponentIDs(
-    const table_id_map_t<offset_t>& maxOffsetMap, storage::MemoryManager* mm) {
+ComponentIDs ComponentIDs::getUnvisitedComponentIDs(const table_id_map_t<offset_t>& maxOffsetMap,
+    storage::MemoryManager* mm) {
     auto result = ComponentIDs();
     for (auto [tableID, maxOffset] : maxOffsetMap) {
         result.denseObjects.allocate(tableID, maxOffset, mm);
@@ -45,7 +44,6 @@ ComponentIDs ComponentIDs::getUnvisitedComponentIDs(
     }
     return result;
 }
-
 
 bool ComponentIDsPair::update(offset_t boundOffset, offset_t nbrOffset) {
     auto boundValue = curData[boundOffset].load(std::memory_order_relaxed);
@@ -58,7 +56,8 @@ bool ComponentIDsPair::update(offset_t boundOffset, offset_t nbrOffset) {
     return false;
 }
 
-void ComponentIDsOutputVertexCompute::vertexCompute(offset_t startOffset, offset_t endOffset, table_id_t tableID) {
+void ComponentIDsOutputVertexCompute::vertexCompute(offset_t startOffset, offset_t endOffset,
+    table_id_t tableID) {
     for (auto i = startOffset; i < endOffset; ++i) {
         if (skip(i)) {
             continue;
@@ -70,5 +69,5 @@ void ComponentIDsOutputVertexCompute::vertexCompute(offset_t startOffset, offset
     }
 }
 
-}
-}
+} // namespace function
+} // namespace kuzu

--- a/src/function/gds/component_ids.h
+++ b/src/function/gds/component_ids.h
@@ -1,0 +1,133 @@
+#pragma once
+
+#include "function/gds/gds_object_manager.h"
+#include "gds_vertex_compute.h"
+
+namespace kuzu {
+namespace function {
+
+static constexpr common::offset_t INVALID_COMPONENT_ID = common::INVALID_OFFSET;
+
+struct OffsetManager {
+    explicit OffsetManager(const common::table_id_map_t<common::offset_t>& maxOffsetMap);
+
+    void pinTableID(common::table_id_t tableID) {
+        curOffset = getStartOffset(tableID);
+    }
+    common::offset_t getStartOffset(common::table_id_t tableID) const {
+        KU_ASSERT(tableIDToStartOffset.contains(tableID));
+        return tableIDToStartOffset.at(tableID);
+    }
+    common::offset_t getCurrentOffset() const {
+        KU_ASSERT(curOffset != common::INVALID_OFFSET);
+        return curOffset;
+    }
+
+private:
+    common::offset_t curOffset = common::INVALID_OFFSET;
+    common::table_id_map_t<common::offset_t> tableIDToStartOffset;
+};
+
+class ComponentIDs {
+public:
+    std::atomic<common::offset_t>* getData(common::table_id_t tableID) {
+        return denseObjects.getData(tableID);
+    }
+    void pinTableID(common::table_id_t tableID) {
+        curData = denseObjects.getData(tableID);
+    }
+
+    void setComponentID(common::offset_t offset, common::offset_t componentID) {
+        KU_ASSERT(curData != nullptr);
+        curData[offset] = componentID;
+    }
+
+    common::offset_t getComponentID(common::offset_t offset) const {
+        KU_ASSERT(curData != nullptr);
+        return curData[offset];
+    }
+    bool hasValidComponentID(common::offset_t offset) const {
+        return getComponentID(offset) != INVALID_COMPONENT_ID;
+    }
+
+    static ComponentIDs getSequenceComponentIDs(const common::table_id_map_t<common::offset_t>& maxOffsetMap, const OffsetManager& offsetManager,
+        storage::MemoryManager* mm);
+    static ComponentIDs getUnvisitedComponentIDs(const common::table_id_map_t<common::offset_t>& maxOffsetMap,
+        storage::MemoryManager* mm);
+
+private:
+    std::atomic<common::offset_t>* curData = nullptr;
+    GDSDenseObjectManager<std::atomic<common::offset_t>> denseObjects;
+};
+
+class InitSequenceComponentIDsVertexCompute : public VertexCompute {
+public:
+    InitSequenceComponentIDsVertexCompute(ComponentIDs& componentIDs, OffsetManager& offsetManager)
+        : componentIDs{componentIDs}, offsetManager{offsetManager} {}
+
+    bool beginOnTable(common::table_id_t tableID) override {
+        componentIDs.pinTableID(tableID);
+        offsetManager.pinTableID(tableID);
+        return true;
+    }
+
+    void vertexCompute(common::offset_t startOffset, common::offset_t endOffset, common::table_id_t) override {
+        for (auto i = startOffset; i < endOffset; ++i) {
+            componentIDs.setComponentID(i, i + offsetManager.getCurrentOffset());
+        }
+    }
+
+    std::unique_ptr<VertexCompute> copy() override {
+        return std::make_unique<InitSequenceComponentIDsVertexCompute>(componentIDs, offsetManager);
+    }
+
+private:
+    ComponentIDs& componentIDs;
+    OffsetManager& offsetManager;
+};
+
+class ComponentIDsPair {
+public:
+    explicit ComponentIDsPair(ComponentIDs& componentIDs) : componentIDs{componentIDs} {}
+
+    void pinCurTableID(common::table_id_t tableID) {
+        curData = componentIDs.getData(tableID);
+    }
+
+    void pinNextTableID(common::table_id_t tableID) {
+        nextData = componentIDs.getData(tableID);
+    }
+
+    bool update(common::offset_t boundOffset, common::offset_t nbrOffset);
+
+private:
+    std::atomic<common::offset_t>* curData = nullptr;
+    std::atomic<common::offset_t>* nextData = nullptr;
+    ComponentIDs& componentIDs;
+};
+
+class ComponentIDsOutputVertexCompute : public GDSResultVertexCompute {
+public:
+    ComponentIDsOutputVertexCompute(storage::MemoryManager* mm, GDSFuncSharedState* sharedState,
+        ComponentIDs& componentIDs)
+        : GDSResultVertexCompute{mm, sharedState}, componentIDs{componentIDs} {
+        nodeIDVector = createVector(common::LogicalType::INTERNAL_ID());
+        componentIDVector = createVector(common::LogicalType::UINT64());
+    }
+
+    void beginOnTableInternal(common::table_id_t tableID) override { componentIDs.pinTableID(tableID); }
+
+    void vertexCompute(common::offset_t startOffset, common::offset_t endOffset, common::table_id_t tableID) override;
+
+    std::unique_ptr<VertexCompute> copy() override {
+        return std::make_unique<ComponentIDsOutputVertexCompute>(mm, sharedState, componentIDs);
+    }
+
+private:
+    ComponentIDs& componentIDs;
+    std::unique_ptr<common::ValueVector> nodeIDVector;
+    std::unique_ptr<common::ValueVector> componentIDVector;
+};
+
+}
+}

--- a/src/function/gds/component_ids.h
+++ b/src/function/gds/component_ids.h
@@ -11,9 +11,7 @@ static constexpr common::offset_t INVALID_COMPONENT_ID = common::INVALID_OFFSET;
 struct OffsetManager {
     explicit OffsetManager(const common::table_id_map_t<common::offset_t>& maxOffsetMap);
 
-    void pinTableID(common::table_id_t tableID) {
-        curOffset = getStartOffset(tableID);
-    }
+    void pinTableID(common::table_id_t tableID) { curOffset = getStartOffset(tableID); }
     common::offset_t getStartOffset(common::table_id_t tableID) const {
         KU_ASSERT(tableIDToStartOffset.contains(tableID));
         return tableIDToStartOffset.at(tableID);
@@ -33,9 +31,7 @@ public:
     std::atomic<common::offset_t>* getData(common::table_id_t tableID) {
         return denseObjects.getData(tableID);
     }
-    void pinTableID(common::table_id_t tableID) {
-        curData = denseObjects.getData(tableID);
-    }
+    void pinTableID(common::table_id_t tableID) { curData = denseObjects.getData(tableID); }
 
     void setComponentID(common::offset_t offset, common::offset_t componentID) {
         KU_ASSERT(curData != nullptr);
@@ -50,10 +46,11 @@ public:
         return getComponentID(offset) != INVALID_COMPONENT_ID;
     }
 
-    static ComponentIDs getSequenceComponentIDs(const common::table_id_map_t<common::offset_t>& maxOffsetMap, const OffsetManager& offsetManager,
-        storage::MemoryManager* mm);
-    static ComponentIDs getUnvisitedComponentIDs(const common::table_id_map_t<common::offset_t>& maxOffsetMap,
-        storage::MemoryManager* mm);
+    static ComponentIDs getSequenceComponentIDs(
+        const common::table_id_map_t<common::offset_t>& maxOffsetMap,
+        const OffsetManager& offsetManager, storage::MemoryManager* mm);
+    static ComponentIDs getUnvisitedComponentIDs(
+        const common::table_id_map_t<common::offset_t>& maxOffsetMap, storage::MemoryManager* mm);
 
 private:
     std::atomic<common::offset_t>* curData = nullptr;
@@ -71,7 +68,8 @@ public:
         return true;
     }
 
-    void vertexCompute(common::offset_t startOffset, common::offset_t endOffset, common::table_id_t) override {
+    void vertexCompute(common::offset_t startOffset, common::offset_t endOffset,
+        common::table_id_t) override {
         for (auto i = startOffset; i < endOffset; ++i) {
             componentIDs.setComponentID(i, i + offsetManager.getCurrentOffset());
         }
@@ -90,13 +88,9 @@ class ComponentIDsPair {
 public:
     explicit ComponentIDsPair(ComponentIDs& componentIDs) : componentIDs{componentIDs} {}
 
-    void pinCurTableID(common::table_id_t tableID) {
-        curData = componentIDs.getData(tableID);
-    }
+    void pinCurTableID(common::table_id_t tableID) { curData = componentIDs.getData(tableID); }
 
-    void pinNextTableID(common::table_id_t tableID) {
-        nextData = componentIDs.getData(tableID);
-    }
+    void pinNextTableID(common::table_id_t tableID) { nextData = componentIDs.getData(tableID); }
 
     bool update(common::offset_t boundOffset, common::offset_t nbrOffset);
 
@@ -115,9 +109,12 @@ public:
         componentIDVector = createVector(common::LogicalType::UINT64());
     }
 
-    void beginOnTableInternal(common::table_id_t tableID) override { componentIDs.pinTableID(tableID); }
+    void beginOnTableInternal(common::table_id_t tableID) override {
+        componentIDs.pinTableID(tableID);
+    }
 
-    void vertexCompute(common::offset_t startOffset, common::offset_t endOffset, common::table_id_t tableID) override;
+    void vertexCompute(common::offset_t startOffset, common::offset_t endOffset,
+        common::table_id_t tableID) override;
 
     std::unique_ptr<VertexCompute> copy() override {
         return std::make_unique<ComponentIDsOutputVertexCompute>(mm, sharedState, componentIDs);
@@ -129,5 +126,5 @@ private:
     std::unique_ptr<common::ValueVector> componentIDVector;
 };
 
-}
-}
+} // namespace function
+} // namespace kuzu

--- a/src/function/gds/strongly_connected_components.cpp
+++ b/src/function/gds/strongly_connected_components.cpp
@@ -1,10 +1,10 @@
 #include "binder/binder.h"
-#include "common/exception/runtime.h"
 #include "function/gds/gds_frontier.h"
 #include "function/gds/gds_function_collection.h"
 #include "function/gds/gds_utils.h"
 #include "gds_vertex_compute.h"
 #include "processor/execution_context.h"
+#include "component_ids.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -15,263 +15,235 @@ using namespace kuzu::graph;
 namespace kuzu {
 namespace function {
 
-static constexpr offset_t SCC_UNSET = std::numeric_limits<offset_t>::max();
-
-struct SccComputationState : GDSAuxiliaryState {
-    std::atomic<bool> allSccIdsSet;
-    AtomicObjectArray<offset_t> sccIDs;
-    AtomicObjectArray<offset_t> fwdColors;
-    AtomicObjectArray<offset_t> bwdColors;
-
-    SccComputationState(const offset_t numNodes, MemoryManager* mm)
-        : sccIDs{AtomicObjectArray<offset_t>(numNodes, mm)},
-          fwdColors{AtomicObjectArray<offset_t>(numNodes, mm)},
-          bwdColors{AtomicObjectArray<offset_t>(numNodes, mm)} {
-        allSccIdsSet.store(false, std::memory_order_relaxed);
-    }
-
-    bool isSccIdSet(offset_t nodeId) { return sccIDs.getRelaxed(nodeId) != SCC_UNSET; }
-
-    // Start by assuming all scc ids are set. `memory_order_seq_cst` is used to ensure that
-    // all threads see the initial value of `allSccIdsSet`.
-    void reset() { allSccIdsSet.store(true, std::memory_order_seq_cst); }
-
-    void beginFrontierCompute(table_id_t, table_id_t) override {}
-
-    void switchToDense(ExecutionContext*, Graph*) override {
-        // Do nothing
-    }
-};
-
-// Initializes `sccIDs` to `SCC_UNSET`.
-class SccSetInitialSccIds : public VertexCompute {
-public:
-    explicit SccSetInitialSccIds(SccComputationState& computationState)
-        : computationState{computationState} {}
-
-    bool beginOnTable(table_id_t) override { return true; }
-
-    void vertexCompute(offset_t startOffset, offset_t endOffset, table_id_t) override {
-        for (auto i = startOffset; i < endOffset; ++i) {
-            computationState.sccIDs.setRelaxed(i, SCC_UNSET);
-        }
-    }
-
-    std::unique_ptr<VertexCompute> copy() override {
-        return std::make_unique<SccSetInitialSccIds>(computationState);
-    }
-
-private:
-    SccComputationState& computationState;
-};
+using Colors = ComponentIDs;
+using ColorsPair = ComponentIDsPair;
 
 // Sets the sccId for vertices whose forward and backward colors are the same.
-// Also sets `allSccIdsSet` to false if any vertex's `sccId` is unset.
-class SccFindNewSccIds : public VertexCompute {
+// Also check if there is still different color.
+class UpdateComponentIDVertexCompute : public GDSVertexCompute {
 public:
-    explicit SccFindNewSccIds(SccComputationState& computationState)
-        : computationState{computationState} {}
+    UpdateComponentIDVertexCompute(NodeOffsetMaskMap* nodeMask, ComponentIDs& componentIDs, Colors& fwdColors, Colors& bwdColors, std::atomic<bool>& hasDifferentColor)
+        : GDSVertexCompute{nodeMask}, componentIDs{componentIDs}, fwdColors {fwdColors}, bwdColors{bwdColors}, hasDifferentColor {hasDifferentColor} {}
 
-    bool beginOnTable(table_id_t) override { return true; }
+    void beginOnTableInternal(table_id_t tableID) override {
+        componentIDs.pinTableID(tableID);
+        fwdColors.pinTableID(tableID);
+        bwdColors.pinTableID(tableID);
+    }
 
     void vertexCompute(offset_t startOffset, offset_t endOffset, table_id_t) override {
         for (auto i = startOffset; i < endOffset; ++i) {
-            if (!computationState.isSccIdSet(i)) {
-                auto fwdColor = computationState.fwdColors.getRelaxed(i);
-                auto bwdColor = computationState.bwdColors.getRelaxed(i);
-                if (fwdColor == bwdColor) {
-                    computationState.sccIDs.setRelaxed(i, fwdColor);
-                } else {
-                    computationState.allSccIdsSet.store(false, std::memory_order_relaxed);
-                }
+            if (skip(i)) {
+                continue;
+            }
+            if (componentIDs.hasValidComponentID(i)) {
+                continue;
+            }
+            auto fwdColor = fwdColors.getComponentID(i);
+            auto bwdColor = bwdColors.getComponentID(i);
+            if (fwdColor == bwdColor) {
+                componentIDs.setComponentID(i, fwdColor);
+            } else {
+                hasDifferentColor.store(true, std::memory_order_relaxed);
             }
         }
     }
 
     std::unique_ptr<VertexCompute> copy() override {
-        return std::make_unique<SccFindNewSccIds>(computationState);
+        return std::make_unique<UpdateComponentIDVertexCompute>(nodeMask, componentIDs, fwdColors, bwdColors, hasDifferentColor);
     }
 
 private:
-    SccComputationState& computationState;
+    ComponentIDs& componentIDs;
+    Colors& fwdColors;
+    Colors& bwdColors;
+    std::atomic<bool>& hasDifferentColor;
 };
 
-// Initializes each vertex's forward and backward colors to its own ID.
-class SccSetInitialColors : public VertexCompute {
+class InitFwdColoringVertexCompute : public GDSVertexCompute {
 public:
-    explicit SccSetInitialColors(SccComputationState& computationState)
-        : computationState{computationState} {}
+    InitFwdColoringVertexCompute(NodeOffsetMaskMap* nodeMask, DenseFrontierPair& frontierPair, ComponentIDs& componentIDs)
+        : GDSVertexCompute{nodeMask}, frontierPair{frontierPair}, componentIDs{componentIDs} {}
 
-    bool beginOnTable(table_id_t) override { return true; }
+    void beginOnTableInternal(table_id_t tableID) override {
+        componentIDs.pinTableID(tableID);
+        frontierPair.pinNextFrontier(tableID);
+    }
 
     void vertexCompute(offset_t startOffset, offset_t endOffset, table_id_t) override {
         for (auto i = startOffset; i < endOffset; ++i) {
-            computationState.fwdColors.setRelaxed(i, i);
-            computationState.bwdColors.setRelaxed(i, i);
-        }
-    }
-
-    std::unique_ptr<VertexCompute> copy() override {
-        return std::make_unique<SccSetInitialColors>(computationState);
-    }
-
-private:
-    SccComputationState& computationState;
-};
-
-// Initializes the current and next frontiers. Only activates the vertices whose sccId has not yet
-// been computed.
-class SccInitializeFrontiers : public VertexCompute {
-public:
-    SccInitializeFrontiers(DenseFrontierPair& frontierPair, SccComputationState& computationState)
-        : frontierPair{frontierPair}, computationState{computationState} {}
-
-    bool beginOnTable(table_id_t) override { return true; }
-
-    void vertexCompute(offset_t startOffset, offset_t endOffset, table_id_t) override {
-        for (auto i = startOffset; i < endOffset; ++i) {
+            if (skip(i)) {
+                continue;
+            }
             // If the SCC ID has already been computed, the node should not be activated.
-            auto initialState =
-                computationState.isSccIdSet(i) ? FRONTIER_INITIAL_VISITED : FRONTIER_UNVISITED;
-            frontierPair.setValueToCurFrontier(i, initialState);
-            frontierPair.setValueToNextFrontier(i, FRONTIER_INITIAL_VISITED);
+            if (componentIDs.hasValidComponentID(i)) {
+                continue;
+            }
+            frontierPair.addNodeToNextFrontier(i);
         }
     }
 
     std::unique_ptr<VertexCompute> copy() override {
-        return std::make_unique<SccInitializeFrontiers>(frontierPair, computationState);
+        return std::make_unique<InitFwdColoringVertexCompute>(nodeMask, frontierPair, componentIDs);
     }
 
 private:
     DenseFrontierPair& frontierPair;
-    SccComputationState& computationState;
+    ComponentIDs& componentIDs;
 };
 
-// Propagates a node's color to its neighbors when it is larger.
-struct SccComputeColors : public EdgeCompute {
-    SccComputationState& computationState;
+class InitBwdColoringVertexCompute : public GDSVertexCompute {
+public:
+    InitBwdColoringVertexCompute(NodeOffsetMaskMap* nodeMask, DenseFrontierPair& frontierPair, ComponentIDs& componentIDs, Colors& fwdColors, OffsetManager& offsetManager)
+        : GDSVertexCompute{nodeMask}, frontierPair{frontierPair}, componentIDs{componentIDs}, fwdColors{fwdColors}, offsetManager{offsetManager} {}
 
-    explicit SccComputeColors(SccComputationState& computationState)
-        : computationState{computationState} {}
+    void beginOnTableInternal(table_id_t tableID) override {
+        componentIDs.pinTableID(tableID);
+        fwdColors.pinTableID(tableID);
+        frontierPair.pinNextFrontier(tableID);
+        offsetManager.pinTableID(tableID);
+    }
+
+    void vertexCompute(offset_t startOffset, offset_t endOffset, table_id_t) override {
+        for (auto i = startOffset; i < endOffset; ++i) {
+            if (skip(i)) {
+                continue;
+            }
+            // If the SCC ID has already been computed, the node should not be activated.
+            if (componentIDs.hasValidComponentID(i)) {
+                continue;
+            }
+            // Only pick the "root" vertex (vertex & component have the same id) of fwd colors
+            // to do backward coloring
+            if (fwdColors.getComponentID(i) == offsetManager.getCurrentOffset() + i) {
+                frontierPair.addNodeToNextFrontier(i);
+            }
+        }
+    }
+
+    std::unique_ptr<VertexCompute> copy() override {
+        return std::make_unique<InitBwdColoringVertexCompute>(nodeMask, frontierPair, componentIDs, fwdColors, offsetManager);
+    }
+
+private:
+    DenseFrontierPair& frontierPair;
+    ComponentIDs& componentIDs;
+    Colors& fwdColors;
+    OffsetManager& offsetManager;
+};
+
+class PropagateIDAuxiliaryState : public GDSAuxiliaryState {
+public:
+    PropagateIDAuxiliaryState(ComponentIDs& componentIDs, ColorsPair& colorsPair) : componentIDs{componentIDs}, colorsPair{colorsPair} {}
+
+    void beginFrontierCompute(table_id_t fromTableID, table_id_t toTableID) override {
+        componentIDs.pinTableID(toTableID);
+        colorsPair.pinCurTableID(fromTableID);
+        colorsPair.pinNextTableID(toTableID);
+    }
+
+    void switchToDense(ExecutionContext*, Graph*) override {}
+
+private:
+    ComponentIDs& componentIDs;
+    ColorsPair& colorsPair;
+};
+
+class PropagateIDEdgeCompute : public EdgeCompute {
+public:
+    explicit PropagateIDEdgeCompute(ComponentIDs& componentIDs, ColorsPair& colorsPair)
+        : componentIDs{componentIDs}, colorsPair{colorsPair} {}
 
     std::vector<nodeID_t> edgeCompute(nodeID_t boundNodeID, graph::NbrScanState::Chunk& chunk,
-        bool isFwd) override {
+        bool) override {
         std::vector<nodeID_t> result;
-        if (computationState.isSccIdSet(boundNodeID.offset)) {
-            return result;
-        }
         chunk.forEach([&](auto nbrNodeID, auto) {
-            if (!computationState.isSccIdSet(nbrNodeID.offset)) {
-                auto& colors = isFwd ? computationState.fwdColors : computationState.bwdColors;
-                if (colors.compare_exchange_strong_max(boundNodeID.offset, nbrNodeID.offset)) {
-                    result.push_back(nbrNodeID);
-                }
+            if (!componentIDs.hasValidComponentID(nbrNodeID.offset) && colorsPair.update(boundNodeID.offset, nbrNodeID.offset)) {
+                result.push_back(nbrNodeID);
             }
         });
         return result;
     }
 
     std::unique_ptr<EdgeCompute> copy() override {
-        return std::make_unique<SccComputeColors>(computationState);
-    }
-};
-
-class SccWriteIdsToOutput : public GDSResultVertexCompute {
-public:
-    SccWriteIdsToOutput(storage::MemoryManager* mm, GDSFuncSharedState* sharedState,
-        SccComputationState& computationState)
-        : GDSResultVertexCompute{mm, sharedState}, computationState{computationState} {
-        nodeIDVector = createVector(LogicalType::INTERNAL_ID());
-        componentIDVector = createVector(LogicalType::UINT64());
-    }
-
-    void beginOnTableInternal(table_id_t) override {}
-
-    void vertexCompute(offset_t startOffset, offset_t endOffset, table_id_t tableID) override {
-        for (auto i = startOffset; i < endOffset; ++i) {
-            if (skip(i)) {
-                continue;
-            }
-            auto nodeID = nodeID_t{i, tableID};
-            nodeIDVector->setValue<nodeID_t>(0, nodeID);
-            componentIDVector->setValue<uint64_t>(0, computationState.sccIDs.getRelaxed(i));
-            localFT->append(vectors);
-        }
-    }
-
-    std::unique_ptr<VertexCompute> copy() override {
-        return std::make_unique<SccWriteIdsToOutput>(mm, sharedState, computationState);
+        return std::make_unique<PropagateIDEdgeCompute>(componentIDs, colorsPair);
     }
 
 private:
-    SccComputationState& computationState;
-    std::unique_ptr<ValueVector> nodeIDVector;
-    std::unique_ptr<ValueVector> componentIDVector;
+    ComponentIDs& componentIDs;
+    ColorsPair& colorsPair;
 };
 
 static constexpr uint8_t MAX_ITERATION = 100;
 
-static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
+static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
     auto clientContext = input.context->clientContext;
     auto sharedState = input.sharedState->ptrCast<GDSFuncSharedState>();
+    auto nodeMask = sharedState->getGraphNodeMaskMap();
     auto mm = clientContext->getMemoryManager();
     auto graph = sharedState->graph.get();
-    auto getMaxOffsetMap = graph->getMaxOffsetMap(clientContext->getTransaction());
-    auto it = getMaxOffsetMap.begin();
-    auto tableId = it->first;
-    auto numNodes = it->second;
+    auto maxOffsetMap = graph->getMaxOffsetMap(clientContext->getTransaction());
 
-    auto computationState = SccComputationState(numNodes, mm);
-    // Initialize SCC IDs to unset.
-    auto setInitialSccIds = std::make_unique<SccSetInitialSccIds>(computationState);
-    GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph, *setInitialSccIds);
-
-    // The frontiers will be initialized inside the loop.
     auto currentFrontier = DenseFrontier::getUnvisitedFrontier(input.context, graph);
     auto nextFrontier = DenseFrontier::getUnvisitedFrontier(input.context, graph);
-    // TODO(sdht): refactor when a better FrontierPair API is available.
-    currentFrontier->pinTableID(tableId);
-    nextFrontier->pinTableID(tableId);
     auto frontierPair =
-        std::make_unique<DenseFrontierPair>(std::move(currentFrontier), std::move(nextFrontier));
-    auto initializeFrontiers =
-        std::make_unique<SccInitializeFrontiers>(*frontierPair, computationState);
-    auto setNewSccIds = std::make_unique<SccFindNewSccIds>(computationState);
-    auto setInitialColors = std::make_unique<SccSetInitialColors>(computationState);
-    auto computeColors = std::make_unique<SccComputeColors>(computationState);
-    auto auxiliaryState = std::make_unique<EmptyGDSAuxiliaryState>();
-    auto computeState = GDSComputeState(std::move(frontierPair), std::move(computeColors),
-        std::move(auxiliaryState));
+        std::make_shared<DenseFrontierPair>(std::move(currentFrontier), std::move(nextFrontier));
+
+    auto componentIDs = ComponentIDs::getUnvisitedComponentIDs(maxOffsetMap, mm);
+    auto offsetManager = OffsetManager(maxOffsetMap);
+    auto fwdColors = ComponentIDs::getSequenceComponentIDs(maxOffsetMap, offsetManager, mm);
+    auto bwdColors = ComponentIDs::getSequenceComponentIDs(maxOffsetMap, offsetManager, mm);
+    auto fwdColorsPair = ComponentIDsPair(fwdColors);
+    auto bwdColorsPair = ComponentIDsPair(bwdColors);
+
+    auto initFwdComponentIDsVertexCompute = InitSequenceComponentIDsVertexCompute(fwdColors, offsetManager);
+    auto initBwdComponentIDsVertexCompute = InitSequenceComponentIDsVertexCompute(bwdColors, offsetManager);
+
+    auto initFwdColoringVertexCompute = InitFwdColoringVertexCompute(nodeMask, *frontierPair, componentIDs);
+    auto fwdColoringEdgeCompute = std::make_unique<PropagateIDEdgeCompute>(componentIDs, fwdColorsPair);
+    auto fwdAuxiliaryState = std::make_unique<PropagateIDAuxiliaryState>(componentIDs, fwdColorsPair);
+    auto fwdComputeState = GDSComputeState(frontierPair, std::move(fwdColoringEdgeCompute), std::move(fwdAuxiliaryState));
+
+    auto initBwdColoringVertexCompute = InitBwdColoringVertexCompute(nodeMask, *frontierPair, componentIDs, fwdColors, offsetManager);
+    auto bwdColoringEdgeCompute = std::make_unique<PropagateIDEdgeCompute>(componentIDs, bwdColorsPair);
+    auto bwdAuxiliaryState = std::make_unique<PropagateIDAuxiliaryState>(componentIDs, bwdColorsPair);
+    auto bwdComputeState = GDSComputeState(frontierPair, std::move(bwdColoringEdgeCompute), std::move(bwdAuxiliaryState));
+
     for (auto i = 0; i < MAX_ITERATION; i++) {
-        GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph, *setInitialColors);
+        // Init fwd and bwd component IDs to node offsets.
+        GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph, initFwdComponentIDsVertexCompute);
+        GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph, initBwdComponentIDsVertexCompute);
 
         // Fwd colors.
-        computeState.frontierPair->resetCurrentIter();
-        computeState.frontierPair->setActiveNodesForNextIter();
+        frontierPair->resetValue(input.context, graph, FRONTIER_UNVISITED);
+        fwdComputeState.frontierPair->resetCurrentIter();
+        fwdComputeState.frontierPair->setActiveNodesForNextIter();
         GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph,
-            *initializeFrontiers);
-        GDSUtils::runAlgorithmEdgeCompute(input.context, computeState, graph, ExtendDirection::FWD,
+            initFwdColoringVertexCompute);
+        GDSUtils::runAlgorithmEdgeCompute(input.context, fwdComputeState, graph, ExtendDirection::FWD,
             MAX_ITERATION);
 
         // Bwd colors.
-        computeState.frontierPair->resetCurrentIter();
-        computeState.frontierPair->setActiveNodesForNextIter();
+        frontierPair->resetValue(input.context, graph, FRONTIER_UNVISITED);
+        bwdComputeState.frontierPair->resetCurrentIter();
+        bwdComputeState.frontierPair->setActiveNodesForNextIter();
         GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph,
-            *initializeFrontiers);
-        GDSUtils::runAlgorithmEdgeCompute(input.context, computeState, graph, ExtendDirection::BWD,
+            initBwdColoringVertexCompute);
+        GDSUtils::runAlgorithmEdgeCompute(input.context, bwdComputeState, graph, ExtendDirection::BWD,
             MAX_ITERATION);
 
         // Find new SCC IDs and exit if all IDs have been found.
-        computationState.reset();
-        GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph, *setNewSccIds);
-        if (computationState.allSccIdsSet.load(std::memory_order_relaxed)) {
+        std::atomic<bool> hasDifferentColor = false;
+        auto updateComponentIDsVertexCompute = UpdateComponentIDVertexCompute(nodeMask, componentIDs, fwdColors, bwdColors, hasDifferentColor);
+        GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph, updateComponentIDsVertexCompute);
+        if (!hasDifferentColor) {
             break;
         }
     }
 
-    auto writeSccIdsToOutput =
-        std::make_unique<SccWriteIdsToOutput>(mm, sharedState, computationState);
-    GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph, *writeSccIdsToOutput);
+    auto outputVertexCompute =
+        std::make_unique<ComponentIDsOutputVertexCompute>(mm, sharedState, componentIDs);
+    GDSUtils::runVertexCompute(input.context, GDSDensityState::DENSE, graph, *outputVertexCompute);
 
     sharedState->factorizedTablePool.mergeLocalTables();
     return 0;
@@ -283,12 +255,6 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     const TableFuncBindInput* input) {
     auto graphName = input->getLiteralVal<std::string>(0);
     auto graphEntry = GDSFunction::bindGraphEntry(*context, graphName);
-    if (graphEntry.nodeInfos.size() != 1) {
-        throw RuntimeException("Parallel SCC only supports operations on one node table.");
-    }
-    if (graphEntry.relInfos.size() != 1) {
-        throw RuntimeException("Parallel SCC only supports operations on one edge table.");
-    }
     auto nodeOutput = GDSFunction::bindNodeOutput(*input, graphEntry.getNodeEntries());
     expression_vector columns;
     columns.push_back(nodeOutput->constCast<NodeExpression>().getInternalID());

--- a/src/include/function/gds/gds_frontier.h
+++ b/src/include/function/gds/gds_frontier.h
@@ -110,6 +110,7 @@ public:
 
     // Allocate memory and initialize.
     void init(processor::ExecutionContext* context, graph::Graph* graph, iteration_t val);
+    void resetValue(processor::ExecutionContext* context, graph::Graph* graph, iteration_t val);
 
     void pinTableID(common::table_id_t tableID) override;
 
@@ -284,12 +285,7 @@ public:
         KU_UNREACHABLE;
     }
 
-    void setValueToCurFrontier(common::offset_t offset, iteration_t iter) {
-        curDenseFrontier->addNode(offset, iter);
-    }
-    void setValueToNextFrontier(common::offset_t offset, iteration_t iter) {
-        nextDenseFrontier->addNode(offset, iter);
-    }
+    void resetValue(processor::ExecutionContext* context, graph::Graph* graph, iteration_t val);
 
     GDSDensityState getState() const override { return GDSDensityState::DENSE; }
     bool needSwitchToDense(uint64_t) const override { return false; }

--- a/src/include/function/gds/gds_state.h
+++ b/src/include/function/gds/gds_state.h
@@ -7,11 +7,11 @@ namespace kuzu {
 namespace function {
 
 struct GDSComputeState {
-    std::unique_ptr<FrontierPair> frontierPair = nullptr;
+    std::shared_ptr<FrontierPair> frontierPair = nullptr;
     std::unique_ptr<EdgeCompute> edgeCompute = nullptr;
     std::unique_ptr<GDSAuxiliaryState> auxiliaryState = nullptr;
 
-    GDSComputeState(std::unique_ptr<FrontierPair> frontierPair,
+    GDSComputeState(std::shared_ptr<FrontierPair> frontierPair,
         std::unique_ptr<EdgeCompute> edgeCompute, std::unique_ptr<GDSAuxiliaryState> auxiliaryState)
         : frontierPair{std::move(frontierPair)}, edgeCompute{std::move(edgeCompute)},
           auxiliaryState{std::move(auxiliaryState)} {}

--- a/test/test_files/function/gds/scc.test
+++ b/test/test_files/function/gds/scc.test
@@ -60,6 +60,56 @@
 6|1|[6]
 7|1|[7]
 8|1|[8]
+-STATEMENT CALL strongly_connected_components('Graph2') WITH group_id, min(node.id) as sccId, count(*) as nodeCount, list_sort(collect(node.id)) as nodeIds RETURN sccId, nodeCount, nodeIds ORDER BY sccId;
+---- 8
+1|1|[1]
+2|1|[2]
+3|1|[3]
+4|1|[4]
+5|1|[5]
+6|1|[6]
+7|1|[7]
+8|1|[8]
+-STATEMENT CREATE NODE TABLE N (id INT64 PRIMARY KEY);
+---- ok
+-STATEMENT CREATE REL TABLE R1 (FROM N TO Node);
+---- ok
+-STATEMENT CREATE REL TABLE R2 (FROM Node TO N);
+---- ok
+-STATEMENT CREATE (:N {id:10});
+---- ok
+-STATEMENT MATCH (a:Node {id:2}), (b:N {id:10})
+           CREATE (a)-[:R2]->(b), (a)<-[:R1]-(b)
+---- ok
+-STATEMENT CALL create_projected_graph('Graph3', ['Node', 'N'], ['Edge', 'R1', 'R2'])
+---- ok
+-STATEMENT CALL strongly_connected_components('Graph3') WITH group_id, min(node.id) as sccId, count(*) as nodeCount, list_sort(collect(node.id)) as nodeIds RETURN sccId, nodeCount, nodeIds ORDER BY sccId;
+---- 7
+0|4|[0,1,2,10]
+3|1|[3]
+4|1|[4]
+5|1|[5]
+6|1|[6]
+7|1|[7]
+8|1|[8]
+-STATEMENT CREATE (:N {id:11});
+---- ok
+-STATEMENT MATCH (a:Node {id:3}), (b:N {id:11})
+           CREATE (a)-[:R2]->(b), (a)<-[:R1]-(b)
+---- ok
+-STATEMENT MATCH (a:Node {id:6}), (b:N {id:11})
+           CREATE (a)-[:R2]->(b), (a)<-[:R1]-(b)
+---- ok
+-STATEMENT CALL create_projected_graph('Graph4', ['Node', 'N'], ['Edge', 'R1', 'R2'])
+---- ok
+-STATEMENT CALL strongly_connected_components('Graph4') WITH group_id, min(node.id) as sccId, count(*) as nodeCount, list_sort(collect(node.id)) as nodeIds RETURN sccId, nodeCount, nodeIds ORDER BY sccId;
+---- 6
+0|4|[0,1,2,10]
+3|3|[3,6,11]
+4|1|[4]
+5|1|[5]
+7|1|[7]
+8|1|[8]
 
 -CASE SingleSCCIsolated
 -STATEMENT CREATE NODE TABLE Node(id INT64 PRIMARY KEY);
@@ -148,6 +198,12 @@
 1|4|[1,3,4,6]
 2|1|[2]
 5|3|[5,7,8]
+-STATEMENT CALL strongly_connected_components('Graph2') WITH group_id, min(node.id) as sccId, count(*) as nodeCount, list_sort(collect(node.id)) as nodeIds RETURN sccId, nodeCount, nodeIds ORDER BY sccId;
+---- 4
+0|1|[0]
+1|4|[1,3,4,6]
+2|1|[2]
+5|3|[5,7,8]
 
 -STATEMENT CALL create_projected_graph('Graph3', {'Node': {'filter': 'n.ID <> 4'}}, {'Edge': {'filter': 'r.ID <> 23 '}})
 ---- ok
@@ -161,6 +217,40 @@
 6|1|[6]
 7|1|[7]
 8|1|[8]
+-STATEMENT CALL strongly_connected_components('Graph3') WITH group_id, min(node.id) as sccId, count(*) as nodeCount, list_sort(collect(node.id)) as nodeIds RETURN sccId, nodeCount, nodeIds ORDER BY sccId;
+---- 8
+0|1|[0]
+1|1|[1]
+2|1|[2]
+3|1|[3]
+5|1|[5]
+6|1|[6]
+7|1|[7]
+8|1|[8]
+
+-STATEMENT CREATE NODE TABLE N (id INT64 PRIMARY KEY);
+---- ok
+-STATEMENT CREATE REL TABLE R1 (FROM N TO Node);
+---- ok
+-STATEMENT CREATE REL TABLE R2 (FROM Node TO N);
+---- ok
+-STATEMENT CREATE (:N {id:10});
+---- ok
+-STATEMENT MATCH (a4:Node {id:4}), (a5:Node {id:5}), (b:N {id:10})
+           CREATE (a5)-[:R2]->(b), (a4)<-[:R1]-(b)
+---- ok
+-STATEMENT CALL create_projected_graph('Graph4', ['Node', 'N'], ['Edge', 'R1', 'R2'])
+---- ok
+-STATEMENT CALL strongly_connected_components('Graph4') WITH group_id, min(node.id) as sccId, count(*) as nodeCount, list_sort(collect(node.id)) as nodeIds RETURN sccId, nodeCount, nodeIds ORDER BY sccId;
+---- 1
+0|10|[0,1,2,3,4,5,6,7,8,10]
+-STATEMENT CALL create_projected_graph('Graph5', {'Node': {'filter': ''}, 'N': {'filter': 'n.ID < 4'}}, ['Edge', 'R1', 'R2'])
+---- ok
+-STATEMENT CALL strongly_connected_components('Graph5') WITH group_id, min(node.id) as sccId, count(*) as nodeCount, list_sort(collect(node.id)) as nodeIds RETURN sccId, nodeCount, nodeIds ORDER BY sccId;
+---- 3
+0|5|[0,1,3,4,6]
+2|1|[2]
+5|3|[5,7,8]
 
 -CASE SCCMultiple2
 -STATEMENT CREATE NODE TABLE Node(id INT64 PRIMARY KEY);
@@ -290,14 +380,8 @@
 -STATEMENT CALL strongly_connected_components_kosaraju('SCC1') RETURN node.id, group_id;
 ---- error
 Runtime exception: Kosaraju's SCC only supports operations on one node table.
--STATEMENT CALL strongly_connected_components('SCC1') RETURN node.id, group_id;
----- error
-Runtime exception: Parallel SCC only supports operations on one node table.
 -STATEMENT CALL create_projected_graph('SCC2', ['Person'], ['Knows', 'LivesWith']);
 ---- ok
 -STATEMENT CALL strongly_connected_components_kosaraju('SCC2') RETURN node.id, group_id;
 ---- error
 Runtime exception: Kosaraju's SCC only supports operations on one edge table.
--STATEMENT CALL strongly_connected_components('SCC2') RETURN node.id, group_id;
----- error
-Runtime exception: Parallel SCC only supports operations on one edge table.


### PR DESCRIPTION
# Description

This PR contains the following changes

- make parallel SCC works for multi-labeled graph
- make parallel SCC works for filtered graph
- reuse WCC infrastructure because SCC is conceptually doing forward and backward WCC (coloring) twice
- improve parallel SCC performance because backward coloring only needs to be done on distinct colors.

|  | Master | This PR |
| -------- | ------- | ------- |
| Epinios| 100ms | 70ms |
| Gplus |  450ms | 120ms |


# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).