### PR TITLE
Remove unnecessary copy of ResultSetDescriptor

### DIFF
--- a/extension/vector/src/function/create_hnsw_index.cpp
+++ b/extension/vector/src/function/create_hnsw_index.cpp
@@ -136,7 +136,8 @@ static std::unique_ptr<PhysicalOperator> getPhysicalPlan(PlanMapper* planMapper,
     // Append a dummy sink to the end of the second pipeline
     auto finalizeHNSWDummySink =
         std::make_unique<DummySink>(std::move(finalizeCallOp), planMapper->getOperatorID());
-    finalizeHNSWDummySink->setDescriptor(std::make_unique<ResultSetDescriptor>(logicalOp->getSchema()));
+    finalizeHNSWDummySink->setDescriptor(
+        std::make_unique<ResultSetDescriptor>(logicalOp->getSchema()));
     // Append RelBatchInsert pipelines.
     // Get tables from storage.
     const auto storageManager = clientContext->getStorageManager();

--- a/extension/vector/src/function/create_hnsw_index.cpp
+++ b/extension/vector/src/function/create_hnsw_index.cpp
@@ -106,8 +106,8 @@ static std::unique_ptr<PhysicalOperator> getPhysicalPlan(PlanMapper* planMapper,
     auto indexName = createFuncSharedState->name;
     // Append a dummy sink to end the first pipeline
     auto createDummySink =
-        std::make_unique<DummySink>(std::make_unique<ResultSetDescriptor>(logicalOp->getSchema()),
-            std::move(createHNSWCallOp), planMapper->getOperatorID());
+        std::make_unique<DummySink>(std::move(createHNSWCallOp), planMapper->getOperatorID());
+    createDummySink->setDescriptor(std::make_unique<ResultSetDescriptor>(logicalOp->getSchema()));
     // Append _FinalizeHNSWIndex table function.
     auto clientContext = planMapper->clientContext;
     auto finalizeFuncEntry =
@@ -135,8 +135,8 @@ static std::unique_ptr<PhysicalOperator> getPhysicalPlan(PlanMapper* planMapper,
     finalizeCallOp->addChild(std::move(createDummySink));
     // Append a dummy sink to the end of the second pipeline
     auto finalizeHNSWDummySink =
-        std::make_unique<DummySink>(std::make_unique<ResultSetDescriptor>(logicalOp->getSchema()),
-            std::move(finalizeCallOp), planMapper->getOperatorID());
+        std::make_unique<DummySink>(std::move(finalizeCallOp), planMapper->getOperatorID());
+    finalizeHNSWDummySink->setDescriptor(std::make_unique<ResultSetDescriptor>(logicalOp->getSchema()));
     // Append RelBatchInsert pipelines.
     // Get tables from storage.
     const auto storageManager = clientContext->getStorageManager();

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -248,9 +248,9 @@ std::unique_ptr<PhysicalOperator> GDSFunction::getPhysicalPlan(PlanMapper* planM
     }
     planMapper->addOperatorMapping(logicalOp, call.get());
     physical_op_vector_t children;
-    auto descriptor = std::make_unique<ResultSetDescriptor>(logicalCall->getSchema());
-    auto dummySink = std::make_unique<DummySink>(std::move(descriptor), std::move(call),
+    auto dummySink = std::make_unique<DummySink>( std::move(call),
         planMapper->getOperatorID());
+    dummySink->setDescriptor(std::make_unique<ResultSetDescriptor>(logicalCall->getSchema()));
     children.push_back(std::move(dummySink));
     return planMapper->createFTableScanAligned(columns, logicalCall->getSchema(), table,
         DEFAULT_VECTOR_CAPACITY, std::move(children));

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -248,8 +248,7 @@ std::unique_ptr<PhysicalOperator> GDSFunction::getPhysicalPlan(PlanMapper* planM
     }
     planMapper->addOperatorMapping(logicalOp, call.get());
     physical_op_vector_t children;
-    auto dummySink = std::make_unique<DummySink>( std::move(call),
-        planMapper->getOperatorID());
+    auto dummySink = std::make_unique<DummySink>(std::move(call), planMapper->getOperatorID());
     dummySink->setDescriptor(std::make_unique<ResultSetDescriptor>(logicalCall->getSchema()));
     children.push_back(std::move(dummySink));
     return planMapper->createFTableScanAligned(columns, logicalCall->getSchema(), table,

--- a/src/include/processor/operator/aggregate/base_aggregate.h
+++ b/src/include/processor/operator/aggregate/base_aggregate.h
@@ -117,18 +117,15 @@ class BaseAggregate : public Sink {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::AGGREGATE;
 
 protected:
-    BaseAggregate(std::unique_ptr<ResultSetDescriptor> resultSetDescriptor,
-        std::shared_ptr<BaseAggregateSharedState> sharedState,
+    BaseAggregate(std::shared_ptr<BaseAggregateSharedState> sharedState,
         std::vector<function::AggregateFunction> aggregateFunctions,
         std::vector<AggregateInfo> aggInfos, std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{std::move(resultSetDescriptor), type_, std::move(child), id, std::move(printInfo)},
+        : Sink{type_, std::move(child), id, std::move(printInfo)},
           aggregateFunctions{std::move(aggregateFunctions)}, aggInfos{std::move(aggInfos)},
           sharedState{std::move(sharedState)} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
-
-    std::unique_ptr<PhysicalOperator> copy() override = 0;
 
     bool containDistinctAggregate() const;
 
@@ -136,6 +133,8 @@ protected:
         // Delegated to HashAggregateFinalize so it can be parallelized
         sharedState->readyForFinalization = true;
     }
+
+    std::unique_ptr<PhysicalOperator> copy() override = 0;
 
 protected:
     std::vector<function::AggregateFunction> aggregateFunctions;

--- a/src/include/processor/operator/aggregate/hash_aggregate.h
+++ b/src/include/processor/operator/aggregate/hash_aggregate.h
@@ -153,18 +153,16 @@ public:
         std::vector<function::AggregateFunction> aggregateFunctions,
         std::vector<AggregateInfo> aggInfos, std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : BaseAggregate{std::move(sharedState),
-              std::move(aggregateFunctions), std::move(aggInfos), std::move(child), id,
-              std::move(printInfo)} {}
+        : BaseAggregate{std::move(sharedState), std::move(aggregateFunctions), std::move(aggInfos),
+              std::move(child), id, std::move(printInfo)} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
     void executeInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return make_unique<HashAggregate>(sharedState,
-            copyVector(aggregateFunctions), copyVector(aggInfos), children[0]->copy(), id,
-            printInfo->copy());
+        return make_unique<HashAggregate>(sharedState, copyVector(aggregateFunctions),
+            copyVector(aggInfos), children[0]->copy(), id, printInfo->copy());
     }
 
     const HashAggregateSharedState& getSharedStateReference() const {
@@ -180,6 +178,7 @@ private:
 
 class HashAggregateFinalize final : public Sink {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::AGGREGATE_FINALIZE;
+
 public:
     HashAggregateFinalize(std::shared_ptr<HashAggregateSharedState> sharedState,
         std::unique_ptr<PhysicalOperator> child, uint32_t id,
@@ -200,8 +199,8 @@ public:
     }
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return make_unique<HashAggregateFinalize>(sharedState,
-            children[0]->copy(), id, printInfo->copy());
+        return make_unique<HashAggregateFinalize>(sharedState, children[0]->copy(), id,
+            printInfo->copy());
     }
 
 private:

--- a/src/include/processor/operator/aggregate/simple_aggregate.h
+++ b/src/include/processor/operator/aggregate/simple_aggregate.h
@@ -100,18 +100,16 @@ public:
         std::vector<function::AggregateFunction> aggregateFunctions,
         std::vector<AggregateInfo> aggInfos, std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : BaseAggregate{std::move(sharedState),
-              std::move(aggregateFunctions), std::move(aggInfos), std::move(child), id,
-              std::move(printInfo)} {}
+        : BaseAggregate{std::move(sharedState), std::move(aggregateFunctions), std::move(aggInfos),
+              std::move(child), id, std::move(printInfo)} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
     void executeInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return make_unique<SimpleAggregate>(sharedState,
-            copyVector(aggregateFunctions), copyVector(aggInfos), children[0]->copy(), id,
-            printInfo->copy());
+        return make_unique<SimpleAggregate>(sharedState, copyVector(aggregateFunctions),
+            copyVector(aggInfos), children[0]->copy(), id, printInfo->copy());
     }
 
 private:
@@ -134,7 +132,7 @@ public:
     SimpleAggregateFinalize(std::shared_ptr<SimpleAggregateSharedState> sharedState,
         std::unique_ptr<PhysicalOperator> child, std::vector<AggregateInfo> aggInfos, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{type_,std::move(child), id, std::move(printInfo)},
+        : Sink{type_, std::move(child), id, std::move(printInfo)},
           sharedState{std::move(sharedState)}, aggInfos{std::move(aggInfos)} {}
 
     // Otherwise the runtime metrics for this operator are negative
@@ -146,8 +144,8 @@ public:
     void finalizeInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return make_unique<SimpleAggregateFinalize>(sharedState,
-            children[0]->copy(), copyVector(aggInfos), id, printInfo->copy());
+        return make_unique<SimpleAggregateFinalize>(sharedState, children[0]->copy(),
+            copyVector(aggInfos), id, printInfo->copy());
     }
 
 private:

--- a/src/include/processor/operator/hash_join/hash_join_build.h
+++ b/src/include/processor/operator/hash_join/hash_join_build.h
@@ -83,15 +83,14 @@ private:
 
 class HashJoinBuild : public Sink {
 public:
-    HashJoinBuild(std::unique_ptr<ResultSetDescriptor> resultSetDescriptor,
-        PhysicalOperatorType operatorType, std::shared_ptr<HashJoinSharedState> sharedState,
+    HashJoinBuild(PhysicalOperatorType operatorType, std::shared_ptr<HashJoinSharedState> sharedState,
         std::unique_ptr<HashJoinBuildInfo> info, std::unique_ptr<PhysicalOperator> child,
         uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{std::move(resultSetDescriptor), operatorType, std::move(child), id,
+        : Sink{operatorType, std::move(child), id,
               std::move(printInfo)},
           sharedState{std::move(sharedState)}, info{std::move(info)} {}
 
-    inline std::shared_ptr<HashJoinSharedState> getSharedState() const { return sharedState; }
+    std::shared_ptr<HashJoinSharedState> getSharedState() const { return sharedState; }
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
@@ -100,12 +99,12 @@ public:
     void finalizeInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return make_unique<HashJoinBuild>(resultSetDescriptor->copy(), operatorType, sharedState,
+        return make_unique<HashJoinBuild>(operatorType, sharedState,
             info->copy(), children[0]->copy(), id, printInfo->copy());
     }
 
 protected:
-    virtual inline uint64_t appendVectors() {
+    virtual uint64_t appendVectors() {
         return hashTable->appendVectors(keyVectors, payloadVectors, keyState);
     }
 

--- a/src/include/processor/operator/hash_join/hash_join_build.h
+++ b/src/include/processor/operator/hash_join/hash_join_build.h
@@ -83,11 +83,11 @@ private:
 
 class HashJoinBuild : public Sink {
 public:
-    HashJoinBuild(PhysicalOperatorType operatorType, std::shared_ptr<HashJoinSharedState> sharedState,
-        std::unique_ptr<HashJoinBuildInfo> info, std::unique_ptr<PhysicalOperator> child,
-        uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{operatorType, std::move(child), id,
-              std::move(printInfo)},
+    HashJoinBuild(PhysicalOperatorType operatorType,
+        std::shared_ptr<HashJoinSharedState> sharedState, std::unique_ptr<HashJoinBuildInfo> info,
+        std::unique_ptr<PhysicalOperator> child, uint32_t id,
+        std::unique_ptr<OPPrintInfo> printInfo)
+        : Sink{operatorType, std::move(child), id, std::move(printInfo)},
           sharedState{std::move(sharedState)}, info{std::move(info)} {}
 
     std::shared_ptr<HashJoinSharedState> getSharedState() const { return sharedState; }
@@ -99,8 +99,8 @@ public:
     void finalizeInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return make_unique<HashJoinBuild>(operatorType, sharedState,
-            info->copy(), children[0]->copy(), id, printInfo->copy());
+        return make_unique<HashJoinBuild>(operatorType, sharedState, info->copy(),
+            children[0]->copy(), id, printInfo->copy());
     }
 
 protected:

--- a/src/include/processor/operator/intersect/intersect_build.h
+++ b/src/include/processor/operator/intersect/intersect_build.h
@@ -36,11 +36,11 @@ class IntersectBuild final : public HashJoinBuild {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::INTERSECT_BUILD;
 
 public:
-    IntersectBuild(std::shared_ptr<HashJoinSharedState> sharedState, std::unique_ptr<HashJoinBuildInfo> info,
-        std::unique_ptr<PhysicalOperator> child, uint32_t id,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : HashJoinBuild{type_, std::move(sharedState),
-              std::move(info), std::move(child), id, std::move(printInfo)} {}
+    IntersectBuild(std::shared_ptr<HashJoinSharedState> sharedState,
+        std::unique_ptr<HashJoinBuildInfo> info, std::unique_ptr<PhysicalOperator> child,
+        uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
+        : HashJoinBuild{type_, std::move(sharedState), std::move(info), std::move(child), id,
+              std::move(printInfo)} {}
 
     uint64_t appendVectors() final {
         KU_ASSERT(keyVectors.size() == 1);
@@ -48,8 +48,8 @@ public:
     }
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return make_unique<IntersectBuild>(sharedState, info->copy(),
-            children[0]->copy(), id, printInfo->copy());
+        return make_unique<IntersectBuild>(sharedState, info->copy(), children[0]->copy(), id,
+            printInfo->copy());
     }
 };
 

--- a/src/include/processor/operator/intersect/intersect_build.h
+++ b/src/include/processor/operator/intersect/intersect_build.h
@@ -36,21 +36,20 @@ class IntersectBuild final : public HashJoinBuild {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::INTERSECT_BUILD;
 
 public:
-    IntersectBuild(std::unique_ptr<ResultSetDescriptor> resultSetDescriptor,
-        std::shared_ptr<HashJoinSharedState> sharedState, std::unique_ptr<HashJoinBuildInfo> info,
+    IntersectBuild(std::shared_ptr<HashJoinSharedState> sharedState, std::unique_ptr<HashJoinBuildInfo> info,
         std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : HashJoinBuild{std::move(resultSetDescriptor), type_, std::move(sharedState),
+        : HashJoinBuild{type_, std::move(sharedState),
               std::move(info), std::move(child), id, std::move(printInfo)} {}
-
-    std::unique_ptr<PhysicalOperator> copy() override {
-        return make_unique<IntersectBuild>(resultSetDescriptor->copy(), sharedState, info->copy(),
-            children[0]->copy(), id, printInfo->copy());
-    }
 
     uint64_t appendVectors() final {
         KU_ASSERT(keyVectors.size() == 1);
         return hashTable->appendVectorWithSorting(keyVectors[0], payloadVectors);
+    }
+
+    std::unique_ptr<PhysicalOperator> copy() override {
+        return make_unique<IntersectBuild>(sharedState, info->copy(),
+            children[0]->copy(), id, printInfo->copy());
     }
 };
 

--- a/src/include/processor/operator/order_by/order_by.h
+++ b/src/include/processor/operator/order_by/order_by.h
@@ -33,8 +33,8 @@ public:
     OrderBy(OrderByDataInfo info, std::shared_ptr<SortSharedState> sharedState,
         std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{type_, std::move(child), id, std::move(printInfo)},
-          info{std::move(info)}, sharedState{std::move(sharedState)} {}
+        : Sink{type_, std::move(child), id, std::move(printInfo)}, info{std::move(info)},
+          sharedState{std::move(sharedState)} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) final;
 
@@ -49,8 +49,8 @@ public:
     }
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<OrderBy>(info.copy(), sharedState,
-            children[0]->copy(), id, printInfo->copy());
+        return std::make_unique<OrderBy>(info.copy(), sharedState, children[0]->copy(), id,
+            printInfo->copy());
     }
 
 private:

--- a/src/include/processor/operator/order_by/order_by.h
+++ b/src/include/processor/operator/order_by/order_by.h
@@ -30,11 +30,10 @@ class OrderBy final : public Sink {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::ORDER_BY;
 
 public:
-    OrderBy(std::unique_ptr<ResultSetDescriptor> resultSetDescriptor,
-        std::unique_ptr<OrderByDataInfo> info, std::shared_ptr<SortSharedState> sharedState,
+    OrderBy(OrderByDataInfo info, std::shared_ptr<SortSharedState> sharedState,
         std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{std::move(resultSetDescriptor), type_, std::move(child), id, std::move(printInfo)},
+        : Sink{type_, std::move(child), id, std::move(printInfo)},
           info{std::move(info)}, sharedState{std::move(sharedState)} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) final;
@@ -50,16 +49,16 @@ public:
     }
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<OrderBy>(resultSetDescriptor->copy(), info->copy(), sharedState,
+        return std::make_unique<OrderBy>(info.copy(), sharedState,
             children[0]->copy(), id, printInfo->copy());
     }
 
 private:
-    void initGlobalStateInternal(ExecutionContext* context) final;
+    void initGlobalStateInternal(ExecutionContext* context) override;
 
 private:
-    std::unique_ptr<OrderByDataInfo> info;
-    std::unique_ptr<SortLocalState> localState;
+    OrderByDataInfo info;
+    SortLocalState localState;
     std::shared_ptr<SortSharedState> sharedState;
     std::vector<common::ValueVector*> orderByVectors;
     std::vector<common::ValueVector*> payloadVectors;

--- a/src/include/processor/operator/order_by/order_by_data_info.h
+++ b/src/include/processor/operator/order_by/order_by_data_info.h
@@ -23,16 +23,15 @@ struct OrderByDataInfo {
           keyTypes{std::move(keyTypes)}, payloadTypes{std::move(payloadTypes)},
           isAscOrder{std::move(isAscOrder)}, payloadTableSchema{std::move(payloadTableSchema)},
           keyInPayloadPos{std::move(keyInPayloadPos)} {}
+    EXPLICIT_COPY_DEFAULT_MOVE(OrderByDataInfo);
+
+private:
     OrderByDataInfo(const OrderByDataInfo& other)
         : keysPos{other.keysPos}, payloadsPos{other.payloadsPos},
           keyTypes{common::LogicalType::copy(other.keyTypes)},
           payloadTypes{common::LogicalType::copy(other.payloadTypes)}, isAscOrder{other.isAscOrder},
           payloadTableSchema{other.payloadTableSchema.copy()},
           keyInPayloadPos{other.keyInPayloadPos} {}
-
-    std::unique_ptr<OrderByDataInfo> copy() const {
-        return std::make_unique<OrderByDataInfo>(*this);
-    }
 };
 
 } // namespace processor

--- a/src/include/processor/operator/order_by/order_by_merge.h
+++ b/src/include/processor/operator/order_by/order_by_merge.h
@@ -18,7 +18,7 @@ public:
         std::shared_ptr<KeyBlockMergeTaskDispatcher> sharedDispatcher,
         std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{nullptr /* resultSetDescriptor */, type_, std::move(child), id,
+        : Sink{type_, std::move(child), id,
               std::move(printInfo)},
           sharedState{std::move(sharedState)}, sharedDispatcher{std::move(sharedDispatcher)} {}
 
@@ -26,7 +26,7 @@ public:
     OrderByMerge(std::shared_ptr<SortSharedState> sharedState,
         std::shared_ptr<KeyBlockMergeTaskDispatcher> sharedDispatcher, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{nullptr /* resultSetDescriptor */, type_, id, printInfo->copy()},
+        : Sink{type_, id, printInfo->copy()},
           sharedState{std::move(sharedState)}, sharedDispatcher{std::move(sharedDispatcher)} {}
 
     bool isSource() const override { return true; }

--- a/src/include/processor/operator/order_by/order_by_merge.h
+++ b/src/include/processor/operator/order_by/order_by_merge.h
@@ -18,16 +18,15 @@ public:
         std::shared_ptr<KeyBlockMergeTaskDispatcher> sharedDispatcher,
         std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{type_, std::move(child), id,
-              std::move(printInfo)},
+        : Sink{type_, std::move(child), id, std::move(printInfo)},
           sharedState{std::move(sharedState)}, sharedDispatcher{std::move(sharedDispatcher)} {}
 
     // This constructor is used for cloning only.
     OrderByMerge(std::shared_ptr<SortSharedState> sharedState,
         std::shared_ptr<KeyBlockMergeTaskDispatcher> sharedDispatcher, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{type_, id, printInfo->copy()},
-          sharedState{std::move(sharedState)}, sharedDispatcher{std::move(sharedDispatcher)} {}
+        : Sink{type_, id, printInfo->copy()}, sharedState{std::move(sharedState)},
+          sharedDispatcher{std::move(sharedDispatcher)} {}
 
     bool isSource() const override { return true; }
 

--- a/src/include/processor/operator/order_by/top_k.h
+++ b/src/include/processor/operator/order_by/top_k.h
@@ -170,11 +170,10 @@ class TopK final : public Sink {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::TOP_K;
 
 public:
-    TopK(std::unique_ptr<ResultSetDescriptor> resultSetDescriptor,
-        std::unique_ptr<OrderByDataInfo> info, std::shared_ptr<TopKSharedState> sharedState,
+    TopK(OrderByDataInfo info, std::shared_ptr<TopKSharedState> sharedState,
         uint64_t skipNumber, uint64_t limitNumber, std::unique_ptr<PhysicalOperator> child,
         uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{std::move(resultSetDescriptor), type_, std::move(child), id, std::move(printInfo)},
+        : Sink{type_, std::move(child), id, std::move(printInfo)},
           info(std::move(info)), sharedState{std::move(sharedState)}, skipNumber{skipNumber},
           limitNumber{limitNumber} {}
 
@@ -187,13 +186,13 @@ public:
     void finalize(ExecutionContext* /*context*/) override { sharedState->finalize(); }
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<TopK>(resultSetDescriptor->copy(), info->copy(), sharedState,
+        return std::make_unique<TopK>(info.copy(), sharedState,
             skipNumber, limitNumber, children[0]->copy(), id, printInfo->copy());
     }
 
 private:
-    std::unique_ptr<OrderByDataInfo> info;
-    std::unique_ptr<TopKLocalState> localState;
+    OrderByDataInfo info;
+    TopKLocalState localState;
     std::shared_ptr<TopKSharedState> sharedState;
     uint64_t skipNumber;
     uint64_t limitNumber;

--- a/src/include/processor/operator/order_by/top_k.h
+++ b/src/include/processor/operator/order_by/top_k.h
@@ -170,12 +170,11 @@ class TopK final : public Sink {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::TOP_K;
 
 public:
-    TopK(OrderByDataInfo info, std::shared_ptr<TopKSharedState> sharedState,
-        uint64_t skipNumber, uint64_t limitNumber, std::unique_ptr<PhysicalOperator> child,
-        uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{type_, std::move(child), id, std::move(printInfo)},
-          info(std::move(info)), sharedState{std::move(sharedState)}, skipNumber{skipNumber},
-          limitNumber{limitNumber} {}
+    TopK(OrderByDataInfo info, std::shared_ptr<TopKSharedState> sharedState, uint64_t skipNumber,
+        uint64_t limitNumber, std::unique_ptr<PhysicalOperator> child, uint32_t id,
+        std::unique_ptr<OPPrintInfo> printInfo)
+        : Sink{type_, std::move(child), id, std::move(printInfo)}, info(std::move(info)),
+          sharedState{std::move(sharedState)}, skipNumber{skipNumber}, limitNumber{limitNumber} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
@@ -186,8 +185,8 @@ public:
     void finalize(ExecutionContext* /*context*/) override { sharedState->finalize(); }
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<TopK>(info.copy(), sharedState,
-            skipNumber, limitNumber, children[0]->copy(), id, printInfo->copy());
+        return std::make_unique<TopK>(info.copy(), sharedState, skipNumber, limitNumber,
+            children[0]->copy(), id, printInfo->copy());
     }
 
 private:

--- a/src/include/processor/operator/partitioner.h
+++ b/src/include/processor/operator/partitioner.h
@@ -162,8 +162,7 @@ class Partitioner final : public Sink {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::PARTITIONER;
 
 public:
-    Partitioner(std::unique_ptr<ResultSetDescriptor> resultSetDescriptor, PartitionerInfo info,
-        PartitionerDataInfo dataInfo, std::shared_ptr<PartitionerSharedState> sharedState,
+    Partitioner(PartitionerInfo info, PartitionerDataInfo dataInfo, std::shared_ptr<PartitionerSharedState> sharedState,
         std::unique_ptr<PhysicalOperator> child, physical_op_id id,
         std::unique_ptr<OPPrintInfo> printInfo);
 
@@ -173,7 +172,10 @@ public:
 
     std::shared_ptr<PartitionerSharedState> getSharedState() { return sharedState; }
 
-    std::unique_ptr<PhysicalOperator> copy() override;
+    std::unique_ptr<PhysicalOperator> copy() override {
+        return std::make_unique<Partitioner>(info.copy(), dataInfo.copy(),
+            sharedState, children[0]->copy(), id, printInfo->copy());
+    }
 
     static void initializePartitioningStates(const common::logical_type_vec_t& columnTypes,
         std::vector<std::unique_ptr<PartitioningBuffer>>& partitioningBuffers,

--- a/src/include/processor/operator/partitioner.h
+++ b/src/include/processor/operator/partitioner.h
@@ -162,7 +162,8 @@ class Partitioner final : public Sink {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::PARTITIONER;
 
 public:
-    Partitioner(PartitionerInfo info, PartitionerDataInfo dataInfo, std::shared_ptr<PartitionerSharedState> sharedState,
+    Partitioner(PartitionerInfo info, PartitionerDataInfo dataInfo,
+        std::shared_ptr<PartitionerSharedState> sharedState,
         std::unique_ptr<PhysicalOperator> child, physical_op_id id,
         std::unique_ptr<OPPrintInfo> printInfo);
 
@@ -173,8 +174,8 @@ public:
     std::shared_ptr<PartitionerSharedState> getSharedState() { return sharedState; }
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<Partitioner>(info.copy(), dataInfo.copy(),
-            sharedState, children[0]->copy(), id, printInfo->copy());
+        return std::make_unique<Partitioner>(info.copy(), dataInfo.copy(), sharedState,
+            children[0]->copy(), id, printInfo->copy());
     }
 
     static void initializePartitioningStates(const common::logical_type_vec_t& columnTypes,

--- a/src/include/processor/operator/persistent/batch_insert.h
+++ b/src/include/processor/operator/persistent/batch_insert.h
@@ -108,10 +108,9 @@ class BatchInsert : public Sink {
 
 public:
     BatchInsert(std::string tableName, std::unique_ptr<BatchInsertInfo> info,
-        std::shared_ptr<BatchInsertSharedState> sharedState,
-        std::unique_ptr<ResultSetDescriptor> resultSetDescriptor, uint32_t id,
+        std::shared_ptr<BatchInsertSharedState> sharedState, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{std::move(resultSetDescriptor), type_, id, std::move(printInfo)},
+        : Sink{type_, id, std::move(printInfo)},
           tableName{std::move(tableName)}, info{std::move(info)},
           sharedState{std::move(sharedState)} {}
 

--- a/src/include/processor/operator/persistent/batch_insert.h
+++ b/src/include/processor/operator/persistent/batch_insert.h
@@ -110,9 +110,8 @@ public:
     BatchInsert(std::string tableName, std::unique_ptr<BatchInsertInfo> info,
         std::shared_ptr<BatchInsertSharedState> sharedState, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{type_, id, std::move(printInfo)},
-          tableName{std::move(tableName)}, info{std::move(info)},
-          sharedState{std::move(sharedState)} {}
+        : Sink{type_, id, std::move(printInfo)}, tableName{std::move(tableName)},
+          info{std::move(info)}, sharedState{std::move(sharedState)} {}
 
     ~BatchInsert() override = default;
 

--- a/src/include/processor/operator/persistent/copy_to.h
+++ b/src/include/processor/operator/persistent/copy_to.h
@@ -51,11 +51,10 @@ class CopyTo final : public Sink {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::COPY_TO;
 
 public:
-    CopyTo(std::unique_ptr<ResultSetDescriptor> resultSetDescriptor, CopyToInfo info,
-        std::shared_ptr<function::ExportFuncSharedState> sharedState,
+    CopyTo(CopyToInfo info, std::shared_ptr<function::ExportFuncSharedState> sharedState,
         std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{std::move(resultSetDescriptor), type_, std::move(child), id, std::move(printInfo)},
+        : Sink{type_, std::move(child), id, std::move(printInfo)},
           info{std::move(info)}, sharedState{std::move(sharedState)} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
@@ -64,10 +63,10 @@ public:
 
     void finalize(ExecutionContext* context) override;
 
-    void executeInternal(processor::ExecutionContext* context) override;
+    void executeInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<CopyTo>(resultSetDescriptor->copy(), info.copy(), sharedState,
+        return std::make_unique<CopyTo>(info.copy(), sharedState,
             children[0]->copy(), id, printInfo->copy());
     }
 

--- a/src/include/processor/operator/persistent/copy_to.h
+++ b/src/include/processor/operator/persistent/copy_to.h
@@ -54,8 +54,8 @@ public:
     CopyTo(CopyToInfo info, std::shared_ptr<function::ExportFuncSharedState> sharedState,
         std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{type_, std::move(child), id, std::move(printInfo)},
-          info{std::move(info)}, sharedState{std::move(sharedState)} {}
+        : Sink{type_, std::move(child), id, std::move(printInfo)}, info{std::move(info)},
+          sharedState{std::move(sharedState)} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
@@ -66,8 +66,8 @@ public:
     void executeInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<CopyTo>(info.copy(), sharedState,
-            children[0]->copy(), id, printInfo->copy());
+        return std::make_unique<CopyTo>(info.copy(), sharedState, children[0]->copy(), id,
+            printInfo->copy());
     }
 
 private:

--- a/src/include/processor/operator/persistent/node_batch_insert.h
+++ b/src/include/processor/operator/persistent/node_batch_insert.h
@@ -97,11 +97,10 @@ class NodeBatchInsert final : public BatchInsert {
 public:
     NodeBatchInsert(std::string tableName, std::unique_ptr<BatchInsertInfo> info,
         std::shared_ptr<BatchInsertSharedState> sharedState,
-        std::unique_ptr<ResultSetDescriptor> resultSetDescriptor,
         std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
         : BatchInsert{std::move(tableName), std::move(info), std::move(sharedState),
-              std::move(resultSetDescriptor), id, std::move(printInfo)} {
+              id, std::move(printInfo)} {
         children.push_back(std::move(child));
     }
 
@@ -116,7 +115,7 @@ public:
 
     std::unique_ptr<PhysicalOperator> copy() override {
         return std::make_unique<NodeBatchInsert>(tableName, info->copy(), sharedState,
-            resultSetDescriptor->copy(), children[0]->copy(), id, printInfo->copy());
+            children[0]->copy(), id, printInfo->copy());
     }
 
     // The node group will be reset so that the only values remaining are the ones which were

--- a/src/include/processor/operator/persistent/node_batch_insert.h
+++ b/src/include/processor/operator/persistent/node_batch_insert.h
@@ -99,8 +99,8 @@ public:
         std::shared_ptr<BatchInsertSharedState> sharedState,
         std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : BatchInsert{std::move(tableName), std::move(info), std::move(sharedState),
-              id, std::move(printInfo)} {
+        : BatchInsert{std::move(tableName), std::move(info), std::move(sharedState), id,
+              std::move(printInfo)} {
         children.push_back(std::move(child));
     }
 

--- a/src/include/processor/operator/persistent/rel_batch_insert.h
+++ b/src/include/processor/operator/persistent/rel_batch_insert.h
@@ -70,8 +70,8 @@ public:
         std::shared_ptr<BatchInsertSharedState> sharedState, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo,
         std::shared_ptr<RelBatchInsertProgressSharedState> progressSharedState)
-        : BatchInsert{std::move(tableName), std::move(info), std::move(sharedState),
-              id, std::move(printInfo)},
+        : BatchInsert{std::move(tableName), std::move(info), std::move(sharedState), id,
+              std::move(printInfo)},
           partitionerSharedState{std::move(partitionerSharedState)},
           progressSharedState{std::move(progressSharedState)} {}
 

--- a/src/include/processor/operator/persistent/rel_batch_insert.h
+++ b/src/include/processor/operator/persistent/rel_batch_insert.h
@@ -67,12 +67,11 @@ class RelBatchInsert final : public BatchInsert {
 public:
     RelBatchInsert(std::string tableName, std::unique_ptr<BatchInsertInfo> info,
         std::shared_ptr<PartitionerSharedState> partitionerSharedState,
-        std::shared_ptr<BatchInsertSharedState> sharedState,
-        std::unique_ptr<ResultSetDescriptor> resultSetDescriptor, uint32_t id,
+        std::shared_ptr<BatchInsertSharedState> sharedState, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo,
         std::shared_ptr<RelBatchInsertProgressSharedState> progressSharedState)
         : BatchInsert{std::move(tableName), std::move(info), std::move(sharedState),
-              std::move(resultSetDescriptor), id, std::move(printInfo)},
+              id, std::move(printInfo)},
           partitionerSharedState{std::move(partitionerSharedState)},
           progressSharedState{std::move(progressSharedState)} {}
 
@@ -86,7 +85,7 @@ public:
 
     std::unique_ptr<PhysicalOperator> copy() override {
         return std::make_unique<RelBatchInsert>(tableName, info->copy(), partitionerSharedState,
-            sharedState, resultSetDescriptor->copy(), id, printInfo->copy(), progressSharedState);
+            sharedState, id, printInfo->copy(), progressSharedState);
     }
 
     void updateProgress(const ExecutionContext* context) const;

--- a/src/include/processor/operator/recursive_extend.h
+++ b/src/include/processor/operator/recursive_extend.h
@@ -29,8 +29,8 @@ public:
     RecursiveExtend(std::unique_ptr<function::RJAlgorithm> function, function::RJBindData bindData,
         std::shared_ptr<RecursiveExtendSharedState> sharedState, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{type_, id, std::move(printInfo)},
-          function{std::move(function)}, bindData{bindData}, sharedState{std::move(sharedState)} {}
+        : Sink{type_, id, std::move(printInfo)}, function{std::move(function)}, bindData{bindData},
+          sharedState{std::move(sharedState)} {}
 
     std::shared_ptr<RecursiveExtendSharedState> getSharedState() const { return sharedState; }
 
@@ -41,8 +41,8 @@ public:
     void executeInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<RecursiveExtend>(function->copy(),
-            bindData, sharedState, id, printInfo->copy());
+        return std::make_unique<RecursiveExtend>(function->copy(), bindData, sharedState, id,
+            printInfo->copy());
     }
 
 private:

--- a/src/include/processor/operator/recursive_extend.h
+++ b/src/include/processor/operator/recursive_extend.h
@@ -26,11 +26,10 @@ class RecursiveExtend : public Sink {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::RECURSIVE_EXTEND;
 
 public:
-    RecursiveExtend(std::unique_ptr<ResultSetDescriptor> descriptor,
-        std::unique_ptr<function::RJAlgorithm> function, function::RJBindData bindData,
+    RecursiveExtend(std::unique_ptr<function::RJAlgorithm> function, function::RJBindData bindData,
         std::shared_ptr<RecursiveExtendSharedState> sharedState, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{std::move(descriptor), type_, id, std::move(printInfo)},
+        : Sink{type_, id, std::move(printInfo)},
           function{std::move(function)}, bindData{bindData}, sharedState{std::move(sharedState)} {}
 
     std::shared_ptr<RecursiveExtendSharedState> getSharedState() const { return sharedState; }
@@ -42,7 +41,7 @@ public:
     void executeInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<RecursiveExtend>(resultSetDescriptor->copy(), function->copy(),
+        return std::make_unique<RecursiveExtend>(function->copy(),
             bindData, sharedState, id, printInfo->copy());
     }
 

--- a/src/include/processor/operator/result_collector.h
+++ b/src/include/processor/operator/result_collector.h
@@ -66,11 +66,12 @@ class ResultCollector final : public Sink {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::RESULT_COLLECTOR;
 
 public:
-    ResultCollector(ResultCollectorInfo info, std::shared_ptr<ResultCollectorSharedState> sharedState,
+    ResultCollector(ResultCollectorInfo info,
+        std::shared_ptr<ResultCollectorSharedState> sharedState,
         std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{type_, std::move(child), id, std::move(printInfo)},
-          info{std::move(info)}, sharedState{std::move(sharedState)} {}
+        : Sink{type_, std::move(child), id, std::move(printInfo)}, info{std::move(info)},
+          sharedState{std::move(sharedState)} {}
 
     void executeInternal(ExecutionContext* context) override;
 
@@ -79,8 +80,8 @@ public:
     std::shared_ptr<FactorizedTable> getResultFactorizedTable() { return sharedState->getTable(); }
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<ResultCollector>(info.copy(), sharedState,
-            children[0]->copy(), id, printInfo->copy());
+        return std::make_unique<ResultCollector>(info.copy(), sharedState, children[0]->copy(), id,
+            printInfo->copy());
     }
 
 private:

--- a/src/include/processor/operator/result_collector.h
+++ b/src/include/processor/operator/result_collector.h
@@ -66,11 +66,10 @@ class ResultCollector final : public Sink {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::RESULT_COLLECTOR;
 
 public:
-    ResultCollector(std::unique_ptr<ResultSetDescriptor> resultSetDescriptor,
-        ResultCollectorInfo info, std::shared_ptr<ResultCollectorSharedState> sharedState,
+    ResultCollector(ResultCollectorInfo info, std::shared_ptr<ResultCollectorSharedState> sharedState,
         std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{std::move(resultSetDescriptor), type_, std::move(child), id, std::move(printInfo)},
+        : Sink{type_, std::move(child), id, std::move(printInfo)},
           info{std::move(info)}, sharedState{std::move(sharedState)} {}
 
     void executeInternal(ExecutionContext* context) override;
@@ -80,7 +79,7 @@ public:
     std::shared_ptr<FactorizedTable> getResultFactorizedTable() { return sharedState->getTable(); }
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return make_unique<ResultCollector>(resultSetDescriptor->copy(), info.copy(), sharedState,
+        return std::make_unique<ResultCollector>(info.copy(), sharedState,
             children[0]->copy(), id, printInfo->copy());
     }
 

--- a/src/include/processor/operator/sink.h
+++ b/src/include/processor/operator/sink.h
@@ -10,10 +10,11 @@ namespace processor {
 
 class KUZU_API Sink : public PhysicalOperator {
 public:
-    Sink(PhysicalOperatorType operatorType, physical_op_id id, std::unique_ptr<OPPrintInfo> printInfo)
-        : PhysicalOperator{operatorType, id, std::move(printInfo)} {}
-    Sink(PhysicalOperatorType operatorType, std::unique_ptr<PhysicalOperator> child, physical_op_id id,
+    Sink(PhysicalOperatorType operatorType, physical_op_id id,
         std::unique_ptr<OPPrintInfo> printInfo)
+        : PhysicalOperator{operatorType, id, std::move(printInfo)} {}
+    Sink(PhysicalOperatorType operatorType, std::unique_ptr<PhysicalOperator> child,
+        physical_op_id id, std::unique_ptr<OPPrintInfo> printInfo)
         : PhysicalOperator{operatorType, std::move(child), id, std::move(printInfo)} {}
 
     bool isSink() const override { return true; }
@@ -50,8 +51,7 @@ class KUZU_API DummySink final : public Sink {
 
 public:
     DummySink(std::unique_ptr<PhysicalOperator> child, uint32_t id)
-        : Sink{type_, std::move(child), id,
-              OPPrintInfo::EmptyInfo()} {}
+        : Sink{type_, std::move(child), id, OPPrintInfo::EmptyInfo()} {}
 
     std::unique_ptr<PhysicalOperator> copy() override {
         return std::make_unique<DummySink>(children[0]->copy(), id);

--- a/src/include/processor/operator/sink.h
+++ b/src/include/processor/operator/sink.h
@@ -10,19 +10,19 @@ namespace processor {
 
 class KUZU_API Sink : public PhysicalOperator {
 public:
-    Sink(std::unique_ptr<ResultSetDescriptor> resultSetDescriptor,
-        PhysicalOperatorType operatorType, uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
-        : PhysicalOperator{operatorType, id, std::move(printInfo)},
-          resultSetDescriptor{std::move(resultSetDescriptor)} {}
-    Sink(std::unique_ptr<ResultSetDescriptor> resultSetDescriptor,
-        PhysicalOperatorType operatorType, std::unique_ptr<PhysicalOperator> child, uint32_t id,
+    Sink(PhysicalOperatorType operatorType, physical_op_id id, std::unique_ptr<OPPrintInfo> printInfo)
+        : PhysicalOperator{operatorType, id, std::move(printInfo)} {}
+    Sink(PhysicalOperatorType operatorType, std::unique_ptr<PhysicalOperator> child, physical_op_id id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : PhysicalOperator{operatorType, std::move(child), id, std::move(printInfo)},
-          resultSetDescriptor{std::move(resultSetDescriptor)} {}
+        : PhysicalOperator{operatorType, std::move(child), id, std::move(printInfo)} {}
 
     bool isSink() const override { return true; }
 
-    ResultSetDescriptor* getResultSetDescriptor() { return resultSetDescriptor.get(); }
+    void setDescriptor(std::unique_ptr<ResultSetDescriptor> descriptor) {
+        KU_ASSERT(resultSetDescriptor == nullptr);
+        resultSetDescriptor = std::move(descriptor);
+    }
+    std::unique_ptr<ResultSet> getResultSet(storage::MemoryManager* memoryManager);
 
     void execute(ResultSet* resultSet, ExecutionContext* context) {
         initLocalState(resultSet, context);
@@ -49,13 +49,12 @@ class KUZU_API DummySink final : public Sink {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::DUMMY_SINK;
 
 public:
-    DummySink(std::unique_ptr<ResultSetDescriptor> resultSetDescriptor,
-        std::unique_ptr<PhysicalOperator> child, uint32_t id)
-        : Sink{std::move(resultSetDescriptor), type_, std::move(child), id,
+    DummySink(std::unique_ptr<PhysicalOperator> child, uint32_t id)
+        : Sink{type_, std::move(child), id,
               OPPrintInfo::EmptyInfo()} {}
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<DummySink>(resultSetDescriptor->copy(), children[0]->copy(), id);
+        return std::make_unique<DummySink>(children[0]->copy(), id);
     }
 
 protected:

--- a/src/include/processor/processor_task.h
+++ b/src/include/processor/processor_task.h
@@ -15,9 +15,6 @@ public:
     void run() override;
     void finalizeIfNecessary() override;
 
-    static std::unique_ptr<ResultSet> populateResultSet(Sink* op,
-        storage::MemoryManager* memoryManager);
-
 private:
     bool sharedStateInitialized;
     Sink* sink;

--- a/src/processor/map/create_result_collector.cpp
+++ b/src/processor/map/create_result_collector.cpp
@@ -28,8 +28,8 @@ std::unique_ptr<ResultCollector> PlanMapper::createResultCollector(AccumulateTyp
     auto sharedState = std::make_shared<ResultCollectorSharedState>(std::move(table));
     auto opInfo = ResultCollectorInfo(accumulateType, std::move(tableSchema), payloadsPos);
     auto printInfo = std::make_unique<ResultCollectorPrintInfo>(expressions, accumulateType);
-    auto op = std::make_unique<ResultCollector>(std::move(opInfo), std::move(sharedState), std::move(prevOperator), getOperatorID(),
-        std::move(printInfo));
+    auto op = std::make_unique<ResultCollector>(std::move(opInfo), std::move(sharedState),
+        std::move(prevOperator), getOperatorID(), std::move(printInfo));
     op->setDescriptor(std::make_unique<ResultSetDescriptor>(schema));
     return op;
 }

--- a/src/processor/map/create_result_collector.cpp
+++ b/src/processor/map/create_result_collector.cpp
@@ -28,9 +28,10 @@ std::unique_ptr<ResultCollector> PlanMapper::createResultCollector(AccumulateTyp
     auto sharedState = std::make_shared<ResultCollectorSharedState>(std::move(table));
     auto opInfo = ResultCollectorInfo(accumulateType, std::move(tableSchema), payloadsPos);
     auto printInfo = std::make_unique<ResultCollectorPrintInfo>(expressions, accumulateType);
-    return make_unique<ResultCollector>(std::make_unique<ResultSetDescriptor>(schema),
-        std::move(opInfo), std::move(sharedState), std::move(prevOperator), getOperatorID(),
+    auto op = std::make_unique<ResultCollector>(std::move(opInfo), std::move(sharedState), std::move(prevOperator), getOperatorID(),
         std::move(printInfo));
+    op->setDescriptor(std::make_unique<ResultSetDescriptor>(schema));
+    return op;
 }
 
 } // namespace processor

--- a/src/processor/map/map_aggregate.cpp
+++ b/src/processor/map/map_aggregate.cpp
@@ -94,11 +94,10 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapAggregate(const LogicalOperator
     auto sharedState =
         make_shared<SimpleAggregateSharedState>(clientContext, aggFunctions, aggregateInputInfos);
     auto printInfo = std::make_unique<SimpleAggregatePrintInfo>(aggregates);
-    auto aggregate = make_unique<SimpleAggregate>(std::make_unique<ResultSetDescriptor>(inSchema),
-        sharedState, std::move(aggFunctions), copyVector(aggregateInputInfos),
+    auto aggregate = make_unique<SimpleAggregate>(sharedState, std::move(aggFunctions), copyVector(aggregateInputInfos),
         std::move(prevOperator), getOperatorID(), printInfo->copy());
-    auto finalizer = std::make_unique<SimpleAggregateFinalize>(
-        std::make_unique<ResultSetDescriptor>(inSchema), sharedState, std::move(aggregate),
+    aggregate->setDescriptor(std::make_unique<ResultSetDescriptor>(inSchema));
+    auto finalizer = std::make_unique<SimpleAggregateFinalize>(sharedState, std::move(aggregate),
         std::move(aggregateInputInfos), getOperatorID(), printInfo->copy());
     return make_unique<SimpleAggregateScan>(sharedState, aggOutputPos, std::move(finalizer),
         getOperatorID(), printInfo->copy());
@@ -168,17 +167,16 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createHashAggregate(const expressi
         std::make_shared<HashAggregateSharedState>(clientContext, std::move(aggregateInfo),
             aggFunctions, aggregateInputInfos, std::move(keyTypes), std::move(payloadTypes));
     auto printInfo = std::make_unique<HashAggregatePrintInfo>(allKeys, aggregates);
-    auto aggregate = make_unique<HashAggregate>(std::make_unique<ResultSetDescriptor>(inSchema),
-        sharedState, std::move(aggFunctions), std::move(aggregateInputInfos),
+    auto aggregate = make_unique<HashAggregate>(sharedState, std::move(aggFunctions), std::move(aggregateInputInfos),
         std::move(prevOperator), getOperatorID(), printInfo->copy());
+    aggregate->setDescriptor(std::make_unique<ResultSetDescriptor>(inSchema));
     // Create AggScan.
     expression_vector outputExpressions;
     outputExpressions.insert(outputExpressions.end(), flatKeys.begin(), flatKeys.end());
     outputExpressions.insert(outputExpressions.end(), unFlatKeys.begin(), unFlatKeys.end());
     outputExpressions.insert(outputExpressions.end(), payloads.begin(), payloads.end());
     auto aggOutputPos = getDataPos(aggregates, *outSchema);
-    auto finalizer =
-        std::make_unique<HashAggregateFinalize>(std::make_unique<ResultSetDescriptor>(inSchema),
+    auto finalizer = std::make_unique<HashAggregateFinalize>(
             sharedState, std::move(aggregate), getOperatorID(), printInfo->copy());
     return std::make_unique<HashAggregateScan>(sharedState,
         getDataPos(outputExpressions, *outSchema), std::move(aggOutputPos), std::move(finalizer),

--- a/src/processor/map/map_aggregate.cpp
+++ b/src/processor/map/map_aggregate.cpp
@@ -94,8 +94,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapAggregate(const LogicalOperator
     auto sharedState =
         make_shared<SimpleAggregateSharedState>(clientContext, aggFunctions, aggregateInputInfos);
     auto printInfo = std::make_unique<SimpleAggregatePrintInfo>(aggregates);
-    auto aggregate = make_unique<SimpleAggregate>(sharedState, std::move(aggFunctions), copyVector(aggregateInputInfos),
-        std::move(prevOperator), getOperatorID(), printInfo->copy());
+    auto aggregate = make_unique<SimpleAggregate>(sharedState, std::move(aggFunctions),
+        copyVector(aggregateInputInfos), std::move(prevOperator), getOperatorID(),
+        printInfo->copy());
     aggregate->setDescriptor(std::make_unique<ResultSetDescriptor>(inSchema));
     auto finalizer = std::make_unique<SimpleAggregateFinalize>(sharedState, std::move(aggregate),
         std::move(aggregateInputInfos), getOperatorID(), printInfo->copy());
@@ -167,8 +168,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createHashAggregate(const expressi
         std::make_shared<HashAggregateSharedState>(clientContext, std::move(aggregateInfo),
             aggFunctions, aggregateInputInfos, std::move(keyTypes), std::move(payloadTypes));
     auto printInfo = std::make_unique<HashAggregatePrintInfo>(allKeys, aggregates);
-    auto aggregate = make_unique<HashAggregate>(sharedState, std::move(aggFunctions), std::move(aggregateInputInfos),
-        std::move(prevOperator), getOperatorID(), printInfo->copy());
+    auto aggregate = make_unique<HashAggregate>(sharedState, std::move(aggFunctions),
+        std::move(aggregateInputInfos), std::move(prevOperator), getOperatorID(),
+        printInfo->copy());
     aggregate->setDescriptor(std::make_unique<ResultSetDescriptor>(inSchema));
     // Create AggScan.
     expression_vector outputExpressions;
@@ -176,8 +178,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createHashAggregate(const expressi
     outputExpressions.insert(outputExpressions.end(), unFlatKeys.begin(), unFlatKeys.end());
     outputExpressions.insert(outputExpressions.end(), payloads.begin(), payloads.end());
     auto aggOutputPos = getDataPos(aggregates, *outSchema);
-    auto finalizer = std::make_unique<HashAggregateFinalize>(
-            sharedState, std::move(aggregate), getOperatorID(), printInfo->copy());
+    auto finalizer = std::make_unique<HashAggregateFinalize>(sharedState, std::move(aggregate),
+        getOperatorID(), printInfo->copy());
     return std::make_unique<HashAggregateScan>(sharedState,
         getDataPos(outputExpressions, *outSchema), std::move(aggOutputPos), std::move(finalizer),
         getOperatorID(), printInfo->copy());

--- a/src/processor/map/map_copy_from.cpp
+++ b/src/processor/map/map_copy_from.cpp
@@ -41,9 +41,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createRelBatchInsertOp(
         clientContext->getStorageManager()->compressionEnabled(), direction, partitioningIdx,
         offsetVectorIdx, std::move(columnIDs), std::move(columnTypes), numWarningDataColumns);
     auto printInfo = std::make_unique<RelBatchInsertPrintInfo>(copyFromInfo.tableName);
-    auto batchInsert = std::make_unique<RelBatchInsert>(copyFromInfo.tableName, std::move(relBatchInsertInfo),
-        std::move(partitionerSharedState), std::move(sharedState), operatorID, std::move(printInfo),
-        nullptr);
+    auto batchInsert = std::make_unique<RelBatchInsert>(copyFromInfo.tableName,
+        std::move(relBatchInsertInfo), std::move(partitionerSharedState), std::move(sharedState),
+        operatorID, std::move(printInfo), nullptr);
     batchInsert->setDescriptor(std::make_unique<ResultSetDescriptor>(outFSchema));
     return batchInsert;
 }
@@ -106,9 +106,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyNodeFrom(
 
     auto tableName = copyFromInfo->tableName;
     auto printInfo = std::make_unique<NodeBatchInsertPrintInfo>(tableName);
-    auto batchInsert =
-        std::make_unique<NodeBatchInsert>(tableName, std::move(info), std::move(sharedState),
-           std::move(prevOperator), getOperatorID(), std::move(printInfo));
+    auto batchInsert = std::make_unique<NodeBatchInsert>(tableName, std::move(info),
+        std::move(sharedState), std::move(prevOperator), getOperatorID(), std::move(printInfo));
     batchInsert->setDescriptor(std::make_unique<ResultSetDescriptor>(copyFrom.getSchema()));
     return batchInsert;
 }
@@ -146,8 +145,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPartitioner(
         expressions.push_back(copyFromInfo.columnExprs[info.keyIdx]);
     }
     auto printInfo = std::make_unique<PartitionerPrintInfo>(expressions);
-    auto partitioner = std::make_unique<Partitioner>(std::move(partitionerInfo), std::move(dataInfo), std::move(sharedState),
-        std::move(prevOperator), getOperatorID(), std::move(printInfo));
+    auto partitioner =
+        std::make_unique<Partitioner>(std::move(partitionerInfo), std::move(dataInfo),
+            std::move(sharedState), std::move(prevOperator), getOperatorID(), std::move(printInfo));
     partitioner->setDescriptor(std::make_unique<ResultSetDescriptor>(outFSchema));
     return partitioner;
 }

--- a/src/processor/map/map_copy_from.cpp
+++ b/src/processor/map/map_copy_from.cpp
@@ -41,10 +41,11 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createRelBatchInsertOp(
         clientContext->getStorageManager()->compressionEnabled(), direction, partitioningIdx,
         offsetVectorIdx, std::move(columnIDs), std::move(columnTypes), numWarningDataColumns);
     auto printInfo = std::make_unique<RelBatchInsertPrintInfo>(copyFromInfo.tableName);
-    return std::make_unique<RelBatchInsert>(copyFromInfo.tableName, std::move(relBatchInsertInfo),
-        std::move(partitionerSharedState), std::move(sharedState),
-        std::make_unique<ResultSetDescriptor>(outFSchema), operatorID, std::move(printInfo),
+    auto batchInsert = std::make_unique<RelBatchInsert>(copyFromInfo.tableName, std::move(relBatchInsertInfo),
+        std::move(partitionerSharedState), std::move(sharedState), operatorID, std::move(printInfo),
         nullptr);
+    batchInsert->setDescriptor(std::make_unique<ResultSetDescriptor>(outFSchema));
+    return batchInsert;
 }
 
 std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyFrom(const LogicalOperator* logicalOperator) {
@@ -105,10 +106,10 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyNodeFrom(
 
     auto tableName = copyFromInfo->tableName;
     auto printInfo = std::make_unique<NodeBatchInsertPrintInfo>(tableName);
-    auto descriptor = std::make_unique<ResultSetDescriptor>(copyFrom.getSchema());
     auto batchInsert =
         std::make_unique<NodeBatchInsert>(tableName, std::move(info), std::move(sharedState),
-            std::move(descriptor), std::move(prevOperator), getOperatorID(), std::move(printInfo));
+           std::move(prevOperator), getOperatorID(), std::move(printInfo));
+    batchInsert->setDescriptor(std::make_unique<ResultSetDescriptor>(copyFrom.getSchema()));
     return batchInsert;
 }
 
@@ -145,9 +146,10 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPartitioner(
         expressions.push_back(copyFromInfo.columnExprs[info.keyIdx]);
     }
     auto printInfo = std::make_unique<PartitionerPrintInfo>(expressions);
-    return std::make_unique<Partitioner>(std::make_unique<ResultSetDescriptor>(outFSchema),
-        std::move(partitionerInfo), std::move(dataInfo), std::move(sharedState),
+    auto partitioner = std::make_unique<Partitioner>(std::move(partitionerInfo), std::move(dataInfo), std::move(sharedState),
         std::move(prevOperator), getOperatorID(), std::move(printInfo));
+    partitioner->setDescriptor(std::make_unique<ResultSetDescriptor>(outFSchema));
+    return partitioner;
 }
 
 physical_op_vector_t PlanMapper::mapCopyRelFrom(const LogicalOperator* logicalOperator) {

--- a/src/processor/map/map_copy_to.cpp
+++ b/src/processor/map/map_copy_to.cpp
@@ -32,9 +32,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyTo(const LogicalOperator* l
         CopyToInfo{exportFunc, std::move(bindData), std::move(vectorsToCopyPos), std::move(isFlat)};
     auto printInfo =
         std::make_unique<CopyToPrintInfo>(info.bindData->columnNames, info.bindData->fileName);
-    auto copyTo = std::make_unique<CopyTo>(std::make_unique<ResultSetDescriptor>(childSchema),
-        std::move(info), std::move(sharedState), std::move(prevOperator), getOperatorID(),
+    auto copyTo = std::make_unique<CopyTo>(std::move(info), std::move(sharedState), std::move(prevOperator), getOperatorID(),
         std::move(printInfo));
+    copyTo->setDescriptor(std::make_unique<ResultSetDescriptor>(childSchema));
     return createEmptyFTableScan(FactorizedTable::EmptyTable(clientContext->getMemoryManager()), 0,
         std::move(copyTo));
 }

--- a/src/processor/map/map_copy_to.cpp
+++ b/src/processor/map/map_copy_to.cpp
@@ -32,8 +32,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyTo(const LogicalOperator* l
         CopyToInfo{exportFunc, std::move(bindData), std::move(vectorsToCopyPos), std::move(isFlat)};
     auto printInfo =
         std::make_unique<CopyToPrintInfo>(info.bindData->columnNames, info.bindData->fileName);
-    auto copyTo = std::make_unique<CopyTo>(std::move(info), std::move(sharedState), std::move(prevOperator), getOperatorID(),
-        std::move(printInfo));
+    auto copyTo = std::make_unique<CopyTo>(std::move(info), std::move(sharedState),
+        std::move(prevOperator), getOperatorID(), std::move(printInfo));
     copyTo->setDescriptor(std::make_unique<ResultSetDescriptor>(childSchema));
     return createEmptyFTableScan(FactorizedTable::EmptyTable(clientContext->getMemoryManager()), 0,
         std::move(copyTo));

--- a/src/processor/map/map_dummy_sink.cpp
+++ b/src/processor/map/map_dummy_sink.cpp
@@ -8,7 +8,9 @@ namespace processor {
 std::unique_ptr<PhysicalOperator> PlanMapper::mapDummySink(const LogicalOperator* logicalOperator) {
     auto child = mapOperator(logicalOperator->getChild(0).get());
     auto descriptor = std::make_unique<ResultSetDescriptor>(logicalOperator->getSchema());
-    return std::make_unique<DummySink>(std::move(descriptor), std::move(child), getOperatorID());
+    auto sink = std::make_unique<DummySink>(std::move(child), getOperatorID());
+    sink->setDescriptor(std::move(descriptor));
+    return sink;
 }
 
 } // namespace processor

--- a/src/processor/map/map_hash_join.cpp
+++ b/src/processor/map/map_hash_join.cpp
@@ -89,9 +89,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapHashJoin(const LogicalOperator*
     auto sharedState = std::make_shared<HashJoinSharedState>(std::move(globalHashTable));
     auto buildPrintInfo = std::make_unique<HashJoinBuildPrintInfo>(buildKeys, payloads);
     auto hashJoinBuild =
-        make_unique<HashJoinBuild>(std::make_unique<ResultSetDescriptor>(buildSchema),
-            PhysicalOperatorType::HASH_JOIN_BUILD, sharedState, std::move(buildInfo),
+        std::make_unique<HashJoinBuild>(PhysicalOperatorType::HASH_JOIN_BUILD, sharedState, std::move(buildInfo),
             std::move(buildSidePrevOperator), getOperatorID(), buildPrintInfo->copy());
+    hashJoinBuild->setDescriptor(std::make_unique<ResultSetDescriptor>(buildSchema));
     // Create probe
     std::vector<DataPos> probeKeysDataPos;
     for (auto& probeKey : probeKeys) {

--- a/src/processor/map/map_hash_join.cpp
+++ b/src/processor/map/map_hash_join.cpp
@@ -88,9 +88,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapHashJoin(const LogicalOperator*
         LogicalType::copy(buildKeyTypes), buildInfo->getTableSchema()->copy());
     auto sharedState = std::make_shared<HashJoinSharedState>(std::move(globalHashTable));
     auto buildPrintInfo = std::make_unique<HashJoinBuildPrintInfo>(buildKeys, payloads);
-    auto hashJoinBuild =
-        std::make_unique<HashJoinBuild>(PhysicalOperatorType::HASH_JOIN_BUILD, sharedState, std::move(buildInfo),
-            std::move(buildSidePrevOperator), getOperatorID(), buildPrintInfo->copy());
+    auto hashJoinBuild = std::make_unique<HashJoinBuild>(PhysicalOperatorType::HASH_JOIN_BUILD,
+        sharedState, std::move(buildInfo), std::move(buildSidePrevOperator), getOperatorID(),
+        buildPrintInfo->copy());
     hashJoinBuild->setDescriptor(std::make_unique<ResultSetDescriptor>(buildSchema));
     // Create probe
     std::vector<DataPos> probeKeysDataPos;

--- a/src/processor/map/map_intersect.cpp
+++ b/src/processor/map/map_intersect.cpp
@@ -34,9 +34,10 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapIntersect(const LogicalOperator
         auto sharedState = std::make_shared<HashJoinSharedState>(std::move(globalHashTable));
         sharedStates.push_back(sharedState);
         auto printInfo = std::make_unique<IntersectBuildPrintInfo>(keys, payloadExpressions);
-        children[i] = make_unique<IntersectBuild>(
-            std::make_unique<ResultSetDescriptor>(buildSchema), sharedState, std::move(buildInfo),
+        auto build = std::make_unique<IntersectBuild>(sharedState, std::move(buildInfo),
             std::move(buildPrevOperator), getOperatorID(), std::move(printInfo));
+        build->setDescriptor(std::make_unique<ResultSetDescriptor>(buildSchema));
+        children[i] = std::move(build);
         // Collect intersect info
         std::vector<DataPos> vectorsToScanPos;
         auto expressionsToScan = ExpressionUtil::excludeExpressions(

--- a/src/processor/map/map_order_by.cpp
+++ b/src/processor/map/map_order_by.cpp
@@ -58,9 +58,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapOrderBy(const LogicalOperator* 
     for (auto& expression : payloadExpressions) {
         outPos.emplace_back(outSchema->getExpressionPos(*expression));
     }
-    auto orderByDataInfo = OrderByDataInfo(keysPos, payloadsPos,
-        LogicalType::copy(keyTypes), LogicalType::copy(payloadTypes),
-        logicalOrderBy.getIsAscOrders(), std::move(payloadSchema), std::move(keyInPayloadPos));
+    auto orderByDataInfo = OrderByDataInfo(keysPos, payloadsPos, LogicalType::copy(keyTypes),
+        LogicalType::copy(payloadTypes), logicalOrderBy.getIsAscOrders(), std::move(payloadSchema),
+        std::move(keyInPayloadPos));
     if (logicalOrderBy.hasLimitNum()) {
         auto limitExpr = logicalOrderBy.getLimitNum();
         if (!ExpressionUtil::canEvaluateAsLiteral(*limitExpr)) {
@@ -80,16 +80,16 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapOrderBy(const LogicalOperator* 
         auto topKSharedState = std::make_shared<TopKSharedState>();
         auto printInfo =
             std::make_unique<TopKPrintInfo>(keyExpressions, payloadExpressions, skipNum, limitNum);
-        auto topK = make_unique<TopK>(std::move(orderByDataInfo), topKSharedState, skipNum, limitNum, std::move(prevOperator),
-            getOperatorID(), printInfo->copy());
+        auto topK = make_unique<TopK>(std::move(orderByDataInfo), topKSharedState, skipNum,
+            limitNum, std::move(prevOperator), getOperatorID(), printInfo->copy());
         topK->setDescriptor(std::make_unique<ResultSetDescriptor>(inSchema));
         return make_unique<TopKScan>(outPos, topKSharedState, std::move(topK), getOperatorID(),
             printInfo->copy());
     }
     auto orderBySharedState = std::make_shared<SortSharedState>();
     auto printInfo = std::make_unique<OrderByPrintInfo>(keyExpressions, payloadExpressions);
-    auto orderBy = make_unique<OrderBy>(std::move(orderByDataInfo), orderBySharedState, std::move(prevOperator), getOperatorID(),
-        printInfo->copy());
+    auto orderBy = make_unique<OrderBy>(std::move(orderByDataInfo), orderBySharedState,
+        std::move(prevOperator), getOperatorID(), printInfo->copy());
     orderBy->setDescriptor(std::make_unique<ResultSetDescriptor>(inSchema));
     auto dispatcher = std::make_shared<KeyBlockMergeTaskDispatcher>();
     auto orderByMerge = make_unique<OrderByMerge>(orderBySharedState, std::move(dispatcher),

--- a/src/processor/map/map_path_property_probe.cpp
+++ b/src/processor/map/map_path_property_probe.cpp
@@ -65,9 +65,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPathPropertyProbe(
             std::move(nodeKeyTypes), nodeBuildInfo->getTableSchema()->copy());
         nodeBuildSharedState = std::make_shared<HashJoinSharedState>(std::move(nodeHashTable));
         nodeBuild = make_unique<HashJoinBuild>(
-            std::make_unique<ResultSetDescriptor>(nodeBuildSchema),
             PhysicalOperatorType::HASH_JOIN_BUILD, nodeBuildSharedState, std::move(nodeBuildInfo),
             std::move(nodeBuildPrevOperator), getOperatorID(), std::make_unique<OPPrintInfo>());
+        nodeBuild->setDescriptor(std::make_unique<ResultSetDescriptor>(nodeBuildSchema));
         auto [fieldIndices, columnIndices] = getColIdxToScan(nodePayloads, nodeKeys.size(),
             ListType::getChildType(
                 StructType::getField(rel->getDataType(), InternalKeyword::NODES).getType()));
@@ -91,9 +91,10 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPathPropertyProbe(
             std::move(relKeyTypes), relBuildInfo->getTableSchema()->copy());
         relBuildSharedState = std::make_shared<HashJoinSharedState>(std::move(relHashTable));
         relBuild =
-            std::make_unique<HashJoinBuild>(std::make_unique<ResultSetDescriptor>(relBuildSchema),
+            std::make_unique<HashJoinBuild>(
                 PhysicalOperatorType::HASH_JOIN_BUILD, relBuildSharedState, std::move(relBuildInfo),
                 std::move(relBuildPrvOperator), getOperatorID(), std::make_unique<OPPrintInfo>());
+        relBuild->setDescriptor(std::make_unique<ResultSetDescriptor>(relBuildSchema));
         auto [fieldIndices, columnIndices] = getColIdxToScan(relPayloads, relKeys.size(),
             ListType::getChildType(
                 StructType::getField(rel->getDataType(), InternalKeyword::RELS).getType()));
@@ -106,14 +107,13 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPathPropertyProbe(
     if (logicalChild->getOperatorType() == LogicalOperatorType::SEMI_MASKER) {
         // Create a pipeline to populate semi mask. Pipeline source is the scan of recursive extend
         // result, and pipeline sink is a dummy operator that does not materialize anything.
-        prevOperator = std::make_unique<DummySink>(
-            std::make_unique<ResultSetDescriptor>(logicalChild->getSchema()),
-            std::move(prevOperator), getOperatorID());
+        auto dummySink = std::make_unique<DummySink>(std::move(prevOperator), getOperatorID());
+        dummySink->setDescriptor(std::make_unique<ResultSetDescriptor>(logicalChild->getSchema()));
         auto extend = logicalChild->getChild(0)->ptrCast<LogicalRecursiveExtend>();
         auto columns = extend->getResultColumns();
         auto physicalCall = logicalOpToPhysicalOpMap.at(extend)->ptrCast<RecursiveExtend>();
         physical_op_vector_t children;
-        children.push_back(std::move(prevOperator));
+        children.push_back(std::move(dummySink));
         prevOperator = createFTableScanAligned(columns, extend->getSchema(),
             physicalCall->getSharedState()->factorizedTablePool.getGlobalTable(),
             DEFAULT_VECTOR_CAPACITY, std::move(children));

--- a/src/processor/map/map_path_property_probe.cpp
+++ b/src/processor/map/map_path_property_probe.cpp
@@ -64,9 +64,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPathPropertyProbe(
         auto nodeHashTable = std::make_unique<JoinHashTable>(*clientContext->getMemoryManager(),
             std::move(nodeKeyTypes), nodeBuildInfo->getTableSchema()->copy());
         nodeBuildSharedState = std::make_shared<HashJoinSharedState>(std::move(nodeHashTable));
-        nodeBuild = make_unique<HashJoinBuild>(
-            PhysicalOperatorType::HASH_JOIN_BUILD, nodeBuildSharedState, std::move(nodeBuildInfo),
-            std::move(nodeBuildPrevOperator), getOperatorID(), std::make_unique<OPPrintInfo>());
+        nodeBuild = make_unique<HashJoinBuild>(PhysicalOperatorType::HASH_JOIN_BUILD,
+            nodeBuildSharedState, std::move(nodeBuildInfo), std::move(nodeBuildPrevOperator),
+            getOperatorID(), std::make_unique<OPPrintInfo>());
         nodeBuild->setDescriptor(std::make_unique<ResultSetDescriptor>(nodeBuildSchema));
         auto [fieldIndices, columnIndices] = getColIdxToScan(nodePayloads, nodeKeys.size(),
             ListType::getChildType(
@@ -90,10 +90,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPathPropertyProbe(
         auto relHashTable = std::make_unique<JoinHashTable>(*clientContext->getMemoryManager(),
             std::move(relKeyTypes), relBuildInfo->getTableSchema()->copy());
         relBuildSharedState = std::make_shared<HashJoinSharedState>(std::move(relHashTable));
-        relBuild =
-            std::make_unique<HashJoinBuild>(
-                PhysicalOperatorType::HASH_JOIN_BUILD, relBuildSharedState, std::move(relBuildInfo),
-                std::move(relBuildPrvOperator), getOperatorID(), std::make_unique<OPPrintInfo>());
+        relBuild = std::make_unique<HashJoinBuild>(PhysicalOperatorType::HASH_JOIN_BUILD,
+            relBuildSharedState, std::move(relBuildInfo), std::move(relBuildPrvOperator),
+            getOperatorID(), std::make_unique<OPPrintInfo>());
         relBuild->setDescriptor(std::make_unique<ResultSetDescriptor>(relBuildSchema));
         auto [fieldIndices, columnIndices] = getColIdxToScan(relPayloads, relKeys.size(),
             ListType::getChildType(

--- a/src/processor/map/map_recursive_extend.cpp
+++ b/src/processor/map/map_recursive_extend.cpp
@@ -42,7 +42,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapRecursiveExtend(
     }
     auto printInfo =
         std::make_unique<RecursiveExtendPrintInfo>(extend.getFunction().getFunctionName());
-    auto recursiveExtend = std::make_unique<RecursiveExtend>(extend.getFunction().copy(), bindData, sharedState, getOperatorID(), std::move(printInfo));
+    auto recursiveExtend = std::make_unique<RecursiveExtend>(extend.getFunction().copy(), bindData,
+        sharedState, getOperatorID(), std::move(printInfo));
     // Map node predicate pipeline
     if (extend.hasNodePredicate()) {
         addOperatorMapping(logicalOperator, recursiveExtend.get());

--- a/src/processor/map/map_recursive_extend.cpp
+++ b/src/processor/map/map_recursive_extend.cpp
@@ -42,9 +42,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapRecursiveExtend(
     }
     auto printInfo =
         std::make_unique<RecursiveExtendPrintInfo>(extend.getFunction().getFunctionName());
-    auto descriptor = std::make_unique<ResultSetDescriptor>();
-    auto recursiveExtend = std::make_unique<RecursiveExtend>(std::move(descriptor),
-        extend.getFunction().copy(), bindData, sharedState, getOperatorID(), std::move(printInfo));
+    auto recursiveExtend = std::make_unique<RecursiveExtend>(extend.getFunction().copy(), bindData, sharedState, getOperatorID(), std::move(printInfo));
     // Map node predicate pipeline
     if (extend.hasNodePredicate()) {
         addOperatorMapping(logicalOperator, recursiveExtend.get());

--- a/src/processor/operator/CMakeLists.txt
+++ b/src/processor/operator/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(kuzu_processor_operator
         recursive_extend.cpp
         result_collector.cpp
         semi_masker.cpp
+        sink.cpp
         skip.cpp
         standalone_call.cpp
         table_function_call.cpp

--- a/src/processor/operator/order_by/order_by.cpp
+++ b/src/processor/operator/order_by/order_by.cpp
@@ -17,28 +17,28 @@ std::string OrderByPrintInfo::toString() const {
 }
 
 void OrderBy::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
-    localState = std::make_unique<SortLocalState>();
-    localState->init(*info, *sharedState, context->clientContext->getMemoryManager());
-    for (auto& dataPos : info->payloadsPos) {
+    localState = SortLocalState();
+    localState.init(info, *sharedState, context->clientContext->getMemoryManager());
+    for (auto& dataPos : info.payloadsPos) {
         payloadVectors.push_back(resultSet->getValueVector(dataPos).get());
     }
-    for (auto& dataPos : info->keysPos) {
+    for (auto& dataPos : info.keysPos) {
         orderByVectors.push_back(resultSet->getValueVector(dataPos).get());
     }
 }
 
 void OrderBy::initGlobalStateInternal(ExecutionContext* /*context*/) {
-    sharedState->init(*info);
+    sharedState->init(info);
 }
 
 void OrderBy::executeInternal(ExecutionContext* context) {
     // Append thread-local tuples.
     while (children[0]->getNextTuple(context)) {
         for (auto i = 0u; i < resultSet->multiplicity; i++) {
-            localState->append(orderByVectors, payloadVectors);
+            localState.append(orderByVectors, payloadVectors);
         }
     }
-    localState->finalize(*sharedState);
+    localState.finalize(*sharedState);
 }
 
 } // namespace processor

--- a/src/processor/operator/partitioner.cpp
+++ b/src/processor/operator/partitioner.cpp
@@ -86,8 +86,8 @@ void PartitioningBuffer::merge(const PartitioningBuffer& localPartitioningState)
 Partitioner::Partitioner(PartitionerInfo info, PartitionerDataInfo dataInfo,
     std::shared_ptr<PartitionerSharedState> sharedState, std::unique_ptr<PhysicalOperator> child,
     uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
-    : Sink{type_, std::move(child), id, std::move(printInfo)},
-      dataInfo{std::move(dataInfo)}, info{std::move(info)}, sharedState{std::move(sharedState)} {
+    : Sink{type_, std::move(child), id, std::move(printInfo)}, dataInfo{std::move(dataInfo)},
+      info{std::move(info)}, sharedState{std::move(sharedState)} {
     partitionIdxes = std::make_unique<ValueVector>(LogicalTypeID::INT64);
 }
 

--- a/src/processor/operator/partitioner.cpp
+++ b/src/processor/operator/partitioner.cpp
@@ -83,11 +83,10 @@ void PartitioningBuffer::merge(const PartitioningBuffer& localPartitioningState)
     }
 }
 
-Partitioner::Partitioner(std::unique_ptr<ResultSetDescriptor> resultSetDescriptor,
-    PartitionerInfo info, PartitionerDataInfo dataInfo,
+Partitioner::Partitioner(PartitionerInfo info, PartitionerDataInfo dataInfo,
     std::shared_ptr<PartitionerSharedState> sharedState, std::unique_ptr<PhysicalOperator> child,
     uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
-    : Sink{std::move(resultSetDescriptor), type_, std::move(child), id, std::move(printInfo)},
+    : Sink{type_, std::move(child), id, std::move(printInfo)},
       dataInfo{std::move(dataInfo)}, info{std::move(info)}, sharedState{std::move(sharedState)} {
     partitionIdxes = std::make_unique<ValueVector>(LogicalTypeID::INT64);
 }
@@ -200,11 +199,6 @@ void Partitioner::copyDataToPartitions(MemoryManager& memoryManager,
             localState->getPartitioningBuffer(partitioningIdx)->partitions[partitionIdx];
         partition->append(memoryManager, vectorsToAppend, i, 1);
     }
-}
-
-std::unique_ptr<PhysicalOperator> Partitioner::copy() {
-    return std::make_unique<Partitioner>(resultSetDescriptor->copy(), info.copy(), dataInfo.copy(),
-        sharedState, children[0]->copy(), id, printInfo->copy());
 }
 
 } // namespace processor

--- a/src/processor/operator/result_collector.cpp
+++ b/src/processor/operator/result_collector.cpp
@@ -2,7 +2,6 @@
 
 #include "binder/expression/expression_util.h"
 #include "processor/execution_context.h"
-#include "processor/processor_task.h"
 
 using namespace kuzu::common;
 using namespace kuzu::storage;
@@ -59,8 +58,7 @@ void ResultCollector::executeInternal(ExecutionContext* context) {
 void ResultCollector::finalizeInternal(ExecutionContext* context) {
     switch (info.accumulateType) {
     case AccumulateType::OPTIONAL_: {
-        auto localResultSet = processor::ProcessorTask::populateResultSet(this,
-            context->clientContext->getMemoryManager());
+        auto localResultSet = getResultSet(context->clientContext->getMemoryManager());
         initNecessaryLocalState(localResultSet.get(), context);
         // We should remove currIdx completely as some of the code still relies on currIdx = -1 to
         // check if the state if unFlat or not. This should no longer be necessary.

--- a/src/processor/operator/sink.cpp
+++ b/src/processor/operator/sink.cpp
@@ -1,0 +1,15 @@
+#include "processor/operator/sink.h"
+
+namespace kuzu {
+namespace processor {
+
+std::unique_ptr<ResultSet> Sink::getResultSet(storage::MemoryManager* memoryManager) {
+    if (resultSetDescriptor == nullptr) {
+        // Some pipeline does not need a resultSet, e.g. OrderByMerge
+        return std::unique_ptr<ResultSet>();
+    }
+    return std::make_unique<ResultSet>(resultSetDescriptor.get(), memoryManager);
+}
+
+}
+}

--- a/src/processor/operator/sink.cpp
+++ b/src/processor/operator/sink.cpp
@@ -11,5 +11,5 @@ std::unique_ptr<ResultSet> Sink::getResultSet(storage::MemoryManager* memoryMana
     return std::make_unique<ResultSet>(resultSetDescriptor.get(), memoryManager);
 }
 
-}
-}
+} // namespace processor
+} // namespace kuzu

--- a/src/processor/processor_task.cpp
+++ b/src/processor/processor_task.cpp
@@ -21,27 +21,15 @@ void ProcessorTask::run() {
         sink->initGlobalState(executionContext);
         sharedStateInitialized = true;
     }
-    auto clonedPipelineRoot = sink->copy();
+    auto taskRoot = sink->copy();
     lck.unlock();
-    auto currentSink = (Sink*)clonedPipelineRoot.get();
-    auto resultSet =
-        populateResultSet(currentSink, executionContext->clientContext->getMemoryManager());
-    currentSink->execute(resultSet.get(), executionContext);
+    auto resultSet = sink->getResultSet(executionContext->clientContext->getMemoryManager());
+    taskRoot->ptrCast<Sink>()->execute(resultSet.get(), executionContext);
 }
 
 void ProcessorTask::finalizeIfNecessary() {
     executionContext->clientContext->getProgressBar()->finishPipeline(executionContext->queryID);
     sink->finalize(executionContext);
-}
-
-std::unique_ptr<ResultSet> ProcessorTask::populateResultSet(Sink* op,
-    storage::MemoryManager* memoryManager) {
-    auto resultSetDescriptor = op->getResultSetDescriptor();
-    if (resultSetDescriptor == nullptr) {
-        // Some pipeline does not need a resultSet, e.g. OrderByMerge
-        return nullptr;
-    }
-    return std::make_unique<ResultSet>(resultSetDescriptor, memoryManager);
 }
 
 } // namespace processor


### PR DESCRIPTION
# Description

Move ResultSetDescriptor output sink constructor and copy interface. 

First, it should not be needed in the copied pipeline if we always obtain resultSet from main thread. Second we should try to shorten our operator constructor. Some of them is getting way too long to read.

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).