### PR TITLE
extension(neo4j): print as output the detected properties and types

### DIFF
--- a/extension/neo4j/test/test_files/basic.test
+++ b/extension/neo4j/test/test_files/basic.test
@@ -15,24 +15,45 @@
 ---- 0
 ]
 
+
 -CASE MigrateFromNeo4jBaseCase
 
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/neo4j/build/libneo4j.kuzu_extension"
 ---- ok
--STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "czy990424", ["student", "teacher"], ["knows"]);
----- ok
--STATEMENT match (p:student) return p.*;
----- 5
-0|1|True|35|1900-01-01|5.000000|Alice|[96,54,86,92]|1.731000|0|False|3 years 2 days 13 hours 2 minutes|2011-08-20 11:25:30|A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11|["Aida"]|[10,5]
-1|2|True|30|1900-01-01|5.100000|Bob|[98,42,93,88]|0.990000|2|False|10 years 5 months 13 hours 24 us|2008-11-03 15:25:30.000526|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12|["Bobby"]|[12,8]
-2|1|False|45|1940-06-22|5.000000|Carol|[91,75,21,95]|1.000000|3|True|48 hours 24 minutes 11 seconds|1911-08-20 02:32:21|a0eebc999c0b4ef8bb6d6bb9bd380a13|["Carmen","Fred"]|[4,5]
-3|2|False|20|1950-07-23|4.800000|Dan|[76,88,99,89]|1.300000|5|True|10 years 5 months 13 hours 24 us|2031-11-30 12:25:30|a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a14|["Wolfeschlegelstein","Daniel"]|[1,9]
-4|1|False|20|1980-10-26|4.700000|Elizabeth|[96,59,65,88]|1.463000|7|True|48 hours 24 minutes 11 seconds|1976-12-23 11:21:42|a0eebc99-9c0b4ef8-bb6d6bb9-bd380a15|["Ein"]|[2]
 
--STATEMENT match (s:teacher) return s.*;
+-STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "czy990424", ["Student", "Teacher"], ["KNOWS"]);
+---- 18
+Student|scores|INT64[]|["LongArray"]
+Student|active|BOOL|["Boolean"]
+Student|type|INT64|["Long"]
+Student|uuid|STRING|["String"]
+Student|tags|INT64[]|["LongArray"]
+Student|duration|STRING|["String"]
+Student|dob|DATE|["Date"]
+Student|graduated|BOOL|["Boolean"]
+Student|name|STRING|["String"]
+Student|rank|INT64|["Long"]
+Student|nicknames|STRING[]|["StringArray"]
+Student|age|INT64|["Long"]
+Student|timestamp|TIMESTAMP|["DateTime"]
+Student|height|DOUBLE|["Double"]
+Student|ratio|DOUBLE|["Double"]
+Teacher|code|STRING|["String"]
+KNOWS_Student_Student|length|INT64|["Long"]
+KNOWS_Teacher_Student|reason|STRING|["String"]
+
+-STATEMENT match (p:Student) return p.type, p.active, p.age, p.dob, p.height, p.name, p.scores, p.ratio, p.rank, p.graduated, p.duration, p.timestamp, p.uuid, p.nicknames, p.tags;
+---- 5
+1|True|35|1900-01-01|5.000000|Alice|[96,54,86,92]|1.731000|0|False|3 years 2 days 13 hours 2 minutes|2011-08-20 11:25:30|A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11|["Aida"]|[10,5]
+2|True|30|1900-01-01|5.100000|Bob|[98,42,93,88]|0.990000|2|False|10 years 5 months 13 hours 24 us|2008-11-03 15:25:30.000526|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12|["Bobby"]|[12,8]
+1|False|45|1940-06-22|5.000000|Carol|[91,75,21,95]|1.000000|3|True|48 hours 24 minutes 11 seconds|1911-08-20 02:32:21|a0eebc999c0b4ef8bb6d6bb9bd380a13|["Carmen","Fred"]|[4,5]
+2|False|20|1950-07-23|4.800000|Dan|[76,88,99,89]|1.300000|5|True|10 years 5 months 13 hours 24 us|2031-11-30 12:25:30|a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a14|["Wolfeschlegelstein","Daniel"]|[1,9]
+1|False|20|1980-10-26|4.700000|Elizabeth|[96,59,65,88]|1.463000|7|True|48 hours 24 minutes 11 seconds|1976-12-23 11:21:42|a0eebc99-9c0b4ef8-bb6d6bb9-bd380a15|["Ein"]|[2]
+
+-STATEMENT match (s:teacher) return s.code;
 ---- 2
