### PR TITLE
Test framework respects 'threads' setting unless 'PARALLELISM' is set

### DIFF
--- a/test/include/test_runner/test_group.h
+++ b/test/include/test_runner/test_group.h
@@ -43,7 +43,7 @@ struct TestQueryResult {
 struct TestStatement {
     std::string logMessage;
     std::string query;
-    uint64_t numThreads = 4;
+    std::optional<uint64_t> numThreads;
     bool checkOutputOrder = false;
     bool checkColumnNames = false;
     bool checkPrecision = false;

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -40,7 +40,9 @@ void TestRunner::runTest(TestStatement* statement, Connection& conn,
     // for normal statement
     spdlog::info("DEBUG LOG: {}", statement->logMessage);
     spdlog::info("QUERY: {}", statement->query);
-    conn.setMaxNumThreadForExec(statement->numThreads);
+    if (statement->numThreads) {
+        conn.setMaxNumThreadForExec(*statement->numThreads);
+    }
     testStatement(statement, conn, databasePath);
 }
 


### PR DESCRIPTION
# Description

We were resetting the test parallelism to 4 before executing each statement, this PR updates it so that the parallelism is only force-updated if the `PARALLELISM` token is specified in the test

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).