### PR TITLE
Take into account start row idx for node group when checking if all rows are deleted

### DIFF
--- a/src/storage/store/node_group.cpp
+++ b/src/storage/store/node_group.cpp
@@ -390,7 +390,7 @@ void NodeGroup::checkpoint(MemoryManager& memoryManager, NodeGroupCheckpointStat
     auto checkpointedVersionInfo = checkpointVersionInfo(lock, &DUMMY_CHECKPOINT_TRANSACTION);
     std::unique_ptr<ChunkedNodeGroup> checkpointedChunkedGroup;
     if (checkpointedVersionInfo->getNumDeletions(&DUMMY_CHECKPOINT_TRANSACTION, 0, numRows) ==
-        numRows) {
+        numRows - firstGroup->getStartRowIdx()) {
         reclaimStorage(state.dataFH, lock);
         // TODO(Royi) figure out how to make this rollback-friendly
         checkpointedChunkedGroup =

--- a/test/test_files/function/call/fsm_info.test
+++ b/test/test_files/function/call/fsm_info.test
@@ -142,3 +142,7 @@ True
 -STATEMENT call fsm_info() return count(*)
 ---- 1
 1
+
+-STATEMENT call fsm_info() return start_page_idx
+---- 1
+0

--- a/test/test_files/function/call/fsm_info.test
+++ b/test/test_files/function/call/fsm_info.test
@@ -100,3 +100,45 @@ True
 -STATEMENT CALL fsm_info() with sum(num_pages) as num_free_pages call storage_info('knows1') with num_free_pages, max(num_pages) as largest_range return num_free_pages is null or largest_range >= num_free_pages
 ---- 1
 True
+
+-CASE FSMDeleteFullNodeGroupRepeat
+# After 2-3 cycles of copy -> delete -> checkpoint the number of free pages should stop increasing
+-STATEMENT create node table Person (id INT64, firstName STRING, lastName STRING, gender STRING, birthday INT64, creationDate INT64, locationIP STRING, browserUsed STRING, PRIMARY KEY (id));
+---- ok
+-STATEMENT copy Person from '${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Person.csv'(header=true, delim='|')
+---- ok
+-STATEMENT match (p:Person) delete p
+---- ok
+-STATEMENT checkpoint
+---- ok
+-STATEMENT copy Person from '${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Person.csv'(header=true, delim='|')
+---- ok
+
+-STATEMENT create node table Person1 (id INT64, firstName STRING, lastName STRING, gender STRING, birthday INT64, creationDate INT64, locationIP STRING, browserUsed STRING, PRIMARY KEY (id));
+---- ok
+-STATEMENT copy Person1 from '${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Person.csv'(header=true, delim='|')
+---- ok
+-STATEMENT match (p:Person1) delete p
+---- ok
+-STATEMENT checkpoint
+---- ok
+-STATEMENT copy Person1 from '${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Person.csv'(header=true, delim='|')
+---- ok
+-STATEMENT match (p:Person1) delete p
+---- ok
+-STATEMENT checkpoint
+---- ok
+-STATEMENT copy Person1 from '${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Person.csv'(header=true, delim='|')
+---- ok
+
+-STATEMENT match (p:Person) delete p
+---- ok
+-STATEMENT match (p:Person1) delete p
+---- ok
+-STATEMENT checkpoint
+---- ok
+
+# There shouldn't be gaps in the free pages at the end
+-STATEMENT call fsm_info() return count(*)
+---- 1
+1


### PR DESCRIPTION
# Description

When reclaiming space from a node group we preserve the `numRows`, instead updating the `startRowIdx` of the first chunked group. Thus we cannot only check `numRows` to see how many actual rows are in a node group (used to determine if we can reclaim an entire node group), we also need to take into account the `startRowIdx`. This fixes the issue where repeatedly fully deleting + copying into a node group would still keep increasing the size of the DB.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).