-5|57
-6|unknown
+57
+unknown
 
 -STATEMENT match (a)-[e]->(b) return a._id_,b._id_,e.length, e.reason;
 ---- 8
@@ -44,24 +65,46 @@
 3|0|79|
 5|0||teach
 6|0||teach
--INSERT_STATEMENT_BLOCK CLEAN_DB
--STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "czy990424", ["student"], []);
----- ok
--STATEMENT match (s:student) return s.*;
----- 5
-0|1|True|35|1900-01-01|5.000000|Alice|[96,54,86,92]|1.731000|0|False|3 years 2 days 13 hours 2 minutes|2011-08-20 11:25:30|A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11|["Aida"]|[10,5]
-1|2|True|30|1900-01-01|5.100000|Bob|[98,42,93,88]|0.990000|2|False|10 years 5 months 13 hours 24 us|2008-11-03 15:25:30.000526|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12|["Bobby"]|[12,8]
-2|1|False|45|1940-06-22|5.000000|Carol|[91,75,21,95]|1.000000|3|True|48 hours 24 minutes 11 seconds|1911-08-20 02:32:21|a0eebc999c0b4ef8bb6d6bb9bd380a13|["Carmen","Fred"]|[4,5]
-3|2|False|20|1950-07-23|4.800000|Dan|[76,88,99,89]|1.300000|5|True|10 years 5 months 13 hours 24 us|2031-11-30 12:25:30|a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a14|["Wolfeschlegelstein","Daniel"]|[1,9]
-4|1|False|20|1980-10-26|4.700000|Elizabeth|[96,59,65,88]|1.463000|7|True|48 hours 24 minutes 11 seconds|1976-12-23 11:21:42|a0eebc99-9c0b4ef8-bb6d6bb9-bd380a15|["Ein"]|[2]
 
 -INSERT_STATEMENT_BLOCK CLEAN_DB
--STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "czy990424", ["teacher"], []);
----- ok
--STATEMENT match (s:teacher) return s.*;
+
+-STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "czy990424", ["Student"], []);
+---- 15
+Student|scores|INT64[]|["LongArray"]
+Student|active|BOOL|["Boolean"]
+Student|type|INT64|["Long"]
+Student|uuid|STRING|["String"]
+Student|tags|INT64[]|["LongArray"]
+Student|duration|STRING|["String"]
+Student|dob|DATE|["Date"]
+Student|graduated|BOOL|["Boolean"]
+Student|name|STRING|["String"]
+Student|rank|INT64|["Long"]
+Student|nicknames|STRING[]|["StringArray"]
+Student|age|INT64|["Long"]
+Student|timestamp|TIMESTAMP|["DateTime"]
+Student|height|DOUBLE|["Double"]
+Student|ratio|DOUBLE|["Double"]
+
+-STATEMENT match (p:Student) return p.type, p.active, p.age, p.dob, p.height, p.name, p.scores, p.ratio, p.rank, p.graduated, p.duration, p.timestamp, p.uuid, p.nicknames, p.tags;
+---- 5
+1|True|35|1900-01-01|5.000000|Alice|[96,54,86,92]|1.731000|0|False|3 years 2 days 13 hours 2 minutes|2011-08-20 11:25:30|A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11|["Aida"]|[10,5]
+2|True|30|1900-01-01|5.100000|Bob|[98,42,93,88]|0.990000|2|False|10 years 5 months 13 hours 24 us|2008-11-03 15:25:30.000526|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12|["Bobby"]|[12,8]
+1|False|45|1940-06-22|5.000000|Carol|[91,75,21,95]|1.000000|3|True|48 hours 24 minutes 11 seconds|1911-08-20 02:32:21|a0eebc999c0b4ef8bb6d6bb9bd380a13|["Carmen","Fred"]|[4,5]
+2|False|20|1950-07-23|4.800000|Dan|[76,88,99,89]|1.300000|5|True|10 years 5 months 13 hours 24 us|2031-11-30 12:25:30|a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a14|["Wolfeschlegelstein","Daniel"]|[1,9]
+1|False|20|1980-10-26|4.700000|Elizabeth|[96,59,65,88]|1.463000|7|True|48 hours 24 minutes 11 seconds|1976-12-23 11:21:42|a0eebc99-9c0b4ef8-bb6d6bb9-bd380a15|["Ein"]|[2]
+
+-INSERT_STATEMENT_BLOCK CLEAN_DB
+
+-STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "czy990424", ["Teacher"], []);
+---- 1
+Teacher|code|STRING|["String"]
+
+-STATEMENT match (s:teacher) return s.code;
 ---- 2
