### PR TITLE
Remove planner enumeration logic and output single optimal plan

### DIFF
--- a/extension/algo/test/test_files/basic.test
+++ b/extension/algo/test/test_files/basic.test
@@ -3,7 +3,7 @@
 --
 
 -CASE InstallOfficialExtension
--STATEMENT INSTALL algo FROM 'http://localhost/extension/repo/'
+-STATEMENT FORCE INSTALL algo FROM 'http://localhost/extension/repo/'
 ---- ok
 -STATEMENT load algo
 ---- ok

--- a/extension/delta/test/test_files/delta.test
+++ b/extension/delta/test/test_files/delta.test
@@ -90,7 +90,7 @@ Diana|40|2500.300000|1983-07-20 00:00:00
 Ethan|28|1800.600000|1996-03-10 00:00:00
 
 -CASE InstallOfficialExtension
--STATEMENT INSTALL DELTA FROM 'http://localhost/extension/repo/'
+-STATEMENT FORCE INSTALL DELTA FROM 'http://localhost/extension/repo/'
 ---- ok
 -STATEMENT load extension DELTA
 ---- ok

--- a/extension/duckdb/test/test_files/duckdb.test
+++ b/extension/duckdb/test/test_files/duckdb.test
@@ -306,7 +306,7 @@ You can load it by: load extension postgres;
 Runtime exception: No loaded extension can handle database type: sqlite.
 
 -CASE InstallOfficialExtension
--STATEMENT INSTALL duckdb FROM 'http://localhost/extension/repo/'
+-STATEMENT FORCE INSTALL duckdb FROM 'http://localhost/extension/repo/'
 ---- ok
 -STATEMENT load extension duckdb
 ---- ok

--- a/extension/fts/test/test_files/basic.test
+++ b/extension/fts/test/test_files/basic.test
@@ -307,7 +307,7 @@ title3
 5
 
 -CASE InstallOfficialExtension
--STATEMENT INSTALL fts FROM 'http://localhost/extension/repo/'
+-STATEMENT FORCE INSTALL fts FROM 'http://localhost/extension/repo/'
 ---- ok
 -STATEMENT load fts
 ---- ok

--- a/extension/httpfs/test/test_files/http.test
+++ b/extension/httpfs/test/test_files/http.test
@@ -163,7 +163,7 @@ Runtime exception: Cannot attach an external Kuzu database with non-empty wal fi
 Binder exception: Attaching a kuzu database without an alias is not allowed.
 
 -CASE InstallOfficialExtension
--STATEMENT INSTALL httpfs FROM 'http://localhost/extension/repo/'
+-STATEMENT FORCE INSTALL httpfs FROM 'http://localhost/extension/repo/'
 ---- ok
 -STATEMENT load extension httpfs
 ---- ok

--- a/extension/iceberg/test/test_files/iceberg.test
+++ b/extension/iceberg/test/test_files/iceberg.test
@@ -147,7 +147,7 @@ lineitem_iceberg/metadata/cf3d0be5-cf70-453d-ad8f-48fdc412e608-m0.avro|1|DATA|AD
 6|6|1992-03-07|TAKE BACK RETURN
 
 -CASE InstallOfficialExtension
--STATEMENT INSTALL iceberg FROM 'http://localhost/extension/repo/'
+-STATEMENT FORCE INSTALL iceberg FROM 'http://localhost/extension/repo/'
 ---- ok
 -STATEMENT load extension iceberg
 ---- ok

--- a/extension/json/test/scan_json.test
+++ b/extension/json/test/scan_json.test
@@ -165,7 +165,7 @@ Unable to find primary key value 6.|${KUZU_ROOT_DIRECTORY}/dataset/json-error/in
 [{objectType: contact, schemaVersion: 135, contactIdentifier: 320864, contactNamespace: , contactDetail: {fullname: Renee Luke, email: renee.luke@datapath.com, phone: (678) 252-4828 - Direct}}]
 
 -CASE InstallOfficialExtension
--STATEMENT INSTALL json FROM 'http://localhost/extension/repo/'
+-STATEMENT FORCE INSTALL json FROM 'http://localhost/extension/repo/'
 ---- ok
 -STATEMENT load extension json
 ---- ok

--- a/extension/neo4j/test/test_files/install_neo4j.test
+++ b/extension/neo4j/test/test_files/install_neo4j.test
@@ -3,7 +3,7 @@
 --
 
 -CASE InstallOfficialExtension
--STATEMENT INSTALL neo4j FROM 'http://localhost/extension/repo/'
+-STATEMENT FORCE INSTALL neo4j FROM 'http://localhost/extension/repo/'
 ---- ok
 -STATEMENT load extension neo4j
 ---- ok

--- a/extension/postgres/test/test_files/install_postgres.test
+++ b/extension/postgres/test/test_files/install_postgres.test
@@ -3,7 +3,7 @@
 --
 
 -CASE InstallOfficialExtension
--STATEMENT INSTALL postgres FROM 'http://localhost/extension/repo/'
+-STATEMENT FORCE INSTALL postgres FROM 'http://localhost/extension/repo/'
 ---- ok
 -STATEMENT load extension postgres
 ---- ok

--- a/extension/sqlite/test/test_files/sqlite.test
+++ b/extension/sqlite/test/test_files/sqlite.test
@@ -109,7 +109,7 @@ Conversion Error: timestamp field value out of range: "08:30:00", expected forma
 4|Dan||750.600000|25|1|1998-09-05|1998-09-05 09:15:00|
 
 -CASE InstallOfficialExtension
--STATEMENT INSTALL sqlite FROM 'http://localhost/extension/repo/'
+-STATEMENT FORCE INSTALL sqlite FROM 'http://localhost/extension/repo/'
 ---- ok
 -STATEMENT load extension sqlite
 ---- ok

--- a/extension/vector/test/test_files/small.test
+++ b/extension/vector/test/test_files/small.test
@@ -361,7 +361,7 @@ embeddings|e_hnsw_index|HNSW|[vec]|False|
 embeddings|e_hnsw_index|HNSW|[vec]|True|CALL CREATE_VECTOR_INDEX('embeddings', 'e_hnsw_index', 'vec', mu := 30, ml := 60, pu := 0.050000, metric := 'l2', alpha := 1.100000, efc := 200);
 
 -CASE InstallOfficialExtension
--STATEMENT INSTALL vector FROM 'http://localhost/extension/repo/'
+-STATEMENT FORCE INSTALL vector FROM 'http://localhost/extension/repo/'
 ---- ok
 -STATEMENT LOAD vector
 ---- ok

--- a/src/function/table/table_function.cpp
+++ b/src/function/table/table_function.cpp
@@ -79,13 +79,11 @@ std::vector<std::string> TableFunction::extractYieldVariables(const std::vector<
     return variableNames;
 }
 
