### PR TITLE
Move table entry related initialization to initGlobalStateInternal for NodeBatchInsert

### DIFF
--- a/src/binder/bind/bind_ddl.cpp
+++ b/src/binder/bind/bind_ddl.cpp
@@ -339,7 +339,7 @@ std::unique_ptr<BoundStatement> Binder::bindCreateTableAs(const Statement& state
 
     auto offset =
         createInvisibleVariable(std::string(InternalKeyword::ROW_OFFSET), LogicalType::INT64());
-    auto boundCopyFromInfo = BoundCopyFromInfo(createInfo->tableName, TableType::NODE, std::move(boundSource), std::move(offset),
+    auto boundCopyFromInfo = BoundCopyFromInfo(createInfo->tableName, std::move(boundSource), std::move(offset),
         std::move(columns), std::move(evaluateTypes), nullptr);
 
     return std::make_unique<BoundCreateTable>(std::move(boundCreateInfo));

--- a/src/binder/bind/bind_ddl.cpp
+++ b/src/binder/bind/bind_ddl.cpp
@@ -339,7 +339,7 @@ std::unique_ptr<BoundStatement> Binder::bindCreateTableAs(const Statement& state
 
     auto offset =
         createInvisibleVariable(std::string(InternalKeyword::ROW_OFFSET), LogicalType::INT64());
-    auto boundCopyFromInfo = BoundCopyFromInfo(nullptr, std::move(boundSource), std::move(offset),
+    auto boundCopyFromInfo = BoundCopyFromInfo(createInfo->tableName, TableType::NODE, std::move(boundSource), std::move(offset),
         std::move(columns), std::move(evaluateTypes), nullptr);
 
     return std::make_unique<BoundCreateTable>(std::move(boundCreateInfo));

--- a/src/binder/bind/copy/bind_copy_from.cpp
+++ b/src/binder/bind/copy/bind_copy_from.cpp
@@ -120,7 +120,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyNodeFrom(const Statement& statem
     columns.insert(columns.end(), warningDataExprs.begin(), warningDataExprs.end());
     auto offset =
         createInvisibleVariable(std::string(InternalKeyword::ROW_OFFSET), LogicalType::INT64());
-    auto boundCopyFromInfo = BoundCopyFromInfo(nodeTableEntry, std::move(boundSource),
+    auto boundCopyFromInfo = BoundCopyFromInfo(nodeTableEntry->getName(), common::TableType::NODE, std::move(boundSource),
         std::move(offset), std::move(columns), std::move(evaluateTypes), nullptr /* extraInfo */);
     return std::make_unique<BoundCopyFrom>(std::move(boundCopyFromInfo));
 }
@@ -190,7 +190,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRelFrom(const Statement& stateme
     auto internalIDColumnIndices = std::vector<idx_t>{0, 1, 2};
     auto extraCopyRelInfo =
         std::make_unique<ExtraBoundCopyRelInfo>(internalIDColumnIndices, lookupInfos);
-    auto boundCopyFromInfo = BoundCopyFromInfo(relTableEntry, boundSource->copy(), offset,
+    auto boundCopyFromInfo = BoundCopyFromInfo(relTableEntry, common::TableType::REL, boundSource->copy(), offset,
         std::move(columnExprs), std::move(evaluateTypes), std::move(extraCopyRelInfo));
     return std::make_unique<BoundCopyFrom>(std::move(boundCopyFromInfo));
 }

--- a/src/binder/bind/copy/bind_copy_from.cpp
+++ b/src/binder/bind/copy/bind_copy_from.cpp
@@ -120,7 +120,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyNodeFrom(const Statement& statem
     columns.insert(columns.end(), warningDataExprs.begin(), warningDataExprs.end());
     auto offset =
         createInvisibleVariable(std::string(InternalKeyword::ROW_OFFSET), LogicalType::INT64());
-    auto boundCopyFromInfo = BoundCopyFromInfo(nodeTableEntry->getName(), common::TableType::NODE, std::move(boundSource),
+    auto boundCopyFromInfo = BoundCopyFromInfo(nodeTableEntry->getName(), std::move(boundSource),
         std::move(offset), std::move(columns), std::move(evaluateTypes), nullptr /* extraInfo */);
     return std::make_unique<BoundCopyFrom>(std::move(boundCopyFromInfo));
 }
@@ -190,7 +190,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRelFrom(const Statement& stateme
     auto internalIDColumnIndices = std::vector<idx_t>{0, 1, 2};
     auto extraCopyRelInfo =
         std::make_unique<ExtraBoundCopyRelInfo>(internalIDColumnIndices, lookupInfos);
-    auto boundCopyFromInfo = BoundCopyFromInfo(relTableEntry, common::TableType::REL, boundSource->copy(), offset,
+    auto boundCopyFromInfo = BoundCopyFromInfo(relTableEntry, boundSource->copy(), offset,
         std::move(columnExprs), std::move(evaluateTypes), std::move(extraCopyRelInfo));
     return std::make_unique<BoundCopyFrom>(std::move(boundCopyFromInfo));
 }

--- a/src/include/planner/operator/persistent/logical_copy_from.h
+++ b/src/include/planner/operator/persistent/logical_copy_from.h
@@ -35,13 +35,7 @@ public:
         const logical_op_vector_t& children)
         : LogicalOperator{type_, children}, info{std::move(info)}, outExprs{std::move(outExprs)} {}
 
-    std::string getExpressionsForPrinting() const override {
-        if (std::holds_alternative<std::string>(info.tableInfo)) {
-            return std::get<std::string>(info.tableInfo);
-        } else {
-            return std::get<catalog::TableCatalogEntry*>(info.tableInfo)->getName();
-        }
-    }
+    std::string getExpressionsForPrinting() const override { return info.tableName; }
 
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
@@ -51,7 +45,7 @@ public:
     binder::expression_vector getOutExprs() const { return outExprs; }
 
     std::unique_ptr<OPPrintInfo> getPrintInfo() const override {
-        return std::make_unique<LogicalCopyFromPrintInfo>(getExpressionsForPrinting());
+        return std::make_unique<LogicalCopyFromPrintInfo>(info.tableName);
     }
 
     std::unique_ptr<LogicalOperator> copy() override {

--- a/src/include/planner/operator/persistent/logical_copy_from.h
+++ b/src/include/planner/operator/persistent/logical_copy_from.h
@@ -35,7 +35,13 @@ public:
         const logical_op_vector_t& children)
         : LogicalOperator{type_, children}, info{std::move(info)}, outExprs{std::move(outExprs)} {}
 
-    std::string getExpressionsForPrinting() const override { return info.tableEntry->getName(); }
+    std::string getExpressionsForPrinting() const override {
+        if (std::holds_alternative<std::string>(info.tableInfo)) {
+            return std::get<std::string>(info.tableInfo);
+        } else {
+            return std::get<catalog::TableCatalogEntry*>(info.tableInfo)->getName();
+        }
+    }
 
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
@@ -45,7 +51,7 @@ public:
     binder::expression_vector getOutExprs() const { return outExprs; }
 
     std::unique_ptr<OPPrintInfo> getPrintInfo() const override {
-        return std::make_unique<LogicalCopyFromPrintInfo>(info.tableEntry->getName());
+        return std::make_unique<LogicalCopyFromPrintInfo>(getExpressionsForPrinting());
     }
 
     std::unique_ptr<LogicalOperator> copy() override {

--- a/src/include/processor/operator/persistent/batch_insert.h
+++ b/src/include/processor/operator/persistent/batch_insert.h
@@ -78,6 +78,11 @@ struct KUZU_API BatchInsertSharedState {
         common::UniqLock lockGuard{erroredRowMutex};
         return *numErroredRows;
     }
+
+    template<class TARGET>
+    TARGET* ptrCast() {
+        return common::ku_dynamic_cast<TARGET*>(this);
+    }
 };
 
 struct BatchInsertLocalState {

--- a/src/include/processor/operator/persistent/node_batch_insert.h
+++ b/src/include/processor/operator/persistent/node_batch_insert.h
@@ -104,13 +104,13 @@ struct NodeBatchInsertLocalState final : BatchInsertLocalState {
 
 class NodeBatchInsert final : public BatchInsert {
 public:
-    NodeBatchInsert(std::unique_ptr<BatchInsertInfo> info,
+    NodeBatchInsert(std::string tableName, std::unique_ptr<BatchInsertInfo> info,
         std::shared_ptr<BatchInsertSharedState> sharedState,
         std::unique_ptr<ResultSetDescriptor> resultSetDescriptor,
         std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
         : BatchInsert{std::move(info), std::move(sharedState), std::move(resultSetDescriptor), id,
-              std::move(printInfo)} {
+              std::move(printInfo)}, tableName{tableName} {
         children.push_back(std::move(child));
     }
 
@@ -124,7 +124,7 @@ public:
     void finalizeInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<NodeBatchInsert>(info->copy(), sharedState,
+        return std::make_unique<NodeBatchInsert>(tableName, info->copy(), sharedState,
             resultSetDescriptor->copy(), children[0]->copy(), id, printInfo->copy());
     }
 
@@ -135,6 +135,8 @@ public:
         std::optional<IndexBuilder>& indexBuilder, storage::MemoryManager* mm) const;
 
 private:
+    std::string tableName;
+
     void evaluateExpressions(uint64_t numTuples) const;
     void appendIncompleteNodeGroup(transaction::Transaction* transaction,
         std::unique_ptr<storage::ChunkedNodeGroup> localNodeGroup,

--- a/src/include/processor/operator/persistent/node_batch_insert.h
+++ b/src/include/processor/operator/persistent/node_batch_insert.h
@@ -40,12 +40,12 @@ struct NodeBatchInsertInfo final : BatchInsertInfo {
     evaluator::evaluator_vector_t columnEvaluators;
     std::vector<common::ColumnEvaluateType> evaluateTypes;
 
-    NodeBatchInsertInfo(catalog::TableCatalogEntry* tableEntry, bool compressionEnabled,
-        std::vector<common::column_id_t> columnIDs, std::vector<common::LogicalType> columnTypes,
+    NodeBatchInsertInfo(bool compressionEnabled,
+        std::vector<common::LogicalType> columnTypes,
         std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> columnEvaluators,
         std::vector<common::ColumnEvaluateType> evaluateTypes,
         common::column_id_t numWarningDataColumns)
-        : BatchInsertInfo{tableEntry, compressionEnabled, std::move(columnIDs),
+        : BatchInsertInfo{nullptr, compressionEnabled, std::vector<common::column_id_t>{},
               static_cast<common::column_id_t>(columnTypes.size() - numWarningDataColumns),
               numWarningDataColumns},
           columnTypes{std::move(columnTypes)}, columnEvaluators{std::move(columnEvaluators)},
@@ -78,11 +78,9 @@ struct NodeBatchInsertSharedState final : BatchInsertSharedState {
     // ops.
     std::unique_ptr<storage::ChunkedNodeGroup> sharedNodeGroup;
 
-    NodeBatchInsertSharedState(storage::Table* table, common::column_id_t pkColumnID,
-        common::LogicalType pkType, std::shared_ptr<FactorizedTable> fTable, storage::WAL* wal,
+    NodeBatchInsertSharedState(std::shared_ptr<FactorizedTable> fTable, storage::WAL* wal,
         storage::MemoryManager* mm)
-        : BatchInsertSharedState{table, std::move(fTable), wal, mm}, pkColumnID{pkColumnID},
-          pkType{std::move(pkType)}, globalIndexBuilder(std::nullopt),
+        : BatchInsertSharedState{nullptr, std::move(fTable), wal, mm}, globalIndexBuilder(std::nullopt),
           tableFuncSharedState{nullptr}, sharedNodeGroup{nullptr} {}
 
     void initPKIndex(const ExecutionContext* context);
@@ -110,7 +108,7 @@ public:
         std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
         : BatchInsert{std::move(info), std::move(sharedState), std::move(resultSetDescriptor), id,
-              std::move(printInfo)}, tableName{tableName} {
+              std::move(printInfo)}, tableName{std::move(tableName)} {
         children.push_back(std::move(child));
     }
 

--- a/src/planner/plan/plan_copy.cpp
+++ b/src/planner/plan/plan_copy.cpp
@@ -7,8 +7,6 @@
 #include "planner/operator/scan/logical_index_look_up.h"
 #include "planner/planner.h"
 
-#include <iostream>
-
 using namespace kuzu::binder;
 using namespace kuzu::storage;
 using namespace kuzu::catalog;

--- a/src/planner/plan/plan_copy.cpp
+++ b/src/planner/plan/plan_copy.cpp
@@ -24,8 +24,7 @@ static void appendIndexScan(const ExtraBoundCopyRelInfo& extraInfo, LogicalPlan&
 }
 
 static void appendPartitioner(const BoundCopyFromInfo& copyFromInfo, LogicalPlan& plan) {
-    // tableInfo variant is TableCatalogEntry* since it's a rel batch insert
-    auto tableEntry = std::get<catalog::TableCatalogEntry*>(copyFromInfo.tableInfo);
+    auto tableEntry = copyFromInfo.tableEntry;
     const auto* tableCatalogEntry = tableEntry->constPtrCast<catalog::RelTableCatalogEntry>();
     LogicalPartitionerInfo info(tableEntry, copyFromInfo.offset);
     for (auto direction : tableCatalogEntry->getRelDataDirections()) {

--- a/src/processor/map/map_copy_from.cpp
+++ b/src/processor/map/map_copy_from.cpp
@@ -14,6 +14,8 @@
 #include "storage/store/node_table.h"
 #include "storage/store/rel_table.h"
 
+#include <iostream>
+
 using namespace kuzu::binder;
 using namespace kuzu::catalog;
 using namespace kuzu::common;
@@ -37,10 +39,11 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createRelBatchInsertOp(
         columnTypes.push_back(
             copyFromInfo.columnExprs[copyFromInfo.columnExprs.size() - i]->getDataType().copy());
     }
-    auto relBatchInsertInfo = std::make_unique<RelBatchInsertInfo>(copyFromInfo.tableEntry,
+    auto catalogEntry = std::get<TableCatalogEntry*>(copyFromInfo.tableInfo);
+    auto relBatchInsertInfo = std::make_unique<RelBatchInsertInfo>(catalogEntry,
         clientContext->getStorageManager()->compressionEnabled(), direction, partitioningIdx,
         offsetVectorIdx, std::move(columnIDs), std::move(columnTypes), numWarningDataColumns);
-    auto printInfo = std::make_unique<RelBatchInsertPrintInfo>(copyFromInfo.tableEntry->getName());
+    auto printInfo = std::make_unique<RelBatchInsertPrintInfo>(catalogEntry->getName());
     return std::make_unique<RelBatchInsert>(std::move(relBatchInsertInfo),
         std::move(partitionerSharedState), std::move(sharedState),
         std::make_unique<ResultSetDescriptor>(outFSchema), operatorID, std::move(printInfo));
@@ -52,7 +55,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyFrom(const LogicalOperator*
         copyFrom.getInfo()->getIgnoreErrorsOption());
     physical_op_vector_t children;
     std::shared_ptr<FactorizedTable> fTable;
-    switch (copyFrom.getInfo()->tableEntry->getTableType()) {
+    switch (copyFrom.getInfo()->tableType) {
     case TableType::NODE: {
         auto op = mapCopyNodeFrom(logicalOperator);
         const auto copy = op->ptrCast<NodeBatchInsert>();
@@ -77,27 +80,13 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyNodeFrom(
     auto& copyFrom = logicalOperator->constCast<LogicalCopyFrom>();
     const auto copyFromInfo = copyFrom.getInfo();
     const auto outFSchema = copyFrom.getSchema();
-    auto nodeTableEntry = copyFromInfo->tableEntry->ptrCast<NodeTableCatalogEntry>();
     // Map reader.
     auto prevOperator = mapOperator(copyFrom.getChild(0).get());
-    auto nodeTable = storageManager->getTable(nodeTableEntry->getTableID());
-    auto fTable =
-        FactorizedTableUtils::getSingleStringColumnFTable(clientContext->getMemoryManager());
-    const auto& pkDefinition = nodeTableEntry->getPrimaryKeyDefinition();
-    auto pkColumnID = nodeTableEntry->getColumnID(pkDefinition.getName());
-    auto sharedState = std::make_shared<NodeBatchInsertSharedState>(nodeTable, pkColumnID,
-        pkDefinition.getType().copy(), fTable, &storageManager->getWAL(),
+    auto fTable = FactorizedTableUtils::getSingleStringColumnFTable(clientContext->getMemoryManager());
+    auto sharedState = std::make_shared<NodeBatchInsertSharedState>(nullptr, 0, LogicalType::ANY(),
+        fTable, &storageManager->getWAL(),
         clientContext->getMemoryManager());
 
-    if (prevOperator->getOperatorType() == PhysicalOperatorType::TABLE_FUNCTION_CALL) {
-        const auto call = prevOperator->ptrCast<TableFunctionCall>();
-        sharedState->tableFuncSharedState = call->getSharedState().get();
-    }
-    // Map copy node.
-    std::vector<column_id_t> columnIDs;
-    for (auto& property : nodeTableEntry->getProperties()) {
-        columnIDs.push_back(nodeTableEntry->getColumnID(property.getName()));
-    }
     std::vector<LogicalType> columnTypes;
     std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> columnEvaluators;
     auto exprMapper = ExpressionMapper(outFSchema);
@@ -107,13 +96,14 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyNodeFrom(
     }
     const auto numWarningDataColumns = copyFromInfo->source->getNumWarningDataColumns();
     KU_ASSERT(columnTypes.size() >= numWarningDataColumns);
-    auto info = std::make_unique<NodeBatchInsertInfo>(nodeTableEntry,
-        storageManager->compressionEnabled(), std::move(columnIDs), std::move(columnTypes),
+    auto info = std::make_unique<NodeBatchInsertInfo>(nullptr,
+        storageManager->compressionEnabled(), std::vector<column_id_t>(), std::move(columnTypes),
         std::move(columnEvaluators), copyFromInfo->columnEvaluateTypes, numWarningDataColumns);
 
-    auto printInfo =
-        std::make_unique<NodeBatchInsertPrintInfo>(copyFrom.getInfo()->tableEntry->getName());
-    return std::make_unique<NodeBatchInsert>(std::move(info), sharedState,
+    auto tableName = std::get<std::string>(copyFrom.getInfo()->tableInfo);
+    auto printInfo = std::make_unique<NodeBatchInsertPrintInfo>(tableName);
+
+    return std::make_unique<NodeBatchInsert>(tableName, std::move(info), std::move(sharedState),
         std::make_unique<ResultSetDescriptor>(copyFrom.getSchema()), std::move(prevOperator),
         getOperatorID(), std::move(printInfo));
 }
@@ -159,7 +149,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPartitioner(
 physical_op_vector_t PlanMapper::mapCopyRelFrom(const LogicalOperator* logicalOperator) {
     auto& copyFrom = logicalOperator->constCast<LogicalCopyFrom>();
     const auto copyFromInfo = copyFrom.getInfo();
-    auto& relTableEntry = copyFromInfo->tableEntry->constCast<RelTableCatalogEntry>();
+    auto tableEntry = std::get<TableCatalogEntry*>(copyFromInfo->tableInfo);
+    auto& relTableEntry = tableEntry->constCast<RelTableCatalogEntry>();
     auto partitioner = mapOperator(copyFrom.getChild(0).get());
     KU_ASSERT(partitioner->getOperatorType() == PhysicalOperatorType::PARTITIONER);
     const auto partitionerSharedState = partitioner->ptrCast<Partitioner>()->getSharedState();

--- a/src/processor/map/map_copy_from.cpp
+++ b/src/processor/map/map_copy_from.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createRelBatchInsertOp(
         columnTypes.push_back(
             copyFromInfo.columnExprs[copyFromInfo.columnExprs.size() - i]->getDataType().copy());
     }
-    auto catalogEntry = std::get<TableCatalogEntry*>(copyFromInfo.tableInfo);
+    auto catalogEntry = copyFromInfo.tableEntry;
     auto relBatchInsertInfo = std::make_unique<RelBatchInsertInfo>(catalogEntry,
         clientContext->getStorageManager()->compressionEnabled(), direction, partitioningIdx,
         offsetVectorIdx, std::move(columnIDs), std::move(columnTypes), numWarningDataColumns);
@@ -100,9 +100,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyNodeFrom(
         storageManager->compressionEnabled(), std::vector<column_id_t>(), std::move(columnTypes),
         std::move(columnEvaluators), copyFromInfo->columnEvaluateTypes, numWarningDataColumns);
 
-    auto tableName = std::get<std::string>(copyFrom.getInfo()->tableInfo);
+    auto tableName = copyFromInfo->tableName;
     auto printInfo = std::make_unique<NodeBatchInsertPrintInfo>(tableName);
-
     return std::make_unique<NodeBatchInsert>(tableName, std::move(info), std::move(sharedState),
         std::make_unique<ResultSetDescriptor>(copyFrom.getSchema()), std::move(prevOperator),
         getOperatorID(), std::move(printInfo));
@@ -149,7 +148,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPartitioner(
 physical_op_vector_t PlanMapper::mapCopyRelFrom(const LogicalOperator* logicalOperator) {
     auto& copyFrom = logicalOperator->constCast<LogicalCopyFrom>();
     const auto copyFromInfo = copyFrom.getInfo();
-    auto tableEntry = std::get<TableCatalogEntry*>(copyFromInfo->tableInfo);
+    auto tableEntry = copyFromInfo->tableEntry;
     auto& relTableEntry = tableEntry->constCast<RelTableCatalogEntry>();
     auto partitioner = mapOperator(copyFrom.getChild(0).get());
     KU_ASSERT(partitioner->getOperatorType() == PhysicalOperatorType::PARTITIONER);

--- a/src/processor/map/map_copy_from.cpp
+++ b/src/processor/map/map_copy_from.cpp
@@ -14,8 +14,6 @@
 #include "storage/store/node_table.h"
 #include "storage/store/rel_table.h"
 
-#include <iostream>
-
 using namespace kuzu::binder;
 using namespace kuzu::catalog;
 using namespace kuzu::common;

--- a/src/processor/map/map_copy_from.cpp
+++ b/src/processor/map/map_copy_from.cpp
@@ -81,7 +81,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyNodeFrom(
     // Map reader.
     auto prevOperator = mapOperator(copyFrom.getChild(0).get());
     auto fTable = FactorizedTableUtils::getSingleStringColumnFTable(clientContext->getMemoryManager());
-    auto sharedState = std::make_shared<NodeBatchInsertSharedState>(nullptr, 0, LogicalType::ANY(),
+
+    // First three arguments are placeholders, check NodeBatchInsert::initGlobalStateInternal
+    auto sharedState = std::make_shared<NodeBatchInsertSharedState>(nullptr, 0, LogicalType::ANY(), 
         fTable, &storageManager->getWAL(),
         clientContext->getMemoryManager());
 
@@ -94,7 +96,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyNodeFrom(
     }
     const auto numWarningDataColumns = copyFromInfo->source->getNumWarningDataColumns();
     KU_ASSERT(columnTypes.size() >= numWarningDataColumns);
-    auto info = std::make_unique<NodeBatchInsertInfo>(nullptr,
+    auto info = std::make_unique<NodeBatchInsertInfo>(nullptr, // placeholder
         storageManager->compressionEnabled(), std::vector<column_id_t>(), std::move(columnTypes),
         std::move(columnEvaluators), copyFromInfo->columnEvaluateTypes, numWarningDataColumns);
 

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -63,7 +63,6 @@ void NodeBatchInsert::initGlobalStateInternal(ExecutionContext* context) {
 
     info->tableEntry = nodeTableEntry;
 
-    // Map copy node.
     for (auto& property : nodeTableEntry->getProperties()) {
         info->insertColumnIDs.push_back(nodeTableEntry->getColumnID(property.getName()));
     }

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -1,13 +1,16 @@
 #include "processor/operator/persistent/node_batch_insert.h"
 
+#include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "common/cast.h"
 #include "common/string_format.h"
 #include "processor/execution_context.h"
 #include "processor/operator/persistent/index_builder.h"
+#include "processor/operator/table_function_call.h"
 #include "processor/result/factorized_table_util.h"
 #include "storage/local_storage/local_storage.h"
 #include "storage/store/chunked_node_group.h"
 #include "storage/store/node_table.h"
+#include "storage/storage_manager.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;
@@ -34,8 +37,36 @@ void NodeBatchInsertSharedState::initPKIndex(const ExecutionContext* context) {
 }
 
 void NodeBatchInsert::initGlobalStateInternal(ExecutionContext* context) {
-    const auto nodeSharedState = ku_dynamic_cast<NodeBatchInsertSharedState*>(sharedState.get());
+    auto clientContext = context->clientContext;
+    auto storageManager = clientContext->getStorageManager();
+    auto transaction = clientContext->getTransaction();
+
+    auto tableEntry = clientContext->getCatalog()->getTableCatalogEntry(transaction, tableName);
+    auto nodeTableEntry = tableEntry->ptrCast<NodeTableCatalogEntry>();
+    auto nodeTable = storageManager->getTable(nodeTableEntry->getTableID());
+
+    auto fTable = FactorizedTableUtils::getSingleStringColumnFTable(clientContext->getMemoryManager());
+
+    const auto& pkDefinition = nodeTableEntry->getPrimaryKeyDefinition();
+    auto pkColumnID = nodeTableEntry->getColumnID(pkDefinition.getName());
+
+    auto nodeSharedState = sharedState->ptrCast<NodeBatchInsertSharedState>();
+    nodeSharedState->table = nodeTable;
+    nodeSharedState->pkColumnID = pkColumnID;
+    nodeSharedState->pkType = pkDefinition.getType().copy();
     nodeSharedState->initPKIndex(context);
+
+    if (children[0]->getOperatorType() == PhysicalOperatorType::TABLE_FUNCTION_CALL) {
+        const auto call = children[0]->ptrCast<TableFunctionCall>();
+        nodeSharedState->tableFuncSharedState = call->getSharedState().get();
+    }
+
+    info->tableEntry = nodeTableEntry;
+
+    // Map copy node.
+    for (auto& property : nodeTableEntry->getProperties()) {
+        info->insertColumnIDs.push_back(nodeTableEntry->getColumnID(property.getName()));
+    }
 }
 
 void NodeBatchInsert::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -38,15 +38,10 @@ void NodeBatchInsertSharedState::initPKIndex(const ExecutionContext* context) {
 
 void NodeBatchInsert::initGlobalStateInternal(ExecutionContext* context) {
     auto clientContext = context->clientContext;
-    auto storageManager = clientContext->getStorageManager();
-    auto transaction = clientContext->getTransaction();
-
-    auto tableEntry = clientContext->getCatalog()->getTableCatalogEntry(transaction, tableName);
+    auto tableEntry = clientContext->getCatalog()->getTableCatalogEntry(clientContext->getTransaction(), tableName);
     auto nodeTableEntry = tableEntry->ptrCast<NodeTableCatalogEntry>();
-    auto nodeTable = storageManager->getTable(nodeTableEntry->getTableID());
-
+    auto nodeTable = clientContext->getStorageManager()->getTable(nodeTableEntry->getTableID());
     auto fTable = FactorizedTableUtils::getSingleStringColumnFTable(clientContext->getMemoryManager());
-
     const auto& pkDefinition = nodeTableEntry->getPrimaryKeyDefinition();
     auto pkColumnID = nodeTableEntry->getColumnID(pkDefinition.getName());
 
@@ -57,7 +52,6 @@ void NodeBatchInsert::initGlobalStateInternal(ExecutionContext* context) {
     nodeSharedState->initPKIndex(context);
 
     info->tableEntry = nodeTableEntry;
-
     for (auto& property : nodeTableEntry->getProperties()) {
         info->insertColumnIDs.push_back(nodeTableEntry->getColumnID(property.getName()));
     }

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -56,11 +56,6 @@ void NodeBatchInsert::initGlobalStateInternal(ExecutionContext* context) {
     nodeSharedState->pkType = pkDefinition.getType().copy();
     nodeSharedState->initPKIndex(context);
 
-    if (children[0]->getOperatorType() == PhysicalOperatorType::TABLE_FUNCTION_CALL) {
-        const auto call = children[0]->ptrCast<TableFunctionCall>();
-        nodeSharedState->tableFuncSharedState = call->getSharedState().get();
-    }
-
     info->tableEntry = nodeTableEntry;
 
     for (auto& property : nodeTableEntry->getProperties()) {


### PR DESCRIPTION
These changes are required to finish implementing the `CREATE NODE TABLE ... AS` syntax, because the catalog entry was previously required during binding time for creating a `BoundCopyFormInfo` which would be used to call `planCopyFrom`. With these changes, all the catalog entry related initialization is moved to `initGlobalStateInternal` for `NodeBatchInsert`s which delays the point at which we need the catalog entry, and this allows us to use `planCopyFrom` to implement the copying part of the query.