### PR TITLE
Optimize RelTableScanState during rel table update/delete and detach delete

### DIFF
--- a/src/storage/store/csr_node_group.cpp
+++ b/src/storage/store/csr_node_group.cpp
@@ -101,7 +101,8 @@ void CSRNodeGroup::initScanForCommittedPersistent(const Transaction* transaction
     }
     KU_ASSERT(csrHeader.offset->getNumValues() == csrHeader.length->getNumValues());
     if (relScanState.randomLookup) {
-        auto nodeOffset = relScanState.nodeIDVector->readNodeOffset(0);
+        auto pos = relScanState.nodeIDVector->state->getSelVector()[0];
+        auto nodeOffset = relScanState.nodeIDVector->readNodeOffset(pos);
         auto offsetInGroup = nodeOffset % StorageConfig::NODE_GROUP_SIZE;
         auto offsetToScanFrom = offsetInGroup == 0 ? 0 : offsetInGroup - 1;
         csrHeader.offset->scanCommitted<ResidencyState::ON_DISK>(transaction, offsetState,

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -298,7 +298,7 @@ void RelTable::detachDelete(Transaction* transaction, RelDataDirection direction
     auto relReadState = std::make_unique<RelTableScanState>(
         *transaction->getClientContext()->getMemoryManager(), &deleteState->srcNodeIDVector,
         std::vector{&deleteState->dstNodeIDVector, &deleteState->relIDVector},
-        deleteState->dstNodeIDVector.state);
+        deleteState->dstNodeIDVector.state, true /*randomLookup*/);
     relReadState->setToTable(transaction, this, {NBR_ID_COLUMN_ID, REL_ID_COLUMN_ID}, {},
         direction);
     initScanState(transaction, *relReadState);

--- a/src/storage/store/rel_table_data.cpp
+++ b/src/storage/store/rel_table_data.cpp
@@ -169,9 +169,9 @@ std::pair<CSRNodeGroupScanSource, row_idx_t> RelTableData::findMatchingRow(Trans
     scanChunk.insert(0, std::make_shared<ValueVector>(LogicalType::INTERNAL_ID()));
     std::vector columnIDs = {REL_ID_COLUMN_ID, ROW_IDX_COLUMN_ID};
     std::vector<const Column*> columns{getColumn(REL_ID_COLUMN_ID), nullptr};
-    auto scanState =
-        std::make_unique<RelTableScanState>(*transaction->getClientContext()->getMemoryManager(),
-            &boundNodeIDVector, std::vector{&scanChunk.getValueVectorMutable(0)}, scanChunk.state);
+    auto scanState = std::make_unique<RelTableScanState>(
+        *transaction->getClientContext()->getMemoryManager(), &boundNodeIDVector,
+        std::vector{&scanChunk.getValueVectorMutable(0)}, scanChunk.state, true /*randomLookup*/);
     auto table = transaction->getClientContext()->getStorageManager()->getTable(tableID);
     scanState->setToTable(transaction, table, columnIDs, {}, direction);
     scanState->initState(transaction, getNodeGroup(nodeGroupIdx));
@@ -213,9 +213,9 @@ bool RelTableData::checkIfNodeHasRels(Transaction* transaction,
     scanChunk.insert(0, std::make_shared<ValueVector>(LogicalType::INTERNAL_ID()));
     std::vector columnIDs = {REL_ID_COLUMN_ID};
     std::vector<const Column*> columns{getColumn(REL_ID_COLUMN_ID)};
-    auto scanState =
-        std::make_unique<RelTableScanState>(*transaction->getClientContext()->getMemoryManager(),
-            srcNodeIDVector, std::vector{&scanChunk.getValueVectorMutable(0)}, scanChunk.state);
+    auto scanState = std::make_unique<RelTableScanState>(
+        *transaction->getClientContext()->getMemoryManager(), srcNodeIDVector,
+        std::vector{&scanChunk.getValueVectorMutable(0)}, scanChunk.state, true /*randomLookup*/);
     auto table = transaction->getClientContext()->getStorageManager()->getTable(tableID);
     scanState->setToTable(transaction, table, columnIDs, {}, direction);
     scanState->initState(transaction, getNodeGroup(nodeGroupIdx));


### PR DESCRIPTION
# Description

This PR optimizes the use of `RelTableScanState` during rel table update/delete and detach delete of connected relationships from node tables.

A benchmark is done on a small LDBC-1 dataset.
Queries are as follows:
```
// set
match (p:person)-[e:likeComment]->(c:Comment) where c.browserUsed='Safari' set e.creationDate=cast('2012-10-12', 'timestamp');
// delete
match (p:person)-[e:likeComment]->(c:Comment) where c.browserUsed='Safari' delete e;
// detach delete
match (c:Comment) where c.browserUsed='Safari' detach delete c;
```

The result is as follows (query runtime are in ms).
| workload | master    | this branch |
| --------- | --------- | ----------- |
| set           | 6353.12  | 359.36        |
| delete     | 5682.55  | 380.61         |
| detach delete | 14401.88 | 520.82 |



