### PR TITLE
Gds function supports the node type as an input parameter

### DIFF
--- a/src/binder/bind/bind_table_function.cpp
+++ b/src/binder/bind/bind_table_function.cpp
@@ -25,12 +25,12 @@ BoundTableScanInfo Binder::bindTableFunc(const std::string& tableFuncName,
         auto param = expressionBinder.bindExpression(childExpr);
         if (!childExpr.hasAlias()) {
             ExpressionUtil::validateExpressionType(*param,
-                {ExpressionType::LITERAL, ExpressionType::PARAMETER});
+                {ExpressionType::LITERAL, ExpressionType::PARAMETER, ExpressionType::PATTERN});
             positionalParams.push_back(param);
             positionalParamTypes.push_back(param->getDataType().copy());
         } else {
             ExpressionUtil::validateExpressionType(*param,
-                {ExpressionType::LITERAL, ExpressionType::PARAMETER});
+                {ExpressionType::LITERAL, ExpressionType::PARAMETER, ExpressionType::PATTERN});
             if (param->expressionType == ExpressionType::LITERAL) {
                 auto literalExpr = param->constPtrCast<LiteralExpression>();
                 optionalParams.emplace(childExpr.getAlias(), literalExpr->getValue());

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -197,8 +197,9 @@ void GDSFunction::getLogicalPlan(Planner* planner, const BoundReadingClause& rea
     std::vector<std::shared_ptr<LogicalSemiMasker>> inputNodeMaskPlanRoots;
     for (auto nodeInput : bindData->nodeInputs) {
         auto& node = nodeInput->cast<NodeExpression>();
-
-        planner->getNodeSemiMaskPlan(SemiMaskTargetType::GDS_GRAPH_NODE, node, *plan);
+        auto includeDummySink = nodeInput == bindData->nodeInputs.back();
+        planner->getNodeSemiMaskPlan(SemiMaskTargetType::GDS_GRAPH_NODE, node, *plan,
+            includeDummySink);
         auto semiMasker = PlanMapper::findSemiMaskerInPlan(plan->getLastOperator());
         inputNodeMaskPlanRoots.push_back(semiMasker);
     }

--- a/src/include/function/gds/gds.h
+++ b/src/include/function/gds/gds.h
@@ -37,14 +37,18 @@ struct KUZU_API GDSBindData : public TableFuncBindData {
     std::unique_ptr<GDSOptionalParams> optionalParams;
 
     GDSBindData(binder::expression_vector columns, graph::GraphEntry graphEntry,
-        std::shared_ptr<binder::Expression> nodeOutput,std::unique_ptr<GDSOptionalParams> optionalParams = nullptr)
-        : TableFuncBindData{std::move(columns)}, graphEntry{graphEntry.copy()}, nodeOutput{std::move(nodeOutput)} , optionalParams{std::move(optionalParams)} {}
+        std::shared_ptr<binder::Expression> nodeOutput,
+        std::unique_ptr<GDSOptionalParams> optionalParams = nullptr)
+        : TableFuncBindData{std::move(columns)}, graphEntry{graphEntry.copy()},
+          nodeOutput{std::move(nodeOutput)}, optionalParams{std::move(optionalParams)} {}
 
     GDSBindData(binder::expression_vector columns, graph::GraphEntry graphEntry,
         std::vector<std::shared_ptr<binder::Expression>> nodeInputs,
-        std::shared_ptr<binder::Expression> nodeOutput,std::unique_ptr<GDSOptionalParams> optionalParams = nullptr)
+        std::shared_ptr<binder::Expression> nodeOutput,
+        std::unique_ptr<GDSOptionalParams> optionalParams = nullptr)
         : TableFuncBindData{std::move(columns)}, graphEntry{graphEntry.copy()},
-          nodeInputs{std::move(nodeInputs)}, nodeOutput{std::move(nodeOutput)}  , optionalParams{std::move(optionalParams)} {}
+          nodeInputs{std::move(nodeInputs)}, nodeOutput{std::move(nodeOutput)},
+          optionalParams{std::move(optionalParams)} {}
 
     GDSBindData(const GDSBindData& other)
         : TableFuncBindData{other}, graphEntry{other.graphEntry.copy()},

--- a/src/include/planner/operator/logical_table_function_call.h
+++ b/src/include/planner/operator/logical_table_function_call.h
@@ -3,6 +3,7 @@
 #include "function/table/bind_data.h"
 #include "function/table/table_function.h"
 #include "planner/operator/logical_operator.h"
+#include "sip/logical_semi_masker.h"
 
 namespace kuzu {
 namespace planner {
@@ -33,6 +34,13 @@ public:
     }
     std::vector<std::shared_ptr<LogicalOperator>> getNodeMaskRoots() const { return nodeMaskRoots; }
 
+    void setInputNodeMaskRoots(std::vector<std::shared_ptr<LogicalSemiMasker>> roots) {
+        inputNodeMaskRoots = std::move(roots);
+    }
+    std::vector<std::shared_ptr<LogicalSemiMasker>> getInputNodeMaskRoots() const {
+        return inputNodeMaskRoots;
+    }
+
     void computeFlatSchema() override;
     void computeFactorizedSchema() override;
 
@@ -48,6 +56,8 @@ private:
 
     // TODO(Xiyang): We should unify how masks are planned in GDS and HNSW.
     std::vector<std::shared_ptr<LogicalOperator>> nodeMaskRoots;
+    // Gds function input parameter's nodeMask
+    std::vector<std::shared_ptr<LogicalSemiMasker>> inputNodeMaskRoots;
 };
 
 } // namespace planner

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -210,6 +210,8 @@ public:
 
     LogicalPlan getNodeSemiMaskPlan(SemiMaskTargetType targetType,
         const binder::NodeExpression& node, std::shared_ptr<binder::Expression> nodePredicate);
