### PR TITLE
stringFormat: optionally use std::format for compile-time checks

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -742,7 +742,7 @@ jobs:
 
   sanity-checks:
     name: sanity checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -829,7 +829,7 @@ jobs:
 
   rustfmt-check:
     name: rustfmt check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Update Rust
         run: rustup update
@@ -848,7 +848,7 @@ jobs:
   report-benchmark-result:
     name: report benchmark result
     needs: [ benchmark ]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.event_name == 'pull_request'
     steps:
       - name: Download comparison results
@@ -1015,13 +1015,13 @@ jobs:
 
   shell-test:
     name: shell test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [ sanity-checks ]
     steps:
       - uses: actions/checkout@v4
 
       - name: Build
-        run: make release NUM_THREADS=$(nproc)
+        run: make release NUM_THREADS=$(nproc) USE_STD_FORMAT=1
 
       - name: Test
         working-directory: tools/shell/test

--- a/.github/workflows/multiplatform-build-test.yml
+++ b/.github/workflows/multiplatform-build-test.yml
@@ -666,7 +666,7 @@ jobs:
         run: |
           set +e
           echo NUM_THREADS=$(nproc)
-          make test NUM_THREADS=$(nproc)
+          make test NUM_THREADS=$(nproc) USE_STD_FORMAT=1
           echo "Test,$?" >> status.txt
           make clean
           rm -rf dataset/ldbc-1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,7 @@ option(BUILD_TESTS "Build C++ tests." FALSE)
 option(BUILD_EXTENSION_TESTS "Build C++ extension tests." FALSE)
 option(BUILD_KUZU "Build Kuzu." TRUE)
 option(ENABLE_BACKTRACES "Enable backtrace printing for exceptions and segfaults" FALSE)
+option(USE_STD_FORMAT "Use std::format instead of a custom formatter." FALSE)
 
 option(BUILD_LCOV "Build coverage report." FALSE)
 if(${BUILD_LCOV})
@@ -273,7 +274,7 @@ if(${BUILD_LCOV})
 endif()
 
 if (ENABLE_BACKTRACES)
-    find_package(cpptrace)
+    find_package(cpptrace QUIET)
     if (NOT cpptrace_FOUND)
         include(FetchContent)
         FetchContent_Declare(
@@ -285,6 +286,10 @@ if (ENABLE_BACKTRACES)
         FetchContent_MakeAvailable(cpptrace)
     endif()
     add_compile_definitions(KUZU_BACKTRACE)
+endif()
+
+if (USE_STD_FORMAT)
+    add_compile_definitions(USE_STD_FORMAT)
 endif()
 
 function(add_kuzu_test TEST_NAME)

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,8 @@ ifdef WASM_NODEFS
 	CMAKE_FLAGS += -DWASM_NODEFS=$(WASM_NODEFS)
 endif
 
+CMAKE_FLAGS += -DUSE_STD_FORMAT=$(if $(USE_STD_FORMAT),TRUE,FALSE)
+
 # Must be first in the Makefile so that it is the default target.
 release:
 	$(call run-cmake-release,)

--- a/src/binder/bind/bind_updating_clause.cpp
+++ b/src/binder/bind/bind_updating_clause.cpp
@@ -227,7 +227,8 @@ void Binder::bindInsertRel(std::shared_ptr<RelExpression> rel,
         // LCOV_EXCL_START
         if (entry == nullptr) {
             throw BinderException(
-                stringFormat("Cannot find a valid label in {} to create. This should not happen."));
+                stringFormat("Cannot find a valid label in {} to create. This should not happen.",
+                    rel->toString()));
         }
         // LCOV_EXCL_STOP
     }

--- a/src/extension/extension.cpp
+++ b/src/extension/extension.cpp
@@ -69,9 +69,8 @@ std::string ExtensionSourceUtils::toString(ExtensionSource source) {
 
 static ExtensionRepoInfo getExtensionFilePath(const std::string& extensionName,
     const std::string& extensionRepo, const std::string& fileName) {
-    auto extensionURL =
-        common::stringFormat(extensionRepo + ExtensionUtils::EXTENSION_FILE_REPO_PATH,
-            KUZU_EXTENSION_VERSION, getPlatform(), extensionName, fileName);
+    auto extensionURL = common::stringFormat(ExtensionUtils::EXTENSION_FILE_REPO_PATH,
+        extensionRepo, KUZU_EXTENSION_VERSION, getPlatform(), extensionName, fileName);
     return getExtensionRepoInfo(extensionURL);
 }
 
@@ -94,8 +93,8 @@ ExtensionRepoInfo ExtensionUtils::getExtensionInstallerRepoInfo(const std::strin
 
 ExtensionRepoInfo ExtensionUtils::getSharedLibRepoInfo(const std::string& fileName,
     const std::string& extensionRepo) {
-    auto extensionURL = common::stringFormat(extensionRepo + SHARED_LIB_REPO,
-        KUZU_EXTENSION_VERSION, getPlatform(), fileName);
+    auto extensionURL = common::stringFormat(SHARED_LIB_REPO, extensionRepo, KUZU_EXTENSION_VERSION,
+        getPlatform(), fileName);
     return getExtensionRepoInfo(extensionURL);
 }
 

--- a/src/graph/graph_entry.cpp
+++ b/src/graph/graph_entry.cpp
@@ -11,9 +11,10 @@ namespace kuzu {
 namespace graph {
 
 std::string GraphEntryTableInfo::toString() const {
-    auto result = common::stringFormat("{'table': '{}'", tableName);
+    std::string result = "{";
+    result += stringFormat("'table': '{}'", tableName);
     if (predicate != "") {
-        result += common::stringFormat(",'predicate': '{}'", predicate);
+        result += stringFormat(",'predicate': '{}'", predicate);
     }
     result += "}";
     return result;

--- a/src/include/extension/extension.h
+++ b/src/include/extension/extension.h
@@ -63,9 +63,9 @@ void addFunc(main::Database& database, std::string name, catalog::CatalogEntryTy
 struct KUZU_API ExtensionUtils {
     static constexpr const char* OFFICIAL_EXTENSION_REPO = "http://extension.kuzudb.com/";
 
-    static constexpr const char* EXTENSION_FILE_REPO_PATH = "v{}/{}/{}/{}";
+    static constexpr const char* EXTENSION_FILE_REPO_PATH = "{}v{}/{}/{}/{}";
 
-    static constexpr const char* SHARED_LIB_REPO = "v{}/{}/common/{}";
+    static constexpr const char* SHARED_LIB_REPO = "{}v{}/{}/common/{}";
 
     static constexpr const char* EXTENSION_FILE_NAME = "lib{}.kuzu_extension";
 


### PR DESCRIPTION
The current `stringFormat` implementation does runtime checks for formatting mismatch. C++20's `std::format` does compile-time checks instead.

This PR adds optional support for `std::format` behind an off-by-default CMake flag that simply replaces the implementation behind `stringFormat`.

The idea is to catch missing arguments at compile time in CI. Already found one instance of a missing argument after turning on the flag.

The reason this is not on by default is that `gcc-12` running in self-hosted CI does not support `std::format`.

Caveats:
- The first argument now always needs to be a `const char *`.
- `std::format` does **not** check if there are unused arguments, unlike in `stringFormatHelper`.
- A little inconvenient but support for `{` and `}` is different in the two implementation. `std::format` requires escaping as `{{` and `}}`, while  `stringFormatHelper` does not.
  - This means `{` and `}` cannot appear in a format string as of this PR. I've edited the one instance this currently happens in the code.
  - We could extend the `stringFormatHelper` to detect escaped braces if needed.