### PR TITLE
Change on disk graph rel scan to random lookup

### DIFF
--- a/extension/vector/src/index/hnsw_index.cpp
+++ b/extension/vector/src/index/hnsw_index.cpp
@@ -314,7 +314,7 @@ common::offset_t OnDiskHNSWIndex::searchNNInUpperLayer(transaction::Transaction*
     auto minDist = metricFunc(queryVector, currNodeVector, embeddings->getDimension());
     KU_ASSERT(lastMinDist >= 0);
     KU_ASSERT(minDist >= 0);
-    auto scanState = upperGraph->prepareRelLookup(upperRelTableEntry);
+    auto scanState = upperGraph->prepareRelScan(upperRelTableEntry);
     while (minDist < lastMinDist) {
         lastMinDist = minDist;
         auto neighborItr =
@@ -338,11 +338,11 @@ common::offset_t OnDiskHNSWIndex::searchNNInUpperLayer(transaction::Transaction*
 void OnDiskHNSWIndex::initLowerLayerSearchState(transaction::Transaction* transaction,
     HNSWSearchState& searchState) const {
     searchState.visited.reset();
-    searchState.nbrScanState = lowerGraph->prepareRelLookup(lowerRelTableEntry);
+    searchState.nbrScanState = lowerGraph->prepareRelScan(lowerRelTableEntry);
     searchState.searchType = getFilteredSearchType(transaction, searchState);
     if (searchState.searchType == SearchType::BLIND_TWO_HOP ||
         searchState.searchType == SearchType::DIRECTED_TWO_HOP) {
-        searchState.secondHopNbrScanState = lowerGraph->prepareRelLookup(lowerRelTableEntry);
+        searchState.secondHopNbrScanState = lowerGraph->prepareRelScan(lowerRelTableEntry);
     }
 }
 

--- a/src/include/graph/on_disk_graph.h
+++ b/src/include/graph/on_disk_graph.h
@@ -149,7 +149,7 @@ public:
         catalog::TableCatalogEntry* nbrNodeEntry, std::vector<std::string> relProperties) override;
     // This is used for few random lookups in the relationship table. Internally we skip caching the
     // CSR header during scan.
-    std::unique_ptr<NbrScanState> prepareRelLookup(catalog::TableCatalogEntry* tableEntry) const;
+    std::unique_ptr<NbrScanState> prepareRelScan(catalog::TableCatalogEntry* tableEntry) const;
 
     EdgeIterator scanFwd(common::nodeID_t nodeID, NbrScanState& state) override;
     EdgeIterator scanBwd(common::nodeID_t nodeID, NbrScanState& state) override;

--- a/src/include/storage/store/csr_node_group.h
+++ b/src/include/storage/store/csr_node_group.h
@@ -236,7 +236,7 @@ private:
     NodeGroupScanResult scanCommittedPersistentWithCache(
         const transaction::Transaction* transaction, RelTableScanState& tableState,
         CSRNodeGroupScanState& nodeGroupScanState) const;
-    NodeGroupScanResult scanCommittedPersistentWtihoutCache(
+    NodeGroupScanResult scanCommittedPersistentWithoutCache(
         const transaction::Transaction* transaction, RelTableScanState& tableState,
         CSRNodeGroupScanState& nodeGroupScanState) const;
 

--- a/src/storage/store/csr_chunked_node_group.cpp
+++ b/src/storage/store/csr_chunked_node_group.cpp
@@ -41,13 +41,13 @@ CSRRegion CSRRegion::upgradeLevel(const std::vector<CSRRegion>& leafRegions,
     const idx_t leftLeafRegionIdx = newRegion.getLeftLeafRegionIdx();
     const idx_t rightLeafRegionIdx = newRegion.getRightLeafRegionIdx();
     for (auto leafRegionIdx = leftLeafRegionIdx; leafRegionIdx <= rightLeafRegionIdx;
-         leafRegionIdx++) {
+        leafRegionIdx++) {
         KU_ASSERT(leafRegionIdx < leafRegions.size());
         newRegion.sizeChange += leafRegions[leafRegionIdx].sizeChange;
         newRegion.hasPersistentDeletions |= leafRegions[leafRegionIdx].hasPersistentDeletions;
         newRegion.hasInsertions |= leafRegions[leafRegionIdx].hasInsertions;
         for (auto columnID = 0u; columnID < leafRegions[leafRegionIdx].hasUpdates.size();
-             columnID++) {
+            columnID++) {
             newRegion.hasUpdates[columnID] =
                 static_cast<bool>(newRegion.hasUpdates[columnID]) ||
                 static_cast<bool>(leafRegions[leafRegionIdx].hasUpdates[columnID]);
@@ -93,13 +93,8 @@ offset_t ChunkedCSRHeader::getEndCSROffset(offset_t nodeOffset) const {
 }
 
 length_t ChunkedCSRHeader::getCSRLength(offset_t nodeOffset) const {
-    if (randomLookup) {
-        return length->getData().getValue<length_t>(0);
-    }
-    if (nodeOffset >= offset->getNumValues()) {
-        return 0;
-    }
-    return length->getData().getValue<length_t>(nodeOffset);
+    const auto offset = randomLookup ? 0 : nodeOffset;
+    return offset >= length->getNumValues() ? 0 : length->getData().getValue<length_t>(offset);
 }
 
 length_t ChunkedCSRHeader::getGapSize(offset_t nodeOffset) const {

--- a/src/storage/store/csr_chunked_node_group.cpp
+++ b/src/storage/store/csr_chunked_node_group.cpp
@@ -41,13 +41,13 @@ CSRRegion CSRRegion::upgradeLevel(const std::vector<CSRRegion>& leafRegions,
     const idx_t leftLeafRegionIdx = newRegion.getLeftLeafRegionIdx();
     const idx_t rightLeafRegionIdx = newRegion.getRightLeafRegionIdx();
     for (auto leafRegionIdx = leftLeafRegionIdx; leafRegionIdx <= rightLeafRegionIdx;
-        leafRegionIdx++) {
+         leafRegionIdx++) {
         KU_ASSERT(leafRegionIdx < leafRegions.size());
         newRegion.sizeChange += leafRegions[leafRegionIdx].sizeChange;
         newRegion.hasPersistentDeletions |= leafRegions[leafRegionIdx].hasPersistentDeletions;
         newRegion.hasInsertions |= leafRegions[leafRegionIdx].hasInsertions;
         for (auto columnID = 0u; columnID < leafRegions[leafRegionIdx].hasUpdates.size();
-            columnID++) {
+             columnID++) {
             newRegion.hasUpdates[columnID] =
                 static_cast<bool>(newRegion.hasUpdates[columnID]) ||
                 static_cast<bool>(leafRegions[leafRegionIdx].hasUpdates[columnID]);

--- a/src/storage/store/csr_node_group.cpp
+++ b/src/storage/store/csr_node_group.cpp
@@ -607,7 +607,7 @@ ChunkCheckpointState CSRNodeGroup::checkpointColumnInRegion(const UniqLock& lock
     dummyChunkForNulls->getData().resetToAllNull();
     // Copy per csr list from old chunk and merge with new insertions into the newChunkData.
     for (auto nodeOffset = region.leftNodeOffset; nodeOffset <= region.rightNodeOffset;
-        nodeOffset++) {
+         nodeOffset++) {
         const auto oldCSRLength = csrState.oldHeader->getCSRLength(nodeOffset);
         KU_ASSERT(csrState.oldHeader->getStartCSROffset(nodeOffset) >= leftCSROffset);
         const auto oldStartRow = csrState.oldHeader->getStartCSROffset(nodeOffset) - leftCSROffset;
@@ -692,7 +692,7 @@ void CSRNodeGroup::collectInMemRegionChangesAndUpdateHeaderLength(const UniqLock
     row_idx_t numInsertionsInRegion = 0u;
     if (csrIndex) {
         for (auto nodeOffset = region.leftNodeOffset; nodeOffset <= region.rightNodeOffset;
-            nodeOffset++) {
+             nodeOffset++) {
             auto rows = csrIndex->indices[nodeOffset].getRows();
             row_idx_t numInsertedRows = rows.size();
             row_idx_t numInMemDeletionsInCSR = 0;
@@ -725,7 +725,7 @@ void CSRNodeGroup::collectOnDiskRegionChangesAndUpdateHeaderLength(const UniqLoc
     int64_t numDeletionsInRegion = 0u;
     if (persistentChunkGroup) {
         for (auto nodeOffset = region.leftNodeOffset; nodeOffset <= region.rightNodeOffset;
-            nodeOffset++) {
+             nodeOffset++) {
             const auto numDeletedRows =
                 getNumDeletionsForNodeInPersistentData(nodeOffset, csrState);
             if (numDeletedRows == 0) {

--- a/src/storage/store/csr_node_group.cpp
+++ b/src/storage/store/csr_node_group.cpp
@@ -167,7 +167,7 @@ NodeGroupScanResult CSRNodeGroup::scanCommittedPersistent(const Transaction* tra
     RelTableScanState& tableState, CSRNodeGroupScanState& nodeGroupScanState) const {
     if (tableState.cachedBoundNodeSelVector.getSelSize() == 1) {
         // Note that we don't apply cache when there is only one bound node.
-        return scanCommittedPersistentWtihoutCache(transaction, tableState, nodeGroupScanState);
+        return scanCommittedPersistentWithoutCache(transaction, tableState, nodeGroupScanState);
     }
     return scanCommittedPersistentWithCache(transaction, tableState, nodeGroupScanState);
 }
@@ -214,7 +214,7 @@ NodeGroupScanResult CSRNodeGroup::scanCommittedPersistentWithCache(const Transac
     }
 }
 
-NodeGroupScanResult CSRNodeGroup::scanCommittedPersistentWtihoutCache(
+NodeGroupScanResult CSRNodeGroup::scanCommittedPersistentWithoutCache(
     const Transaction* transaction, RelTableScanState& tableState,
     CSRNodeGroupScanState& nodeGroupScanState) const {
     const auto currNodeOffset = tableState.nodeIDVector->readNodeOffset(
@@ -607,7 +607,7 @@ ChunkCheckpointState CSRNodeGroup::checkpointColumnInRegion(const UniqLock& lock
     dummyChunkForNulls->getData().resetToAllNull();
     // Copy per csr list from old chunk and merge with new insertions into the newChunkData.
     for (auto nodeOffset = region.leftNodeOffset; nodeOffset <= region.rightNodeOffset;
-         nodeOffset++) {
+        nodeOffset++) {
         const auto oldCSRLength = csrState.oldHeader->getCSRLength(nodeOffset);
         KU_ASSERT(csrState.oldHeader->getStartCSROffset(nodeOffset) >= leftCSROffset);
         const auto oldStartRow = csrState.oldHeader->getStartCSROffset(nodeOffset) - leftCSROffset;
@@ -692,7 +692,7 @@ void CSRNodeGroup::collectInMemRegionChangesAndUpdateHeaderLength(const UniqLock
     row_idx_t numInsertionsInRegion = 0u;
     if (csrIndex) {
         for (auto nodeOffset = region.leftNodeOffset; nodeOffset <= region.rightNodeOffset;
-             nodeOffset++) {
+            nodeOffset++) {
             auto rows = csrIndex->indices[nodeOffset].getRows();
             row_idx_t numInsertedRows = rows.size();
             row_idx_t numInMemDeletionsInCSR = 0;
@@ -725,7 +725,7 @@ void CSRNodeGroup::collectOnDiskRegionChangesAndUpdateHeaderLength(const UniqLoc
     int64_t numDeletionsInRegion = 0u;
     if (persistentChunkGroup) {
         for (auto nodeOffset = region.leftNodeOffset; nodeOffset <= region.rightNodeOffset;
-             nodeOffset++) {
+            nodeOffset++) {
             const auto numDeletedRows =
                 getNumDeletionsForNodeInPersistentData(nodeOffset, csrState);
             if (numDeletedRows == 0) {


### PR DESCRIPTION
# Description

This avoids unnecessary cache of csr header in OnDiskGraphNbrScanState for GDS.


| | master | | | | this branch | | | |
|---|---|---|---|---|---|---|---|---|
| **# threads** | **1** | **2** | **4** | **8** | **1** | **2** | **4** | **8** |
| **PageRank** | 20750.8 | 10629.6 | 5572.64 | 3284.5 | 2927.85 | 1507.17 | 808.04 | 508.085 |
| **SCC-kosaraju** | 2221.76 | - | - | - | 381.074 | - | - | - |
| **SCC** | 3574.19 | 1839.16 | 957.872 | 533.347 | 447.806 | 241.394 | 132.318 | 87.285 |
| **WCC** | 3709.8 | 1896.88 | 976.021 | 515.917 | 487.515 | 256.866 | 140.078 | 82.041 |
| **kCore** | 11620.1 | 7052.99 | 5304.59 | 5665.6 | 3603.07 | 2176.27 | 1708.51 | 2251.78 |