+    LogicalPlan getNodeSemiMaskPlan(SemiMaskTargetType targetType,
+        const binder::NodeExpression& node, LogicalPlan& plan);
     // This is mostly used when we try to reinterpret function output as node and read its
     // properties, e.g. query_vector_index, gds algorithms ...
     LogicalPlan getNodePropertyScanPlan(const binder::NodeExpression& node);

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -211,7 +211,7 @@ public:
     LogicalPlan getNodeSemiMaskPlan(SemiMaskTargetType targetType,
         const binder::NodeExpression& node, std::shared_ptr<binder::Expression> nodePredicate);
     LogicalPlan getNodeSemiMaskPlan(SemiMaskTargetType targetType,
-        const binder::NodeExpression& node, LogicalPlan& plan);
+        const binder::NodeExpression& node, LogicalPlan& plan, bool includeDummySink);
     // This is mostly used when we try to reinterpret function output as node and read its
     // properties, e.g. query_vector_index, gds algorithms ...
     LogicalPlan getNodePropertyScanPlan(const binder::NodeExpression& node);

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -234,6 +234,8 @@ public:
         const planner::Schema& schema);
     static planner::LogicalSemiMasker* findSemiMaskerInPlan(
         planner::LogicalOperator* logicalOperator);
+    static std::shared_ptr<planner::LogicalSemiMasker> findSemiMaskerInPlan(
+        std::shared_ptr<planner::LogicalOperator> logicalOperator);
     static FactorizedTableSchema createFlatFTableSchema(
         const binder::expression_vector& expressions, const planner::Schema& schema);
     std::unique_ptr<common::SemiMask> createSemiMask(common::table_id_t tableID) const;

