### PR TITLE
ci: modify existing benchmark comment instead of multiple new comments

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -865,7 +865,7 @@ jobs:
       - name: Report benchmark result
         uses: thollander/actions-comment-pull-request@v3
         with:
-          filePath: compare_result.md
+          file-path: compare_result.md
           comment-tag: benchmark-execution
 
   clang-tidy:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -863,9 +863,10 @@ jobs:
           name: comparison-results
 
       - name: Report benchmark result
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@v3
         with:
           filePath: compare_result.md
+          comment-tag: benchmark-execution
 
   clang-tidy:
     name: clang tidy & clangd diagnostics check


### PR DESCRIPTION
Currently, new PR commits create new benchmark comments, taking up space when scrolling through other comments.

This PR makes the benchmark results appear in only one commit.

Note that codecov already works this way.
