### PR TITLE
ci: fix multiplatform builds

### DIFF
--- a/.github/workflows/multiplatform-build-test.yml
+++ b/.github/workflows/multiplatform-build-test.yml
@@ -780,6 +780,7 @@ jobs:
       DISCORD_CHANNEL_ID: ${{ secrets.DISCORD_CHANNEL_ID }}
       DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
       GITHUB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    if: ${{ always() }}
     needs:
       [
         macos-build-test,

--- a/.github/workflows/multiplatform-build-test.yml
+++ b/.github/workflows/multiplatform-build-test.yml
@@ -2,7 +2,6 @@ name: Multiplatform Build and Test
 
 env:
   USE_EXISTING_BINARY_DATASET: 1
-  PIP_BREAK_SYSTEM_PACKAGES: 1
 
 on:
   workflow_dispatch:
@@ -62,6 +61,7 @@ jobs:
         continue-on-error: true
         run: |
           set +e
+          echo NUM_THREADS=$(sysctl -n hw.physicalcpu)
           make test NUM_THREADS=$(sysctl -n hw.physicalcpu)
           echo "Test,$?" >> status.txt
           make clean
@@ -91,6 +91,8 @@ jobs:
         continue-on-error: true
         run: |
           set +e
+          python --version
+          pip --version
           make pytest NUM_THREADS=$(sysctl -n hw.physicalcpu)
           echo "Python test,$?" >> status.txt
 
@@ -103,6 +105,8 @@ jobs:
         continue-on-error: true
         run: |
           set +e
+          node --version
+          npm --version
           make nodejstest NUM_THREADS=$(sysctl -n hw.physicalcpu)
           echo "Node.js test,$?" >> status.txt
 
@@ -110,6 +114,7 @@ jobs:
         continue-on-error: true
         run: |
           set +e
+          java --version
           make javatest NUM_THREADS=$(sysctl -n hw.physicalcpu)
           echo "Java test,$?" >> status.txt
 
@@ -129,6 +134,7 @@ jobs:
         working-directory: tools/rust_api
         run: |
           set +e
+          cargo --version
           cargo test --release --features arrow
           echo "Rust test,$?" >> ../../status.txt
 
@@ -195,10 +201,11 @@ jobs:
         continue-on-error: true
         shell: cmd
         run: |
+          echo NUMBER_OF_PROCESSORS=%NUMBER_OF_PROCESSORS%
           make test NUM_THREADS=%NUMBER_OF_PROCESSORS%
           echo Test,%ERRORLEVEL% >> status.txt
           make clean
-          Remove-Item -Recurse -Force dataset\ldbc-1
+          rm -rf dataset/ldbc-1
 
       - name: Build
         continue-on-error: true
@@ -225,6 +232,8 @@ jobs:
         continue-on-error: true
         shell: cmd
         run: |
+          python --version
+          pip --version
           make pytest NUM_THREADS=%NUMBER_OF_PROCESSORS%
           echo Python test,%ERRORLEVEL% >> status.txt
 
@@ -238,6 +247,8 @@ jobs:
         continue-on-error: true
         shell: cmd
         run: |
+          node --version
+          npm --version
           make nodejstest NUM_THREADS=%NUMBER_OF_PROCESSORS%
           echo Node.js test,%ERRORLEVEL% >> status.txt
 
@@ -253,6 +264,7 @@ jobs:
         continue-on-error: true
         shell: cmd
         run: |
+          java --version
           make javatest NUM_THREADS=%NUMBER_OF_PROCESSORS%
           echo Java test,%ERRORLEVEL% >> status.txt
 
@@ -269,6 +281,7 @@ jobs:
         continue-on-error: true
         shell: cmd
         run: |
+          cargo --version
           set OPENSSL_DIR=C:\Program Files\OpenSSL-Win64
           set CXXFLAGS=/std:c++20
           set CARGO_BUILD_JOBS=%NUMBER_OF_PROCESSORS%
@@ -351,6 +364,7 @@ jobs:
         continue-on-error: true
         run: |
           set +e
+          echo NUM_THREADS=$(nproc)
           make test NUM_THREADS=$(nproc)
           echo "Test,$?" >> status.txt
           make clean
@@ -373,6 +387,8 @@ jobs:
       - name: Ensure Python dependencies
         continue-on-error: true
         run: |
+          python -m venv /opt/venv
+          source /opt/venv/bin/activate
           pip install torch~=2.6.0 --extra-index-url https://download.pytorch.org/whl/cpu
           pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.6.0+cpu.html
 
@@ -380,6 +396,9 @@ jobs:
         continue-on-error: true
         run: |
           set +e
+          source /opt/venv/bin/activate
+          python --version
+          pip --version
           make pytest NUM_THREADS=$(nproc)
           echo "Python test,$?" >> status.txt
 
@@ -392,6 +411,8 @@ jobs:
         continue-on-error: true
         run: |
           set +e
+          node --version
+          npm --version
           make nodejstest NUM_THREADS=$(nproc)
           echo "Node.js test,$?" >> status.txt
 
@@ -399,6 +420,7 @@ jobs:
         continue-on-error: true
         run: |
           set +e
+          java --version
           make javatest NUM_THREADS=$(nproc)
           echo "Java test,$?" >> status.txt
 
@@ -425,6 +447,7 @@ jobs:
         working-directory: tools/rust_api
         run: |
           set +e
+          cargo --version
           cargo test --release --features arrow
           echo "Rust test,$?" >> ../../status.txt
 
@@ -507,6 +530,7 @@ jobs:
         continue-on-error: true
         run: |
           set +e
+          echo NUM_THREADS=$(nproc)
           make test NUM_THREADS=$(nproc)
           echo "Test,$?" >> status.txt
           make clean
@@ -539,6 +563,8 @@ jobs:
         run: |
           set +e
           source /opt/venv/bin/activate
+          python --version
+          pip --version
           make pytest NUM_THREADS=$(nproc)
           echo "Python test,$?" >> status.txt
 
@@ -551,6 +577,8 @@ jobs:
         continue-on-error: true
         run: |
           set +e
+          node --version
+          npm --version
           make nodejstest NUM_THREADS=$(nproc)
           echo "Node.js test,$?" >> status.txt
 
@@ -558,6 +586,7 @@ jobs:
         continue-on-error: true
         run: |
           set +e
+          java --version
           make javatest NUM_THREADS=$(nproc)
           echo "Java test,$?" >> status.txt
 
@@ -584,6 +613,7 @@ jobs:
         working-directory: tools/rust_api
         run: |
           set +e
+          cargo --version
           cargo test --release --features arrow
           echo "Rust test,$?" >> ../../status.txt
 
@@ -638,6 +668,7 @@ jobs:
         continue-on-error: true
         run: |
           set +e
+          echo NUM_THREADS=$(nproc)
           make test NUM_THREADS=$(nproc)
           echo "Test,$?" >> status.txt
           make clean
@@ -660,6 +691,8 @@ jobs:
       - name: Ensure Python dependencies
         continue-on-error: true
         run: |
+          python -m venv /opt/venv
+          source /opt/venv/bin/activate
           pip install torch~=2.6.0 --extra-index-url https://download.pytorch.org/whl/cpu
           pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.6.0+cpu.html
 
@@ -667,6 +700,9 @@ jobs:
         continue-on-error: true
         run: |
           set +e
+          source /opt/venv/bin/activate
+          python --version
+          pip --version
           make pytest NUM_THREADS=$(nproc)
           echo "Python test,$?" >> status.txt
 
@@ -679,6 +715,8 @@ jobs:
         continue-on-error: true
         run: |
           set +e
+          node --version
+          npm --version
           make nodejstest NUM_THREADS=$(nproc)
           echo "Node.js test,$?" >> status.txt
 
@@ -686,6 +724,7 @@ jobs:
         continue-on-error: true
         run: |
           set +e
+          java --version
           make javatest NUM_THREADS=$(nproc)
           echo "Java test,$?" >> status.txt
 
@@ -712,6 +751,7 @@ jobs:
         continue-on-error: true
         run: |
           set +e
+          cargo --version
           cargo test --release --features arrow
           echo "Rust test,$?" >> ../../status.txt
 

--- a/.github/workflows/multiplatform-build-test.yml
+++ b/.github/workflows/multiplatform-build-test.yml
@@ -35,11 +35,11 @@ jobs:
   macos-build-test:
     strategy:
       matrix:
-        runner: [macos-13, macos-14]
+        runner: [ macos-14, macos-15 ]
       fail-fast: false
     name: ${{ matrix.runner }}
     runs-on: ${{ matrix.runner }}
-    needs: [generate-binary-demo]
+    needs: [ generate-binary-demo ]
     defaults:
       run:
         shell: bash
@@ -56,25 +56,7 @@ jobs:
       - uses: actions/setup-python@v4
         continue-on-error: true
         with:
-          python-version: "3.10"
-
-      - name: Ensure Python dependencies
-        continue-on-error: true
-        run: |
-          pip install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
-
-      - name: Ensure Node.js dependencies
-        continue-on-error: true
-        working-directory: tools/nodejs_api
-        run: npm install --include=dev
-
-      - name: Build
-        continue-on-error: true
-        run: |
-          set +e
-          make release NUM_THREADS=$(sysctl -n hw.physicalcpu)
-          echo "Build,$?" > status.txt
+          python-version: "3.11"
 
       - name: Test
         continue-on-error: true
@@ -82,9 +64,15 @@ jobs:
           set +e
           make test NUM_THREADS=$(sysctl -n hw.physicalcpu)
           echo "Test,$?" >> status.txt
+          make clean
+          rm -rf dataset/ldbc-1
 
-      - name: Remove ldbc-1
-        run: rm -rf dataset/ldbc-1
+      - name: Build
+        continue-on-error: true
+        run: |
+          set +e
+          make release NUM_THREADS=$(sysctl -n hw.physicalcpu)
+          echo "Build,$?" >> status.txt
 
       - name: C and C++ examples
         continue-on-error: true
@@ -93,12 +81,23 @@ jobs:
           make example NUM_THREADS=$(sysctl -n hw.physicalcpu)
           echo "C and C++ examples,$?" >> status.txt
 
+      - name: Ensure Python dependencies
+        continue-on-error: true
+        run: |
+          pip install torch~=2.6.0 --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.6.0+cpu.html
+
       - name: Python test
         continue-on-error: true
         run: |
           set +e
           make pytest NUM_THREADS=$(sysctl -n hw.physicalcpu)
           echo "Python test,$?" >> status.txt
+
+      - name: Ensure Node.js dependencies
+        continue-on-error: true
+        working-directory: tools/nodejs_api
+        run: npm install --include=dev
 
       - name: Node.js test
         continue-on-error: true
@@ -154,10 +153,10 @@ jobs:
   windows-build-test:
     strategy:
       matrix:
-        runner: [windows-2019, windows-2022, windows-2025]
+        runner: [ windows-2022, windows-2025 ]
       fail-fast: false
     name: ${{ matrix.runner }}
-    needs: [generate-binary-demo]
+    needs: [ generate-binary-demo ]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Disable Windows Defender
@@ -190,20 +189,16 @@ jobs:
       - uses: actions/setup-python@v4
         continue-on-error: true
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
-      - name: Ensure Python dependencies
+      - name: Test
         continue-on-error: true
         shell: cmd
         run: |
-          pip install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --user -r tools\python_api\requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
-
-      - name: Ensure Node.js dependencies
-        continue-on-error: true
-        shell: cmd
-        working-directory: .\tools\nodejs_api
-        run: npm install --include=dev
+          make test NUM_THREADS=%NUMBER_OF_PROCESSORS%
+          echo Test,%ERRORLEVEL% >> status.txt
+          make clean
+          Remove-Item -Recurse -Force dataset\ldbc-1
 
       - name: Build
         continue-on-error: true
@@ -212,22 +207,19 @@ jobs:
           make release NUM_THREADS=%NUMBER_OF_PROCESSORS%
           echo Build,%ERRORLEVEL% > status.txt
 
-      - name: Test
-        continue-on-error: true
-        shell: cmd
-        run: |
-          make test NUM_THREADS=%NUMBER_OF_PROCESSORS%
-          echo Test,%ERRORLEVEL% >> status.txt
-
-      - name: Remove ldbc-1
-        run: Remove-Item -Recurse -Force dataset\ldbc-1
-
       - name: C and C++ examples
         continue-on-error: true
         shell: cmd
         run: |
           make example NUM_THREADS=%NUMBER_OF_PROCESSORS%
           echo C and C++ examples,%ERRORLEVEL% >> status.txt
+
+      - name: Ensure Python dependencies
+        continue-on-error: true
+        shell: cmd
+        run: |
+          pip install torch~=2.6.0 --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install --user -r tools\python_api\requirements_dev.txt -f https://data.pyg.org/whl/torch-2.6.0+cpu.html
 
       - name: Python test
         continue-on-error: true
@@ -236,12 +228,26 @@ jobs:
           make pytest NUM_THREADS=%NUMBER_OF_PROCESSORS%
           echo Python test,%ERRORLEVEL% >> status.txt
 
+      - name: Ensure Node.js dependencies
+        continue-on-error: true
+        shell: cmd
+        working-directory: .\tools\nodejs_api
+        run: npm install --include=dev
+
       - name: Node.js test
         continue-on-error: true
         shell: cmd
         run: |
           make nodejstest NUM_THREADS=%NUMBER_OF_PROCESSORS%
           echo Node.js test,%ERRORLEVEL% >> status.txt
+
+      - name: Set up JDK 11
+        continue-on-error: true
+        if: ${{ matrix.runner == 'windows-2022' }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
 
       - name: Java test
         continue-on-error: true
@@ -263,7 +269,6 @@ jobs:
         continue-on-error: true
         shell: cmd
         run: |
-          make clean
           set OPENSSL_DIR=C:\Program Files\OpenSSL-Win64
           set CXXFLAGS=/std:c++20
           set CARGO_BUILD_JOBS=%NUMBER_OF_PROCESSORS%
@@ -293,10 +298,10 @@ jobs:
   debian-ubuntu-build-test:
     strategy:
       matrix:
-        image: ["ubuntu:22.04", "ubuntu:24.04", "ubuntu:24.10", "debian:12", "debian:sid"]
+        image: [ "ubuntu:22.04", "ubuntu:24.04", "ubuntu:25.04", "debian:12", "debian:sid" ]
       fail-fast: false
     name: ${{ matrix.image }}
-    needs: [generate-binary-demo]
+    needs: [ generate-binary-demo ]
     runs-on: ubuntu-24.04
     container:
       image: ${{ matrix.image }}
@@ -306,7 +311,7 @@ jobs:
       JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
     steps:
       - name: Setup Node.js
-        if: ${{ matrix.image != 'debian:sid' }}
+        if: ${{ matrix.image != 'debian:sid' && matrix.image != 'ubuntu:25.04' }}
         continue-on-error: true
         run: |
           apt-get update
@@ -317,9 +322,16 @@ jobs:
 
       - name: Install packages
         continue-on-error: true
-        run: |    
+        run: |
           apt-get update
-          apt-get install -y git build-essential cmake gcc g++ python3 python3-dev python3-pip openjdk-17-jdk nodejs ca-certificates curl gnupg
+          apt-get install -y git build-essential cmake python3 python3-dev python3-pip openjdk-17-jdk nodejs ca-certificates curl gnupg ${{ matrix.image == 'ubuntu:22.04' && 'gcc-12 g++-12' || 'gcc g++' }}
+
+      - name: Setup gcc 12
+        if: ${{ matrix.image == 'ubuntu:22.04' }}
+        continue-on-error: true
+        run: |
+          update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100
+          update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100
 
       - name: Install npm
         if: ${{ matrix.image == 'debian:sid' }}
@@ -335,40 +347,21 @@ jobs:
           name: binary-demo
           path: ${{ github.workspace }}/dataset/binary-demo
 
-      - name: Ensure Python dependencies
-        continue-on-error: true
-        run: |
-          pip install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
-
-      - name: Ensure Node.js dependencies
-        working-directory: tools/nodejs_api
-        continue-on-error: true
-        run: npm install --include=dev
-
-      - name: Install Rust
-        continue-on-error: true
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-update-default-toolchain
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          $HOME/.cargo/bin/rustup toolchain install 1.81
-
-      - name: Build
-        continue-on-error: true
-        run: |
-          set +e
-          make release NUM_THREADS=$(nproc)
-          echo "Build,$?" > status.txt
-
       - name: Test
         continue-on-error: true
         run: |
           set +e
           make test NUM_THREADS=$(nproc)
           echo "Test,$?" >> status.txt
+          make clean
+          rm -rf dataset/ldbc-1
 
-      - name: Remove ldbc-1
-        run: rm -rf dataset/ldbc-1
+      - name: Build
+        continue-on-error: true
+        run: |
+          set +e
+          make release NUM_THREADS=$(nproc)
+          echo "Build,$?" >> status.txt
 
       - name: C and C++ examples
         continue-on-error: true
@@ -377,12 +370,23 @@ jobs:
           make example NUM_THREADS=$(nproc)
           echo "C and C++ examples,$?" >> status.txt
 
+      - name: Ensure Python dependencies
+        continue-on-error: true
+        run: |
+          pip install torch~=2.6.0 --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.6.0+cpu.html
+
       - name: Python test
         continue-on-error: true
         run: |
           set +e
           make pytest NUM_THREADS=$(nproc)
           echo "Python test,$?" >> status.txt
+
+      - name: Ensure Node.js dependencies
+        working-directory: tools/nodejs_api
+        continue-on-error: true
+        run: npm install --include=dev
 
       - name: Node.js test
         continue-on-error: true
@@ -400,6 +404,13 @@ jobs:
 
       - name: Cleanup
         run: make clean
+
+      - name: Install Rust
+        continue-on-error: true
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-update-default-toolchain
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          $HOME/.cargo/bin/rustup toolchain install 1.81
 
       - name: Rust share build
         continue-on-error: true
@@ -441,17 +452,17 @@ jobs:
   rhel-fedora-build-test:
     strategy:
       matrix:
-        image: ["rockylinux:8", "rockylinux:9", "fedora:38", "fedora:39"]
+        image: [ "rockylinux:8", "rockylinux:9", "fedora:41", "fedora:42" ]
       fail-fast: false
     name: ${{ matrix.image }}
-    needs: [generate-binary-demo]
+    needs: [ generate-binary-demo ]
     runs-on: ubuntu-24.04
     container:
       image: ${{ matrix.image }}
     env:
       CC: gcc
       CXX: g++
-      JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+      JAVA_HOME: /usr/lib/jvm/java-${{ matrix.image == 'fedora:42' && '21' || '17' }}-openjdk
       HOME: /root
     steps:
       - name: Enable EPEL
@@ -471,18 +482,17 @@ jobs:
         continue-on-error: true
         run: |
           curl -fsSL https://rpm.nodesource.com/setup_20.x | bash -
-          dnf install -y git cmake ${{ matrix.image == 'rockylinux:8' && 'gcc-toolset-12 python3.11 python3.11-devel' || 'gcc gcc-c++ python3-devel' }} java-17-openjdk-devel nodejs
+          dnf install -y git cmake nodejs ${{ (matrix.image == 'rockylinux:8' || matrix.image ==  'rockylinux:9') && 'gcc-toolset-12 python3.11 python3.11-devel' || 'gcc gcc-c++ python3-devel' }} ${{ matrix.image == 'fedora:42' && 'java-21-openjdk-devel' || 'java-17-openjdk-devel' }}
+          dnf clean all
 
-      - name: Enable gcc-toolset-12 and python3.11 on Rocky Linux 8
+      - name: Enable gcc-toolset-12 and python3.11 on Rocky Linux
+        if: ${{ matrix.image == 'rockylinux:8' || matrix.image ==  'rockylinux:9' }}
         continue-on-error: true
-        if: matrix.image == 'rockylinux:8'
         run: |
-          alternatives --set python /usr/bin/python3.11
-          alternatives --set python3 /usr/bin/python3.11
-          echo "PYTHON_EXECUTABLE=/usr/bin/python3.11" >> $GITHUB_ENV
-          echo "PYBIND11_PYTHON_VERSION=3.11" >> $GITHUB_ENV
           source /opt/rh/gcc-toolset-12/enable
           echo $PATH >> $GITHUB_PATH
+          echo "PYTHON_EXECUTABLE=/usr/bin/python3.11" >> $GITHUB_ENV
+          echo "PYBIND11_PYTHON_VERSION=3.11" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
         continue-on-error: true
@@ -493,42 +503,21 @@ jobs:
           name: binary-demo
           path: ${{ github.workspace }}/dataset/binary-demo
 
-      - name: Ensure Python dependencies
-        continue-on-error: true
-        run: |
-          python3 -m venv /opt/venv
-          source /opt/venv/bin/activate
-          pip3 install torch~=2.2.1 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip3 install -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.1+cpu.html
-
-      - name: Ensure Node.js dependencies
-        continue-on-error: true
-        working-directory: tools/nodejs_api
-        run: npm install --include=dev
-
-      - name: Install Rust
-        continue-on-error: true
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-update-default-toolchain
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          $HOME/.cargo/bin/rustup toolchain install 1.81
-
-      - name: Build
-        continue-on-error: true
-        run: |
-          set +e
-          make release NUM_THREADS=$(nproc)
-          echo "Build,$?" > status.txt
-
       - name: Test
         continue-on-error: true
         run: |
           set +e
           make test NUM_THREADS=$(nproc)
           echo "Test,$?" >> status.txt
+          make clean
+          rm -rf dataset/ldbc-1
 
-      - name: Remove ldbc-1
-        run: rm -rf dataset/ldbc-1
+      - name: Build
+        continue-on-error: true
+        run: |
+          set +e
+          make release NUM_THREADS=$(nproc)
+          echo "Build,$?" >> status.txt
 
       - name: C and C++ examples
         continue-on-error: true
@@ -537,6 +526,14 @@ jobs:
           make example NUM_THREADS=$(nproc)
           echo "C and C++ examples,$?" >> status.txt
 
+      - name: Ensure Python dependencies
+        continue-on-error: true
+        run: |
+          ${{ (matrix.image == 'rockylinux:8' || matrix.image ==  'rockylinux:9') && 'python3.11' || 'python3' }} -m venv /opt/venv
+          source /opt/venv/bin/activate
+          pip3 install torch~=2.6.0 --extra-index-url https://download.pytorch.org/whl/cpu
+          pip3 install -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.6.0+cpu.html
+
       - name: Python test
         continue-on-error: true
         run: |
@@ -544,6 +541,11 @@ jobs:
           source /opt/venv/bin/activate
           make pytest NUM_THREADS=$(nproc)
           echo "Python test,$?" >> status.txt
+
+      - name: Ensure Node.js dependencies
+        continue-on-error: true
+        working-directory: tools/nodejs_api
+        run: npm install --include=dev
 
       - name: Node.js test
         continue-on-error: true
@@ -561,6 +563,13 @@ jobs:
 
       - name: Cleanup
         run: make clean
+
+      - name: Install Rust
+        continue-on-error: true
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-update-default-toolchain
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          $HOME/.cargo/bin/rustup toolchain install 1.81
 
       - name: Rust share build
         continue-on-error: true
@@ -602,7 +611,7 @@ jobs:
   archlinux-build-test:
     name: archlinux
     runs-on: ubuntu-24.04
-    needs: [generate-binary-demo]
+    needs: [ generate-binary-demo ]
     container:
       image: archlinux:latest
     env:
@@ -625,40 +634,21 @@ jobs:
           name: binary-demo
           path: ${{ github.workspace }}/dataset/binary-demo
 
-      - name: Ensure Python dependencies
-        continue-on-error: true
-        run: |
-          pip install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
-
-      - name: Ensure Node.js dependencies
-        continue-on-error: true
-        working-directory: tools/nodejs_api
-        run: npm install --include=dev
-
-      - name: Install Rust
-        continue-on-error: true
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-update-default-toolchain
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          $HOME/.cargo/bin/rustup toolchain install 1.81
-
-      - name: Build
-        continue-on-error: true
-        run: |
-          set +e
-          make release NUM_THREADS=$(nproc)
-          echo "Build,$?" > status.txt
-
       - name: Test
         continue-on-error: true
         run: |
           set +e
           make test NUM_THREADS=$(nproc)
           echo "Test,$?" >> status.txt
+          make clean
+          rm -rf dataset/ldbc-1
 
-      - name: Remove ldbc-1
-        run: rm -rf dataset/ldbc-1
+      - name: Build
+        continue-on-error: true
+        run: |
+          set +e
+          make release NUM_THREADS=$(nproc)
+          echo "Build,$?" >> status.txt
 
       - name: C and C++ examples
         continue-on-error: true
@@ -667,12 +657,23 @@ jobs:
           make example NUM_THREADS=$(nproc)
           echo "C and C++ examples,$?" >> status.txt
 
+      - name: Ensure Python dependencies
+        continue-on-error: true
+        run: |
+          pip install torch~=2.6.0 --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.6.0+cpu.html
+
       - name: Python test
         continue-on-error: true
         run: |
           set +e
           make pytest NUM_THREADS=$(nproc)
           echo "Python test,$?" >> status.txt
+
+      - name: Ensure Node.js dependencies
+        continue-on-error: true
+        working-directory: tools/nodejs_api
+        run: npm install --include=dev
 
       - name: Node.js test
         continue-on-error: true
@@ -690,6 +691,13 @@ jobs:
 
       - name: Cleanup
         run: make clean
+
+      - name: Install Rust
+        continue-on-error: true
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-update-default-toolchain
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          $HOME/.cargo/bin/rustup toolchain install stable
 
       - name: Rust share build
         continue-on-error: true

--- a/.github/workflows/multiplatform-build-test.yml
+++ b/.github/workflows/multiplatform-build-test.yml
@@ -90,9 +90,9 @@ jobs:
       - name: Python test
         continue-on-error: true
         run: |
-          set +e
           python --version
           pip --version
+          set +e
           make pytest NUM_THREADS=$(sysctl -n hw.physicalcpu)
           echo "Python test,$?" >> status.txt
 
@@ -104,17 +104,17 @@ jobs:
       - name: Node.js test
         continue-on-error: true
         run: |
-          set +e
           node --version
           npm --version
+          set +e
           make nodejstest NUM_THREADS=$(sysctl -n hw.physicalcpu)
           echo "Node.js test,$?" >> status.txt
 
       - name: Java test
         continue-on-error: true
         run: |
-          set +e
           java --version
+          set +e
           make javatest NUM_THREADS=$(sysctl -n hw.physicalcpu)
           echo "Java test,$?" >> status.txt
 
@@ -133,8 +133,8 @@ jobs:
         continue-on-error: true
         working-directory: tools/rust_api
         run: |
-          set +e
           cargo --version
+          set +e
           cargo test --release --features arrow
           echo "Rust test,$?" >> ../../status.txt
 
@@ -212,7 +212,7 @@ jobs:
         shell: cmd
         run: |
           make release NUM_THREADS=%NUMBER_OF_PROCESSORS%
-          echo Build,%ERRORLEVEL% > status.txt
+          echo Build,%ERRORLEVEL% >> status.txt
 
       - name: C and C++ examples
         continue-on-error: true
@@ -247,8 +247,6 @@ jobs:
         continue-on-error: true
         shell: cmd
         run: |
-          node --version
-          npm --version
           make nodejstest NUM_THREADS=%NUMBER_OF_PROCESSORS%
           echo Node.js test,%ERRORLEVEL% >> status.txt
 
@@ -292,6 +290,8 @@ jobs:
         continue-on-error: true
         shell: cmd
         run: |
+          set OPENSSL_DIR=C:\Program Files\OpenSSL-Win64
+          set CXXFLAGS=/std:c++20
           set CARGO_BUILD_JOBS=%NUMBER_OF_PROCESSORS%
           cargo build --release --features arrow
           echo Rust example,%ERRORLEVEL% >> status.txt
@@ -323,7 +323,7 @@ jobs:
       CXX: g++
       JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
     steps:
-      - name: Setup Node.js
+      - name: Setup Node.js repo
         if: ${{ matrix.image != 'debian:sid' && matrix.image != 'ubuntu:25.04' }}
         continue-on-error: true
         run: |
@@ -337,7 +337,7 @@ jobs:
         continue-on-error: true
         run: |
           apt-get update
-          apt-get install -y git build-essential cmake python3 python3-dev python3-pip openjdk-17-jdk nodejs ca-certificates curl gnupg ${{ matrix.image == 'ubuntu:22.04' && 'gcc-12 g++-12' || 'gcc g++' }}
+          apt-get install -y git build-essential cmake python3 python3-dev python3-venv python3-pip openjdk-17-jdk ca-certificates curl gnupg ${{ matrix.image == 'ubuntu:22.04' && 'gcc-12 g++-12' || 'gcc g++' }} ${{ (matrix.image == 'debian:sid' || matrix.image == 'ubuntu:25.04') && 'nodejs npm' || 'nodejs' }}
 
       - name: Setup gcc 12
         if: ${{ matrix.image == 'ubuntu:22.04' }}
@@ -345,11 +345,6 @@ jobs:
         run: |
           update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100
           update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100
-
-      - name: Install npm
-        if: ${{ matrix.image == 'debian:sid' }}
-        continue-on-error: true
-        run: apt-get install -y npm
 
       - uses: actions/checkout@v4
         continue-on-error: true
@@ -387,18 +382,18 @@ jobs:
       - name: Ensure Python dependencies
         continue-on-error: true
         run: |
-          python -m venv /opt/venv
-          source /opt/venv/bin/activate
+          python3 -m venv /opt/venv
+          . /opt/venv/bin/activate
           pip install torch~=2.6.0 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.6.0+cpu.html
+          pip install -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.6.0+cpu.html
 
       - name: Python test
         continue-on-error: true
         run: |
-          set +e
-          source /opt/venv/bin/activate
+          . /opt/venv/bin/activate
           python --version
           pip --version
+          set +e
           make pytest NUM_THREADS=$(nproc)
           echo "Python test,$?" >> status.txt
 
@@ -410,17 +405,17 @@ jobs:
       - name: Node.js test
         continue-on-error: true
         run: |
-          set +e
           node --version
           npm --version
+          set +e
           make nodejstest NUM_THREADS=$(nproc)
           echo "Node.js test,$?" >> status.txt
 
       - name: Java test
         continue-on-error: true
         run: |
-          set +e
           java --version
+          set +e
           make javatest NUM_THREADS=$(nproc)
           echo "Java test,$?" >> status.txt
 
@@ -446,8 +441,8 @@ jobs:
         continue-on-error: true
         working-directory: tools/rust_api
         run: |
-          set +e
           cargo --version
+          set +e
           cargo test --release --features arrow
           echo "Rust test,$?" >> ../../status.txt
 
@@ -514,6 +509,8 @@ jobs:
         run: |
           source /opt/rh/gcc-toolset-12/enable
           echo $PATH >> $GITHUB_PATH
+          alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+          alternatives --set python3 /usr/bin/python3.11
           echo "PYTHON_EXECUTABLE=/usr/bin/python3.11" >> $GITHUB_ENV
           echo "PYBIND11_PYTHON_VERSION=3.11" >> $GITHUB_ENV
 
@@ -553,7 +550,7 @@ jobs:
       - name: Ensure Python dependencies
         continue-on-error: true
         run: |
-          ${{ (matrix.image == 'rockylinux:8' || matrix.image ==  'rockylinux:9') && 'python3.11' || 'python3' }} -m venv /opt/venv
+          python3 -m venv /opt/venv
           source /opt/venv/bin/activate
           pip3 install torch~=2.6.0 --extra-index-url https://download.pytorch.org/whl/cpu
           pip3 install -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.6.0+cpu.html
@@ -561,10 +558,10 @@ jobs:
       - name: Python test
         continue-on-error: true
         run: |
-          set +e
           source /opt/venv/bin/activate
           python --version
           pip --version
+          set +e
           make pytest NUM_THREADS=$(nproc)
           echo "Python test,$?" >> status.txt
 
@@ -576,17 +573,17 @@ jobs:
       - name: Node.js test
         continue-on-error: true
         run: |
-          set +e
           node --version
           npm --version
+          set +e
           make nodejstest NUM_THREADS=$(nproc)
           echo "Node.js test,$?" >> status.txt
 
       - name: Java test
         continue-on-error: true
         run: |
-          set +e
           java --version
+          set +e
           make javatest NUM_THREADS=$(nproc)
           echo "Java test,$?" >> status.txt
 
@@ -612,8 +609,8 @@ jobs:
         continue-on-error: true
         working-directory: tools/rust_api
         run: |
-          set +e
           cargo --version
+          set +e
           cargo test --release --features arrow
           echo "Rust test,$?" >> ../../status.txt
 
@@ -691,18 +688,18 @@ jobs:
       - name: Ensure Python dependencies
         continue-on-error: true
         run: |
-          python -m venv /opt/venv
+          python3 -m venv /opt/venv
           source /opt/venv/bin/activate
           pip install torch~=2.6.0 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.6.0+cpu.html
+          pip install -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.6.0+cpu.html
 
       - name: Python test
         continue-on-error: true
         run: |
-          set +e
           source /opt/venv/bin/activate
           python --version
           pip --version
+          set +e
           make pytest NUM_THREADS=$(nproc)
           echo "Python test,$?" >> status.txt
 
@@ -714,17 +711,17 @@ jobs:
       - name: Node.js test
         continue-on-error: true
         run: |
-          set +e
           node --version
           npm --version
+          set +e
           make nodejstest NUM_THREADS=$(nproc)
           echo "Node.js test,$?" >> status.txt
 
       - name: Java test
         continue-on-error: true
         run: |
-          set +e
           java --version
+          set +e
           make javatest NUM_THREADS=$(nproc)
           echo "Java test,$?" >> status.txt
 
@@ -750,8 +747,8 @@ jobs:
         working-directory: tools/rust_api
         continue-on-error: true
         run: |
-          set +e
           cargo --version
+          set +e
           cargo test --release --features arrow
           echo "Rust test,$?" >> ../../status.txt
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,8 @@ if(MSVC)
     add_compile_options("/EHa")
     # Reduces the size of the static library by roughly 1/2
     add_compile_options("/Zc:inline")
+    # Disable type conversion warnings
+    add_compile_options(/wd4244 /wd4267)
     # Remove the default to avoid warnings
     STRING(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     STRING(REPLACE "/EHs" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
@@ -277,7 +279,7 @@ if (ENABLE_BACKTRACES)
         FetchContent_Declare(
           cpptrace
           GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
-          GIT_TAG        v0.5.4
+          GIT_TAG        v0.8.3
           GIT_SHALLOW    TRUE
         )
         FetchContent_MakeAvailable(cpptrace)

--- a/scripts/multiplatform-test-helper/collect-results.py
+++ b/scripts/multiplatform-test-helper/collect-results.py
@@ -40,12 +40,13 @@ def main():
     for platform in results_df_hash.keys():
         results_summary[platform] = []
         for stage in stages:
-            status = (
-                "✅"
-                if stage in results_exit_codes_hash[platform]
-                and results_exit_codes_hash[platform][stage] == 0
-                else "❌"
-            )
+            if stage in results_exit_codes_hash[platform]:
+                if results_exit_codes_hash[platform][stage] == 0:
+                    status = "✅"
+                else:
+                    status = "❌"
+            else:
+                status = "❓"
             results_summary[platform].append({"stage": stage, "status": status})
 
     summary_df = {"stage": stages}

--- a/scripts/multiplatform-test-helper/notify-discord.py
+++ b/scripts/multiplatform-test-helper/notify-discord.py
@@ -12,7 +12,7 @@ messages = []
 
 if __name__ == "__main__":
     if not len(sys.argv) == 2:
-        print("Usage: python send-dicord-notification.py <result.json>")
+        print("Usage: python send-discord-notification.py <result.json>")
         sys.exit(1)
     if not os.path.isfile(sys.argv[1]):
         print(f"Error: {sys.argv[1]} is not a file")

--- a/scripts/multiplatform-test-helper/notify-discord.py
+++ b/scripts/multiplatform-test-helper/notify-discord.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     message += "## Multiplatform test result:\n"
     with open(sys.argv[1], "r") as f:
         result = json.load(f)
-        for platform in result:
+        for platform in sorted(result.keys()):
             if len(message) >= 1500:
                 messages.append(message)
                 message = ""


### PR DESCRIPTION
~~Just a few builds fail now~~. Just 1 build fails now. Made builds `relwithdebinfo` to share build output and reduce build times.

- `macos-13` -> `macos-15`
- Removed `windows-2019`, builds were all failing
- `fedora-38` & `fedora-39` -> `fedora-41` & `fedora-42`
- `ubuntu-24.10` -> `ubuntu-25.04`
- Moved to torch 2.6.0 on all platforms
- Reorganized builds to share artifacts -> reduced runtime by about 30min on most platforms
- Removed `PIP_BREAK_SYSTEM_PACKAGES`

Just `rockylinux-8`'s tests are [failing](https://github.com/kuzudb/kuzu/actions/runs/14960623078/job/42022033695) now:
```
 The following tests FAILED:
	268 - OptimizerTest.SingleNodeTwoHopJoins (Failed)
	2046 - e2e_test_function~gds~weighted_shortest.WeightedShortestPath (Failed)
```
