### PR TITLE
Clear the JSONAllocator after each batch processed

### DIFF
--- a/extension/json/src/include/common/json_common.h
+++ b/extension/json/src/include/common/json_common.h
@@ -18,6 +18,7 @@ public:
         : overflowBuffer{&mm}, yyjsonAlc{allocate, reallocate, free, &overflowBuffer} {}
 
     yyjson_alc* getYYJsonAlc() { return &yyjsonAlc; }
+    void reset() { overflowBuffer.resetBuffer(); }
 
 private:
     static void* allocate(void* context, size_t size) {


### PR DESCRIPTION
The JSONAllocator in #5256 is never clearing the memory it uses until the end and as a result is significantly slower and uses much more memory than necessary.

master (d5d4ba9f4e6e8f, peak 1.2GB memory for LDBC-10):
| Dataset | 1 Thread | 4 Threads |
| --- | --- | --- |
| LDBC-1 | 0.55s | 0.16s | 
| LDBC-10 | 5.7s | 1.4s | 

Testing on query `load from 'test.json' RETURN id, content;`, after a few warmup runs
With #5256 (c6cc24a681728, peak 17GB memory for LDBC-10):
| Dataset | 1 Thread | 4 Threads |
| --- | --- | --- |
| LDBC-1 | 1.1s | 0.31s | 
| LDBC-10 | 18s | 6.1s | 

After this change (peak 1.2GB for LDBC-10):
| Dataset | 1 Thread | 4 Threads |
| --- | --- | --- |
| LDBC-1 | 0.61s | 0.19s |
| LDBC-10 | 5.7s | 1.5s |

I'm not seeing any noticeable advantage from the allocator, but it's at least no longer causing a regression (looks slightly worse in the benchmarks I did, but the difference is within the margin of error I was seeing for the benchmarks).