-void TableFunction::getLogicalPlan(planner::Planner* planner,
+void TableFunction::getLogicalPlan(Planner* planner,
     const binder::BoundReadingClause& boundReadingClause, binder::expression_vector predicates,
-    std::vector<std::unique_ptr<planner::LogicalPlan>>& plans) {
-    for (auto& plan : plans) {
-        auto op = planner->getTableFunctionCall(boundReadingClause);
-        planner->planReadOp(op, predicates, *plan);
-    }
+    LogicalPlan& plan) {
+    auto op = planner->getTableFunctionCall(boundReadingClause);
+    planner->planReadOp(op, predicates, plan);
 }
 
 std::unique_ptr<PhysicalOperator> TableFunction::getPhysicalPlan(PlanMapper* planMapper,

--- a/src/include/binder/bound_attach_database.h
+++ b/src/include/binder/bound_attach_database.h
@@ -13,10 +13,10 @@ public:
               BoundStatementResult::createSingleStringColumnResult()},
           attachInfo{std::move(attachInfo)} {}
 
-    binder::AttachInfo getAttachInfo() const { return attachInfo; }
+    AttachInfo getAttachInfo() const { return attachInfo; }
 
 private:
-    binder::AttachInfo attachInfo;
+    AttachInfo attachInfo;
 };
 
 } // namespace binder

