### PR TITLE
Reduce preserving of capacity for string offset/data chunks

### DIFF
--- a/src/storage/store/dictionary_column.cpp
+++ b/src/storage/store/dictionary_column.cpp
@@ -166,7 +166,7 @@ bool DictionaryColumn::canOffsetCommitInPlace(const ChunkState& offsetState,
     const ChunkState& dataState, uint64_t numNewStrings, uint64_t totalStringLengthToAdd) {
     auto totalStringOffsetsAfterUpdate = dataState.metadata.numValues + totalStringLengthToAdd;
     auto offsetCapacity =
-        offsetState.metadata.compMeta.numValues(KUZU_PAGE_SIZE, dataColumn->getDataType()) *
+        offsetState.metadata.compMeta.numValues(KUZU_PAGE_SIZE, offsetColumn->getDataType()) *
         offsetState.metadata.getNumPages();
     auto numStringsAfterUpdate = offsetState.metadata.numValues + numNewStrings;
     if (numStringsAfterUpdate > offsetCapacity) {

--- a/src/storage/store/string_chunk_data.cpp
+++ b/src/storage/store/string_chunk_data.cpp
@@ -22,9 +22,8 @@ StringChunkData::StringChunkData(MemoryManager& mm, LogicalType dataType, uint64
           true /*hasNullData*/},
       indexColumnChunk{ColumnChunkFactory::createColumnChunkData(mm, LogicalType::UINT32(),
           enableCompression, capacity, residencyState, false /*hasNullData*/)},
-      dictionaryChunk{std::make_unique<DictionaryChunk>(mm,
-          residencyState == ResidencyState::IN_MEMORY ? 0 : capacity, enableCompression,
-          residencyState)},
+      dictionaryChunk{
+          std::make_unique<DictionaryChunk>(mm, capacity, enableCompression, residencyState)},
       needFinalize{false} {}
 
 StringChunkData::StringChunkData(MemoryManager& mm, bool enableCompression,

--- a/test/test_files/function/call/storage_info.test
+++ b/test/test_files/function/call/storage_info.test
@@ -12,10 +12,11 @@
 -STATEMENT checkpoint
 -STATEMENT copy edge from (unwind range (0, 149998) as i return i, i + 1, 'hello')
 ---- ok
--STATEMENT call storage_info('edge') where (column_name = 'fwd_value_data' or column_name = 'bwd_value_data') and node_group_id = 0 return num_pages
+-STATEMENT call storage_info('edge') where compression <> 'UNCOMPRESSED' and compression <> 'BOOLEAN_BITPACKING' and compression <> 'CONSTANT' with count(*) as num_compressed_cols
+           call storage_info('edge') where (column_name = 'fwd_value_data' or column_name = 'bwd_value_data') and node_group_id = 0 return num_pages = 1 or num_compressed_cols = 0
 ---- 2
-1
-1
+True
+True
 
 -CASE CallStorageInfo
 # Expected outputs depend on number of node groups

--- a/test/test_files/function/call/storage_info.test
+++ b/test/test_files/function/call/storage_info.test
@@ -1,6 +1,22 @@
 -DATASET CSV tinysnb
 --
 
+-CASE DictionaryCompression
+-SKIP_IN_MEM
+-STATEMENT create node table tab(id serial, primary key (id))
+---- ok
+-STATEMENT create rel table edge(from tab to tab, value string)
+---- ok
+-STATEMENT unwind range (1, 150000) as i create (:tab)
+---- ok
+-STATEMENT checkpoint
+-STATEMENT copy edge from (unwind range (0, 149998) as i return i, i + 1, 'hello')
+---- ok
+-STATEMENT call storage_info('edge') where (column_name = 'fwd_value_data' or column_name = 'bwd_value_data') and node_group_id = 0 return num_pages
+---- 2
+1
+1
+
 -CASE CallStorageInfo
 # Expected outputs depend on number of node groups
 -SKIP_NODE_GROUP_SIZE_TESTS


### PR DESCRIPTION
# Description

Since we now have FSM we can be less aggressive with prereserving space for string offset/data chunks (since we can now reuse freed pages from out-of-place updates). This reduces the inital capacity of the data chunk to 0 and the offset chunk to 3 which reduces the amount of wasted space when the size of those chunks is small (e.g. when there is high duplication for dictionary compression)

On the dataset in the test added (rel table, single additional string column with all string values identical):

Query: `call storage_info('edge') where (column_name = 'fwd_value_data' or column_name = 'bwd_value_data') return sum(num_pages);`

`sum(num_pages)` on master|`sum(num_pages)` on branch
----|----
92|4

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).