### PR TITLE
Simplify project filtered graph syntax

### DIFF
--- a/extension/algo/test/test_files/k_core.test
+++ b/extension/algo/test/test_files/k_core.test
@@ -47,7 +47,7 @@ Greg|3
 Harry|2
 Ian|1
 James|1
--STATEMENT CALL PROJECT_GRAPH('PK2', ['User'], {'friend': {'filter': 'r.id < 10'}});
+-STATEMENT CALL PROJECT_GRAPH('PK2', ['User'], {'friend': 'r.id < 10'});
 ---- ok
 -STATEMENT CALL k_core_decomposition('PK2') RETURN node.name, k_degree;
 ---- 10
@@ -61,7 +61,7 @@ Greg|2
 Harry|1
 Ian|0
 James|0
--STATEMENT CALL PROJECT_GRAPH('PK3', {'User': {'filter': 'n.id > 3'}}, {'friend': {'filter': 'r.id <= 11'}});
+-STATEMENT CALL PROJECT_GRAPH('PK3', {'User': 'n.id > 3'}, {'friend': 'r.id <= 11'});
 ---- ok
 -STATEMENT CALL k_core_decomposition('PK3') RETURN node.name, k_degree;
 ---- 7
@@ -72,7 +72,7 @@ Greg|3
 Harry|1
 Ian|0
 James|0
--STATEMENT CALL PROJECT_GRAPH('PK4', {'User': {'filter': 'n.id > 3 AND n.id < 7'}}, {'friend': {'filter': 'r.id >= 0'}});
+-STATEMENT CALL PROJECT_GRAPH('PK4', {'User': 'n.id > 3 AND n.id < 7'}, {'friend': 'r.id >= 0'});
 ---- ok
 -STATEMENT CALL k_core_decomposition('PK4') RETURN node.name, k_degree;
 ---- 3

--- a/extension/algo/test/test_files/page_rank.test
+++ b/extension/algo/test/test_files/page_rank.test
@@ -29,7 +29,7 @@ Farooq|0.213750
 Greg|0.213750
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|0.150000
 
--STATEMENT CALL PROJECT_GRAPH('PK2', ['person'], {'knows': {'filter': 'r.date > date("1906-01-01")'}})
+-STATEMENT CALL PROJECT_GRAPH('PK2', ['person'], {'knows': 'r.date > date("1906-01-01")'})
 ---- ok
 -STATEMENT CALL page_rank('PK2') RETURN node.fName, rank;
 ---- 8
@@ -41,7 +41,7 @@ Elizabeth|0.018750
 Farooq|0.018750
 Greg|0.018750
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|0.018750
--STATEMENT CALL PROJECT_GRAPH('PK3', {'person': {'filter': 'n.ID > 3'}}, {'knows': {'filter': 'r.date > date("1906-01-01")'}})
+-STATEMENT CALL PROJECT_GRAPH('PK3', {'person': 'n.ID > 3'}, {'knows': 'r.date > date("1906-01-01")'})
 ---- ok
 -STATEMENT CALL page_rank('PK3') RETURN node.fName, rank;
 ---- 5
@@ -90,7 +90,7 @@ Binder exception: Max iteration must be a positive integer.
 ---- error
 Binder exception: Unknown optional parameter: maxIteratioN
 -STATEMENT CALL PROJECT_GRAPH('G1'
-        , {'person': {'filter': 'n.ID < 10'}, 'organisation': {'filter': ''}}
+        , {'person': 'n.ID < 10', 'organisation': ''}
         , ['knows', 'studyAt'])
 ---- ok
 -STATEMENT CALL page_rank('G1') RETURN node.fName, node.name, rank;

--- a/extension/algo/test/test_files/scc.test
+++ b/extension/algo/test/test_files/scc.test
@@ -50,7 +50,7 @@
 6|1|[6]
 7|1|[7]
 8|1|[8]
--STATEMENT CALL PROJECT_GRAPH('Graph2', {'Node': {'filter': 'n.ID > 0'}}, ['Edge'])
+-STATEMENT CALL PROJECT_GRAPH('Graph2', {'Node': 'n.ID > 0'}, ['Edge'])
 ---- ok
 -STATEMENT CALL strongly_connected_components_kosaraju('Graph2') WITH group_id, min(node.id) as sccId, count(*) as nodeCount, list_sort(collect(node.id)) as nodeIds RETURN sccId, nodeCount, nodeIds ORDER BY sccId;
 ---- 8
@@ -196,7 +196,7 @@
 2|1|[2]
 5|3|[5,7,8]
 
