### PR TITLE
Truncate free pages at the end of the file in finalizeCheckpoint

### DIFF
--- a/src/include/storage/free_space_manager.h
+++ b/src/include/storage/free_space_manager.h
@@ -41,7 +41,8 @@ public:
 
 private:
     PageRange splitPageRange(PageRange chunk, common::page_idx_t numRequiredPages);
-    void mergePageRanges(free_list_t newInitialEntries);
+    void mergePageRanges(free_list_t newInitialEntries, FileHandle *fileHandle);
+    void handleLastPageRange(PageRange pageRange,FileHandle *fileHandle);
     void resetFreeLists();
     static common::idx_t getLevel(common::page_idx_t numPages);
 

--- a/src/include/storage/free_space_manager.h
+++ b/src/include/storage/free_space_manager.h
@@ -41,8 +41,8 @@ public:
 
 private:
     PageRange splitPageRange(PageRange chunk, common::page_idx_t numRequiredPages);
-    void mergePageRanges(free_list_t newInitialEntries, FileHandle *fileHandle);
-    void handleLastPageRange(PageRange pageRange,FileHandle *fileHandle);
+    void mergePageRanges(free_list_t newInitialEntries, FileHandle* fileHandle);
+    void handleLastPageRange(PageRange pageRange, FileHandle* fileHandle);
     void resetFreeLists();
     static common::idx_t getLevel(common::page_idx_t numPages);
 

--- a/src/storage/free_space_manager.cpp
+++ b/src/storage/free_space_manager.cpp
@@ -16,7 +16,7 @@ static FreeSpaceManager::sorted_free_list_t& getFreeList(
     return freeLists[level];
 }
 
-FreeSpaceManager::FreeSpaceManager() : freeLists{}, numEntries(0){};
+FreeSpaceManager::FreeSpaceManager() : freeLists{}, numEntries(0) {};
 
 common::idx_t FreeSpaceManager::getLevel(common::page_idx_t numPages) {
     // level is exponent of largest power of 2 that is <= numPages
@@ -136,7 +136,7 @@ void FreeSpaceManager::finalizeCheckpoint(FileHandle* fileHandle) {
         }
     }
 
-    mergePageRanges(std::move(uncheckpointedFreePageRanges));
+    mergePageRanges(std::move(uncheckpointedFreePageRanges), fileHandle);
     uncheckpointedFreePageRanges.clear();
 }
 
@@ -145,8 +145,8 @@ void FreeSpaceManager::resetFreeLists() {
     numEntries = 0;
 }
 