-5|57
-6|unknown
+57
+unknown
+
 
 -CASE MigrateFromEmptyNeo4j
 
@@ -70,46 +113,47 @@
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/neo4j/build/libneo4j.kuzu_extension"
 ---- ok
 -STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "czy990424", [], []);
----- ok
+---- 0
 -STATEMENT CALL SHOW_TABLES() RETURN *;
 ---- 0
 
+
 -CASE MigrateFromBothEmptyNodes
-# Created by query in neo4j: create (a)-[:emptyrel]->(b)
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/neo4j/build/libneo4j.kuzu_extension"
 ---- ok
--STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "kuzuneo4j", [], ["emptyrel"]);
----- ok
+-STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "czy990424", [], ["RELTOEMPTY2"]);
+---- 0
+
 
 -CASE MigrateFromOneEmptyNodes
-# Created by query in neo4j: create (a:person)-[:emptyrel1]->(b)
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/neo4j/build/libneo4j.kuzu_extension"
 ---- ok
--STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "kuzuneo4j", ["person"], ["emptyrel1"]);
----- ok
--STATEMENT MATCH (a:person) RETURN label(a)
+-STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "czy990424", ["Node"], ["RELTOEMPTY2"]);
+---- 0
+-STATEMENT MATCH (a:Node) RETURN label(a)
 ---- 1
-person
+Node
+
 
 -CASE MigrateWithTypesCustomPort
-# Created by query in neo4j: CREATE (:types_test {
-#                               boolean: true,
-#                               date: date('2023-10-23'),
-#                               duration: duration('P1Y2M3DT4H5M6S'),
-#                               float: 3.1415,
-#                               integer: 42,
-#                               list: ["A", "B", "C"],
-#                               local_datetime: localdatetime('2023-10-23T14:30:45'),
-#                               local_time: localtime('14:30:45'),
-#                               point: point({x: 12.34, y: 56.78}),
-#                               string: 'Sample text',
-#                               zoned_datetime: datetime('2023-10-23T14:30:45+01:00'),
-#                               zoned_time: time('14:30:45+01:00')
-#                               })
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/neo4j/build/libneo4j.kuzu_extension"
 ---- ok
--STATEMENT CALL NEO4J_MIGRATE("http://localhost:7475", "neo4j", "kuzuneo4j", ["types_test"], []);
----- ok
--STATEMENT MATCH (a:types_test) RETURN a.*
+
+-STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "czy990424", ["AllTypes"], []);
+---- 12
+AllTypes|duration|STRING|["Duration"]
+AllTypes|date|DATE|["Date"]
+AllTypes|zoned_datetime|TIMESTAMP|["DateTime"]
+AllTypes|boolean|BOOL|["Boolean"]
+AllTypes|local_time|STRING|["LocalTime"]
+AllTypes|float|DOUBLE|["Double"]
+AllTypes|zoned_time|STRING|["Time"]
+AllTypes|list|STRING[]|["StringArray"]
+AllTypes|string|STRING|["String"]
+AllTypes|integer|INT64|["Long"]
+AllTypes|local_datetime|STRING|["LocalDateTime"]
+AllTypes|point|STRING|["Point"]
+
+-STATEMENT MATCH (a:AllTypes) RETURN a.boolean, a.date, a.duration, a.float, a.integer, a.list, a.local_datetime, a.local_time, a.point, a.string, a.zoned_datetime, a.zoned_time
 ---- 1
-0|True|2023-10-23|P1Y2M3DT4H5M6S|3.141500|42|["A","B","C"]|2023-10-23T14:30:45|14:30:45|{"crs":"cartesian","x":12.34,"y":56.78,"z":null}|Sample text|2023-10-23 13:30:45|14:30:45+01:00
+True|2023-10-23|P1Y2M3DT4H5M6S|3.141500|42|["A","B","C"]|2023-10-23T14:30:45|14:30:45|{"crs":"cartesian","x":12.34,"y":56.78,"z":null}|Sample text|2023-10-23 13:30:45|14:30:45+01:00

--- a/extension/neo4j/test/test_files/doc_example.test
+++ b/extension/neo4j/test/test_files/doc_example.test
@@ -1,12 +1,12 @@
 -DATASET CSV empty