--- a/src/include/binder/bound_create_macro.h
+++ b/src/include/binder/bound_create_macro.h
@@ -7,16 +7,18 @@ namespace kuzu {
 namespace binder {
 
 class BoundCreateMacro final : public BoundStatement {
+    static constexpr common::StatementType type_ = common::StatementType::CREATE_MACRO;
+
 public:
     explicit BoundCreateMacro(std::string macroName,
         std::unique_ptr<function::ScalarMacroFunction> macro)
-        : BoundStatement{common::StatementType::CREATE_MACRO,
+        : BoundStatement{type_,
               BoundStatementResult::createSingleStringColumnResult("result" /* columnName */)},
           macroName{std::move(macroName)}, macro{std::move(macro)} {}
 
-    inline std::string getMacroName() const { return macroName; }
+    std::string getMacroName() const { return macroName; }
 
-    inline std::unique_ptr<function::ScalarMacroFunction> getMacro() const { return macro->copy(); }
+    std::unique_ptr<function::ScalarMacroFunction> getMacro() const { return macro->copy(); }
 
 private:
     std::string macroName;

--- a/src/include/binder/bound_explain.h
+++ b/src/include/binder/bound_explain.h
@@ -7,17 +7,18 @@ namespace kuzu {
 namespace binder {
 
 class BoundExplain final : public BoundStatement {
+    static constexpr common::StatementType type_ = common::StatementType::EXPLAIN;
+
 public:
     explicit BoundExplain(std::unique_ptr<BoundStatement> statementToExplain,
         common::ExplainType explainType)
-        : BoundStatement{common::StatementType::EXPLAIN,
-              BoundStatementResult::createSingleStringColumnResult(
-                  "explain result" /* columnName */)},
+        : BoundStatement{type_, BoundStatementResult::createSingleStringColumnResult(
+                                    "explain result" /* columnName */)},
           statementToExplain{std::move(statementToExplain)}, explainType{explainType} {}
 
-    inline BoundStatement* getStatementToExplain() const { return statementToExplain.get(); }
+    BoundStatement* getStatementToExplain() const { return statementToExplain.get(); }
 
-    inline common::ExplainType getExplainType() const { return explainType; }
+    common::ExplainType getExplainType() const { return explainType; }
 
 private:
     std::unique_ptr<BoundStatement> statementToExplain;

--- a/src/include/binder/bound_extension_statement.h
+++ b/src/include/binder/bound_extension_statement.h
@@ -9,10 +9,11 @@ namespace binder {
 using namespace kuzu::extension;
 
 class BoundExtensionStatement final : public BoundStatement {
+    static constexpr common::StatementType type_ = common::StatementType::EXTENSION;
+
 public:
     explicit BoundExtensionStatement(std::unique_ptr<ExtensionAuxInfo> info)
-        : BoundStatement{common::StatementType::EXTENSION,
-              BoundStatementResult::createSingleStringColumnResult()},
+        : BoundStatement{type_, BoundStatementResult::createSingleStringColumnResult()},
           info{std::move(info)} {}
 
     std::unique_ptr<ExtensionAuxInfo> getAuxInfo() const { return info->copy(); }

--- a/src/include/binder/bound_standalone_call.h
+++ b/src/include/binder/bound_standalone_call.h
@@ -8,11 +8,12 @@ namespace kuzu {
 namespace binder {
 
 class BoundStandaloneCall final : public BoundStatement {
+    static constexpr common::StatementType type_ = common::StatementType::STANDALONE_CALL;
+
 public:
     BoundStandaloneCall(const main::Option* option, std::shared_ptr<Expression> optionValue)
-        : BoundStatement{common::StatementType::STANDALONE_CALL,
-              BoundStatementResult::createEmptyResult()},
-          option{option}, optionValue{std::move(optionValue)} {}
+        : BoundStatement{type_, BoundStatementResult::createEmptyResult()}, option{option},
+          optionValue{std::move(optionValue)} {}
 
     const main::Option* getOption() const { return option; }
 

--- a/src/include/binder/bound_statement.h
+++ b/src/include/binder/bound_statement.h
@@ -18,6 +18,9 @@ public:
     common::StatementType getStatementType() const { return statementType; }
 
     const BoundStatementResult* getStatementResult() const { return &statementResult; }
+    std::shared_ptr<Expression> getSingleColumnExpr() const {
+        return statementResult.getSingleColumnExpr();
+    }
 
     BoundStatementResult* getStatementResultUnsafe() { return &statementResult; }
 

--- a/src/include/binder/bound_use_database.h
+++ b/src/include/binder/bound_use_database.h
@@ -6,9 +6,11 @@ namespace kuzu {
 namespace binder {
 
 class BoundUseDatabase final : public BoundDatabaseStatement {
+    static constexpr common::StatementType type_ = common::StatementType::USE_DATABASE;
+
 public:
     explicit BoundUseDatabase(std::string dbName)
-        : BoundDatabaseStatement{common::StatementType::USE_DATABASE, std::move(dbName)} {}
+        : BoundDatabaseStatement{type_, std::move(dbName)} {}
 };
 
 } // namespace binder

--- a/src/include/binder/copy/bound_copy_to.h
+++ b/src/include/binder/copy/bound_copy_to.h
@@ -7,10 +7,12 @@ namespace kuzu {
 namespace binder {
 
 class BoundCopyTo final : public BoundStatement {
+    static constexpr common::StatementType type_ = common::StatementType::COPY_TO;
+
 public:
     BoundCopyTo(std::unique_ptr<function::ExportFuncBindData> bindData,
         function::ExportFunction exportFunc, std::unique_ptr<BoundStatement> query)
-        : BoundStatement{common::StatementType::COPY_TO, BoundStatementResult::createEmptyResult()},
+        : BoundStatement{type_, BoundStatementResult::createEmptyResult()},
           bindData{std::move(bindData)}, exportFunc{std::move(exportFunc)},
           query{std::move(query)} {}
 

--- a/src/include/binder/ddl/bound_alter.h
+++ b/src/include/binder/ddl/bound_alter.h
@@ -7,13 +7,14 @@ namespace kuzu {
 namespace binder {
 
 class BoundAlter final : public BoundStatement {
+    static constexpr common::StatementType type_ = common::StatementType::ALTER;
+
 public:
     explicit BoundAlter(BoundAlterInfo info)
-        : BoundStatement{common::StatementType::ALTER,
-              BoundStatementResult::createSingleStringColumnResult()},
+        : BoundStatement{type_, BoundStatementResult::createSingleStringColumnResult()},
           info{std::move(info)} {}
 
-    inline const BoundAlterInfo* getInfo() const { return &info; }
+    const BoundAlterInfo& getInfo() const { return info; }
 
 private:
     BoundAlterInfo info;

--- a/src/include/binder/ddl/bound_create_sequence.h
+++ b/src/include/binder/ddl/bound_create_sequence.h
@@ -6,13 +6,14 @@ namespace kuzu {
 namespace binder {
 
 class BoundCreateSequence final : public BoundStatement {
+    static constexpr common::StatementType type_ = common::StatementType::CREATE_SEQUENCE;
+
 public:
     explicit BoundCreateSequence(BoundCreateSequenceInfo info)
-        : BoundStatement{common::StatementType::CREATE_SEQUENCE,
-              BoundStatementResult::createSingleStringColumnResult()},
+        : BoundStatement{type_, BoundStatementResult::createSingleStringColumnResult()},
           info{std::move(info)} {}
 
-    const BoundCreateSequenceInfo* getInfo() const { return &info; }
+    const BoundCreateSequenceInfo& getInfo() const { return info; }
 
 private:
     BoundCreateSequenceInfo info;

--- a/src/include/binder/ddl/bound_create_table.h
+++ b/src/include/binder/ddl/bound_create_table.h
@@ -7,13 +7,14 @@ namespace kuzu {
 namespace binder {
 
 class BoundCreateTable final : public BoundStatement {
+    static constexpr common::StatementType type_ = common::StatementType::CREATE_TABLE;
+
 public:
     explicit BoundCreateTable(BoundCreateTableInfo info)
-        : BoundStatement{common::StatementType::CREATE_TABLE,
-              BoundStatementResult::createSingleStringColumnResult()},
+        : BoundStatement{type_, BoundStatementResult::createSingleStringColumnResult()},
           info{std::move(info)} {}
 
-    inline const BoundCreateTableInfo* getInfo() const { return &info; }
+    const BoundCreateTableInfo& getInfo() const { return info; }
 
 private:
     BoundCreateTableInfo info;

--- a/src/include/binder/query/bound_regular_query.h
+++ b/src/include/binder/query/bound_regular_query.h
@@ -7,16 +7,16 @@ namespace kuzu {
 namespace binder {
 
 class BoundRegularQuery final : public BoundStatement {
+    static constexpr common::StatementType type_ = common::StatementType::QUERY;
 
 public:
     explicit BoundRegularQuery(std::vector<bool> isUnionAll, BoundStatementResult statementResult)
-        : BoundStatement{common::StatementType::QUERY, std::move(statementResult)},
-          isUnionAll{std::move(isUnionAll)} {}
+        : BoundStatement{type_, std::move(statementResult)}, isUnionAll{std::move(isUnionAll)} {}
 
     void addSingleQuery(NormalizedSingleQuery singleQuery) {
         singleQueries.push_back(std::move(singleQuery));
     }
-    uint64_t getNumSingleQueries() const { return singleQueries.size(); }
+    common::idx_t getNumSingleQueries() const { return singleQueries.size(); }
     NormalizedSingleQuery* getSingleQueryUnsafe(common::idx_t idx) { return &singleQueries[idx]; }
     const NormalizedSingleQuery* getSingleQuery(common::idx_t idx) const {
         return &singleQueries[idx];

--- a/src/include/function/export/export_function.h
+++ b/src/include/function/export/export_function.h
@@ -68,6 +68,7 @@ using export_combine_t = std::function<void(ExportFuncSharedState&, ExportFuncLo
 using export_finalize_t = std::function<void(ExportFuncSharedState&)>;
 
 struct KUZU_API ExportFunction : public Function {
+    ExportFunction() = default;
     explicit ExportFunction(std::string name) : Function{std::move(name), {}} {}
 
     ExportFunction(std::string name, export_init_local_t initLocal,

--- a/src/include/function/gds/gds.h
+++ b/src/include/function/gds/gds.h
@@ -95,7 +95,7 @@ public:
         const TableFuncInitSharedStateInput& input);
     static void getLogicalPlan(planner::Planner* planner,
         const binder::BoundReadingClause& readingClause, binder::expression_vector predicates,
-        std::vector<std::unique_ptr<planner::LogicalPlan>>& logicalPlans);
+        planner::LogicalPlan& plan);
     static std::unique_ptr<processor::PhysicalOperator> getPhysicalPlan(
         processor::PlanMapper* planMapper, const planner::LogicalOperator* logicalOp);
 };

--- a/src/include/function/scalar_macro_function.h
+++ b/src/include/function/scalar_macro_function.h
@@ -21,11 +21,9 @@ struct ScalarMacroFunction {
         : expression{std::move(expression)}, positionalArgs{std::move(positionalArgs)},
           defaultArgs{std::move(defaultArgs)} {}
 
-    inline std::string getDefaultParameterName(uint64_t idx) const {
-        return defaultArgs[idx].first;
-    }
+    std::string getDefaultParameterName(uint64_t idx) const { return defaultArgs[idx].first; }
 
-    inline uint64_t getNumArgs() const { return positionalArgs.size() + defaultArgs.size(); }
+    uint64_t getNumArgs() const { return positionalArgs.size() + defaultArgs.size(); }
 
     std::vector<std::string> getPositionalArgs() const { return positionalArgs; }
 

--- a/src/include/function/table/table_function.h
+++ b/src/include/function/table/table_function.h
@@ -138,9 +138,9 @@ using table_func_finalize_t =
     std::function<void(const processor::ExecutionContext*, TableFuncSharedState*)>;
 using table_func_rewrite_t =
     std::function<std::string(main::ClientContext&, const TableFuncBindData& bindData)>;
-using table_func_get_logical_plan_t = std::function<void(planner::Planner*,
-    const binder::BoundReadingClause&, std::vector<std::shared_ptr<binder::Expression>>,
-    std::vector<std::unique_ptr<planner::LogicalPlan>>&)>;
+using table_func_get_logical_plan_t =
+    std::function<void(planner::Planner*, const binder::BoundReadingClause&,
+        std::vector<std::shared_ptr<binder::Expression>>, planner::LogicalPlan&)>;
 using table_func_get_physical_plan_t = std::function<std::unique_ptr<processor::PhysicalOperator>(
     processor::PlanMapper*, const planner::LogicalOperator*)>;
 using table_func_infer_input_types =
@@ -189,7 +189,7 @@ struct KUZU_API TableFunction final : Function {
     // Get logical plan func
     static void getLogicalPlan(planner::Planner* planner,
         const binder::BoundReadingClause& boundReadingClause, binder::expression_vector predicates,
-        std::vector<std::unique_ptr<planner::LogicalPlan>>& plans);
+        planner::LogicalPlan& plan);
     // Get physical plan func
     static std::unique_ptr<processor::PhysicalOperator> getPhysicalPlan(
         processor::PlanMapper* planMapper, const planner::LogicalOperator* logicalOp);

--- a/src/include/planner/join_order_enumerator_context.h
+++ b/src/include/planner/join_order_enumerator_context.h
@@ -17,26 +17,25 @@ public:
 
     void init(const binder::QueryGraph* queryGraph, const binder::expression_vector& predicates);
 
-    inline binder::expression_vector getWhereExpressions() { return whereExpressionsSplitOnAND; }
+    binder::expression_vector getWhereExpressions() { return whereExpressionsSplitOnAND; }
 
-    inline bool containPlans(const binder::SubqueryGraph& subqueryGraph) const {
+    bool containPlans(const binder::SubqueryGraph& subqueryGraph) const {
         return subPlansTable->containSubgraphPlans(subqueryGraph);
     }
-    inline std::vector<std::unique_ptr<LogicalPlan>>& getPlans(
+    std::vector<std::unique_ptr<LogicalPlan>>& getPlans(
         const binder::SubqueryGraph& subqueryGraph) const {
         return subPlansTable->getSubgraphPlans(subqueryGraph);
     }
-    inline void addPlan(const binder::SubqueryGraph& subqueryGraph,
-        std::unique_ptr<LogicalPlan> plan) {
+    void addPlan(const binder::SubqueryGraph& subqueryGraph, std::unique_ptr<LogicalPlan> plan) {
         subPlansTable->addPlan(subqueryGraph, std::move(plan));
     }
 
-    inline binder::SubqueryGraph getEmptySubqueryGraph() const {
+    binder::SubqueryGraph getEmptySubqueryGraph() const {
         return binder::SubqueryGraph(*queryGraph);
     }
     binder::SubqueryGraph getFullyMatchedSubqueryGraph() const;
 
-    inline const binder::QueryGraph* getQueryGraph() { return queryGraph; }
+    const binder::QueryGraph* getQueryGraph() { return queryGraph; }
 
     void resetState();
 

--- a/src/include/planner/operator/logical_plan.h
+++ b/src/include/planner/operator/logical_plan.h
@@ -13,6 +13,7 @@ class KUZU_API LogicalPlan {
 
 public:
     LogicalPlan() : cost{0} {}
+    EXPLICIT_COPY_DEFAULT_MOVE(LogicalPlan);
 
     void setLastOperator(std::shared_ptr<LogicalOperator> op) { lastOperator = std::move(op); }
 
@@ -40,7 +41,8 @@ public:
 
     std::unique_ptr<LogicalPlan> shallowCopy() const;
 
-    std::unique_ptr<LogicalPlan> deepCopy() const;
+private:
+    LogicalPlan(const LogicalPlan& other) : lastOperator{other.lastOperator}, cost{other.cost} {}
 
 private:
     std::shared_ptr<LogicalOperator> lastOperator;

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -66,74 +66,59 @@ public:
     explicit Planner(main::ClientContext* clientContext);
     DELETE_COPY_AND_MOVE(Planner);
 
-    std::unique_ptr<LogicalPlan> getBestPlan(const binder::BoundStatement& statement);
-
-    std::vector<std::unique_ptr<LogicalPlan>> getAllPlans(const binder::BoundStatement& statement);
+    LogicalPlan planStatement(const binder::BoundStatement& statement);
 
     // Plan simple statement.
-    void appendCreateTable(const binder::BoundStatement& statement, LogicalPlan& plan);
-    void appendCreateType(const binder::BoundStatement& statement, LogicalPlan& plan);
-    void appendCreateSequence(const binder::BoundStatement& statement, LogicalPlan& plan);
-    void appendDrop(const binder::BoundStatement& statement, LogicalPlan& plan);
-    void appendAlter(const binder::BoundStatement& statement, LogicalPlan& plan);
-    void appendStandaloneCall(const binder::BoundStatement& statement, LogicalPlan& plan);
-    void appendStandaloneCallFunction(const binder::BoundStatement& statement, LogicalPlan& plan);
-    void appendExplain(const binder::BoundStatement& statement, LogicalPlan& plan);
-    void appendCreateMacro(const binder::BoundStatement& statement, LogicalPlan& plan);
-    void appendTransaction(const binder::BoundStatement& statement, LogicalPlan& plan);
-    void appendExtension(const binder::BoundStatement& statement, LogicalPlan& plan);
-    void appendAttachDatabase(const binder::BoundStatement& statement, LogicalPlan& plan);
-    void appendDetachDatabase(const binder::BoundStatement& statement, LogicalPlan& plan);
-    void appendUseDatabase(const binder::BoundStatement& statement, LogicalPlan& plan);
+    LogicalPlan planCreateTable(const binder::BoundStatement& statement);
+    LogicalPlan planCreateType(const binder::BoundStatement& statement);
+    LogicalPlan planCreateSequence(const binder::BoundStatement& statement);
+    LogicalPlan planCreateMacro(const binder::BoundStatement& statement);
+    LogicalPlan planDrop(const binder::BoundStatement& statement);
+    LogicalPlan planAlter(const binder::BoundStatement& statement);
+    LogicalPlan planStandaloneCall(const binder::BoundStatement& statement);
+    LogicalPlan planStandaloneCallFunction(const binder::BoundStatement& statement);
+    LogicalPlan planExplain(const binder::BoundStatement& statement);
+    LogicalPlan planTransaction(const binder::BoundStatement& statement);
+    LogicalPlan planExtension(const binder::BoundStatement& statement);
+    LogicalPlan planAttachDatabase(const binder::BoundStatement& statement);
+    LogicalPlan planDetachDatabase(const binder::BoundStatement& statement);
+    LogicalPlan planUseDatabase(const binder::BoundStatement& statement);
 
     // Plan copy.
-    std::unique_ptr<LogicalPlan> planCopyTo(const binder::BoundStatement& statement);
-    std::unique_ptr<LogicalPlan> planCopyFrom(const binder::BoundStatement& statement);
-    std::unique_ptr<LogicalPlan> planCopyNodeFrom(const binder::BoundCopyFromInfo* info,
+    LogicalPlan planCopyTo(const binder::BoundStatement& statement);
+    LogicalPlan planCopyFrom(const binder::BoundStatement& statement);
+    LogicalPlan planCopyNodeFrom(const binder::BoundCopyFromInfo* info,
         binder::expression_vector outExprs);
-    std::unique_ptr<LogicalPlan> planCopyRelFrom(const binder::BoundCopyFromInfo* info,
+    LogicalPlan planCopyRelFrom(const binder::BoundCopyFromInfo* info,
         binder::expression_vector outExprs);
 
     // Plan export/import database
-    std::unique_ptr<LogicalPlan> planExportDatabase(const binder::BoundStatement& statement);
-    std::unique_ptr<LogicalPlan> planImportDatabase(const binder::BoundStatement& statement);
+    LogicalPlan planExportDatabase(const binder::BoundStatement& statement);
+    LogicalPlan planImportDatabase(const binder::BoundStatement& statement);
 
     // Plan query.
-    std::vector<std::unique_ptr<LogicalPlan>> planQuery(
-        const binder::BoundStatement& boundStatement);
-    std::vector<std::unique_ptr<LogicalPlan>> planSingleQuery(
-        const binder::NormalizedSingleQuery* singleQuery);
-    std::vector<std::unique_ptr<LogicalPlan>> planQueryPart(
-        const binder::NormalizedQueryPart* queryPart,
-        std::vector<std::unique_ptr<LogicalPlan>> prevPlans);
+    LogicalPlan planQuery(const binder::BoundStatement& boundStatement);
+    LogicalPlan planSingleQuery(const binder::NormalizedSingleQuery& singleQuery);
+    void planQueryPart(const binder::NormalizedQueryPart& queryPart, LogicalPlan& prevPlan);
 
     // Plan read.
-    void planReadingClause(const binder::BoundReadingClause& readingClause,
-        std::vector<std::unique_ptr<LogicalPlan>>& prevPlans);
-    void planMatchClause(const binder::BoundReadingClause& readingClause,
-        std::vector<std::unique_ptr<LogicalPlan>>& plans);
-    void planUnwindClause(const binder::BoundReadingClause& readingClause,
-        std::vector<std::unique_ptr<LogicalPlan>>& plans);
-    void planTableFunctionCall(const binder::BoundReadingClause& readingClause,
-        std::vector<std::unique_ptr<LogicalPlan>>& plans);
+    void planReadingClause(const binder::BoundReadingClause& readingClause, LogicalPlan& plan);
+    void planMatchClause(const binder::BoundReadingClause& readingClause, LogicalPlan& plan);
+    void planUnwindClause(const binder::BoundReadingClause& readingClause, LogicalPlan& plan);
+    void planTableFunctionCall(const binder::BoundReadingClause& readingClause, LogicalPlan& plan);
 
     void planReadOp(std::shared_ptr<LogicalOperator> op,
         const binder::expression_vector& predicates, LogicalPlan& plan);
-    void planLoadFrom(const binder::BoundReadingClause& readingClause,
-        std::vector<std::unique_ptr<LogicalPlan>>& plans);
+    void planLoadFrom(const binder::BoundReadingClause& readingClause, LogicalPlan& plan);
 
     // Plan updating
-    void planUpdatingClause(const binder::BoundUpdatingClause* updatingClause,
-        std::vector<std::unique_ptr<LogicalPlan>>& plans);
-    void planUpdatingClause(const binder::BoundUpdatingClause* updatingClause, LogicalPlan& plan);
-    void planInsertClause(const binder::BoundUpdatingClause* updatingClause, LogicalPlan& plan);
-    void planMergeClause(const binder::BoundUpdatingClause* updatingClause, LogicalPlan& plan);
-    void planSetClause(const binder::BoundUpdatingClause* updatingClause, LogicalPlan& plan);
-    void planDeleteClause(const binder::BoundUpdatingClause* updatingClause, LogicalPlan& plan);
+    void planUpdatingClause(const binder::BoundUpdatingClause& updatingClause, LogicalPlan& plan);
+    void planInsertClause(const binder::BoundUpdatingClause& updatingClause, LogicalPlan& plan);
+    void planMergeClause(const binder::BoundUpdatingClause& updatingClause, LogicalPlan& plan);
+    void planSetClause(const binder::BoundUpdatingClause& updatingClause, LogicalPlan& plan);
+    void planDeleteClause(const binder::BoundUpdatingClause& updatingClause, LogicalPlan& plan);
 
     // Plan projection
-    void planProjectionBody(const binder::BoundProjectionBody* projectionBody,
-        const std::vector<std::unique_ptr<LogicalPlan>>& plans);
     void planProjectionBody(const binder::BoundProjectionBody* projectionBody, LogicalPlan& plan);
     void planAggregate(const binder::expression_vector& expressionsToAggregate,
         const binder::expression_vector& expressionsToGroupBy, LogicalPlan& plan);
@@ -160,18 +145,13 @@ public:
         Schema* outerSchema);
 
     // Plan query graphs
-    std::unique_ptr<LogicalPlan> planQueryGraphCollection(
+    LogicalPlan planQueryGraphCollectionInNewContext(
         const binder::QueryGraphCollection& queryGraphCollection,
         const QueryGraphPlanningInfo& info);
-    std::unique_ptr<LogicalPlan> planQueryGraphCollectionInNewContext(
-        const binder::QueryGraphCollection& queryGraphCollection,
+    LogicalPlan planQueryGraphCollection(const binder::QueryGraphCollection& queryGraphCollection,
         const QueryGraphPlanningInfo& info);
-
-    std::vector<std::unique_ptr<LogicalPlan>> enumerateQueryGraphCollection(
-        const binder::QueryGraphCollection& queryGraphCollection,
+    LogicalPlan planQueryGraph(const binder::QueryGraph& queryGraph,
         const QueryGraphPlanningInfo& info);
-    std::vector<std::unique_ptr<LogicalPlan>> enumerateQueryGraph(
-        const binder::QueryGraph& queryGraph, const QueryGraphPlanningInfo& info);
 
     // Plan node/rel table scan
     void planBaseTableScans(const QueryGraphPlanningInfo& info);
@@ -203,10 +183,6 @@ public:
     void planInnerHashJoin(const binder::SubqueryGraph& subgraph,
         const binder::SubqueryGraph& otherSubgraph,
         const std::vector<std::shared_ptr<binder::NodeExpression>>& joinNodes, bool flipPlan);
-
-    std::vector<std::unique_ptr<LogicalPlan>> planCrossProduct(
-        std::vector<std::unique_ptr<LogicalPlan>> leftPlans,
-        std::vector<std::unique_ptr<LogicalPlan>> rightPlans);
 
     LogicalPlan getNodeSemiMaskPlan(SemiMaskTargetType targetType,
         const binder::NodeExpression& node, std::shared_ptr<binder::Expression> nodePredicate);
@@ -334,11 +310,8 @@ public:
     static std::shared_ptr<LogicalOperator> getTableFunctionCall(
         const binder::BoundReadingClause& readingClause);
 
-    std::unique_ptr<LogicalPlan> createUnionPlan(
-        std::vector<std::unique_ptr<LogicalPlan>>& childrenPlans, bool isUnionAll);
-    std::unique_ptr<LogicalPlan> getBestPlan(std::vector<std::unique_ptr<LogicalPlan>> plans);
-
-    static std::vector<std::unique_ptr<LogicalPlan>> getInitialEmptyPlans();
+    LogicalPlan createUnionPlan(std::vector<LogicalPlan>& childrenPlans, bool isUnionAll);
+    LogicalPlan getBestPlan(std::vector<LogicalPlan> plans);
 
     binder::expression_vector getProperties(const binder::Expression& pattern) const;
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -491,11 +491,10 @@ std::unique_ptr<PreparedStatement> ClientContext::prepareNoLock(
                     boundStatement->getStatementResult()->copy());
                 // planning
                 auto planner = Planner(this);
-                auto bestPlan = planner.getBestPlan(*boundStatement);
+                auto bestPlan = planner.planStatement(*boundStatement);
                 // optimizing
-                optimizer::Optimizer::optimize(bestPlan.get(), this,
-                    planner.getCardinalityEstimator());
-                preparedStatement->logicalPlan = std::move(bestPlan);
+                optimizer::Optimizer::optimize(&bestPlan, this, planner.getCardinalityEstimator());
+                preparedStatement->logicalPlan = bestPlan.shallowCopy();
             },
             preparedStatement->isReadOnly(), preparedStatement->isTransactionStatement(),
             TransactionHelper::getAction(shouldCommitNewTransaction,

--- a/src/planner/operator/logical_plan.cpp
+++ b/src/planner/operator/logical_plan.cpp
@@ -22,13 +22,5 @@ std::unique_ptr<LogicalPlan> LogicalPlan::shallowCopy() const {
     return plan;
 }
 
-std::unique_ptr<LogicalPlan> LogicalPlan::deepCopy() const {
-    KU_ASSERT(!isEmpty());
-    auto plan = std::make_unique<LogicalPlan>();
-    plan->lastOperator = lastOperator->copy(); // deep copy sub-plan
-    plan->cost = cost;
-    return plan;
-}
-
 } // namespace planner
 } // namespace kuzu

--- a/src/planner/plan/plan_projection.cpp
+++ b/src/planner/plan/plan_projection.cpp
@@ -7,13 +7,6 @@ using namespace kuzu::binder;
 namespace kuzu {
 namespace planner {
 
-void Planner::planProjectionBody(const BoundProjectionBody* projectionBody,
-    const std::vector<std::unique_ptr<LogicalPlan>>& plans) {
-    for (auto& plan : plans) {
-        planProjectionBody(projectionBody, *plan);
-    }
-}
-
 void Planner::planProjectionBody(const BoundProjectionBody* projectionBody, LogicalPlan& plan) {
     auto expressionsToProject = projectionBody->getProjectionExpressions();
     if (expressionsToProject.empty()) {

--- a/src/planner/plan/plan_single_query.cpp
+++ b/src/planner/plan/plan_single_query.cpp
@@ -10,43 +10,38 @@ namespace planner {
 // Note: we cannot append ResultCollector for plans enumerated for single query before there could
 // be a UNION on top which requires further flatten. So we delay ResultCollector appending to
 // enumerate regular query level.
-std::vector<std::unique_ptr<LogicalPlan>> Planner::planSingleQuery(
-    const NormalizedSingleQuery* singleQuery) {
-    auto propertyCollector = binder::PropertyCollector();
-    propertyCollector.visitSingleQuery(*singleQuery);
+LogicalPlan Planner::planSingleQuery(const NormalizedSingleQuery& singleQuery) {
+    auto propertyCollector = PropertyCollector();
+    propertyCollector.visitSingleQuery(singleQuery);
     auto properties = propertyCollector.getProperties();
     for (auto& expr : propertyCollector.getProperties()) {
         auto& property = expr->constCast<PropertyExpression>();
         propertyExprCollection.addProperties(property.getVariableName(), expr);
     }
     context.resetState();
-    auto plans = getInitialEmptyPlans();
-    for (auto i = 0u; i < singleQuery->getNumQueryParts(); ++i) {
-        plans = planQueryPart(singleQuery->getQueryPart(i), std::move(plans));
+    auto plan = LogicalPlan();
+    for (auto i = 0u; i < singleQuery.getNumQueryParts(); ++i) {
+        planQueryPart(*singleQuery.getQueryPart(i), plan);
     }
-    return plans;
+    return plan;
 }
 
-std::vector<std::unique_ptr<LogicalPlan>> Planner::planQueryPart(
-    const NormalizedQueryPart* queryPart, std::vector<std::unique_ptr<LogicalPlan>> prevPlans) {
-    std::vector<std::unique_ptr<LogicalPlan>> plans = std::move(prevPlans);
+void Planner::planQueryPart(const NormalizedQueryPart& queryPart, LogicalPlan& plan) {
     // plan read
-    for (auto i = 0u; i < queryPart->getNumReadingClause(); i++) {
-        planReadingClause(*queryPart->getReadingClause(i), plans);
+    for (auto i = 0u; i < queryPart.getNumReadingClause(); i++) {
+        planReadingClause(*queryPart.getReadingClause(i), plan);
     }
     // plan update
-    for (auto i = 0u; i < queryPart->getNumUpdatingClause(); ++i) {
-        planUpdatingClause(queryPart->getUpdatingClause(i), plans);
+    for (auto i = 0u; i < queryPart.getNumUpdatingClause(); ++i) {
+        planUpdatingClause(*queryPart.getUpdatingClause(i), plan);
     }
-    if (queryPart->hasProjectionBody()) {
-        planProjectionBody(queryPart->getProjectionBody(), plans);
-        if (queryPart->hasProjectionBodyPredicate()) {
-            for (auto& plan : plans) {
-                appendFilter(queryPart->getProjectionBodyPredicate(), *plan);
-            }
+    // plan projection
+    if (queryPart.hasProjectionBody()) {
+        planProjectionBody(queryPart.getProjectionBody(), plan);
+        if (queryPart.hasProjectionBodyPredicate()) {
+            appendFilter(queryPart.getProjectionBodyPredicate(), plan);
         }
     }
-    return plans;
 }
 
 } // namespace planner

--- a/src/planner/plan/plan_update.cpp
+++ b/src/planner/plan/plan_update.cpp
@@ -11,15 +11,8 @@ using namespace kuzu::binder;
 namespace kuzu {
 namespace planner {
 
-void Planner::planUpdatingClause(const BoundUpdatingClause* updatingClause,
-    std::vector<std::unique_ptr<LogicalPlan>>& plans) {
-    for (auto& plan : plans) {
-        planUpdatingClause(updatingClause, *plan);
-    }
-}
-
-void Planner::planUpdatingClause(const BoundUpdatingClause* updatingClause, LogicalPlan& plan) {
-    switch (updatingClause->getClauseType()) {
+void Planner::planUpdatingClause(const BoundUpdatingClause& updatingClause, LogicalPlan& plan) {
+    switch (updatingClause.getClauseType()) {
     case ClauseType::INSERT: {
         planInsertClause(updatingClause, plan);
         return;
@@ -41,8 +34,8 @@ void Planner::planUpdatingClause(const BoundUpdatingClause* updatingClause, Logi
     }
 }
 
-void Planner::planInsertClause(const BoundUpdatingClause* updatingClause, LogicalPlan& plan) {
-    auto& insertClause = updatingClause->constCast<BoundInsertClause>();
+void Planner::planInsertClause(const BoundUpdatingClause& updatingClause, LogicalPlan& plan) {
+    auto& insertClause = updatingClause.constCast<BoundInsertClause>();
     if (plan.isEmpty()) { // E.g. CREATE (a:Person {age:20})
         appendDummyScan(plan);
     } else {
@@ -56,8 +49,8 @@ void Planner::planInsertClause(const BoundUpdatingClause* updatingClause, Logica
     }
 }
 
-void Planner::planMergeClause(const BoundUpdatingClause* updatingClause, LogicalPlan& plan) {
-    auto& mergeClause = updatingClause->constCast<BoundMergeClause>();
+void Planner::planMergeClause(const BoundUpdatingClause& updatingClause, LogicalPlan& plan) {
+    auto& mergeClause = updatingClause.constCast<BoundMergeClause>();
     expression_vector predicates;
     if (mergeClause.hasPredicate()) {
         predicates = mergeClause.getPredicate()->splitOnAND();
@@ -118,9 +111,9 @@ void Planner::planMergeClause(const BoundUpdatingClause* updatingClause, Logical
     plan.setLastOperator(merge);
 }
 
-void Planner::planSetClause(const BoundUpdatingClause* updatingClause, LogicalPlan& plan) {
+void Planner::planSetClause(const BoundUpdatingClause& updatingClause, LogicalPlan& plan) {
     appendAccumulate(plan);
-    auto& setClause = updatingClause->constCast<BoundSetClause>();
+    auto& setClause = updatingClause.constCast<BoundSetClause>();
     if (setClause.hasNodeInfo()) {
         appendSetProperty(setClause.getNodeInfos(), plan);
     }
@@ -129,9 +122,9 @@ void Planner::planSetClause(const BoundUpdatingClause* updatingClause, LogicalPl
     }
 }
 
-void Planner::planDeleteClause(const BoundUpdatingClause* updatingClause, LogicalPlan& plan) {
+void Planner::planDeleteClause(const BoundUpdatingClause& updatingClause, LogicalPlan& plan) {
     appendAccumulate(plan);
-    auto& deleteClause = updatingClause->constCast<BoundDeleteClause>();
+    auto& deleteClause = updatingClause.constCast<BoundDeleteClause>();
     if (deleteClause.hasRelInfo()) {
         appendDelete(deleteClause.getRelInfos(), plan);
     }

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -1,4 +1,5 @@
 #include "planner/planner.h"
+
 #include "main/client_context.h"
 
 using namespace kuzu::binder;

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -1,6 +1,4 @@
 #include "planner/planner.h"
-
-#include "binder/bound_explain.h"
 #include "main/client_context.h"
 
 using namespace kuzu::binder;
@@ -27,7 +25,7 @@ expression_vector PropertyExprCollection::getProperties(const Expression& patter
     return patternNameToProperties.at(pattern.getUniqueName());
 }
 
-binder::expression_vector PropertyExprCollection::getProperties() const {
+expression_vector PropertyExprCollection::getProperties() const {
     expression_vector result;
     for (auto& [_, exprs] : patternNameToProperties) {
         for (auto& expr : exprs) {
@@ -38,7 +36,7 @@ binder::expression_vector PropertyExprCollection::getProperties() const {
 }
 
 void PropertyExprCollection::addProperties(const std::string& patternName,
-    std::shared_ptr<binder::Expression> property) {
+    std::shared_ptr<Expression> property) {
     if (!patternNameToProperties.contains(patternName)) {
         patternNameToProperties.insert({patternName, expression_vector{}});
     }
@@ -59,94 +57,68 @@ Planner::Planner(main::ClientContext* clientContext) : clientContext{clientConte
     context = JoinOrderEnumeratorContext();
 }
 
-std::unique_ptr<LogicalPlan> Planner::getBestPlan(const BoundStatement& statement) {
-    auto plan = std::make_unique<LogicalPlan>();
+LogicalPlan Planner::planStatement(const BoundStatement& statement) {
     switch (statement.getStatementType()) {
     case StatementType::QUERY: {
-        plan = getBestPlan(planQuery(statement));
+        return planQuery(statement);
     } break;
     case StatementType::CREATE_TABLE: {
-        appendCreateTable(statement, *plan);
+        return planCreateTable(statement);
     } break;
     case StatementType::CREATE_SEQUENCE: {
-        appendCreateSequence(statement, *plan);
+        return planCreateSequence(statement);
     } break;
     case StatementType::CREATE_TYPE: {
-        appendCreateType(statement, *plan);
+        return planCreateType(statement);
     } break;
     case StatementType::COPY_FROM: {
-        plan = planCopyFrom(statement);
+        return planCopyFrom(statement);
     } break;
     case StatementType::COPY_TO: {
-        plan = planCopyTo(statement);
+        return planCopyTo(statement);
     } break;
     case StatementType::DROP: {
-        appendDrop(statement, *plan);
+        return planDrop(statement);
     } break;
     case StatementType::ALTER: {
-        appendAlter(statement, *plan);
+        return planAlter(statement);
     } break;
     case StatementType::STANDALONE_CALL: {
-        appendStandaloneCall(statement, *plan);
+        return planStandaloneCall(statement);
     } break;
     case StatementType::STANDALONE_CALL_FUNCTION: {
-        appendStandaloneCallFunction(statement, *plan);
+        return planStandaloneCallFunction(statement);
     } break;
     case StatementType::EXPLAIN: {
-        appendExplain(statement, *plan);
+        return planExplain(statement);
     } break;
     case StatementType::CREATE_MACRO: {
-        appendCreateMacro(statement, *plan);
+        return planCreateMacro(statement);
     } break;
     case StatementType::TRANSACTION: {
-        appendTransaction(statement, *plan);
+        return planTransaction(statement);
     } break;
     case StatementType::EXTENSION: {
-        appendExtension(statement, *plan);
+        return planExtension(statement);
     } break;
     case StatementType::EXPORT_DATABASE: {
-        plan = planExportDatabase(statement);
+        return planExportDatabase(statement);
     } break;
     case StatementType::IMPORT_DATABASE: {
-        plan = planImportDatabase(statement);
+        return planImportDatabase(statement);
     } break;
     case StatementType::ATTACH_DATABASE: {
-        appendAttachDatabase(statement, *plan);
+        return planAttachDatabase(statement);
     } break;
     case StatementType::DETACH_DATABASE: {
-        appendDetachDatabase(statement, *plan);
+        return planDetachDatabase(statement);
     } break;
     case StatementType::USE_DATABASE: {
-        appendUseDatabase(statement, *plan);
+        return planUseDatabase(statement);
     } break;
     default:
         KU_UNREACHABLE;
     }
-    return plan;
-}
-
-std::vector<std::unique_ptr<LogicalPlan>> Planner::getAllPlans(const BoundStatement& statement) {
-    // We enumerate all plans for our testing framework. This API should only be used for QUERY,
-    // EXPLAIN, but not DDL or COPY.
-    std::vector<std::unique_ptr<LogicalPlan>> plans;
-    switch (statement.getStatementType()) {
-    case StatementType::QUERY: {
-        for (auto& plan : planQuery(statement)) {
-            // Avoid sharing operator across plans.
-            plans.push_back(plan->deepCopy());
-        }
-    } break;
-    case StatementType::EXPLAIN: {
-        auto& explain = ku_dynamic_cast<const BoundExplain&>(statement);
-        plans = getAllPlans(*explain.getStatementToExplain());
-        for (auto& plan : plans) {
-            appendExplain(explain, *plan);
-        }
-    } break;
-    default:
-        KU_UNREACHABLE;
-    }
-    return plans;
 }
 
 } // namespace planner

--- a/src/planner/query_planner.cpp
+++ b/src/planner/query_planner.cpp
@@ -8,90 +8,40 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace planner {
 
-static std::vector<std::vector<std::unique_ptr<LogicalPlan>>> cartesianProductChildrenPlans(
-    std::vector<std::vector<std::unique_ptr<LogicalPlan>>> childrenLogicalPlans) {
-    std::vector<std::vector<std::unique_ptr<LogicalPlan>>> resultChildrenPlans;
-    for (auto& childLogicalPlans : childrenLogicalPlans) {
-        std::vector<std::vector<std::unique_ptr<LogicalPlan>>> curChildResultLogicalPlans;
-        for (auto& childLogicalPlan : childLogicalPlans) {
-            if (resultChildrenPlans.empty()) {
-                std::vector<std::unique_ptr<LogicalPlan>> logicalPlans;
-                logicalPlans.push_back(childLogicalPlan->shallowCopy());
-                curChildResultLogicalPlans.push_back(std::move(logicalPlans));
-            } else {
-                for (auto& resultChildPlans : resultChildrenPlans) {
-                    std::vector<std::unique_ptr<LogicalPlan>> logicalPlans;
-                    logicalPlans.reserve(resultChildPlans.size());
-                    for (auto& resultChildPlan : resultChildPlans) {
-                        logicalPlans.push_back(resultChildPlan->shallowCopy());
-                    }
-                    logicalPlans.push_back(childLogicalPlan->shallowCopy());
-                    curChildResultLogicalPlans.push_back(std::move(logicalPlans));
-                }
-            }
-        }
-        resultChildrenPlans = std::move(curChildResultLogicalPlans);
-    }
-    return resultChildrenPlans;
-}
-
-std::vector<std::unique_ptr<LogicalPlan>> Planner::planQuery(const BoundStatement& boundStatement) {
-    std::vector<std::unique_ptr<LogicalPlan>> resultPlans;
-    auto& regularQuery = (BoundRegularQuery&)boundStatement;
+LogicalPlan Planner::planQuery(const BoundStatement& boundStatement) {
+    std::unique_ptr<LogicalPlan> resultPlans;
+    auto& regularQuery = boundStatement.constCast<BoundRegularQuery>();
     if (regularQuery.getNumSingleQueries() == 1) {
-        resultPlans = planSingleQuery(regularQuery.getSingleQuery(0));
-    } else {
-        std::vector<std::vector<std::unique_ptr<LogicalPlan>>> childrenLogicalPlans(
-            regularQuery.getNumSingleQueries());
-        for (auto i = 0u; i < regularQuery.getNumSingleQueries(); i++) {
-            childrenLogicalPlans[i] = planSingleQuery(regularQuery.getSingleQuery(i));
-        }
-        auto childrenPlans = cartesianProductChildrenPlans(std::move(childrenLogicalPlans));
-        for (auto& childrenPlan : childrenPlans) {
-            resultPlans.push_back(createUnionPlan(childrenPlan, regularQuery.getIsUnionAll(0)));
-        }
+        return planSingleQuery(*regularQuery.getSingleQuery(0));
     }
-    return resultPlans;
+    std::vector<LogicalPlan> childrenPlans;
+    for (auto i = 0u; i < regularQuery.getNumSingleQueries(); i++) {
+        childrenPlans.push_back(planSingleQuery(*regularQuery.getSingleQuery(i)));
+    }
+    return createUnionPlan(childrenPlans, regularQuery.getIsUnionAll(0));
 }
 
-std::unique_ptr<LogicalPlan> Planner::getBestPlan(std::vector<std::unique_ptr<LogicalPlan>> plans) {
-    auto bestPlan = std::move(plans[0]);
-    for (auto i = 1u; i < plans.size(); ++i) {
-        if (plans[i]->getCost() < bestPlan->getCost()) {
-            bestPlan = std::move(plans[i]);
-        }
-    }
-    return bestPlan;
-}
-
-std::unique_ptr<LogicalPlan> Planner::createUnionPlan(
-    std::vector<std::unique_ptr<LogicalPlan>>& childrenPlans, bool isUnionAll) {
+LogicalPlan Planner::createUnionPlan(std::vector<LogicalPlan>& childrenPlans, bool isUnionAll) {
     KU_ASSERT(!childrenPlans.empty());
-    auto plan = std::make_unique<LogicalPlan>();
+    auto plan = LogicalPlan();
     std::vector<std::shared_ptr<LogicalOperator>> children;
     children.reserve(childrenPlans.size());
     for (auto& childPlan : childrenPlans) {
-        children.push_back(childPlan->getLastOperator());
+        children.push_back(childPlan.getLastOperator());
     }
     // we compute the schema based on first child
-    auto union_ = make_shared<LogicalUnion>(childrenPlans[0]->getSchema()->getExpressionsInScope(),
-        std::move(children));
+    auto union_ = std::make_shared<LogicalUnion>(
+        childrenPlans[0].getSchema()->getExpressionsInScope(), std::move(children));
     for (auto i = 0u; i < childrenPlans.size(); ++i) {
-        appendFlattens(union_->getGroupsPosToFlatten(i), *childrenPlans[i]);
-        union_->setChild(i, childrenPlans[i]->getLastOperator());
+        appendFlattens(union_->getGroupsPosToFlatten(i), childrenPlans[i]);
+        union_->setChild(i, childrenPlans[i].getLastOperator());
     }
     union_->computeFactorizedSchema();
-    plan->setLastOperator(union_);
+    plan.setLastOperator(union_);
     if (!isUnionAll) {
-        appendDistinct(union_->getExpressionsToUnion(), *plan);
+        appendDistinct(union_->getExpressionsToUnion(), plan);
     }
     return plan;
-}
-
-std::vector<std::unique_ptr<LogicalPlan>> Planner::getInitialEmptyPlans() {
-    std::vector<std::unique_ptr<LogicalPlan>> plans;
-    plans.push_back(std::make_unique<LogicalPlan>());
-    return plans;
 }
 
 expression_vector Planner::getProperties(const Expression& pattern) const {


### PR DESCRIPTION
# Description

This is our initial attempt to rework the legacy optimizer. It contains the following changes

- remove plan enumeration interface. It was originally used in testing to cover different factorization cases. This functionality should be replaced by join hints. And planner always outputs a single optimal plan.
- use `LogicalPlan` instead of `unique_ptr<LogicalPlan>`. I don't know why we use smart point in the first place. It looks completely unnecessary. As a consequence, I also remove deepCopy interface. With a follow-up PR I'll also remove shallow copy.