### PR TITLE
Throw error during import db

### DIFF
--- a/dataset/import_db_error/schema.cypher
+++ b/dataset/import_db_error/schema.cypher
@@ -1,0 +1,2 @@
+CREATE NODE TABLE person (ID INT64 PRIMARY KEY,fName STRING);
+CREATE REL TABLE follows(FROM person TO org, year INT64);

--- a/extension/fts/test/test_files/fts_small.test
+++ b/extension/fts/test/test_files/fts_small.test
@@ -385,7 +385,7 @@ student|studentIdx|FTS|[firstName]|True|CALL CREATE_FTS_INDEX('student', 'studen
 -RELOADDB
 -STATEMENT EXPORT DATABASE '${KUZU_EXPORT_DB_DIRECTORY}_fts/fts_small_export_test'
 ---- ok
--RELOADDB
+-IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_fts/fts_small_export_test"
 -STATEMENT IMPORT DATABASE '${KUZU_EXPORT_DB_DIRECTORY}_fts/fts_small_export_test'
 ---- ok
 -STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'Alice') RETURN node.ID, score
@@ -394,9 +394,8 @@ Catalog exception: function QUERY_FTS_INDEX is not defined. This function exists
 -STATEMENT LOAD EXTENSION "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension"
 ---- ok
 -STATEMENT CALL QUERY_FTS_INDEX('doc', 'docIdx', 'Alice') RETURN node.ID, score
----- 2
-0|0.271133
-3|0.209476
+---- error
+Binder exception: Table doc doesn't have an index with name docIdx.
 
 -CASE RussianDoc
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension';

--- a/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
@@ -93,7 +93,7 @@ static std::string getFromToStr(table_id_t tableID, Catalog* catalog,
         catalog->getTableCatalogEntry(transaction, entry.getSrcTableID())->getName();
     auto dstTableName =
         catalog->getTableCatalogEntry(transaction, entry.getDstTableID())->getName();
-    return stringFormat("FROM {} TO {}", srcTableName, dstTableName);
+    return stringFormat("FROM `{}` TO `{}`", srcTableName, dstTableName);
 }
 
 std::string RelGroupCatalogEntry::toCypher(const ToCypherInfo& info) const {

--- a/src/catalog/catalog_entry/rel_table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_table_catalog_entry.cpp
@@ -131,7 +131,7 @@ std::string RelTableCatalogEntry::toCypher(const ToCypherInfo& info) const {
     auto transaction = clientContext->getTransaction();
     auto srcTableName = catalog->getTableCatalogEntry(transaction, srcTableID)->getName();
     auto dstTableName = catalog->getTableCatalogEntry(transaction, dstTableID)->getName();
-    std::string tableInfo = stringFormat("CREATE REL TABLE `{}` (FROM {} TO {}, ", getName(),
+    std::string tableInfo = stringFormat("CREATE REL TABLE `{}` (FROM `{}` TO `{}`, ", getName(),
         srcTableName, dstTableName);
     ss << tableInfo << propertiesToCypher() << getMultiplicityStr() << ");";
     return ss.str();

--- a/src/processor/operator/simple/export_db.cpp
+++ b/src/processor/operator/simple/export_db.cpp
@@ -130,7 +130,10 @@ std::string getIndexCypher(ClientContext* clientContext, const FileScanInfo& exp
     IndexToCypherInfo info{clientContext, exportFileInfo};
     for (auto entry :
         clientContext->getCatalog()->getIndexEntries(clientContext->getTransaction())) {
-        ss << entry->toCypher(info) << std::endl;
+        auto indexCypher = entry->toCypher(info);
+        if (!indexCypher.empty()) {
+            ss << indexCypher << std::endl;
+        }
     }
     return ss.str();
 }

--- a/src/processor/operator/simple/export_db.cpp
+++ b/src/processor/operator/simple/export_db.cpp
@@ -105,7 +105,10 @@ std::string getSchemaCypher(ClientContext* clientContext) {
         ss << catalog->getScalarMacroFunction(transaction, macroName)->toCypher(macroName)
            << std::endl;
     }
-    ss << clientContext->getExtensionManager()->toCypher() << std::endl;
+    auto extensionCypher = clientContext->getExtensionManager()->toCypher();
+    if (!extensionCypher.empty()) {
+        ss << extensionCypher << std::endl;
+    }
     return ss.str();
 }
 

--- a/test/test_files/copy/export_import_db.test
+++ b/test/test_files/copy/export_import_db.test
@@ -260,5 +260,13 @@ Farooq|1
 ---- ok
 -STATEMENT EXPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/special_char" (format="csv");
 ---- ok
+-IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/special_char"
 -STATEMENT IMPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/special_char";
 ---- ok
+
+-CASE ImportError
+-SKIP_WASM
+-SKIP_IN_MEM
+-STATEMENT IMPORT Database "${KUZU_ROOT_DIRECTORY}/dataset/import_db_error"
+---- error
+Runtime exception: Import database failed: Binder exception: Table org does not exist.


### PR DESCRIPTION
# Description

Import db bugs can be hidden as we never threw exceptions when there are errors executing exported queries. An example is in https://github.com/kuzudb/kuzu/actions/runs/14645929753/job/41101417275?pr=5226. where we exported rel tables that shouldn't be exported, which lead to import database failures. However, the failure is never reported.

Add error throw in this PR along with some minor fixes to existing test cases.