+-SKIP
 
 --
 
 -CASE MigrateFromNeo4jDocSample
--SKIP
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/neo4j/build/libneo4j.kuzu_extension"
 ---- ok
--STATEMENT CALL NEO4J_MIGRATE("localhost", "neo4j", "kuzuneo4j", ["User", "City"], ["Follows", "LivesIn"]);
+-STATEMENT CALL NEO4J_MIGRATE("localhost", "neo4j", "czy990424", ["User", "City"], ["Follows", "LivesIn"]);
 ---- ok
 -STATEMENT CALL SHOW_TABLES() RETURN *;
 ---- 4

--- a/extension/neo4j/test/test_files/error.test
+++ b/extension/neo4j/test/test_files/error.test
@@ -7,37 +7,37 @@
 -CASE IncorrectServerInfo
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/neo4j/build/libneo4j.kuzu_extension"
 ---- ok
--STATEMENT CALL NEO4J_MIGRATE("http://incorrecturl.com", "neo4j", "czy990424", ["person", "student"], ["knows"]);
+-STATEMENT CALL NEO4J_MIGRATE("http://incorrect-url-does-not-exist.com:7474", "neo4j", "czy990424", ["person", "student"], ["KNOWS"]);
 ---- error
-Runtime exception: Failed to connect to neo4j server. Please check whether it is valid neo4j server url.
--STATEMENT CALL NEO4J_MIGRATE("localhost", "neo4j!", "czy990424", ["person", "student"], ["knows"]);
+Runtime exception: Failed to connect to Neo4j. Please check whether it is a valid connection url.
+-STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j!", "czy990424", ["Person", "Student"], ["KNOWS"]);
 ---- error
 Runtime exception: Failed to connect to neo4j. Server returned: 401, Response: {"errors":[{"code":"Neo.ClientError.Security.Unauthorized","message":"Invalid credential."}]}.
--STATEMENT CALL NEO4J_MIGRATE("localhost", "neo4j", "czy990424!", ["person", "student"], ["knows"]);
+-STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "czy990424!", ["Person", "Student"], ["KNOWS"]);
 ---- error
 Runtime exception: Failed to connect to neo4j. Server returned: 401, Response: {"errors":[{"code":"Neo.ClientError.Security.Unauthorized","message":"Invalid credential."}]}.
 
 -CASE InvalidTableName
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/neo4j/build/libneo4j.kuzu_extension"
 ---- ok
--STATEMENT CALL NEO4J_MIGRATE("localhost", "neo4j", "czy990424", ["person123", "student"], ["knows"]);
+-STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "czy990424", ["Person123", "Student"], ["KNOWS"]);
 ---- error
-Runtime exception: NODE: person123 does not exist in neo4j.
--STATEMENT CALL NEO4J_MIGRATE("localhost", "neo4j", "czy990424", ["412313"], []);
+Runtime exception: NODE 'Person123' does not exist in neo4j.
+-STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "czy990424", ["412313"], []);
 ---- error
-Runtime exception: NODE: 412313 does not exist in neo4j.
--STATEMENT CALL NEO4J_MIGRATE("localhost", "neo4j", "czy990424", ["student", "teacher"], ["knows11"]);
+Runtime exception: NODE '412313' does not exist in neo4j.
+-STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "czy990424", ["Student", "Teacher"], ["knows11"]);
 ---- error
-Runtime exception: REL: knows11 does not exist in neo4j.
--STATEMENT CALL NEO4J_MIGRATE("localhost", "neo4j", "czy990424", [], ["555"]);
+Runtime exception: REL 'knows11' does not exist in neo4j.
+-STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "czy990424", [], ["555"]);
 ---- error
-Runtime exception: REL: 555 does not exist in neo4j.
--STATEMENT CALL NEO4J_MIGRATE("localhost", "neo4j", "czy990424", [], ["knows"]);
+Runtime exception: REL '555' does not exist in neo4j.
+-STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "czy990424", [], ["KNOWS"]);
 ---- error
-Runtime exception: The dependent source node label: student of knows must be imported into kuzu.
--STATEMENT CALL NEO4J_MIGRATE("localhost", "neo4j", "czy990424", ["student"], ["knows"]);
+Runtime exception: The source node label 'Student' of 'KNOWS' must be present in the nodes import list.
+-STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "czy990424", ["Student"], ["KNOWS"]);
 ---- error
