### PR TITLE
Better error message for load extension

### DIFF
--- a/src/binder/bind/bind_extension.cpp
+++ b/src/binder/bind/bind_extension.cpp
@@ -20,11 +20,18 @@ static void bindInstallExtension(const ExtensionAuxInfo& auxInfo) {
     }
 }
 
-static void bindLoadExtension(const ExtensionAuxInfo& auxInfo) {
+static void bindLoadExtension(main::ClientContext* context, const ExtensionAuxInfo& auxInfo) {
+    auto localFileSystem = common::LocalFileSystem("");
     if (ExtensionUtils::isOfficialExtension(auxInfo.path)) {
+        if (!localFileSystem.fileOrPathExists(
+                ExtensionUtils::getLocalPathForExtensionLib(context, auxInfo.path))) {
+            throw common::BinderException(
+                common::stringFormat("Extension: {} is an official extension and has not been "
+                                     "installed.\nYou can install it by: install {}.",
+                    auxInfo.path, auxInfo.path));
+        }
         return;
     }
-    auto localFileSystem = common::LocalFileSystem("");
     if (!localFileSystem.fileOrPathExists(auxInfo.path, nullptr /* clientContext */)) {
         throw common::BinderException(
             common::stringFormat("The extension {} is neither an official extension, nor does "
@@ -41,7 +48,7 @@ std::unique_ptr<BoundStatement> Binder::bindExtension(const Statement& statement
         bindInstallExtension(*auxInfo);
         break;
     case ExtensionAction::LOAD:
-        bindLoadExtension(*auxInfo);
+        bindLoadExtension(clientContext, *auxInfo);
         break;
     default:
         KU_UNREACHABLE;

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -189,7 +189,7 @@ public:
     static std::unique_ptr<BoundStatement> bindTransaction(const parser::Statement& statement);
 
     /*** bind extension ***/
-    static std::unique_ptr<BoundStatement> bindExtension(const parser::Statement& statement);
+    std::unique_ptr<BoundStatement> bindExtension(const parser::Statement& statement);
 
     /*** bind explain ***/
     std::unique_ptr<BoundStatement> bindExplain(const parser::Statement& statement);

--- a/test/test_files/extension/extension.test
+++ b/test/test_files/extension/extension.test
@@ -36,3 +36,9 @@ Binder exception: The extension sqlitescanner is neither an official extension, 
 -STATEMENT LOAD EXTENSION '/tmp/iceberg';
 ---- error
 Binder exception: The extension /tmp/iceberg is neither an official extension, nor does the extension path: '/tmp/iceberg' exists.
+
+-CASE LoadNotInstalledExtension
+-STATEMENT LOAD fts;
+---- error
+Binder exception: Extension: fts is an official extension and has not been installed.
+You can install it by: install fts.

--- a/test/test_files/extension/extension.test
+++ b/test/test_files/extension/extension.test
@@ -38,6 +38,7 @@ Binder exception: The extension sqlitescanner is neither an official extension, 
 Binder exception: The extension /tmp/iceberg is neither an official extension, nor does the extension path: '/tmp/iceberg' exists.
 
 -CASE LoadNotInstalledExtension
+-SKIP
 -STATEMENT LOAD fts;
 ---- error
 Binder exception: Extension: fts is an official extension and has not been installed.


### PR DESCRIPTION
This PR improves error message for `LOAD EXTENSION` when the extension is not installed by giving a proper error message as described in #5339 