--STATEMENT CALL PROJECT_GRAPH('Graph2', ['Node'], {'Edge': {'filter': 'r.ID <> 17 '}})
+-STATEMENT CALL PROJECT_GRAPH('Graph2', ['Node'], {'Edge': 'r.ID <> 17'})
 ---- ok
 -STATEMENT CALL strongly_connected_components_kosaraju('Graph2') WITH group_id, min(node.id) as sccId, count(*) as nodeCount, list_sort(collect(node.id)) as nodeIds RETURN sccId, nodeCount, nodeIds ORDER BY sccId;
 ---- 4
@@ -211,7 +211,7 @@
 2|1|[2]
 5|3|[5,7,8]
 
--STATEMENT CALL PROJECT_GRAPH('Graph3', {'Node': {'filter': 'n.ID <> 4'}}, {'Edge': {'filter': 'r.ID <> 23 '}})
+-STATEMENT CALL PROJECT_GRAPH('Graph3', {'Node': 'n.ID <> 4'}, {'Edge': 'r.ID <> 23 '})
 ---- ok
 -STATEMENT CALL strongly_connected_components_kosaraju('Graph3') WITH group_id, min(node.id) as sccId, count(*) as nodeCount, list_sort(collect(node.id)) as nodeIds RETURN sccId, nodeCount, nodeIds ORDER BY sccId;
 ---- 8
@@ -250,7 +250,7 @@
 -STATEMENT CALL strongly_connected_components('Graph4') WITH group_id, min(node.id) as sccId, count(*) as nodeCount, list_sort(collect(node.id)) as nodeIds RETURN sccId, nodeCount, nodeIds ORDER BY sccId;
 ---- 1
 0|10|[0,1,2,3,4,5,6,7,8,10]
--STATEMENT CALL PROJECT_GRAPH('Graph5', {'Node': {'filter': ''}, 'N': {'filter': 'n.ID < 4'}}, ['Edge', 'R1', 'R2'])
+-STATEMENT CALL PROJECT_GRAPH('Graph5', {'Node': '', 'N':'n.ID < 4'}, ['Edge', 'R1', 'R2'])
 ---- ok
 -STATEMENT CALL strongly_connected_components('Graph5') WITH group_id, min(node.id) as sccId, count(*) as nodeCount, list_sort(collect(node.id)) as nodeIds RETURN sccId, nodeCount, nodeIds ORDER BY sccId;
 ---- 3

--- a/extension/algo/test/test_files/snap/bitcoin_otc.test
+++ b/extension/algo/test/test_files/snap/bitcoin_otc.test
@@ -144,7 +144,7 @@
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/algo/build/libalgo.kuzu_extension'
 ---- ok
 
--STATEMENT CALL PROJECT_GRAPH('G', {'nodes': { 'filter': 'n.id < 1000' }}, ['edges'])
+-STATEMENT CALL PROJECT_GRAPH('G', {'nodes': 'n.id < 1000' }, ['edges'])
 ---- ok
 
 -LOG WCC
@@ -229,7 +229,7 @@
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/algo/build/libalgo.kuzu_extension'
 ---- ok
 
--STATEMENT CALL PROJECT_GRAPH('G', {'nodes': { 'filter': 'n.id >= 1000' }}, ['edges'])
+-STATEMENT CALL PROJECT_GRAPH('G', {'nodes':'n.id >= 1000'}, ['edges'])
 ---- ok
 
 -LOG WCC

--- a/extension/algo/test/test_files/snap/email_eu_core.test
+++ b/extension/algo/test/test_files/snap/email_eu_core.test
@@ -100,7 +100,7 @@
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/algo/build/libalgo.kuzu_extension'
 ---- ok
 
--STATEMENT CALL PROJECT_GRAPH('G', {'nodes': { 'filter': 'n.id < 100' }}, ['edges'])
+-STATEMENT CALL PROJECT_GRAPH('G', {'nodes': 'n.id < 100' }, ['edges'])
 ---- ok
 
 -LOG WCC
@@ -166,7 +166,7 @@
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/algo/build/libalgo.kuzu_extension'
 ---- ok
 
--STATEMENT CALL PROJECT_GRAPH('G', {'nodes': { 'filter': 'n.id >= 100' }}, ['edges'])
+-STATEMENT CALL PROJECT_GRAPH('G', {'nodes': 'n.id >= 100' }, ['edges'])
 ---- ok
 
 -LOG WCC

--- a/extension/algo/test/test_files/snap/epinions.test
+++ b/extension/algo/test/test_files/snap/epinions.test
@@ -97,7 +97,7 @@
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/algo/build/libalgo.kuzu_extension'
 ---- ok
 
