### PR TITLE
Optimize timestamp parsing

### DIFF
--- a/src/common/types/dtime_t.cpp
+++ b/src/common/types/dtime_t.cpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "common/assert.h"
 #include "common/exception/conversion.h"
 #include "common/string_format.h"
 #include "common/types/cast_helpers.h"
@@ -214,6 +215,7 @@ void Time::convert(dtime_t dtime, int32_t& hour, int32_t& min, int32_t& sec, int
     sec = int32_t(time / Interval::MICROS_PER_SEC);
     time -= int64_t(sec) * Interval::MICROS_PER_SEC;
     micros = int32_t(time);
+    KU_ASSERT(Time::isValid(hour, min, sec, micros));
 }
 
 } // namespace common

--- a/src/common/types/timestamp_t.cpp
+++ b/src/common/types/timestamp_t.cpp
@@ -3,7 +3,6 @@
 #include <chrono>
 
 #include "common/exception/conversion.h"
-#include "common/string_utils.h"
 #include "function/arithmetic/multiply.h"
 
 namespace kuzu {
@@ -118,16 +117,7 @@ bool Timestamp::tryConvertTimestamp(const char* str, uint64_t len, timestamp_t& 
     date_t date;
     dtime_t time;
 
-    // Find the string len for date
-    uint32_t dateStrLen = 0;
-    // Skip leading spaces.
-    while (StringUtils::isSpace(str[dateStrLen])) {
-        dateStrLen++;
-    }
-    while (dateStrLen < len && str[dateStrLen] != ' ' && str[dateStrLen] != 'T') {
-        dateStrLen++;
-    }
-    if (!Date::tryConvertDate(str, dateStrLen, pos, date)) {
+    if (!Date::tryConvertDate(str, len, pos, date, true /*allowTrailing*/)) {
         return false;
     }
     if (pos == len) {
@@ -247,9 +237,6 @@ timestamp_t Timestamp::fromDateTime(date_t date, dtime_t time) {
     int32_t year = 0, month = 0, day = 0, hour = 0, minute = 0, second = 0, microsecond = -1;
     Date::convert(date, year, month, day);
     Time::convert(time, hour, minute, second, microsecond);
-    if (!Date::isValid(year, month, day) || !Time::isValid(hour, minute, second, microsecond)) {
-        throw ConversionException("Invalid date or time format");
-    }
     result.value = date.days * Interval::MICROS_PER_DAY + time.micros;
     return result;
 }

--- a/src/include/common/types/date_t.h
+++ b/src/include/common/types/date_t.h
@@ -79,7 +79,7 @@ public:
     KUZU_API static std::string toString(date_t date);
     // Try to convert text in a buffer to a date; returns true if parsing was successful
     KUZU_API static bool tryConvertDate(const char* buf, uint64_t len, uint64_t& pos,
-        date_t& result);
+        date_t& result, bool allowTrailing = false);
 
     // private:
     // Returns true if (year) is a leap year, and false otherwise


### PR DESCRIPTION
Removes some redundant validity checks and an unnecessary second pass over the date portion of the timestamp.

This improved the single-threaded copy from #5256 (roughly, `load from 'test1.json' RETURN *;`, where test1.json is created from ldbc-sf1) on my machine from about ~1.45s to ~1.26s.