### PR TITLE
shell: add support for ENTER from middle of a query

### DIFF
--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -3562,8 +3562,7 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char* buf, size_t buflen, 
                 l.len = 1;
             }
             return (int)l.len;
-        case 10:
-        case ENTER: /* enter */ {
+        case ENTER:
             if (mlmode && l.len > 0) {
                 // check if this forms a complete Cypher statement or not or if enter is pressed in
                 // the middle of a line
@@ -3576,6 +3575,8 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char* buf, size_t buflen, 
                     break;
                 }
             }
+            [[fallthrough]];
+        case 10: /* ctrl+j */ {
             history_len--;
             free(history[history_len]);
             l.continuePromptActive = false;

--- a/tools/shell/test/test_shell_basics.py
+++ b/tools/shell/test/test_shell_basics.py
@@ -46,6 +46,13 @@ def test_invalid_cast(temp_db) -> None:
         'Error: Conversion exception: Cast failed. Could not convert "****" to INT8.',
     )
 
+def test_enter_in_between_input(temp_db) -> None:
+    test = ShellTest().add_argument(temp_db)
+    test.start()
+    test.send_statement("CREATE NODE TABLE Test (id INT64 PRIMARY KEY);")
+    test.send_statement("\x1b[D" * 5) # left arrow
+    test.send_control_statement("j") # ctrl + j
+    assert test.shell_process.expect_exact(["\u2502 Table Test has been created. \u2502", pexpect.EOF]) == 0
 
 def test_multiline(temp_db) -> None:
     test = (
@@ -59,7 +66,6 @@ def test_multiline(temp_db) -> None:
     )
     result = test.run()
     result.check_stdout("\u2502 databases rule \u2502")
-
 
 def test_multi_queries_one_line(temp_db) -> None:
     # two successful queries


### PR DESCRIPTION
Currently, when editing in the multiline mode, after editing a query, the cursor needs to be manually navigated to the end of the query before pressing ENTER to execute the query, otherwise the CLI just appends a new line.

This PR adds the ability to execute a query even if the cursor is in the middle of a query by pressing `SHIFT+ENTER` or `CTRL+J`. This is a minor quality of life improvement as compared to `CTRL+E -> ENTER`.

Tested on Linux and macOS. Needs a test on Windows.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).