--STATEMENT CALL PROJECT_GRAPH('G', {'N': { 'filter': 'n.id >= 1000' }}, ['R'])
+-STATEMENT CALL PROJECT_GRAPH('G', {'N': 'n.id >= 1000' }, ['R'])
 ---- ok
 
 -LOG WCC
@@ -191,7 +191,7 @@
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/algo/build/libalgo.kuzu_extension'
 ---- ok
 
--STATEMENT CALL PROJECT_GRAPH('G', {'N': { 'filter': 'n.id < 1000' }}, ['R'])
+-STATEMENT CALL PROJECT_GRAPH('G', {'N': 'n.id < 1000' }, ['R'])
 ---- ok
 
 -LOG WCC

--- a/extension/algo/test/test_files/snap/facebook.test
+++ b/extension/algo/test/test_files/snap/facebook.test
@@ -101,7 +101,7 @@
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/algo/build/libalgo.kuzu_extension'
 ---- ok
 
--STATEMENT CALL PROJECT_GRAPH('G', {'nodes': { 'filter': 'n.id < 1000' }}, ['edges'])
+-STATEMENT CALL PROJECT_GRAPH('G', {'nodes': 'n.id < 1000' }, ['edges'])
 ---- ok
 
 -LOG WCC
@@ -196,7 +196,7 @@
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/algo/build/libalgo.kuzu_extension'
 ---- ok
 
--STATEMENT CALL PROJECT_GRAPH('G', {'nodes': { 'filter': 'n.id >= 1000' }}, ['edges'])
+-STATEMENT CALL PROJECT_GRAPH('G', {'nodes': 'n.id >= 1000'}, ['edges'])
 ---- ok
 
 -LOG WCC

--- a/extension/algo/test/test_files/snap/gnutella.test
+++ b/extension/algo/test/test_files/snap/gnutella.test
@@ -89,7 +89,7 @@
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/algo/build/libalgo.kuzu_extension'
 ---- ok
 
--STATEMENT CALL PROJECT_GRAPH('G', {'nodes': { 'filter': 'n.id >= 1000' }}, ['edges'])
+-STATEMENT CALL PROJECT_GRAPH('G', {'nodes': 'n.id >= 1000' }, ['edges'])
 ---- ok
 
 -LOG WCC
@@ -179,7 +179,7 @@
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/algo/build/libalgo.kuzu_extension'
 ---- ok
 
--STATEMENT CALL PROJECT_GRAPH('G', {'nodes': { 'filter': 'n.id < 1000' }}, ['edges'])
+-STATEMENT CALL PROJECT_GRAPH('G', {'nodes': 'n.id < 1000' }, ['edges'])
 ---- ok
 
 -LOG WCC

--- a/extension/algo/test/test_files/snap/grqc.test
+++ b/extension/algo/test/test_files/snap/grqc.test
@@ -100,7 +100,7 @@
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/algo/build/libalgo.kuzu_extension'
 ---- ok
 
--STATEMENT CALL PROJECT_GRAPH('G', {'nodes': { 'filter': 'n.id < 1000' }}, ['edges'])
+-STATEMENT CALL PROJECT_GRAPH('G', {'nodes': 'n.id < 1000' }, ['edges'])
 ---- ok
 
 -LOG WCC
@@ -179,7 +179,7 @@
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/algo/build/libalgo.kuzu_extension'
 ---- ok
 
--STATEMENT CALL PROJECT_GRAPH('G', {'nodes': { 'filter': 'n.id >= 1000' }}, ['edges'])
+-STATEMENT CALL PROJECT_GRAPH('G', {'nodes':  'n.id >= 1000'}, ['edges'])
 ---- ok
 
 -LOG WCC

--- a/extension/algo/test/test_files/snap/lastFM.test
+++ b/extension/algo/test/test_files/snap/lastFM.test
@@ -74,7 +74,7 @@
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/algo/build/libalgo.kuzu_extension'
 ---- ok
 
--STATEMENT CALL PROJECT_GRAPH('G', {'nodes': { 'filter': 'n.id >= 1000' }}, ['edges'])
+-STATEMENT CALL PROJECT_GRAPH('G', {'nodes':'n.id >= 1000' }, ['edges'])
 ---- ok
 
 -LOG WCC
@@ -168,7 +168,7 @@
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/algo/build/libalgo.kuzu_extension'
 ---- ok
 
--STATEMENT CALL PROJECT_GRAPH('G', {'nodes': { 'filter': 'n.id < 1000' }}, ['edges'])
+-STATEMENT CALL PROJECT_GRAPH('G', {'nodes': 'n.id < 1000' }, ['edges'])
 ---- ok
 
 -LOG WCC