-void FreeSpaceManager::mergePageRanges(free_list_t newInitialEntries) {
-    std::vector<PageRange> allEntries = std::move(newInitialEntries);
+void FreeSpaceManager::mergePageRanges(free_list_t newInitialEntries, FileHandle* fileHandle) {
+    free_list_t allEntries = std::move(newInitialEntries);
     for (const auto& freeList : freeLists) {
         allEntries.insert(allEntries.end(), freeList.begin(), freeList.end());
     }
@@ -169,7 +169,15 @@ void FreeSpaceManager::mergePageRanges(free_list_t newInitialEntries) {
             prevEntry = entry;
         }
     }
-    addFreePages(prevEntry);
+    handleLastPageRange(prevEntry, fileHandle);
+}
+
+void FreeSpaceManager::handleLastPageRange(PageRange pageRange, FileHandle* fileHandle) {
+    if (pageRange.startPageIdx + pageRange.numPages == fileHandle->getNumPages()) {
+        fileHandle->removePageIdxAndTruncateIfNecessary(pageRange.startPageIdx);
+    } else {
+        addFreePages(pageRange);
+    }
 }
 
 common::row_idx_t FreeSpaceManager::getNumEntries() const {

--- a/src/storage/free_space_manager.cpp
+++ b/src/storage/free_space_manager.cpp
@@ -16,7 +16,7 @@ static FreeSpaceManager::sorted_free_list_t& getFreeList(
     return freeLists[level];
 }
 
-FreeSpaceManager::FreeSpaceManager() : freeLists{}, numEntries(0) {};
+FreeSpaceManager::FreeSpaceManager() : freeLists{}, numEntries(0){};
 
 common::idx_t FreeSpaceManager::getLevel(common::page_idx_t numPages) {
     // level is exponent of largest power of 2 that is <= numPages

--- a/test/test_files/dml_node/delete/delete_empty.test
+++ b/test/test_files/dml_node/delete/delete_empty.test
@@ -125,16 +125,14 @@ True
 ---- 0
 -STATEMENT match (p:Post) delete p
 ---- ok
--STATEMENT call fsm_info() return sum(num_pages) > 0
----- 1
-True
-# copy again, most of the free pages should be reused
+# copy again, page allocation should start from 0 as the dropped pages are reclaimed + truncated
 -STATEMENT COPY Post FROM "${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Post.csv"(parallel=false)
 ---- ok
-# if most free pages were used the start page idx of free entries should be much larger than their size
--STATEMENT CALL fsm_info() with sum(num_pages) as num_free_pages, min(start_page_idx > 3 * num_pages) as check return num_free_pages is null or check
+-STATEMENT call fsm_info() return *
+---- 0
+-STATEMENT CALL storage_info('Post') where start_page_idx = 0 return count(*)
 ---- 1
-True
+1
 -RELOADDB
 # try some queries
 -STATEMENT match(p:Post) return count(*)

--- a/test/test_files/dml_node/delete/delete_empty.test
+++ b/test/test_files/dml_node/delete/delete_empty.test
@@ -104,9 +104,22 @@
            return num_deleted = node_group_capacity
 ---- 1
 True
--STATEMENT call fsm_info() return sum(num_pages) > 0
+
+# on the next allocation the pages for the deleted node group should be reused
+-STATEMENT create node table other(id INT64, primary key(id))
+---- ok
+-STATEMENT begin transaction;
+        create (:other{id: 1});
+        create (:other{id: 2});
+        commit;
+---- ok
+---- ok
+---- ok
+---- ok
+-STATEMENT call storage_info('other') where start_page_idx = 0 return count (*)
 ---- 1
-True
+1
+
 -STATEMENT match (p:Post) with count(*) as remaining
            optional match (p:Post) where p.ID = 1030792523231 with p.imageFile as imageFile, remaining
            return remaining = 0 or imageFile = 'photo1030792523231.jpg'

--- a/test/test_files/dml_rel/delete/delete_empty.test
+++ b/test/test_files/dml_rel/delete/delete_empty.test
@@ -76,16 +76,15 @@ Runtime exception: Cannot detach delete from node table 'person' as it has conne
 ---- ok
 -STATEMENT match (a)-[k:knows]->(b) delete k
 ---- ok
--STATEMENT call fsm_info() return sum(num_pages) > 0
----- 1
-True
-# re-copy, most of the pages should be reused
+# re-copy, page allocation should start from end of Person since the pages for knows are reclaimed + truncated
 -STATEMENT copy knows from ["${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Person_knows_Person.csv","${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Person_knows_Person_1.csv"](parallel=false)
 ---- ok
-# if most free pages were used the start page idx of free entries should be much larger than their size
--STATEMENT CALL fsm_info() with sum(num_pages) as num_free_pages, min(start_page_idx > 3 * num_pages) as check return num_free_pages is null or check
+-STATEMENT call fsm_info() return *
+---- 0
+-STATEMENT CALL storage_info('Person') where start_page_idx < 4294967295 with max(start_page_idx + num_pages) as expected_start_page_idx
+        CALL storage_info('knows') where start_page_idx = expected_start_page_idx return count(*)
 ---- 1
-True
+1
 -RELOADDB
 # try some queries
 -STATEMENT match (a)-[k:knows]->(b) return count(*)

--- a/test/test_files/function/call/fsm_info.test
+++ b/test/test_files/function/call/fsm_info.test
@@ -102,7 +102,6 @@ True
 True
 
 -CASE FSMDeleteFullNodeGroupRepeat
-# After 2-3 cycles of copy -> delete -> checkpoint the number of free pages should stop increasing
 -STATEMENT create node table Person (id INT64, firstName STRING, lastName STRING, gender STRING, birthday INT64, creationDate INT64, locationIP STRING, browserUsed STRING, PRIMARY KEY (id));
 ---- ok
 -STATEMENT copy Person from '${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Person.csv'(header=true, delim='|')
@@ -138,11 +137,11 @@ True
 -STATEMENT checkpoint
 ---- ok
 
-# There shouldn't be gaps in the free pages at the end
--STATEMENT call fsm_info() return count(*)
+# After the deletions the data file should be empty due to reclaiming + truncation
+-STATEMENT call fsm_info() return *
+---- 0
+-STATEMENT copy Person from '${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Person.csv'(header=true, delim='|')
+---- ok
+-STATEMENT call storage_info('Person') where start_page_idx = 0 return count (*)
 ---- 1
 1
-
--STATEMENT call fsm_info() return start_page_idx
----- 1
-0

--- a/test/test_files/transaction/ddl/ddl_empty.test
+++ b/test/test_files/transaction/ddl/ddl_empty.test
@@ -572,15 +572,20 @@ Binder exception: Cannot find property since for k.
 ---- ok
 -STATEMENT COPY movies FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vMovies.csv";
 ---- ok
--STATEMENT call fsm_info() return *
----- 0
 -STATEMENT drop table movies
 ---- ok
 -STATEMENT checkpoint
 ---- ok
--STATEMENT call fsm_info() return sum(num_pages) > 0
+
+-STATEMENT create node table movies (name STRING, length INT32, note STRING, description STRUCT(rating DOUBLE, stars INT8, views INT64, release TIMESTAMP, release_ns TIMESTAMP_NS, release_ms TIMESTAMP_MS, release_sec TIMESTAMP_SEC, release_tz TIMESTAMP_TZ, film DATE, u8 UINT8, u16 UINT16, u32 UINT32, u64 UINT64, hugedata INT128), content BYTEA, audience MAP(STRING, INT64), grade union(credit boolean, grade1 double, grade2 int64), PRIMARY KEY (name));
+---- ok
+-STATEMENT COPY movies FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vMovies.csv";
+---- ok
+-STATEMENT call fsm_info() return *
+---- 0
+-STATEMENT CALL storage_info('movies') where start_page_idx = 0 return count(*)
 ---- 1
-True
+1
 
 -CASE DropNodeTableRollbackRecovery
 -SKIP_IN_MEM
@@ -625,8 +630,6 @@ True
 ---- ok
 -STATEMENT COPY knows FROM ["${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv", "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows_2.csv"];
 ---- ok
--STATEMENT call fsm_info() return *
----- 0
 -STATEMENT drop table knows
 ---- ok
 -STATEMENT checkpoint
@@ -634,9 +637,17 @@ True
 -STATEMENT match (a)-[k:knows]->(b) return a.id, b.id
 ---- error
 Binder exception: Table knows does not exist.
--STATEMENT call fsm_info() return sum(num_pages) > 0
+
+-STATEMENT create rel table knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, comments STRING[], summary STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[])), notes UNION(firstmet DATE, type INT16, comment STRING), someMap MAP(STRING, STRING), MANY_MAnY);
+---- ok
+-STATEMENT COPY knows FROM ["${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv", "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows_2.csv"];
+---- ok
+-STATEMENT call fsm_info() return *
+---- 0
+-STATEMENT CALL storage_info('person') where start_page_idx < 4294967295 with max(start_page_idx + num_pages) as expected_start_page_idx
+        CALL storage_info('knows') where start_page_idx = expected_start_page_idx return count(*)
 ---- 1
-True
+1
 
 -CASE DropRelTableRollbackRecovery
 -SKIP_IN_MEM


### PR DESCRIPTION
# Description

Can slightly reduce the size of the data.kz file + prevents cases such as having 5 free pages at the end of the file and requesting a chunk of 7 pages which would previously cause unnecessary fragmentation.

When incrementally copying from epinions split over 50 partitions, this reduces the size of data.kz from 16MB to 14MB.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).