### PR TITLE
Replace comparisons with toLower/toUpper with caseInsensitiveEquals

### DIFF
--- a/extension/json/src/functions/table_functions/json_scan.cpp
+++ b/extension/json/src/functions/table_functions/json_scan.cpp
@@ -721,9 +721,9 @@ private:
 
 uint64_t JsonScanBindData::getFieldIdx(const std::string& fieldName) const {
     // From and to are case-insensitive for backward compatibility.
-    if (StringUtils::getLower(fieldName) == "from") {
+    if (StringUtils::caseInsensitiveEquals(fieldName, "from")) {
         return colNameToIdx.at("from");
-    } else if (StringUtils::getLower(fieldName) == "to") {
+    } else if (StringUtils::caseInsensitiveEquals(fieldName, "to")) {
         return colNameToIdx.at("to");
     }
     auto itr = colNameToIdx.find(fieldName);

--- a/src/common/string_utils.cpp
+++ b/src/common/string_utils.cpp
@@ -211,7 +211,7 @@ uint64_t StringUtils::caseInsensitiveHash(const std::string& str) {
     return hash;
 }
 
-bool StringUtils::caseInsensitiveEquals(const std::string& left, const std::string& right) {
+bool StringUtils::caseInsensitiveEquals(std::string_view left, std::string_view right) {
     if (left.size() != right.size()) {
         return false;
     }

--- a/src/function/cast_string_non_nested_functions.cpp
+++ b/src/function/cast_string_non_nested_functions.cpp
@@ -166,16 +166,17 @@ static RE2& realPattern() {
 }
 
 bool isAnyType(std::string_view cpy) {
-    std::string cpy_upper = std::string(cpy);
-    StringUtils::toUpper(cpy_upper);
-    return cpy.size() == 0 || cpy_upper == "NULL" || cpy_upper == "NAN";
+    return cpy.size() == 0 || StringUtils::caseInsensitiveEquals(cpy, "NULL") ||
+           StringUtils::caseInsensitiveEquals(cpy, "NAN");
 }
 
 bool isINF(std::string_view cpy) {
-    std::string cpy_upper = std::string(cpy);
-    StringUtils::toUpper(cpy_upper);
-    return cpy_upper == "INF" || cpy_upper == "+INF" || cpy_upper == "-INF" ||
-           cpy_upper == "INFINITY" || cpy_upper == "+INFINITY" || cpy_upper == "-INFINITY";
+    return StringUtils::caseInsensitiveEquals(cpy, "INF") ||
+           StringUtils::caseInsensitiveEquals(cpy, "+INF") ||
+           StringUtils::caseInsensitiveEquals(cpy, "-INF") ||
+           StringUtils::caseInsensitiveEquals(cpy, "INFINITY") ||
+           StringUtils::caseInsensitiveEquals(cpy, "+INFINITY") ||
+           StringUtils::caseInsensitiveEquals(cpy, "-INFINITY");
 }
 
 LogicalType inferMinimalTypeFromString(std::string_view str) {

--- a/src/include/common/string_utils.h
+++ b/src/include/common/string_utils.h
@@ -82,7 +82,7 @@ public:
 
     static uint64_t caseInsensitiveHash(const std::string& str);
 
-    static bool caseInsensitiveEquals(const std::string& left, const std::string& right);
+    static bool caseInsensitiveEquals(std::string_view left, std::string_view right);
 
     // join multiple strings into one string. Components are concatenated by the given separator
     static std::string join(const std::vector<std::string>& input, const std::string& separator);


### PR DESCRIPTION
For #5256. This improved the single-threaded performance significantly. On my machine the same benchmark used in #5256 took 2.8s initially (in an in-memory database) and improved to 1.7s with this change.

`toLower`/`toUpper` are not very fast since they operate entirely out of place. We could probably also create versions of them that do faster in-place modifications, or which skip changes if they aren't necessary, but that wasn't needed here.
I'd actually implemented a unicode-aware version of `caseInsensitiveEquals` before realising that it doesn't make a difference in this use-case and we already have an ascii-only version (which should generally be faster on ascii strings since it can assume that strings of different lengths are not equal, but unicode upper-case and lower-case characters do not necessarily have the same number of codepoints, so my unicode-aware implementation was a little slower, but still much faster than `toLower`).