### PR TITLE
Add sparse weight shortest destination

### DIFF
--- a/src/function/gds/wsp_destinations.cpp
+++ b/src/function/gds/wsp_destinations.cpp
@@ -29,9 +29,7 @@ public:
     explicit SparseCostsReference(GDSSpareObjectManager<double>& sparseObjects)
         : sparseObjects{sparseObjects} {}
 
-    void pinTableID(table_id_t tableID) override {
-        curData = sparseObjects.getData(tableID);
-    }
+    void pinTableID(table_id_t tableID) override { curData = sparseObjects.getData(tableID); }
 
     void setCost(offset_t offset, double cost) override {
         KU_ASSERT(curData != nullptr);
@@ -66,11 +64,10 @@ private:
 
 class DenseCostsReference : public Costs {
 public:
-    explicit DenseCostsReference(GDSDenseObjectManager<std::atomic<double>>& denseObjects) : denseObjects{denseObjects} {}
+    explicit DenseCostsReference(GDSDenseObjectManager<std::atomic<double>>& denseObjects)
+        : denseObjects{denseObjects} {}
 
-    void pinTableID(table_id_t tableID) override {
-        curData = denseObjects.getData(tableID);
-    }
+    void pinTableID(table_id_t tableID) override { curData = denseObjects.getData(tableID); }
 
     void setCost(offset_t offset, double cost) override {
         KU_ASSERT(curData != nullptr);
@@ -100,8 +97,9 @@ private:
 
 class CostsPair {
 public:
-    explicit CostsPair(const table_id_map_t<offset_t>& maxOffsetMap) : maxOffsetMap{maxOffsetMap},
-        densityState{GDSDensityState::SPARSE}, sparseObjects{maxOffsetMap} {
+    explicit CostsPair(const table_id_map_t<offset_t>& maxOffsetMap)
+        : maxOffsetMap{maxOffsetMap}, densityState{GDSDensityState::SPARSE},
+          sparseObjects{maxOffsetMap} {
         curSparseCosts = std::make_unique<SparseCostsReference>(sparseObjects);
         nextSparseCosts = std::make_unique<SparseCostsReference>(sparseObjects);
         denseObjects = GDSDenseObjectManager<std::atomic<double>>();
@@ -109,9 +107,7 @@ public:
         nextDenseCosts = std::make_unique<DenseCostsReference>(denseObjects);
     }
 
-    Costs* getCurrentCosts() {
-        return curCosts;
-    }
+    Costs* getCurrentCosts() { return curCosts; }
 
     void pinCurTableID(table_id_t tableID) {
         switch (densityState) {
@@ -194,7 +190,8 @@ public:
             auto nbrNodeID = neighbors[i];
             auto weight = propertyVectors[0]->template getValue<T>(i);
             checkWeight(weight);
-            if (costsPair->update(boundNodeID.offset, nbrNodeID.offset, static_cast<double>(weight))) {
+            if (costsPair->update(boundNodeID.offset, nbrNodeID.offset,
+                    static_cast<double>(weight))) {
                 result.push_back(nbrNodeID);
             }
         });

--- a/src/function/gds/wsp_paths.cpp
+++ b/src/function/gds/wsp_paths.cpp
@@ -71,7 +71,7 @@ public:
         std::vector<ParentList*> curPath;
         curPath.push_back(parent);
         while (parent->getCost() != 0) {
-            parent = bfsGraph.getParentListHead(parent->getNodeID().offset);
+            parent = bfsGraph.getParentListHead(parent->getNodeID());
             curPath.push_back(parent);
         }
         curPath.pop_back();

--- a/test/test_files/function/gds/weighted_shortest.test
+++ b/test/test_files/function/gds/weighted_shortest.test
@@ -216,6 +216,48 @@ E|F|40.000000
 ---- error
 Binder exception: DECIMAL(38, 4) weight type is not supported for weighted shortest path.
 
+-STATEMENT CREATE NODE TABLE N2 (ID STRING PRIMARY KEY);
+---- ok
+-STATEMENT CREATE (:N2 {ID:'AA'});
+---- ok
+-STATEMENT CREATE REL TABLE NRN2 (FROM N TO N2, cost1 INT64);
+---- ok
+-STATEMENT CREATE REL TABLE N2RN (FROM N2 TO N, cost1 INT64);
+---- ok
+-STATEMENT MATCH (n2:N2 {ID:'AA'}), (a:N {ID:'A'}), (b:N {ID: 'B'})
+            CREATE (a)-[:NRN2{cost1:1}]->(n2)-[:N2RN{cost1:1}]->(b)
+---- ok
+-STATEMENT MATCH p = (a)-[e* WSHORTEST(cost1) ]->(b)
+        WHERE a.ID = 'A'
+        RETURN b.ID, e_weight
+---- 6
+AA|1.000000
+B|2.000000
+C|50.000000
+D|42.000000
+E|72.000000
+F|112.000000
+-STATEMENT MATCH p = (a)-[e* WSHORTEST(cost1) ]->(b)
+        WHERE a.ID = 'A'
+        RETURN b.ID, e_weight, properties(nodes(p), "ID"), properties(rels(p), "cost1")
+---- 6
+AA|1.000000|[A,AA]|[1]
+B|2.000000|[A,AA,B]|[1,1]
+C|50.000000|[A,C]|[50]
+D|42.000000|[A,AA,B,D]|[1,1,40]
+E|72.000000|[A,AA,B,D,E]|[1,1,40,30]
+F|112.000000|[A,AA,B,D,E,F]|[1,1,40,30,40]
+
+-STATEMENT MATCH  (a:N {ID:'A'}), (b:N {ID: 'B'})
+            CREATE (a)-[:R{cost1:2}]->(b)
+---- ok
+-STATEMENT MATCH p = (a)-[e* ALL WSHORTEST(cost1) ]->(b)
+        WHERE a.ID = 'A' AND b.ID = 'F'
+        RETURN b.ID, e_weight, properties(nodes(p), "ID"), properties(rels(p), "cost1")
+---- 2
+F|112.000000|[A,AA,B,D,E,F]|[1,1,40,30,40]
+F|112.000000|[A,B,D,E,F]|[2,40,30,40]
+
 -CASE NegativeWeight
 -STATEMENT MATCH (a {ID:'A'}), (b {ID:'B'})
         CREATE (a)-[r {cost1:-1}]->(b)


### PR DESCRIPTION
# Description

Fix minor bugs for shortest and all shortest path on multi-labeled graph. Add sparse version of weighted-shortest-path destinations.

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).