### PR TITLE
Pass LogicalType to ColumnChunk by rvalue

### DIFF
--- a/src/include/storage/store/column_chunk.h
+++ b/src/include/storage/store/column_chunk.h
@@ -37,13 +37,9 @@ struct ColumnCheckpointState {
 
 class ColumnChunk {
 public:
-    // TODO(bmwinger): the dataType reference is copied when passing it to the ColumnChunkData
-    // It would be better to take it by value so that the caller can choose to either move or copy
-    // it
-    ColumnChunk(MemoryManager& memoryManager, const common::LogicalType& dataType,
-        uint64_t capacity, bool enableCompression, ResidencyState residencyState,
-        bool initializeToZero = true);
-    ColumnChunk(MemoryManager& memoryManager, const common::LogicalType& dataType,
+    ColumnChunk(MemoryManager& memoryManager, common::LogicalType&& dataType, uint64_t capacity,
+        bool enableCompression, ResidencyState residencyState, bool initializeToZero = true);
+    ColumnChunk(MemoryManager& memoryManager, common::LogicalType&& dataType,
         bool enableCompression, ColumnChunkMetadata metadata);
     ColumnChunk(bool enableCompression, std::unique_ptr<ColumnChunkData> data);
 

--- a/src/storage/store/chunked_node_group.cpp
+++ b/src/storage/store/chunked_node_group.cpp
@@ -370,7 +370,7 @@ void ChunkedNodeGroup::addColumn(const Transaction* transaction,
     auto& dataType = addColumnState.propertyDefinition.getType();
     chunks.push_back(
         std::make_unique<ColumnChunk>(*transaction->getClientContext()->getMemoryManager(),
-            dataType, capacity, enableCompression, ResidencyState::IN_MEMORY));
+            dataType.copy(), capacity, enableCompression, ResidencyState::IN_MEMORY));
     auto& chunkData = chunks.back()->getData();
     auto numExistingRows = getNumRows();
     chunkData.populateWithDefaultVal(addColumnState.defaultEvaluator, numExistingRows,

--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -15,18 +15,18 @@ using namespace kuzu::transaction;
 namespace kuzu {
 namespace storage {
 
-ColumnChunk::ColumnChunk(MemoryManager& memoryManager, const LogicalType& dataType,
-    uint64_t capacity, bool enableCompression, ResidencyState residencyState, bool initializeToZero)
+ColumnChunk::ColumnChunk(MemoryManager& memoryManager, LogicalType&& dataType, uint64_t capacity,
+    bool enableCompression, ResidencyState residencyState, bool initializeToZero)
     : enableCompression{enableCompression} {
-    data = ColumnChunkFactory::createColumnChunkData(memoryManager, dataType.copy(),
+    data = ColumnChunkFactory::createColumnChunkData(memoryManager, std::move(dataType),
         enableCompression, capacity, residencyState, true, initializeToZero);
     KU_ASSERT(residencyState != ResidencyState::ON_DISK);
 }
 
-ColumnChunk::ColumnChunk(MemoryManager& memoryManager, const LogicalType& dataType,
+ColumnChunk::ColumnChunk(MemoryManager& memoryManager, LogicalType&& dataType,
     bool enableCompression, ColumnChunkMetadata metadata)
     : enableCompression{enableCompression} {
-    data = ColumnChunkFactory::createColumnChunkData(memoryManager, dataType.copy(),
+    data = ColumnChunkFactory::createColumnChunkData(memoryManager, std::move(dataType),
         enableCompression, metadata, true, true);
 }
 
@@ -242,8 +242,8 @@ std::pair<std::unique_ptr<ColumnChunk>, std::unique_ptr<ColumnChunk>> ColumnChun
     // TODO(Guodong): Actually for row idx in a column chunk, UINT32 should be enough.
     auto updatedRows = std::make_unique<ColumnChunk>(mm, LogicalType::UINT64(), numUpdatedRows,
         false, ResidencyState::IN_MEMORY);
-    auto updatedData = std::make_unique<ColumnChunk>(mm, getDataType(), numUpdatedRows, false,
-        ResidencyState::IN_MEMORY);
+    auto updatedData = std::make_unique<ColumnChunk>(mm, getDataType().copy(), numUpdatedRows,
+        false, ResidencyState::IN_MEMORY);
     const auto numUpdateVectors = updateInfo->getNumVectors();
     row_idx_t numAppendedRows = 0;
     for (auto vectorIdx = 0u; vectorIdx < numUpdateVectors; vectorIdx++) {

--- a/src/storage/store/csr_node_group.cpp
+++ b/src/storage/store/csr_node_group.cpp
@@ -825,7 +825,7 @@ void CSRNodeGroup::checkpointInMemOnly(const UniqLock& lock, NodeGroupCheckpoint
     for (auto i = 0u; i < numColumnsToCheckpoint; i++) {
         const auto columnID = csrState.columnIDs[i];
         KU_ASSERT(columnID < dataTypes.size());
-        dataChunksToFlush[i] = std::make_unique<ColumnChunk>(*state.mm, dataTypes[columnID],
+        dataChunksToFlush[i] = std::make_unique<ColumnChunk>(*state.mm, dataTypes[columnID].copy(),
             chunkCapacity, enableCompression, ResidencyState::IN_MEMORY);
     }
 


### PR DESCRIPTION
In several places we were copying the LogicalType prior to passing it by reference and copying it again.