### PR TITLE
QUERY_VECTOR_INDEX + MATCH bind error

### DIFF
--- a/extension/vector/src/function/query_hnsw_index.cpp
+++ b/extension/vector/src/function/query_hnsw_index.cpp
@@ -115,8 +115,10 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     auto boundInput = BoundQueryHNSWIndexInput{nodeTableEntry, graphEntry.copy(), indexEntry,
         std::move(inputQueryExpression), static_cast<uint64_t>(k)};
     auto config = QueryHNSWConfig{input->optionalParams};
-    return std::make_unique<QueryHNSWIndexBindData>(context, std::move(columns), boundInput, config,
-        outputNode);
+    auto bindData = std::make_unique<QueryHNSWIndexBindData>(context, std::move(columns),
+    boundInput, config, outputNode);
+    context->setUseInternalCatalogEntry(false /* useInternalCatalogEntry */);
+    return bindData;
 }
 
 template<VectorElementType T>


### PR DESCRIPTION
# Description

Execution query like `call QUERY_VECTOR_INDEX(...) yield ... match ... return ...` error.

Caused by useInternalCatalogEntry_ not being reset to false due to the vertex index catalog table being found during binding

Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).