--- a/extension/algo/test/test_files/snap/wiki_vote.test
+++ b/extension/algo/test/test_files/snap/wiki_vote.test
@@ -101,7 +101,7 @@
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/algo/build/libalgo.kuzu_extension'
 ---- ok
 
--STATEMENT CALL PROJECT_GRAPH('G', {'nodes': { 'filter': 'n.id >= 1000' }}, ['edges'])
+-STATEMENT CALL PROJECT_GRAPH('G', {'nodes':'n.id >= 1000'}, ['edges'])
 ---- ok
 
 -LOG WCC
@@ -195,7 +195,7 @@
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/algo/build/libalgo.kuzu_extension'
 ---- ok
 
--STATEMENT CALL PROJECT_GRAPH('G', {'nodes': { 'filter': 'n.id < 1000' }}, ['edges'])
+-STATEMENT CALL PROJECT_GRAPH('G', {'nodes': 'n.id < 1000' }, ['edges'])
 ---- ok
 
 -LOG WCC

--- a/extension/algo/test/test_files/special_projected_graph.test
+++ b/extension/algo/test/test_files/special_projected_graph.test
@@ -50,25 +50,22 @@
 Binder exception: organisation is connected to studyAt but not projected.
 -STATEMENT CALL PROJECT_GRAPH('err', true, 'studyAt');
 ---- error
-Binder exception: Input argument True has data type BOOL. STRUCT or LIST was expected.
+Binder exception: Argument True has data type BOOL. LIST or STRUCT was expected.
 -STATEMENT CALL PROJECT_GRAPH('err', ['person'], 'studyAt');
 ---- error
-Binder exception: Input argument studyAt has data type STRING. STRUCT or LIST was expected.
+Binder exception: Argument studyAt has data type STRING. LIST or STRUCT was expected.
 -STATEMENT CALL PROJECT_GRAPH('err', ['person'], {'knows': ['filter']});
 ---- error
-Binder exception: [filter] has data type STRING[]. STRUCT was expected.
--STATEMENT CALL PROJECT_GRAPH('err', ['person'], {'knows': {'dummy': 'r.date > date("1999-01-01")'}});
+Binder exception: [filter] has data type STRING[] but STRING was expected.
+-STATEMENT CALL PROJECT_GRAPH('err', ['person'], [{'knows': {'dummy': 'r.date > date("1999-01-01")'}}]);
 ---- error
-Binder exception: Unrecognized configuration dummy. Supported configuration is 'filter'.
--STATEMENT CALL PROJECT_GRAPH('err', ['person'], {'knows': {'filter': 'r.dummy > date("1999-01-01")'}});
+Binder exception: {knows: {dummy: r.date > date("1999-01-01")}} has data type STRUCT(knows STRUCT(dummy STRING)) but STRING was expected.
+-STATEMENT CALL PROJECT_GRAPH('err', ['person'], {'knows': 'r.dummy > date("1999-01-01")'});
 ---- error
 Binder exception: Cannot find property dummy for r.
--STATEMENT CALL PROJECT_GRAPH('err', ['person'], {'knows': {'filter': 'r.comments > date("1999-01-01")'}});
+-STATEMENT CALL PROJECT_GRAPH('err', ['person'], {'knows': 'r.comments > date("1999-01-01")'});
 ---- error
 Binder exception: Type Mismatch: Cannot compare types STRING[] and DATE
--STATEMENT CALL PROJECT_GRAPH('err', [{'person':{'filter': 'n.ID>0'}}, {'organisation':{'filter': 'n.ID>0'}}], []);
----- error
-Binder exception: {organisation: {filter: n.ID>0}} has data type STRUCT(organisation STRUCT(filter STRING)) but STRING was expected.
 -STATEMENT CALL PROJECT_GRAPH('G', ['person'], ['knows']);
 ---- ok
 -STATEMENT DROP TABLE knows;

--- a/extension/algo/test/test_files/wcc.test
+++ b/extension/algo/test/test_files/wcc.test
@@ -17,7 +17,7 @@ Elizabeth|4
 Farooq|4
 Greg|4
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|7
--STATEMENT CALL PROJECT_GRAPH('PK2', ['person'], {'knows': {'filter': 'r.date > date("1999-01-01")'}})
+-STATEMENT CALL PROJECT_GRAPH('PK2', ['person'], {'knows': 'r.date > date("1999-01-01")'})
 ---- ok
 -STATEMENT CALL weakly_connected_components('PK2') RETURN node.fName, group_id;
 ---- 8