--- a/src/planner/plan/plan_node_semi_mask.cpp
+++ b/src/planner/plan/plan_node_semi_mask.cpp
@@ -28,6 +28,11 @@ LogicalPlan Planner::getNodeSemiMaskPlan(SemiMaskTargetType targetType, const No
     appendScanNodeTable(node.getInternalID(), node.getTableIDs(), getProperties(node), plan);
     appendFilter(nodePredicate, plan);
     exitPropertyExprCollection(std::move(prevCollection));
+    return getNodeSemiMaskPlan(targetType, node, plan);
+}
+
+LogicalPlan Planner::getNodeSemiMaskPlan(SemiMaskTargetType targetType, const NodeExpression& node,
+    LogicalPlan& plan) {
     auto semiMasker = std::make_shared<LogicalSemiMasker>(SemiMaskKeyType::NODE, targetType,
         node.getInternalID(), node.getTableIDs(), plan.getLastOperator());
     semiMasker->computeFactorizedSchema();

--- a/src/processor/map/map_semi_masker.cpp
+++ b/src/processor/map/map_semi_masker.cpp
@@ -52,7 +52,12 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapSemiMasker(
             switch (semiMasker.getTargetType()) {
             case SemiMaskTargetType::GDS_GRAPH_NODE: {
                 auto funcSharedState = sharedState->ptrCast<function::GDSFuncSharedState>();
-                initMask(masksPerTable, funcSharedState->getGraphNodeMaskMap()->getMasks());
+                if (funcSharedState->getGraphNodeMaskMap() != nullptr) {
+                    initMask(masksPerTable, funcSharedState->getGraphNodeMaskMap()->getMasks());
+                }
+                for (auto& [_, value] : funcSharedState->getInputGraphNodeMaskMap()) {
+                    initMask(masksPerTable, value->getMasks());
+                }
             } break;
             case SemiMaskTargetType::SCAN_NODE: {
                 auto tableFunc = physicalOp->ptrCast<TableFunctionCall>();

--- a/src/processor/map/map_table_function_call.cpp
+++ b/src/processor/map/map_table_function_call.cpp
@@ -14,8 +14,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapTableFunctionCall(
     KU_ASSERT(getPhysicalPlanFunc);
     auto res = getPhysicalPlanFunc(this, logicalOperator);
     logicalOpToPhysicalOpMap.insert({logicalOperator, res.get()});
+    auto tableFuncOp = logicalOpToPhysicalOpMap[logicalOperator];
     for (auto i = 0u; i < call.getNumChildren(); ++i) {
-        res->addChild(mapOperator(call.getChild(i).get()));
+        tableFuncOp->addChild(mapOperator(call.getChild(i).get()));
     }
     return res;
 }

--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -212,6 +212,20 @@ std::unique_ptr<SemiMask> PlanMapper::createSemiMask(table_id_t tableID) const {
     return SemiMaskUtil::createMask(table->getNumTotalRows(clientContext->getTransaction()));
 }
 
+std::shared_ptr<LogicalSemiMasker> PlanMapper::findSemiMaskerInPlan(
+    std::shared_ptr<LogicalOperator> logicalOperator) {
+    if (logicalOperator->getOperatorType() == LogicalOperatorType::SEMI_MASKER) {
+        return std::dynamic_pointer_cast<LogicalSemiMasker>(logicalOperator);
+    }
+    for (auto& child : logicalOperator->getChildren()) {
+        const auto semiMasker = findSemiMaskerInPlan(child);
+        if (semiMasker) {
+            return semiMasker;
+        }
+    }
+    return nullptr;
+}
+
 LogicalSemiMasker* PlanMapper::findSemiMaskerInPlan(LogicalOperator* logicalOperator) {
     if (logicalOperator->getOperatorType() == LogicalOperatorType::SEMI_MASKER) {
         return logicalOperator->ptrCast<LogicalSemiMasker>();

--- a/test/test_files/function/call/call.test
+++ b/test/test_files/function/call/call.test
@@ -279,7 +279,7 @@ Binder exception: Show connection can only be called on a rel table!
 Binder exception: Show connection can only be called on a rel table!
 -STATEMENT MATCH (a:person) CALL show_connection(a.fName) RETURN *
 ---- error
-Binder exception: a.fName has type PROPERTY but LITERAL,PARAMETER was expected.
+Binder exception: a.fName has type PROPERTY but LITERAL,PARAMETER,PATTERN was expected.
 
 -LOG BMInfo
 -STATEMENT CALL bm_info() RETURN mem_limit


### PR DESCRIPTION
# Description

Support query like `match (a:person {id:933}) ,(b:person {id:899}) call gds_func('projected_graph_name',a,b) return ...`

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).