### PR TITLE
DEV-5372 cli piping into queries leads to silent exit

### DIFF
--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -588,7 +588,7 @@ void EmbeddedShell::run() {
     int numCtrlC = 0;
     continueLine = false;
     currLine = "";
-    bool reQuery = false;
+    std::string lineStr;
 
 #ifndef _WIN32
     termios raw{};
@@ -611,10 +611,17 @@ void EmbeddedShell::run() {
     SetConsoleOutputCP(CP_UTF8);
 #endif
 
-    while (
-        (line = linenoise(continueLine ? ALTPROMPT : PROMPT, CONPROMPT, SCONPROMPT)) != nullptr) {
-        reQuery = false;
-        auto lineStr = std::string(line);
+    while (true)
+    {
+        line = linenoise(continueLine ? ALTPROMPT : PROMPT, CONPROMPT, SCONPROMPT);
+
+        if (line == nullptr && !continueLine)
+            break;
+        else if (line == nullptr)
+            lineStr = ";";
+        else
+            lineStr = std::string(line);
+
         lineStr = lineStr.erase(lineStr.find_last_not_of(" \t\n\r\f\v") + 1);
         if (!lineStr.empty() && lineStr[0] == ctrl_c) {
             if (!continueLine && lineStr[1] == '\0') {
@@ -639,7 +646,6 @@ void EmbeddedShell::run() {
                 free(line);
                 break;
             }
-            reQuery = true;
         }
         for (auto& queryResult : queryResults) {
             if (queryResult->isSuccess()) {
@@ -649,21 +655,15 @@ void EmbeddedShell::run() {
                 printErrorMessage(lineStr, *queryResult);
             }
         }
+        if (line == nullptr)
+            break;
         if (!continueLine && !historyLine.empty()) {
             linenoiseHistoryAdd(historyLine.c_str());
         }
         linenoiseHistorySave(path_to_history);
         free(line);
     }
-    if (reQuery) {
-        auto queryResults = processInput(";");
-        if (!queryResults.empty())
-            for (auto& queryResult : queryResults)
-                if (queryResult->isSuccess()) {
-                    printInterrupted = false;
-                    printExecutionResult(*queryResult);
-                }
-    }
+
 #ifndef _WIN32
     /* Don't even check the return value as it's too late. */
     if (noEcho && tcsetattr(STDIN_FILENO, TCSANOW, &orig_termios) != -1)

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -524,7 +524,7 @@ std::vector<std::unique_ptr<QueryResult>> EmbeddedShell::processInput(std::strin
         input = std::move(currLine) + std::move(input);
         currLine = "";
         continueLine = false;
-    } 
+    }
     input = input.erase(input.find_last_not_of(" \t\n\r\f\v") + 1);
     // Decode escape sequences
     std::string unicodeInput;
@@ -658,10 +658,9 @@ void EmbeddedShell::run() {
         linenoiseHistorySave(path_to_history);
         free(line);
     }
-    if (!seenSemiColon)
-    {
+    if (!seenSemiColon) {
         auto queryResults = processInput(";");
-        if (!queryResults.empty()) 
+        if (!queryResults.empty())
             for (auto& queryResult : queryResults) {
                 if (queryResult->isSuccess()) {
                     printInterrupted = false;
@@ -670,7 +669,6 @@ void EmbeddedShell::run() {
                     printErrorMessage(lineStr, *queryResult);
                 }
             }
-
     }
 #ifndef _WIN32
     /* Don't even check the return value as it's too late. */

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -589,7 +589,6 @@ void EmbeddedShell::run() {
     // `true` when a multiline query is incomplete. See `EmbeddedShell::processInput`.
     continueLine = false;
     currLine = "";
-    std::string lineStr;
 
 #ifndef _WIN32
     termios raw{};
@@ -620,6 +619,7 @@ void EmbeddedShell::run() {
             break;
         }
 
+        std::string lineStr;
         if (line == nullptr) {
             // EOF is reached, but there is an incomplete query (`continueLine` == true).
             // Mark as complete with a semicolon and attempt to process the query.
@@ -628,7 +628,6 @@ void EmbeddedShell::run() {
             // Not EOF. We take the input as is.
             lineStr = std::string(line);
         }
-
         lineStr = lineStr.erase(lineStr.find_last_not_of(" \t\n\r\f\v") + 1);
         if (!lineStr.empty() && lineStr[0] == ctrl_c) {
             if (!continueLine && lineStr[1] == '\0') {

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -617,7 +617,7 @@ void EmbeddedShell::run() {
         reQuery = false;
         lineStr = std::string(line);
         if (!lineStr.empty() && lineStr.back() == ';')
-        lineStr = lineStr.erase(lineStr.find_last_not_of(" \t\n\r\f\v") + 1);
+            lineStr = lineStr.erase(lineStr.find_last_not_of(" \t\n\r\f\v") + 1);
         if (!lineStr.empty() && lineStr[0] == ctrl_c) {
             if (!continueLine && lineStr[1] == '\0') {
                 numCtrlC++;
@@ -660,11 +660,11 @@ void EmbeddedShell::run() {
     if (reQuery) {
         auto queryResults = processInput(";");
         if (!queryResults.empty())
-            for (auto& queryResult : queryResults) 
+            for (auto& queryResult : queryResults)
                 if (queryResult->isSuccess()) {
                     printInterrupted = false;
                     printExecutionResult(*queryResult);
-                } 
+                }
     }
 #ifndef _WIN32
     /* Don't even check the return value as it's too late. */

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -618,12 +618,12 @@ void EmbeddedShell::run() {
         if (line == nullptr && !continueLine) {
             break;
 
-        // EOF is reached, but there is a query not terminated by a semiColon <- indicated by continueLine being true
-        // we add a semiColon and attempt to process the query
+            // EOF is reached, but there is a query not terminated by a semiColon <- indicated by
+            // continueLine being true we add a semiColon and attempt to process the query
         } else if (line == nullptr) {
             lineStr = ";";
 
-        // Not EOF. We take the input as is.
+            // Not EOF. We take the input as is.
         } else {
             lineStr = std::string(line);
         }

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -588,7 +588,6 @@ void EmbeddedShell::run() {
     int numCtrlC = 0;
     continueLine = false;
     currLine = "";
-    std::string lineStr;
     bool reQuery = false;
 
 #ifndef _WIN32
@@ -615,9 +614,8 @@ void EmbeddedShell::run() {
     while (
         (line = linenoise(continueLine ? ALTPROMPT : PROMPT, CONPROMPT, SCONPROMPT)) != nullptr) {
         reQuery = false;
-        lineStr = std::string(line);
-        if (!lineStr.empty() && lineStr.back() == ';')
-            lineStr = lineStr.erase(lineStr.find_last_not_of(" \t\n\r\f\v") + 1);
+        auto lineStr = std::string(line);
+        lineStr = lineStr.erase(lineStr.find_last_not_of(" \t\n\r\f\v") + 1);
         if (!lineStr.empty() && lineStr[0] == ctrl_c) {
             if (!continueLine && lineStr[1] == '\0') {
                 numCtrlC++;

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -613,6 +613,8 @@ void EmbeddedShell::run() {
     while (
         (line = linenoise(continueLine ? ALTPROMPT : PROMPT, CONPROMPT, SCONPROMPT)) != nullptr) {
         auto lineStr = std::string(line);
+        if (lineStr.back() == ';')
+            lineStr.push_back(';');
         lineStr = lineStr.erase(lineStr.find_last_not_of(" \t\n\r\f\v") + 1);
         if (!lineStr.empty() && lineStr[0] == ctrl_c) {
             if (!continueLine && lineStr[1] == '\0') {

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -525,7 +525,7 @@ std::vector<std::unique_ptr<QueryResult>> EmbeddedShell::processInput(std::strin
         currLine = "";
         continueLine = false;
     }
-    else if (input.back() != ';')
+    else if (!input.empty() && input.back() != ';')
         input.push_back(';');
     input = input.erase(input.find_last_not_of(" \t\n\r\f\v") + 1);
     // Decode escape sequences

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -611,8 +611,7 @@ void EmbeddedShell::run() {
     SetConsoleOutputCP(CP_UTF8);
 #endif
 
-    while (true)
-    {
+    while (true) {
         line = linenoise(continueLine ? ALTPROMPT : PROMPT, CONPROMPT, SCONPROMPT);
 
         if (line == nullptr && !continueLine)

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -524,8 +524,7 @@ std::vector<std::unique_ptr<QueryResult>> EmbeddedShell::processInput(std::strin
         input = std::move(currLine) + std::move(input);
         currLine = "";
         continueLine = false;
-    }
-    else if (!input.empty() && input.back() != ';')
+    } else if (!input.empty() && input.back() != ';')
         input.push_back(';');
     input = input.erase(input.find_last_not_of(" \t\n\r\f\v") + 1);
     // Decode escape sequences

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -613,7 +613,7 @@ void EmbeddedShell::run() {
     while (
         (line = linenoise(continueLine ? ALTPROMPT : PROMPT, CONPROMPT, SCONPROMPT)) != nullptr) {
         auto lineStr = std::string(line);
-        if (lineStr.back() == ';')
+        if (lineStr.back() != ';')
             lineStr.push_back(';');
         lineStr = lineStr.erase(lineStr.find_last_not_of(" \t\n\r\f\v") + 1);
         if (!lineStr.empty() && lineStr[0] == ctrl_c) {

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -586,7 +586,8 @@ void EmbeddedShell::run() {
     char* line = nullptr;
     const char ctrl_c = '\3';
     int numCtrlC = 0;
-    continueLine = false; // Set to true when a multiline query is setup (seeProcessInput)
+    // Set to true when a multiline query is incomplete. See `EmbeddedShell::processInput`.
+    continueLine = false;
     currLine = "";
     std::string lineStr;
 
@@ -614,17 +615,17 @@ void EmbeddedShell::run() {
     while (true) {
         line = linenoise(continueLine ? ALTPROMPT : PROMPT, CONPROMPT, SCONPROMPT);
 
-        // EOF is reached and there is no input left to process
         if (line == nullptr && !continueLine) {
+            // EOF is reached and there is no input left to process.
             break;
+        }
 
-            // EOF is reached, but there is a query not terminated by a semiColon <- indicated by
-            // continueLine being true we add a semiColon and attempt to process the query
-        } else if (line == nullptr) {
+        if (line == nullptr) {
+            // EOF is reached, but there is an incomplete query (`continueLine` == true).
+            // Mark as complete with a semicolon and attempt to process the query.
             lineStr = ";";
-
-            // Not EOF. We take the input as is.
         } else {
+            // Not EOF. We take the input as is.
             lineStr = std::string(line);
         }
 

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -586,7 +586,7 @@ void EmbeddedShell::run() {
     char* line = nullptr;
     const char ctrl_c = '\3';
     int numCtrlC = 0;
-    continueLine = false;
+    continueLine = false; // Set to true when a multiline query is setup (seeProcessInput)
     currLine = "";
     std::string lineStr;
 
@@ -614,12 +614,19 @@ void EmbeddedShell::run() {
     while (true) {
         line = linenoise(continueLine ? ALTPROMPT : PROMPT, CONPROMPT, SCONPROMPT);
 
-        if (line == nullptr && !continueLine)
+        // EOF is reached and there is no input left to process
+        if (line == nullptr && !continueLine) {
             break;
-        else if (line == nullptr)
+
+        // EOF is reached, but there is a query not terminated by a semiColon <- indicated by continueLine being true
+        // we add a semiColon and attempt to process the query
+        } else if (line == nullptr) {
             lineStr = ";";
-        else
+
+        // Not EOF. We take the input as is.
+        } else {
             lineStr = std::string(line);
+        }
 
         lineStr = lineStr.erase(lineStr.find_last_not_of(" \t\n\r\f\v") + 1);
         if (!lineStr.empty() && lineStr[0] == ctrl_c) {
@@ -654,8 +661,11 @@ void EmbeddedShell::run() {
                 printErrorMessage(lineStr, *queryResult);
             }
         }
-        if (line == nullptr)
+
+        // We do not want to add EOF to our history.
+        if (line == nullptr) {
             break;
+        }
         if (!continueLine && !historyLine.empty()) {
             linenoiseHistoryAdd(historyLine.c_str());
         }

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -525,6 +525,8 @@ std::vector<std::unique_ptr<QueryResult>> EmbeddedShell::processInput(std::strin
         currLine = "";
         continueLine = false;
     }
+    else if (input.back() != ';')
+        input.push_back(';');
     input = input.erase(input.find_last_not_of(" \t\n\r\f\v") + 1);
     // Decode escape sequences
     std::string unicodeInput;
@@ -613,8 +615,6 @@ void EmbeddedShell::run() {
     while (
         (line = linenoise(continueLine ? ALTPROMPT : PROMPT, CONPROMPT, SCONPROMPT)) != nullptr) {
         auto lineStr = std::string(line);
-        if (lineStr.back() != ';')
-            lineStr.push_back(';');
         lineStr = lineStr.erase(lineStr.find_last_not_of(" \t\n\r\f\v") + 1);
         if (!lineStr.empty() && lineStr[0] == ctrl_c) {
             if (!continueLine && lineStr[1] == '\0') {

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -525,6 +525,8 @@ std::vector<std::unique_ptr<QueryResult>> EmbeddedShell::processInput(std::strin
         currLine = "";
         continueLine = false;
     }
+    else if (input.back() != ';')
+        input.push_back(';');
     input = input.erase(input.find_last_not_of(" \t\n\r\f\v") + 1);
     // Decode escape sequences
     std::string unicodeInput;

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -525,8 +525,6 @@ std::vector<std::unique_ptr<QueryResult>> EmbeddedShell::processInput(std::strin
         currLine = "";
         continueLine = false;
     }
-    else if (input.back() != ';')
-        input.push_back(';');
     input = input.erase(input.find_last_not_of(" \t\n\r\f\v") + 1);
     // Decode escape sequences
     std::string unicodeInput;

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -586,7 +586,7 @@ void EmbeddedShell::run() {
     char* line = nullptr;
     const char ctrl_c = '\3';
     int numCtrlC = 0;
-    // Set to true when a multiline query is incomplete. See `EmbeddedShell::processInput`.
+    // `true` when a multiline query is incomplete. See `EmbeddedShell::processInput`.
     continueLine = false;
     currLine = "";
     std::string lineStr;
@@ -616,7 +616,7 @@ void EmbeddedShell::run() {
         line = linenoise(continueLine ? ALTPROMPT : PROMPT, CONPROMPT, SCONPROMPT);
 
         if (line == nullptr && !continueLine) {
-            // EOF is reached and there is no input left to process.
+            // EOF is reached and there is no input left to process. Exit loop.
             break;
         }
 
@@ -663,10 +663,6 @@ void EmbeddedShell::run() {
             }
         }
 
-        // We do not want to add EOF to our history.
-        if (line == nullptr) {
-            break;
-        }
         if (!continueLine && !historyLine.empty()) {
             linenoiseHistoryAdd(historyLine.c_str());
         }

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -524,7 +524,7 @@ std::vector<std::unique_ptr<QueryResult>> EmbeddedShell::processInput(std::strin
         input = std::move(currLine) + std::move(input);
         currLine = "";
         continueLine = false;
-    } else if (!input.empty() && input.back() != ';')
+    } else if (!input.empty() && input[0] != ':' && input.back() != ';')
         input.push_back(';');
     input = input.erase(input.find_last_not_of(" \t\n\r\f\v") + 1);
     // Decode escape sequences

--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -3604,8 +3604,6 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char* buf, size_t buflen, 
                 }
                 l.buf[new_len++] = l.buf[i];
             }
-            if (new_len > 0 && l.buf[new_len - 1] != ';')
-                    l.buf[new_len++] = ';';
             l.buf[new_len] = '\0';
             return (int)new_len;
         }

--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -3604,6 +3604,8 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char* buf, size_t buflen, 
                 }
                 l.buf[new_len++] = l.buf[i];
             }
+            if (new_len > 0 && l.buf[new_len - 1] != ';')
+                    l.buf[new_len++] = ';';
             l.buf[new_len] = '\0';
             return (int)new_len;
         }


### PR DESCRIPTION
# Description
echo "return 1" | ./kuzu`

Piping the query above leads directly to an exit of the shell instance with no error message as to what went wrong. The only issue was a missing semicolon. i.e 

echo "return 1;" | ./kuzu`

would run as intended. 

The suggested behaviour was to treat EOF as a ';' and run the query. 

This fix adds a semi colon to the end of input if there is not one already there. 

![image](https://github.com/user-attachments/assets/d22aea1c-64d5-4d6b-9bf0-f8a14245dcb5)


Fixes # (issue)
#5372 

# Contributor agreement

- [X] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).