@@ -30,7 +30,7 @@ Farooq|5
 Greg|6
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|7
 
--STATEMENT CALL PROJECT_GRAPH('PK3', {'person': {'filter': 'n.ID > 2'}}, ['knows'])
+-STATEMENT CALL PROJECT_GRAPH('PK3', {'person': 'n.ID > 2'}, ['knows'])
 ---- ok
 -STATEMENT CALL weakly_connected_components('PK3') RETURN node.fName, group_id;
 ---- 6
@@ -41,7 +41,7 @@ Farooq|4
 Greg|4
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|7
 
--STATEMENT CALL PROJECT_GRAPH('PK4', {'person': {'filter': 'n.ID <> 7'}}, ['knows'])
+-STATEMENT CALL PROJECT_GRAPH('PK4', {'person': 'n.ID <> 7'}, ['knows'])
 ---- ok
 -STATEMENT CALL weakly_connected_components('PK4') RETURN node.fName, group_id;
 ---- 7
@@ -53,7 +53,7 @@ Farooq|5
 Greg|6
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|7
 
--STATEMENT CALL PROJECT_GRAPH('PK5', {'person': {'filter': 'n.ID > 5'}}, {'knows': {'filter': 'r.date > date("1999-01-01")'}})
+-STATEMENT CALL PROJECT_GRAPH('PK5', {'person': 'n.ID > 5'}, {'knows': 'r.date > date("1999-01-01")'})
 ---- ok
 -STATEMENT CALL weakly_connected_components('PK5') RETURN node.fName, group_id;
 ---- 4
@@ -102,7 +102,7 @@ Farooq|5
 Greg|6
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|7
 
--STATEMENT CALL PROJECT_GRAPH('G2', {'person': {'filter': 'n.ID > 2'}, 'organisation': {'filter': 'n.ID > 2'}}, ['knows', 'studyAt'])
+-STATEMENT CALL PROJECT_GRAPH('G2', {'person': 'n.ID > 2', 'organisation': 'n.ID > 2'}, ['knows', 'studyAt'])
 ---- ok
 -STATEMENT CALL weakly_connected_components('G2') RETURN node.ID, node.fName, node.name, group_id;
 ---- 8

--- a/extension/vector/test/test_files/demo.test
+++ b/extension/vector/test/test_files/demo.test
@@ -36,7 +36,7 @@ The Quantum World
 Learning Machines
 -STATEMENT CALL PROJECT_GRAPH(
                'filtered_book',
-               {'Book': {'filter': 'n.published_year > 2010'}},
+               {'Book': 'n.published_year > 2010'},
                []
            );
 ---- ok

--- a/extension/vector/test/test_files/filter.test
+++ b/extension/vector/test/test_files/filter.test
@@ -14,7 +14,7 @@
 ---- ok
 -STATEMENT CALL CREATE_VECTOR_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'dotproduct');
 ---- ok
--STATEMENT CALL PROJECT_GRAPH('emb-graph', {'embeddings': {'filter': 'n.id < 100'}}, []);
+-STATEMENT CALL PROJECT_GRAPH('emb-graph', {'embeddings': 'n.id < 100'}, []);
 ---- ok
 -STATEMENT CALL QUERY_VECTOR_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3, efs := 500) RETURN node.id ORDER BY distance;
 -CHECK_ORDER
@@ -52,7 +52,7 @@
 ---- ok
 -STATEMENT CALL CREATE_VECTOR_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'dotproduct');
 ---- ok
--STATEMENT CALL PROJECT_GRAPH('emb-graph', {'embeddings': {'filter': 'n.id < 50'}}, []);
+-STATEMENT CALL PROJECT_GRAPH('emb-graph', {'embeddings': 'n.id < 50'}, []);
 ---- ok
 -STATEMENT CALL QUERY_VECTOR_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3, efs := 500) RETURN node.id ORDER BY distance;
 -CHECK_ORDER
@@ -78,7 +78,7 @@
 ---- ok
 -STATEMENT CALL CREATE_VECTOR_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'dotproduct');
 ---- ok
--STATEMENT CALL PROJECT_GRAPH('emb-graph', {'embeddings': {'filter': 'n.id < 600'}}, []);
+-STATEMENT CALL PROJECT_GRAPH('emb-graph', {'embeddings': 'n.id < 600'}, []);
 ---- ok
 -STATEMENT CALL QUERY_VECTOR_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3, efs := 500) RETURN node.id ORDER BY distance;
 -CHECK_ORDER
@@ -104,7 +104,7 @@
 ---- ok
 -STATEMENT CALL CREATE_VECTOR_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'l2');
 ---- ok
