### PR TITLE
Ease the type check on WASM prepared statement

### DIFF
--- a/tools/wasm/src_js/sync/connection.js
+++ b/tools/wasm/src_js/sync/connection.js
@@ -125,16 +125,14 @@ class Connection {
   execute(preparedStatement, params = {}) {
     this._checkConnection();
     if (!preparedStatement ||
-      typeof preparedStatement !== "object" ||
-      preparedStatement.constructor.name !== "PreparedStatement" ||
       preparedStatement._isClosed) {
-      throw new Error("preparedStatement must be a valid PreparedStatement object.");
+      throw new Error("preparedStatement is not valid or is closed.");
     }
     if (!preparedStatement.isSuccess()) {
       throw new Error(preparedStatement.getErrorMessage());
     }
-    if (params.constructor.name !== "Object") {
-      throw new Error("params must be a plain object.");
+    if (!params) {
+      throw new Error("params is not valid.");
     }
     const paramsArray = [];
     for (const key in params) {

--- a/tools/wasm/test/test_connection.js
+++ b/tools/wasm/test/test_connection.js
@@ -94,17 +94,17 @@ describe("Execute", function () {
     }
   });
 
-  it("should throw error if the parameters is not a plain object", async function () {
+  it("should throw error if the parameters is null", async function () {
     try {
       const preparedStatement = await conn.prepare(
         "MATCH (a:person) WHERE a.ID = $1 RETURN COUNT(*)"
       );
       assert.exists(preparedStatement);
       assert.isTrue(preparedStatement.isSuccess());
-      await conn.execute(preparedStatement, []);
-      assert.fail("No error thrown when params is not a plain object.");
+      await conn.execute(preparedStatement, null);
+      assert.fail("No error thrown when params is null.");
     } catch (e) {
-      assert.equal(e.message, "params must be a plain object.");
+      assert.equal(e.message, "params is not valid.");
     }
   });
 });


### PR DESCRIPTION
# Description

The current check for `PreparedStatement` object for WASM is too strong. In some minified build process, it can cause errors, because the constructor name is shotened and the `PreparedStatement` class name is no longer kept, causing the check to fail despite the object is valid.