### PR TITLE
neo4j: fix properties parsing, allow all types

### DIFF
--- a/extension/neo4j/src/function/neo4j_migrate.cpp
+++ b/extension/neo4j/src/function/neo4j_migrate.cpp
@@ -129,8 +129,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* /*context*/,
     auto password = input->getLiteralVal<std::string>(2);
     auto cli = std::make_shared<httplib::Client>(url, 7474);
     cli->set_basic_auth(userName, password);
-    cli->set_connection_timeout(std::chrono::seconds(30));
-    cli->set_read_timeout(std::chrono::seconds(30));
+    cli->set_connection_timeout(std::chrono::seconds(1000));
+    cli->set_read_timeout(std::chrono::seconds(1000));
     validateConnectionString(*cli);
     auto nodes = getNodeOrRels(*cli, TableType::NODE, input->getParam(3));
     auto rels = getNodeOrRels(*cli, TableType::REL, input->getParam(4));
@@ -246,6 +246,10 @@ std::vector<std::string> getRelProperties(httplib::Client& cli, std::string srcL
     auto data = executeNeo4jQuery(cli, neo4jQuery);
     std::vector<std::string> relProperties;
     for (auto& row : data) {
+        if (row["row"][0].is_null()) {
+            // Skip null properties.
+            continue;
+        }
         relProperties.push_back(row["row"][0].get<std::string>());
     }
     std::sort(relProperties.begin(), relProperties.end(),

--- a/extension/neo4j/src/function/neo4j_migrate.cpp
+++ b/extension/neo4j/src/function/neo4j_migrate.cpp
@@ -11,7 +11,6 @@
 #include "function/table/table_function.h"
 #include "httplib.h"
 #include "json.hpp"
-#include "main/neo4j_extension.h"
 
 namespace kuzu {
 namespace neo4j_extension {
@@ -109,11 +108,13 @@ static std::vector<std::string> getNodeOrRels(httplib::Client& cli, common::Tabl
         // Importing multi-label nodes is not supported right now.
         if (tableType == common::TableType::NODE) {
             auto res = executeNeo4jQuery(cli,
-                common::stringFormat("match (n:{}) where size(labels(n)) > 1 return labels(n)",
+                stringFormat("match (n:{}) where size(labels(n)) > 1 return labels(n) limit 1",
                     label));
             if (!res.empty()) {
+                auto row = res[0]["row"];
                 throw common::RuntimeException{common::stringFormat(
-                    "Importing nodes with multi-labels is not supported right now.")};
+                    "Importing nodes with multi-labels is not supported right now. Found: {}",
+                    to_string(row))};
             }
         }
         labels.push_back(std::move(label));
@@ -128,8 +129,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(ClientContext* /*context*/,
     auto password = input->getLiteralVal<std::string>(2);
     auto cli = std::make_shared<httplib::Client>(url, 7474);
     cli->set_basic_auth(userName, password);
-    cli->set_connection_timeout(std::chrono::seconds(1000));
-    cli->set_read_timeout(std::chrono::seconds(1000));
+    cli->set_connection_timeout(std::chrono::seconds(30));
+    cli->set_read_timeout(std::chrono::seconds(30));
     validateConnectionString(*cli);
     auto nodes = getNodeOrRels(*cli, TableType::NODE, input->getParam(3));
     auto rels = getNodeOrRels(*cli, TableType::REL, input->getParam(4));
@@ -168,8 +169,6 @@ LogicalType convertFromNeo4jTypeStr(const std::string& neo4jTypeStr) {
         return LogicalType{LogicalTypeID::INT64};
     } else if (neo4jTypeStr == "Integer") {
         return LogicalType{LogicalTypeID::INT32};
-    } else if (neo4jTypeStr == "String") {
-        return LogicalType{LogicalTypeID::STRING};
     } else if (neo4jTypeStr == "Date") {
         return LogicalType{LogicalTypeID::DATE};
     } else if (neo4jTypeStr == "DateTime") {
@@ -187,8 +186,7 @@ LogicalType convertFromNeo4jTypeStr(const std::string& neo4jTypeStr) {
     } else if (neo4jTypeStr == "StringArray") {
         return LogicalType::LIST(LogicalType::STRING());
     } else {
-        throw common::RuntimeException{
-            "Neo4j type: " + neo4jTypeStr + " is not supported right now."};
+        return LogicalType{LogicalTypeID::STRING};
     }
 }
 
@@ -247,8 +245,8 @@ std::vector<std::string> getRelProperties(httplib::Client& cli, std::string srcL
             srcLabel, relLabel, dstLabel);
     auto data = executeNeo4jQuery(cli, neo4jQuery);
     std::vector<std::string> relProperties;
-    for (auto& row : data[0]["row"]) {
-        relProperties.push_back(row.get<std::string>());
+    for (auto& row : data) {
+        relProperties.push_back(row["row"][0].get<std::string>());
     }
     std::sort(relProperties.begin(), relProperties.end(),
         [](std::string& left, std::string& right) { return left < right; });

--- a/extension/neo4j/test/test_files/basic.test
+++ b/extension/neo4j/test/test_files/basic.test
@@ -86,3 +86,26 @@
 -STATEMENT MATCH (a:person) RETURN label(a)
 ---- 1
 person
+
+-CASE MigrateFromNodeWithTypes
+# Created by query in neo4j: CREATE (:types_test {
+#                               boolean: true,
+#                               date: date('2023-10-23'),
+#                               duration: duration('P1Y2M3DT4H5M6S'),
+#                               float: 3.1415,
+#                               integer: 42,
+#                               list: ["A", "B", "C"],
+#                               local_datetime: localdatetime('2023-10-23T14:30:45'),
+#                               local_time: localtime('14:30:45'),
+#                               point: point({x: 12.34, y: 56.78}),
+#                               string: 'Sample text',
+#                               zoned_datetime: datetime('2023-10-23T14:30:45+01:00'),
+#                               zoned_time: time('14:30:45+01:00')
+#                               })
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/neo4j/build/libneo4j.kuzu_extension"
+---- ok
+-STATEMENT CALL NEO4J_MIGRATE("localhost", "neo4j", "kuzuneo4j", ["types_test"], []);
+---- ok
+-STATEMENT MATCH (a:types_test) RETURN a.*
+---- 1
+1|True|2023-10-23|P1Y2M3DT4H5M6S|3.141500|42|["A","B","C"]|2023-10-23T14:30:45|14:30:45|{"crs":"cartesian","x":12.34,"y":56.78,"z":null}|Sample text|2023-10-23 13:30:45|14:30:45+01:00


### PR DESCRIPTION
- Fixes https://github.com/kuzudb/kuzu/issues/5352
- Instead of throwing an unknown type error, which I expect a lot of users to encounter pretty soon, let's accept all unknown types as string? Tested and works for all types in https://github.com/kuzudb/kuzu/issues/5351. Optional for this release and will revert if needed.
- 1000 seconds is quite a long timeout for the network connection. Setting it to 30s instead, for much quicker feedback to the users in case of any network error. 

Found a bug in the apoc exporter where timestamps are not exported properly in ISO format. Times like `09:00:00` will be truncated to `09:00`. This will cause the Kuzu parser to fail. Expecting this to be a common issue users with timestamps will face.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
Closes #5352
Closes #5351