--STATEMENT CALL PROJECT_GRAPH('emb-graph', {'embeddings': {'filter': 'n.id < 100'}}, []);
+-STATEMENT CALL PROJECT_GRAPH('emb-graph', {'embeddings': 'n.id < 100'}, []);
 ---- ok
 -STATEMENT CALL QUERY_VECTOR_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3, efs := 500) RETURN node.id ORDER BY distance;
 -CHECK_ORDER
@@ -130,7 +130,7 @@
 ---- ok
 -STATEMENT CALL CREATE_VECTOR_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'l2');
 ---- ok
--STATEMENT CALL PROJECT_GRAPH('emb-graph', {'embeddings': {'filter': 'n.id < 50'}}, []);
+-STATEMENT CALL PROJECT_GRAPH('emb-graph', {'embeddings': 'n.id < 50'}, []);
 ---- ok
 -STATEMENT CALL QUERY_VECTOR_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3, efs := 500) RETURN node.id ORDER BY distance;
 -CHECK_ORDER
@@ -156,7 +156,7 @@
 ---- ok
 -STATEMENT CALL CREATE_VECTOR_INDEX('embeddings', 'e_hnsw_index', 'vec', metric := 'l2');
 ---- ok
--STATEMENT CALL PROJECT_GRAPH('emb-graph', {'embeddings': {'filter': 'n.id < 600'}}, []);
+-STATEMENT CALL PROJECT_GRAPH('emb-graph', {'embeddings': 'n.id < 600'}, []);
 ---- ok
 -STATEMENT CALL QUERY_VECTOR_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3, efs := 500) RETURN node.id ORDER BY distance;
 -CHECK_ORDER
@@ -182,7 +182,7 @@
 ---- ok
 -STATEMENT CALL CREATE_VECTOR_INDEX('embeddings', 'e_hnsw_index', 'vec');
 ---- ok
--STATEMENT CALL PROJECT_GRAPH('emb-graph', {'embeddings': {'filter': 'n.id < 100'}}, []);
+-STATEMENT CALL PROJECT_GRAPH('emb-graph', {'embeddings': 'n.id < 100'}, []);
 ---- ok
 -STATEMENT CALL QUERY_VECTOR_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3, efs := 500) RETURN node.id ORDER BY distance;
 -CHECK_ORDER
@@ -208,7 +208,7 @@
 ---- ok
 -STATEMENT CALL CREATE_VECTOR_INDEX('embeddings', 'e_hnsw_index', 'vec');
 ---- ok
--STATEMENT CALL PROJECT_GRAPH('emb-graph', {'embeddings': {'filter': 'n.id < 50'}}, []);
+-STATEMENT CALL PROJECT_GRAPH('emb-graph', {'embeddings': 'n.id < 50'}, []);
 ---- ok
 -STATEMENT CALL QUERY_VECTOR_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3, efs := 500) RETURN node.id ORDER BY distance;
 -CHECK_ORDER
@@ -234,7 +234,7 @@
 ---- ok
 -STATEMENT CALL CREATE_VECTOR_INDEX('embeddings', 'e_hnsw_index', 'vec');
 ---- ok
--STATEMENT CALL PROJECT_GRAPH('emb-graph', {'embeddings': {'filter': 'n.id < 600'}}, []);
+-STATEMENT CALL PROJECT_GRAPH('emb-graph', {'embeddings': 'n.id < 600'}, []);
 ---- ok
 -STATEMENT CALL QUERY_VECTOR_INDEX('emb-graph', 'e_hnsw_index', CAST([0.1521,0.3021,0.5366,0.2774,0.5593,0.5589,0.1365,0.8557],'FLOAT[8]'), 3, efs := 500) RETURN node.id ORDER BY distance;
 -CHECK_ORDER

--- a/src/function/table/project_graph.cpp
+++ b/src/function/table/project_graph.cpp
@@ -71,7 +71,9 @@ static std::vector<GraphEntryTableInfo> extractGraphEntryTableInfos(const Value&
         }
     } break;
     default:
-        throw BinderException(stringFormat("Argument {} has data type {}. LIST or STRUCT was expected.", value.toString(), value.getDataType().toString()));
+        throw BinderException(
+            stringFormat("Argument {} has data type {}. LIST or STRUCT was expected.",
+                value.toString(), value.getDataType().toString()));
     }
     return infos;
 }

--- a/src/function/table/project_graph.cpp
+++ b/src/function/table/project_graph.cpp
@@ -1,6 +1,5 @@
 #include "common/exception/binder.h"
 #include "common/exception/runtime.h"
