### PR TITLE
Flush + populate warnings after COPY FROM subquery

### DIFF
--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -231,9 +231,15 @@ void NodeBatchInsert::finalize(ExecutionContext* context) {
     }
 
     // we want to flush all index errors before children call finalize
-    // as the children are resposible for populating the errors and sending it to the warning
-    // context
+    // as the children (if they are table function calls) are responsible for populating the errors
+    // and sending it to the warning context
     PhysicalOperator::finalize(context);
+
+    // if the child is a subquery it will not send the errors to the warning context
+    // sends any remaining warnings in this case
+    // if the child is a table function call it will have already sent the warnings so this line
+    // will do nothing
+    context->clientContext->getWarningContextUnsafe().defaultPopulateAllWarnings(context->queryID);
 }
 
 void NodeBatchInsert::finalizeInternal(ExecutionContext* context) {

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -256,6 +256,8 @@ void RelBatchInsert::finalizeInternal(ExecutionContext* context) {
                     warningCount, context->queryID);
             FactorizedTableUtils::appendStringToTable(sharedState->fTable.get(), warningMsg,
                 context->clientContext->getMemoryManager());
+            context->clientContext->getWarningContextUnsafe().defaultPopulateAllWarnings(
+                context->queryID);
         }
     }
     sharedState->numRows.store(0);

--- a/test/test_files/exceptions/copy/ignore_invalid_row.test
+++ b/test/test_files/exceptions/copy/ignore_invalid_row.test
@@ -161,6 +161,46 @@ Quoted newlines are not supported in parallel CSV reader. Please specify PARALLE
 4|9|11|vgood
 6|1|1|vbad
 
+-CASE CopyRelNoIgnoreErrorsAfterCopyNodeFromSubquery
+-STATEMENT CREATE NODE TABLE tab (id int64, primary key(id))
+---- ok
+-STATEMENT CREATE REL TABLE edge (FROM tab TO tab)
+---- ok
+-STATEMENT COPY tab FROM (unwind [0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2] as i return i) (IGNORE_ERRORS=true)
+---- ok
+-STATEMENT COPY edge FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/eWatches.csv"(SKIP=6)
+---- ok
+-STATEMENT match (a:tab)-[:edge]->(b:tab) return a.id, b.id
+---- 3
+2|0
+6|0
+7|0
+-STATEMENT CALL SHOW_WARNINGS() RETURN message
+---- 3
+Found duplicated primary key value 0, which violates the uniqueness constraint of the primary key column.
+Found duplicated primary key value 1, which violates the uniqueness constraint of the primary key column.
+Found duplicated primary key value 2, which violates the uniqueness constraint of the primary key column.
+
+-CASE CopyRelNoIgnoreErrorsAfterCopyRelFromSubquery
+-STATEMENT CREATE NODE TABLE tab (id int64, primary key(id))
+---- ok
+-STATEMENT CREATE REL TABLE edge (FROM tab TO tab)
+---- ok
+-STATEMENT COPY tab FROM (unwind [0, 1, 2, 3, 4, 5, 6, 7] as i return i)
+---- ok
+-STATEMENT COPY edge FROM (return 10, 11) (ignore_errors=true)
+---- ok
+-STATEMENT COPY edge FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/eWatches.csv"(SKIP=6)
+---- ok
+-STATEMENT match (a:tab)-[:edge]->(b:tab) return a.id, b.id
+---- 3
+2|0
+6|0
+7|0
+-STATEMENT CALL SHOW_WARNINGS() RETURN message
+---- 1
+Unable to find primary key value 10.
+
 -CASE ParallelSkipInvalidRelMissingPK
 -STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/vPerson-valid.csv"(AUTO_DETECT=false)
 ---- ok


### PR DESCRIPTION
# Description

When we COPY FROM subquery the source isn't a table function so we don't have a `finalizeFunc` that we can use to flush the warning context for the current query so the warnings currently aren't flushed. This PR adds a call at the end of node/rel batch insert's `finalizeInternal` to flush/populate any warnings that weren't handled by the source operator.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).