-Runtime exception: The dependent source node label: teacher of knows must be imported into kuzu.
--STATEMENT CALL NEO4J_MIGRATE("localhost", "neo4j", "czy990424", ["two_labels_b"], ["knows"]);
+Runtime exception: The source node label 'Teacher' of 'KNOWS' must be present in the nodes import list.
+-STATEMENT CALL NEO4J_MIGRATE("http://localhost:7474", "neo4j", "czy990424", ["TwoLabels1"], ["KNOWS2"]);
 ---- error
-Runtime exception: Importing nodes with multi-labels is not supported right now.
+Runtime exception: Importing nodes with multi-labels is not supported right now. Found: [["TwoLabels1","TwoLabels2"]]

--- a/extension/neo4j/test/test_files/install_neo4j.test
+++ b/extension/neo4j/test/test_files/install_neo4j.test
@@ -1,4 +1,5 @@
 -DATASET CSV empty
+-SKIP
 
 --
 
@@ -15,6 +16,6 @@
 ---- ok
 
 -CASE MigrateWithoutLoading
--STATEMENT CALL NEO4J_MIGRATE("localhost", "neo4j", "kuzuneo4j", ["User", "City"], ["Follows", "LivesIn"]);
+-STATEMENT CALL NEO4J_MIGRATE("localhost", "neo4j", "czy990424", ["User", "City"], ["Follows", "LivesIn"]);
 ---- error
 Catalog exception: function NEO4J_MIGRATE is not defined. This function exists in the NEO4J extension. You can install and load the extension by running 'INSTALL NEO4J; LOAD EXTENSION NEO4J;'.