-#include "common/string_utils.h"
 #include "common/types/value/nested.h"
 #include "function/gds/gds.h"
 #include "function/table/bind_data.h"
@@ -49,55 +48,30 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
     return 0;
 }
 
-static std::vector<std::string> getAsStringVector(const Value& value) {
-    std::vector<std::string> result;
-    for (auto i = 0u; i < NestedVal::getChildrenSize(&value); ++i) {
-        auto childVal = NestedVal::getChildVal(&value, i);
-        childVal->validateType(LogicalTypeID::STRING);
-        result.push_back(childVal->getValue<std::string>());
-    }
-    return result;
-}
-
-static std::string getPredicateStr(Value& val) {
-    auto& type = val.getDataType();
-    if (type.getLogicalTypeID() != LogicalTypeID::STRUCT) {
-        throw BinderException(stringFormat("{} has data type {}. STRUCT was expected.",
-            val.toString(), type.toString()));
-    }
-    auto numFields = StructType::getNumFields(type);
-    for (auto i = 0u; i < numFields; i++) {
-        auto fieldName = StructType::getField(type, i).getName();
-        if (StringUtils::getUpper(fieldName) == "FILTER") {
-            const auto childVal = NestedVal::getChildVal(&val, i);
-            childVal->validateType(LogicalTypeID::STRING);
-            return childVal->getValue<std::string>();
-        }
-        throw BinderException(stringFormat(
-            "Unrecognized configuration {}. Supported configuration is 'filter'.", fieldName));
-    }
-    return {};
+static std::string getStringVal(const Value& value) {
+    value.validateType(LogicalTypeID::STRING);
+    return value.getValue<std::string>();
 }
 
 static std::vector<GraphEntryTableInfo> extractGraphEntryTableInfos(const Value& value) {
     std::vector<GraphEntryTableInfo> infos;
     switch (value.getDataType().getLogicalTypeID()) {
     case LogicalTypeID::LIST: {
-        for (auto name : getAsStringVector(value)) {
-            infos.emplace_back(name, "" /* empty predicate */);
+        for (auto i = 0u; i < NestedVal::getChildrenSize(&value); ++i) {
+            auto tableName = getStringVal(*NestedVal::getChildVal(&value, i));
+            infos.emplace_back(tableName, "" /* empty predicate */);
         }
     } break;
     case LogicalTypeID::STRUCT: {
         for (auto i = 0u; i < StructType::getNumFields(value.getDataType()); ++i) {
             auto& field = StructType::getField(value.getDataType(), i);
-            infos.emplace_back(field.getName(),
-                getPredicateStr(*NestedVal::getChildVal(&value, i)));
+            auto tableName = field.getName();
+            auto predicate = getStringVal(*NestedVal::getChildVal(&value, i));
+            infos.emplace_back(tableName, predicate);
         }
     } break;
     default:
-        throw BinderException(
-            stringFormat("Input argument {} has data type {}. STRUCT or LIST was expected.",
-                value.toString(), value.getDataType().toString()));
+        throw BinderException(stringFormat("Argument {} has data type {}. LIST or STRUCT was expected.", value.toString(), value.getDataType().toString()));
     }
     return infos;
 }

--- a/src/function/table/show_projected_graphs.cpp
+++ b/src/function/table/show_projected_graphs.cpp
@@ -50,11 +50,11 @@ static std::string getNodeOrRelInfo(const std::vector<graph::GraphEntryTableInfo
     if (tableInfo.empty()) {
         return "";
     }
-    std::string info = "{";
+    std::string info = "[";
     for (auto i = 0u; i < tableInfo.size(); i++) {
         info += tableInfo[i].toString();
         if (i == tableInfo.size() - 1) {
-            info += "}";
+            info += "]";
         } else {
             info += ",";
         }

--- a/test/test_files/function/gds/basic.test
+++ b/test/test_files/function/gds/basic.test
@@ -22,31 +22,31 @@ Dan|12
 
 -STATEMENT CALL SHOW_PROJECTED_GRAPHS() RETURN *;
 ---- 2
-PKWO|{{'table': 'person'},{'table': 'organisation'}}|{{'table': 'knows'},{'table': 'workAt'}}
-PK|{{'table': 'person'}}|{{'table': 'knows'}}
--STATEMENT CALL PROJECT_GRAPH('withFilter', {'person': {'filter': 'n.age > 35'}}, {'knows': {'filter': 'size(r.comments) > 5'}})
+PKWO|[{'table': 'person'},{'table': 'organisation'}]|[{'table': 'knows'},{'table': 'workAt'}]
+PK|[{'table': 'person'}]|[{'table': 'knows'}]
+-STATEMENT CALL PROJECT_GRAPH('withFilter', {'person': 'n.age > 35'}, {'knows':'size(r.comments) > 5'})
 ---- ok
 -STATEMENT CALL SHOW_PROJECTED_GRAPHS() RETURN *;
 ---- 3
-PKWO|{{'table': 'person'},{'table': 'organisation'}}|{{'table': 'knows'},{'table': 'workAt'}}
-PK|{{'table': 'person'}}|{{'table': 'knows'}}
-withFilter|{{'table': 'person','predicate': 'n.age > 35'}}|{{'table': 'knows','predicate': 'size(r.comments) > 5'}}
--STATEMENT CALL PROJECT_GRAPH('multipleTableWithFilter', {'person': {'filter': 'n.age > 35'}, 'organisation': {'filter': 'n.ID > 2'}}, {'knows': {'filter': 'size(r.comments) > 5'}})
+PKWO|[{'table': 'person'},{'table': 'organisation'}]|[{'table': 'knows'},{'table': 'workAt'}]
+PK|[{'table': 'person'}]|[{'table': 'knows'}]
+withFilter|[{'table': 'person','predicate': 'n.age > 35'}]|[{'table': 'knows','predicate': 'size(r.comments) > 5'}]
+-STATEMENT CALL PROJECT_GRAPH('multipleTableWithFilter', {'person': 'n.age > 35', 'organisation': 'n.ID > 2'}, {'knows': 'size(r.comments) > 5'})
 ---- ok
 -STATEMENT CALL SHOW_PROJECTED_GRAPHS() RETURN *;
 ---- 4
-PKWO|{{'table': 'person'},{'table': 'organisation'}}|{{'table': 'knows'},{'table': 'workAt'}}
-PK|{{'table': 'person'}}|{{'table': 'knows'}}
-multipleTableWithFilter|{{'table': 'person','predicate': 'n.age > 35'},{'table': 'organisation','predicate': 'n.ID > 2'}}|{{'table': 'knows','predicate': 'size(r.comments) > 5'}}
-withFilter|{{'table': 'person','predicate': 'n.age > 35'}}|{{'table': 'knows','predicate': 'size(r.comments) > 5'}}
+PKWO|[{'table': 'person'},{'table': 'organisation'}]|[{'table': 'knows'},{'table': 'workAt'}]
+PK|[{'table': 'person'}]|[{'table': 'knows'}]
+multipleTableWithFilter|[{'table': 'person','predicate': 'n.age > 35'},{'table': 'organisation','predicate': 'n.ID > 2'}]|[{'table': 'knows','predicate': 'size(r.comments) > 5'}]
+withFilter|[{'table': 'person','predicate': 'n.age > 35'}]|[{'table': 'knows','predicate': 'size(r.comments) > 5'}]
 -STATEMENT CALL PROJECT_GRAPH('emptygraph', [], [])
 ---- ok
 -STATEMENT CALL SHOW_PROJECTED_GRAPHS() RETURN *;
 ---- 5
-PKWO|{{'table': 'person'},{'table': 'organisation'}}|{{'table': 'knows'},{'table': 'workAt'}}
-PK|{{'table': 'person'}}|{{'table': 'knows'}}
-multipleTableWithFilter|{{'table': 'person','predicate': 'n.age > 35'},{'table': 'organisation','predicate': 'n.ID > 2'}}|{{'table': 'knows','predicate': 'size(r.comments) > 5'}}
-withFilter|{{'table': 'person','predicate': 'n.age > 35'}}|{{'table': 'knows','predicate': 'size(r.comments) > 5'}}
+PKWO|[{'table': 'person'},{'table': 'organisation'}]|[{'table': 'knows'},{'table': 'workAt'}]
+PK|[{'table': 'person'}]|[{'table': 'knows'}]
+multipleTableWithFilter|[{'table': 'person','predicate': 'n.age > 35'},{'table': 'organisation','predicate': 'n.ID > 2'}]|[{'table': 'knows','predicate': 'size(r.comments) > 5'}]
+withFilter|[{'table': 'person','predicate': 'n.age > 35'}]|[{'table': 'knows','predicate': 'size(r.comments) > 5'}]
 emptygraph||
 -STATEMENT CALL drop_projected_graph('dummy')
 ---- error


### PR DESCRIPTION
# Description

Remove one nested level (i.e. the 'filter' level) when projecting filtered graph, the new syntax becomes

```
CALL project_graph(
     graph_name,
      {
         <node_table_name>: <predicate>,
          ....
      },
      {
         <rel_table_name>: <predicate>,
          ....
      }
)
```

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).