### PR TITLE
Reclaim allocated pages during rollback

### DIFF
--- a/src/include/storage/free_space_manager.h
+++ b/src/include/storage/free_space_manager.h
@@ -29,7 +29,7 @@ public:
 
     // These pages are not reusable until the end of the next checkpoint
     void addUncheckpointedFreePages(PageRange entry);
-    void rollbackCheckpoint();
+    void rollback();
 
     void serialize(common::Serializer& serializer) const;
     void deserialize(common::Deserializer& deSer);

--- a/src/include/storage/page_manager.h
+++ b/src/include/storage/page_manager.h
@@ -26,8 +26,11 @@ public:
 
     void serialize(common::Serializer& serializer);
     void deserialize(common::Deserializer& deSer);
+
+    void rollback();
+    void commit();
+
     void finalizeCheckpoint();
-    void rollbackCheckpoint() { freeSpaceManager->rollbackCheckpoint(); }
 
     common::row_idx_t getNumFreeEntries() const { return freeSpaceManager->getNumEntries(); }
     std::vector<PageRange> getFreeEntries(common::row_idx_t startOffset,
@@ -36,7 +39,10 @@ public:
     }
 
 private:
+    void pushUncommittedAllocatedPages(PageRange pages);
+
     std::unique_ptr<FreeSpaceManager> freeSpaceManager;
+    std::vector<PageRange> uncommittedAllocatedPages;
     std::mutex mtx;
     FileHandle* fileHandle;
 };

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -6,7 +6,6 @@
 #include "common/task_system/progress_bar.h"
 #include "processor/execution_context.h"
 #include "processor/result/factorized_table_util.h"
-#include "storage/local_storage/local_storage.h"
 #include "storage/storage_utils.h"
 #include "storage/store/column_chunk_data.h"
 #include "storage/store/rel_table.h"

--- a/src/storage/free_space_manager.cpp
+++ b/src/storage/free_space_manager.cpp
@@ -16,7 +16,7 @@ static FreeSpaceManager::sorted_free_list_t& getFreeList(
     return freeLists[level];
 }
 
-FreeSpaceManager::FreeSpaceManager() : freeLists{}, numEntries(0){};
+FreeSpaceManager::FreeSpaceManager() : freeLists{}, numEntries(0) {};
 
 common::idx_t FreeSpaceManager::getLevel(common::page_idx_t numPages) {
     // level is exponent of largest power of 2 that is <= numPages
@@ -41,7 +41,7 @@ void FreeSpaceManager::addUncheckpointedFreePages(PageRange entry) {
     uncheckpointedFreePageRanges.push_back(entry);
 }
 
-void FreeSpaceManager::rollbackCheckpoint() {
+void FreeSpaceManager::rollback() {
     uncheckpointedFreePageRanges.clear();
 }
 

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -219,7 +219,7 @@ void StorageManager::rollbackCheckpoint(main::ClientContext& clientContext) {
         KU_ASSERT(tables.contains(tableEntry->getTableID()));
         tables.at(tableEntry->getTableID())->rollbackCheckpoint();
     }
-    dataFH->getPageManager()->rollbackCheckpoint();
+    dataFH->getPageManager()->rollback();
 }
 
 } // namespace storage

--- a/test/test_files/function/call/fsm_info.test
+++ b/test/test_files/function/call/fsm_info.test
@@ -146,3 +146,22 @@ True
 -STATEMENT call fsm_info() return start_page_idx
 ---- 1
 0
+
+-CASE NodeCopyRollback
+-STATEMENT create node table Comment (id int64, creationDate INT64, locationIP STRING, browserUsed STRING, content STRING, length INT32, PRIMARY KEY (id));
+---- ok
+-STATEMENT copy Comment from ["dataset/ldbc-sf01/Comment.csv", "dataset/ldbc-sf01/Comment.csv"](header=true, delim="|")
+---- error(regex)
+Copy exception: Found duplicated primary key value \d+, which violates the uniqueness constraint of the primary key column.
+
+# Optimistically-flushed pages should now be free
+-STATEMENT call fsm_info() return sum(num_pages) > 0
+---- 1
+True
+
+# Freed pages should be reused after another copy (we check that by seeing if page 0 is reused)
+-STATEMENT copy Comment from "dataset/ldbc-sf01/Comment.csv"(header=true, delim="|")
+---- ok
+-STATEMENT call storage_info("Comment") where start_page_idx = 0 return count(*)
+---- 1
+1


### PR DESCRIPTION
# Description

The `PageManager` now keeps track of which pages were allocated during the current transaction/checkpoint operation. On rollback, the tracked pages are marked as free so that they can be used in future transactions.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).