--- a/extension/neo4j/test/test_files/neo4j.cypher
+++ b/extension/neo4j/test/test_files/neo4j.cypher
@@ -1,0 +1,36 @@
+// sudo docker run -it --rm --name neo4j --publish=7474:7474 --publish=7687:7687 --user="$(id -u):$(id -g)" -v /tmp:/tmp -v ~/neo4j/logs:/logs -v ~/neo4j/config:/conf -v ~/neo4j/plugins:/plugins --env NEO4J_AUTH=neo4j/czy990424 --env NEO4J_dbms_usage__report_enabled=false --env NEO4J_server_memory_pagecache_size=4G --env NEO4J_server_memory_heap_max__size=4G -e NEO4J_dbms_security_procedures_unrestricted=gds.\* -e NEO4J_apoc_export_file_enabled=true -e NEO4J_apoc_import_file_use__neo4j__config=false -e JAVA_OPTS=--add-opens=java.base/java.nio=ALL-UNNAMED neo4j:latest
+MATCH ()-[r]->() delete r; MATCH (n) delete n;
+CREATE
+    (a:Student {type: 1, active: true, age: 35, dob: date("1900-01-01"), height: 5.0, name: "Alice", scores: [96,54,86,92], ratio: 1.731, rank: 0, graduated: false, duration: "3 years 2 days 13 hours 2 minutes", timestamp: datetime("2011-08-20T11:25:30"), uuid: "A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11", nicknames: ["Aida"], tags: [10,5]}),
+    (b:Student {type: 2, active: true, age: 30, dob: date("1900-01-01"), height: 5.1, name: "Bob", scores: [98,42,93,88], ratio: 0.99, rank: 2, graduated: false, duration: "10 years 5 months 13 hours 24 us", timestamp: datetime("2008-11-03T15:25:30.000526"), uuid: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12", nicknames: ["Bobby"], tags: [12,8]}),
+    (c:Student {type: 1, active: false, age: 45, dob: date("1940-06-22"), height: 5.0, name: "Carol", scores: [91,75,21,95], ratio: 1.0, rank: 3, graduated: true, duration: "48 hours 24 minutes 11 seconds", timestamp: datetime("1911-08-20T02:32:21"), uuid: "a0eebc999c0b4ef8bb6d6bb9bd380a13", nicknames: ["Carmen","Fred"], tags: [4,5]}),
+    (d:Student {type: 2, active: false, age: 20, dob: date("1950-07-23"), height: 4.8, name: "Dan", scores: [76,88,99,89], ratio: 1.3, rank: 5, graduated: true, duration: "10 years 5 months 13 hours 24 us", timestamp: datetime("2031-11-30T12:25:30"), uuid: "a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a14", nicknames: ["Wolfeschlegelstein","Daniel"], tags: [1,9]}),
+    (e:Student {type: 1, active: false, age: 20, dob: date("1980-10-26"), height: 4.7, name: "Elizabeth", scores: [96,59,65,88], ratio: 1.463, rank: 7, graduated: true, duration: "48 hours 24 minutes 11 seconds", timestamp: datetime("1976-12-23T11:21:42"), uuid: "a0eebc99-9c0b4ef8-bb6d6bb9-bd380a15", nicknames: ["Ein"], tags: [2]}),
+    (f:Teacher {code: "57"}),
+    (g:Teacher {code: "unknown"}),
+    (a)-[:KNOWS {length: 50}]->(b),
+    (a)-[:KNOWS {length: 50}]->(c),
+    (a)-[:KNOWS {length: 50}]->(d),
+    (b)-[:KNOWS {length: 41}]->(a),
+    (c)-[:KNOWS {length: 56}]->(a),
+    (d)-[:KNOWS {length: 79}]->(a),
+    (f)-[:KNOWS {reason: "teach"}]->(a),
+    (g)-[:KNOWS {reason: "teach"}]->(a),
+    ()-[:RELTOEMPTY2]->(),
+    (:Node)-[:RELTOEMPTY1]->(),
+    (:AllTypes {
+        boolean: true,
+        date: date('2023-10-23'),
+        duration: duration('P1Y2M3DT4H5M6S'),
+        float: 3.1415,
+        integer: 42,
+        list: ["A", "B", "C"],
+        local_datetime: localdatetime('2023-10-23T14:30:45'),
+        local_time: localtime('14:30:45'),
+        point: point({x: 12.34, y: 56.78}),
+        string: 'Sample text',
+        zoned_datetime: datetime('2023-10-23T14:30:45+01:00'),
+        zoned_time: time('14:30:45+01:00')
+    }),
+    (:TwoLabels1:TwoLabels2)-[:KNOWS2]->()
+;


### PR DESCRIPTION
Currently, `neo4j_migrate` output the results of only the last `LOAD FROM` query.

Instead, this PR changes the output to the following:
```
kuzu> CALL NEO4J_MIGRATE("localhost:7475", "", "", ["Person"], ["FRIENDS","KNOWS"]);
┌───────────────────────┬───────────────┬───────────┬───────────────┐
│ kuzu_table            │ kuzu_property │ kuzu_type │ neo4j_types   │
│ STRING                │ STRING        │ STRING    │ STRING        │
├───────────────────────┼───────────────┼───────────┼───────────────┤
│ Person                │ score         │ DOUBLE    │ ["Double"]    │
│ Person                │ loginTime     │ STRING    │ ["LocalTime"] │
│ Person                │ timezone      │ STRING    │ ["Time"]      │
│ Person                │ name          │ STRING    │ ["String"]    │
│ Person                │ verified      │ BOOL      │ ["Boolean"]   │
│ Person                │ location      │ STRING    │ ["Point"]     │
│ Person                │ sessionTime   │ STRING    │ ["Duration"]  │
│ Person                │ id            │ INT64     │ ["Long"]      │
│ Person                │ createdZoned  │ TIMESTAMP │ ["DateTime"]  │
│ Person                │ age           │ INT64     │ ["Long"]      │
│          ·            │      ·        │    ·      │      ·        │
│          ·            │      ·        │    ·      │      ·        │
│          ·            │      ·        │    ·      │      ·        │
│ FRIENDS_Person_Person │ duration      │ STRING    │ ["Duration"]  │
│ FRIENDS_Person_Person │ lastContact   │ TIMESTAMP │ ["DateTime"]  │
│ FRIENDS_Person_Person │ notes         │ STRING    │ ["String"]    │
│ FRIENDS_Person_Person │ since         │ DATE      │ ["Date"]      │
│ FRIENDS_Person_Person │ strength      │ DOUBLE    │ ["Double"]    │
│ KNOWS_Person_Person   │ active        │ BOOL      │ ["Boolean"]   │
│ KNOWS_Person_Person   │ duration      │ STRING    │ ["Duration"]  │
│ KNOWS_Person_Person   │ lastContact   │ TIMESTAMP │ ["DateTime"]  │
│ KNOWS_Person_Person   │ since         │ DATE      │ ["Date"]      │
│ KNOWS_Person_Person   │ strength      │ DOUBLE    │ ["Double"]    │
└───────────────────────┴───────────────┴───────────┴───────────────┘
(24 tuples, 20 shown)
(4 columns)
Time: 158.94ms (compiling), 16.78ms (executing)
```

- [ ] Let me know if this PR is okay, then I'll change the test outputs as well.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).