### PR TITLE
Fix get_as_arrow with null array

### DIFF
--- a/tools/python_api/test/test_arrow.py
+++ b/tools/python_api/test/test_arrow.py
@@ -480,6 +480,16 @@ def test_to_arrow_map(conn_db_readonly: ConnDB) -> None:
     ]
 
 
+def test_to_arrow_array(conn_db_readonly: ConnDB) -> None:
+    conn = conn_db_readonly[0]
+    results = (
+        conn.execute("RETURN cast(null as int64[3])")
+        .get_as_arrow(8)[0]
+        .to_pylist()
+    )
+    assert results == [None]
+
+
 def test_to_arrow_complex(conn_db_readonly: ConnDB) -> None:
     conn, db = conn_db_readonly
 

--- a/tools/python_api/test/test_arrow.py
+++ b/tools/python_api/test/test_arrow.py
@@ -480,14 +480,15 @@ def test_to_arrow_map(conn_db_readonly: ConnDB) -> None:
     ]
 
 
-def test_to_arrow_array(conn_db_readonly: ConnDB) -> None:
-    conn = conn_db_readonly[0]
-    results = (
-        conn.execute("RETURN cast(null as int64[3])")
-        .get_as_arrow(8)[0]
-        .to_pylist()
-    )
-    assert results == [None]
+def test_to_arrow_array(conn_db_readwrite: ConnDB) -> None:
+    conn = conn_db_readwrite[0]
+    conn.execute("CREATE NODE TABLE school (id int64 primary key, prop1 int64[3])")
+    conn.execute("CREATE (p:school {id: 5})")
+    conn.execute("CREATE (p:school {id: 8, prop1: [2,3,1]})")
+    conn.execute("CREATE (p:school {id: 18, prop1: null})")
+    results = conn.execute("match (p:school) return p.*").get_as_arrow(8)
+    assert results[0].to_pylist() == [5,8,18]
+    assert results[1].to_pylist() == [None,[2,3,1],None]
 
 
 def test_to_arrow_complex(conn_db_readonly: ConnDB) -> None:


### PR DESCRIPTION
Fixes `get_as_arrow` with null array bug as reported by #5289 
Closes #5289 