### PR TITLE
Optimize set of nodeID for basic scan node table queries

### DIFF
--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -207,8 +207,9 @@ bool NodeTableScanState::scanNext(Transaction* transaction) {
         nodeGroupStartOffset = transaction->getUncommittedOffset(tableID, nodeGroupStartOffset);
     }
     for (auto i = 0u; i < scanResult.numRows; i++) {
-        nodeIDVector->setValue(i,
-            nodeID_t{nodeGroupStartOffset + scanResult.startRow + i, tableID});
+        auto& nodeID = nodeIDVector->getValue<nodeID_t>(i);
+        nodeID.tableID = tableID;
+        nodeID.offset = nodeGroupStartOffset + scanResult.startRow + i;
     }
     return true;
 }
@@ -511,7 +512,7 @@ void NodeTable::commit(Transaction* transaction, TableCatalogEntry* tableEntry,
     // 2. Set deleted flag for tuples that are deleted in local storage.
     row_idx_t numLocalRows = 0u;
     for (auto localNodeGroupIdx = 0u; localNodeGroupIdx < localNodeTable.getNumNodeGroups();
-         localNodeGroupIdx++) {
+        localNodeGroupIdx++) {
         const auto localNodeGroup = localNodeTable.getNodeGroup(localNodeGroupIdx);
         if (localNodeGroup->hasDeletions(transaction)) {
             // TODO(Guodong): Assume local storage is small here. Should optimize the loop away by
@@ -651,7 +652,7 @@ void NodeTable::scanPKColumn(const Transaction* transaction, PKColumnScanHelper&
 
     const auto numNodeGroups = nodeGroups_.getNumNodeGroups();
     for (node_group_idx_t nodeGroupToScan = 0u; nodeGroupToScan < numNodeGroups;
-         ++nodeGroupToScan) {
+        ++nodeGroupToScan) {
         scanState->nodeGroup = nodeGroups_.getNodeGroupNoLock(nodeGroupToScan);
 
         // It is possible for the node group to have no chunked groups if we are rolling back due to


### PR DESCRIPTION
# Description

The large num of constructing and copying of nodeID_t objects impose quite large overheads for basic node table scans.

On my local Mac mini desktop, on ldbc-100, the following query can be improved quite a bit.
```
MATCH (comment:Comment) WHERE comment.length < 150 RETURN count(*);
```

| master | this branch |
| ------- | ----------- |
| 68.84ms | 37.13ms  |

TODO:
- There could be more places we're allocating and copying internalID_t objects. We should rewrite them all.