### PR TITLE
Skip reconstructing line for compressed CSV errors

### DIFF
--- a/src/common/file_system/compressed_file_system.cpp
+++ b/src/common/file_system/compressed_file_system.cpp
@@ -27,6 +27,11 @@ void CompressedFileSystem::syncFile(const kuzu::common::FileInfo& fileInfo) cons
     return compressedFileInfo.childFileInfo->syncFile();
 }
 
+void CompressedFileSystem::readFromFile(FileInfo& /*fileInfo*/, void* /*buffer*/,
+    uint64_t /*numBytes*/, uint64_t /*position*/) const {
+    throw IOException("Only sequential read is allowed in compressed file system.");
+}
+
 void CompressedFileInfo::initialize() {
     close();
     streamData.inputBufSize = compressedFS.getInputBufSize();

--- a/src/common/file_system/file_info.cpp
+++ b/src/common/file_system/file_info.cpp
@@ -43,5 +43,9 @@ void FileInfo::truncate(uint64_t size) {
     fileSystem->truncate(*this, size);
 }
 
+bool FileInfo::canPerformSeek() const {
+    return fileSystem->canPerformSeek();
+}
+
 } // namespace common
 } // namespace kuzu

--- a/src/include/common/file_system/compressed_file_system.h
+++ b/src/include/common/file_system/compressed_file_system.h
@@ -34,6 +34,8 @@ public:
     virtual idx_t getInputBufSize() = 0;
     virtual idx_t getOutputBufSize() = 0;
 
+    bool canPerformSeek() const override { return false; }
+
 protected:
     std::vector<std::string> glob(main::ClientContext* /*context*/,
         const std::string& /*path*/) const override {
@@ -41,10 +43,7 @@ protected:
     }
 
     void readFromFile(FileInfo& /*fileInfo*/, void* /*buffer*/, uint64_t /*numBytes*/,
-        uint64_t /*position*/) const override {
-        // Only sequential read is allowed in compressed file system.
-        KU_UNREACHABLE;
-    }
+        uint64_t /*position*/) const override;
 
     int64_t readFile(FileInfo& fileInfo, void* buf, size_t numBytes) const override;
 

--- a/src/include/common/file_system/file_info.h
+++ b/src/include/common/file_system/file_info.h
@@ -33,6 +33,8 @@ struct KUZU_API FileInfo {
 
     void truncate(uint64_t size);
 
+    bool canPerformSeek() const;
+
     template<class TARGET>
     TARGET* ptrCast() {
         return common::ku_dynamic_cast<TARGET*>(this);

--- a/src/include/common/file_system/file_system.h
+++ b/src/include/common/file_system/file_system.h
@@ -86,6 +86,8 @@ public:
 
     virtual void syncFile(const FileInfo& fileInfo) const = 0;
 
+    virtual bool canPerformSeek() const { return true; }
+
     template<class TARGET>
     TARGET* ptrCast() {
         return common::ku_dynamic_cast<TARGET*>(this);

--- a/src/include/processor/operator/persistent/reader/csv/base_csv_reader.h
+++ b/src/include/processor/operator/persistent/reader/csv/base_csv_reader.h
@@ -69,7 +69,7 @@ public:
     // Get the file offset of the current buffer position.
     uint64_t getFileOffset() const;
 
-    std::string reconstructLine(uint64_t startPosition, uint64_t endPosition);
+    std::string reconstructLine(uint64_t startPosition, uint64_t endPosition, bool completedLine);
 
     static common::column_id_t appendWarningDataColumns(std::vector<std::string>& resultColumnNames,
         std::vector<common::LogicalType>& resultColumnTypes,

--- a/test/test_files/exceptions/copy/ignore_invalid_row.test
+++ b/test/test_files/exceptions/copy/ignore_invalid_row.test
@@ -401,3 +401,14 @@ Conversion exception: Cast failed. Could not convert "1111111111111111111111111"
 Conversion exception: Cast failed. Could not convert "412316860444aa" to INT64.|${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/Comment.csv|26|412316860444aa...
 Conversion exception: Cast failed. Could not convert "549755815939aa" to INT64.|${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/Comment.csv|536|549755815939aa...
 Conversion exception: Cast failed. Could not convert "687194770008aa" to INT64.|${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/Comment.csv|995|687194770008aa...
+
+-CASE SkipInvalidLoadFromCompressedCSV
+-STATEMENT LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/vMovie.csv.gz" (IGNORE_ERRORS=true, HEADER=true, ESCAPE="~", AUTO_DETECT=false) RETURN COUNT(*)
+---- 1
+6
+-STATEMENT CALL show_warnings() RETURN message, file_path, line_number, skipped_line_or_record
+---- 4
+neither QUOTE nor ESCAPE is proceeded by ESCAPE.|${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/vMovie.csv.gz|4|
+quote should be followed by end of file, end of value, end of row or another quote.|${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/vMovie.csv.gz|6|
+expected 3 values per row, but got 2.|${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/vMovie.csv.gz|8|
+unterminated quotes.|${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/vMovie.csv.gz|11|


### PR DESCRIPTION
# Description

The compressed filesystem doesn't support seeking so our method of reconstructing erroneous lines (instantiating a CSV reader and seeking to the byte offset of the line) does not work in this case. Instead we will leave the reconstructed line as empty.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).