### PR TITLE
Clear unnecessary source operator copy

### DIFF
--- a/extension/vector/src/function/create_hnsw_index.cpp
+++ b/extension/vector/src/function/create_hnsw_index.cpp
@@ -131,7 +131,7 @@ static std::unique_ptr<PhysicalOperator> getPhysicalPlan(PlanMapper* planMapper,
     finalizeFuncSharedState->maxMorselSize = 1;
     finalizeFuncSharedState->bindData = logicalCallBoundData->copy();
     auto finalizeCallOp = std::make_unique<TableFunctionCall>(std::move(info), sharedState,
-        planMapper->getOperatorID(), std::make_unique<OPPrintInfo>());
+        planMapper->getOperatorID(), OPPrintInfo::EmptyInfo());
     finalizeCallOp->addChild(std::move(createDummySink));
     // Append a dummy sink to the end of the second pipeline
     auto finalizeHNSWDummySink =

--- a/src/include/processor/operator/aggregate/hash_aggregate.h
+++ b/src/include/processor/operator/aggregate/hash_aggregate.h
@@ -181,13 +181,10 @@ class HashAggregateFinalize final : public Sink {
 
 public:
     HashAggregateFinalize(std::shared_ptr<HashAggregateSharedState> sharedState,
-        std::unique_ptr<PhysicalOperator> child, uint32_t id,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{type_, std::move(child), id, std::move(printInfo)},
+        physical_op_id id, std::unique_ptr<OPPrintInfo> printInfo)
+        : Sink{type_,  id, std::move(printInfo)},
           sharedState{std::move(sharedState)} {}
 
-    // Otherwise the runtime metrics for this operator are negative
-    // since it doesn't call children[0]->getNextTuple
     bool isSource() const override { return true; }
 
     void executeInternal(ExecutionContext* /*context*/) override {
@@ -199,8 +196,7 @@ public:
     }
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return make_unique<HashAggregateFinalize>(sharedState, children[0]->copy(), id,
-            printInfo->copy());
+        return make_unique<HashAggregateFinalize>(sharedState, id, printInfo->copy());
     }
 
 private:

--- a/src/include/processor/operator/aggregate/hash_aggregate.h
+++ b/src/include/processor/operator/aggregate/hash_aggregate.h
@@ -180,10 +180,9 @@ class HashAggregateFinalize final : public Sink {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::AGGREGATE_FINALIZE;
 
 public:
-    HashAggregateFinalize(std::shared_ptr<HashAggregateSharedState> sharedState,
-        physical_op_id id, std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{type_,  id, std::move(printInfo)},
-          sharedState{std::move(sharedState)} {}
+    HashAggregateFinalize(std::shared_ptr<HashAggregateSharedState> sharedState, physical_op_id id,
+        std::unique_ptr<OPPrintInfo> printInfo)
+        : Sink{type_, id, std::move(printInfo)}, sharedState{std::move(sharedState)} {}
 
     bool isSource() const override { return true; }
 

--- a/src/include/processor/operator/aggregate/hash_aggregate_scan.h
+++ b/src/include/processor/operator/aggregate/hash_aggregate_scan.h
@@ -9,14 +9,6 @@ namespace processor {
 class HashAggregateScan final : public BaseAggregateScan {
 public:
     HashAggregateScan(std::shared_ptr<HashAggregateSharedState> sharedState,
-        std::vector<DataPos> groupByKeyVectorsPos, std::vector<DataPos> aggregatesPos,
-        std::unique_ptr<PhysicalOperator> child, uint32_t id,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : BaseAggregateScan{std::move(aggregatesPos), std::move(child), id, std::move(printInfo)},
-          groupByKeyVectorsPos{std::move(groupByKeyVectorsPos)},
-          sharedState{std::move(sharedState)} {}
-
-    HashAggregateScan(std::shared_ptr<HashAggregateSharedState> sharedState,
         std::vector<DataPos> groupByKeyVectorsPos, std::vector<DataPos> aggregatesPos, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
         : BaseAggregateScan{std::move(aggregatesPos), id, std::move(printInfo)},

--- a/src/include/processor/operator/aggregate/simple_aggregate.h
+++ b/src/include/processor/operator/aggregate/simple_aggregate.h
@@ -130,10 +130,10 @@ class SimpleAggregateFinalize final : public Sink {
 
 public:
     SimpleAggregateFinalize(std::shared_ptr<SimpleAggregateSharedState> sharedState,
-    std::vector<AggregateInfo> aggInfos, physical_op_id id,
+        std::vector<AggregateInfo> aggInfos, physical_op_id id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{type_,  id, std::move(printInfo)},
-          sharedState{std::move(sharedState)}, aggInfos{std::move(aggInfos)} {}
+        : Sink{type_, id, std::move(printInfo)}, sharedState{std::move(sharedState)},
+          aggInfos{std::move(aggInfos)} {}
 
     bool isSource() const override { return true; }
 
@@ -142,8 +142,8 @@ public:
     void finalizeInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<SimpleAggregateFinalize>(sharedState,
-            copyVector(aggInfos), id, printInfo->copy());
+        return std::make_unique<SimpleAggregateFinalize>(sharedState, copyVector(aggInfos), id,
+            printInfo->copy());
     }
 
 private:

--- a/src/include/processor/operator/aggregate/simple_aggregate.h
+++ b/src/include/processor/operator/aggregate/simple_aggregate.h
@@ -130,13 +130,11 @@ class SimpleAggregateFinalize final : public Sink {
 
 public:
     SimpleAggregateFinalize(std::shared_ptr<SimpleAggregateSharedState> sharedState,
-        std::unique_ptr<PhysicalOperator> child, std::vector<AggregateInfo> aggInfos, uint32_t id,
+    std::vector<AggregateInfo> aggInfos, physical_op_id id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{type_, std::move(child), id, std::move(printInfo)},
+        : Sink{type_,  id, std::move(printInfo)},
           sharedState{std::move(sharedState)}, aggInfos{std::move(aggInfos)} {}
 
-    // Otherwise the runtime metrics for this operator are negative
-    // since it doesn't call children[0]->getNextTuple
     bool isSource() const override { return true; }
 
     void executeInternal(ExecutionContext* context) override;
@@ -144,7 +142,7 @@ public:
     void finalizeInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return make_unique<SimpleAggregateFinalize>(sharedState, children[0]->copy(),
+        return std::make_unique<SimpleAggregateFinalize>(sharedState,
             copyVector(aggInfos), id, printInfo->copy());
     }
 

--- a/src/include/processor/operator/aggregate/simple_aggregate_scan.h
+++ b/src/include/processor/operator/aggregate/simple_aggregate_scan.h
@@ -9,12 +9,6 @@ namespace processor {
 class SimpleAggregateScan final : public BaseAggregateScan {
 public:
     SimpleAggregateScan(std::shared_ptr<SimpleAggregateSharedState> sharedState,
-        std::vector<DataPos> aggregatesPos, std::unique_ptr<PhysicalOperator> child, uint32_t id,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : BaseAggregateScan{std::move(aggregatesPos), std::move(child), id, std::move(printInfo)},
-          sharedState{std::move(sharedState)}, outDataChunk{nullptr} {}
-
-    SimpleAggregateScan(std::shared_ptr<SimpleAggregateSharedState> sharedState,
         std::vector<DataPos> aggregatesPos, uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
         : BaseAggregateScan{std::move(aggregatesPos), id, std::move(printInfo)},
           sharedState{std::move(sharedState)}, outDataChunk{nullptr} {}
@@ -23,7 +17,6 @@ public:
 
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
-    // SimpleAggregateScan is the source operator of a pipeline, so it should not clone its child.
     std::unique_ptr<PhysicalOperator> copy() override {
         return make_unique<SimpleAggregateScan>(sharedState, aggregatesPos, id, printInfo->copy());
     }

--- a/src/include/processor/operator/cross_product.h
+++ b/src/include/processor/operator/cross_product.h
@@ -40,13 +40,6 @@ class CrossProduct final : public PhysicalOperator {
 
 public:
     CrossProduct(CrossProductInfo info, CrossProductLocalState localState,
-        std::unique_ptr<PhysicalOperator> probeChild, std::unique_ptr<PhysicalOperator> buildChild,
-        physical_op_id id, std::unique_ptr<OPPrintInfo> printInfo)
-        : PhysicalOperator{type_, std::move(probeChild), std::move(buildChild), id,
-              std::move(printInfo)},
-          info{std::move(info)}, localState{std::move(localState)} {}
-
-    CrossProduct(CrossProductInfo info, CrossProductLocalState localState,
         std::unique_ptr<PhysicalOperator> child, physical_op_id id,
         std::unique_ptr<OPPrintInfo> printInfo)
         : PhysicalOperator{type_, std::move(child), id, std::move(printInfo)},

--- a/src/include/processor/operator/filter.h
+++ b/src/include/processor/operator/filter.h
@@ -60,7 +60,7 @@ struct NodeLabelFilterInfo {
     NodeLabelFilterInfo(const NodeLabelFilterInfo& other)
         : nodeVectorPos{other.nodeVectorPos}, nodeLabelSet{other.nodeLabelSet} {}
 
-    inline std::unique_ptr<NodeLabelFilterInfo> copy() const {
+    std::unique_ptr<NodeLabelFilterInfo> copy() const {
         return std::make_unique<NodeLabelFilterInfo>(*this);
     }
 };

--- a/src/include/processor/operator/hash_join/hash_join_probe.h
+++ b/src/include/processor/operator/hash_join/hash_join_probe.h
@@ -68,16 +68,6 @@ class HashJoinProbe : public PhysicalOperator, public SelVectorOverWriter {
 public:
     HashJoinProbe(std::shared_ptr<HashJoinSharedState> sharedState, common::JoinType joinType,
         bool flatProbe, const ProbeDataInfo& probeDataInfo,
-        std::unique_ptr<PhysicalOperator> probeChild, std::unique_ptr<PhysicalOperator> buildChild,
-        uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
-        : PhysicalOperator{type_, std::move(probeChild), std::move(buildChild), id,
-              std::move(printInfo)},
-          sharedState{std::move(sharedState)}, joinType{joinType}, flatProbe{flatProbe},
-          probeDataInfo{probeDataInfo}, markVector(nullptr) {}
-
-    // This constructor is used for cloning only.
-    HashJoinProbe(std::shared_ptr<HashJoinSharedState> sharedState, common::JoinType joinType,
-        bool flatProbe, const ProbeDataInfo& probeDataInfo,
         std::unique_ptr<PhysicalOperator> probeChild, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
         : PhysicalOperator{type_, std::move(probeChild), id, std::move(printInfo)},

--- a/src/include/processor/operator/intersect/intersect.h
+++ b/src/include/processor/operator/intersect/intersect.h
@@ -32,9 +32,9 @@ class Intersect : public PhysicalOperator {
 public:
     Intersect(const DataPos& outputDataPos, std::vector<IntersectDataInfo> intersectDataInfos,
         std::vector<std::shared_ptr<HashJoinSharedState>> sharedHTs,
-        std::vector<std::unique_ptr<PhysicalOperator>> children, uint32_t id,
+        std::unique_ptr<PhysicalOperator> probeChild, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : PhysicalOperator{type_, std::move(children), id, std::move(printInfo)},
+        : PhysicalOperator{type_, std::move(probeChild), id, std::move(printInfo)},
           outputDataPos{outputDataPos}, intersectDataInfos{std::move(intersectDataInfos)},
           sharedHTs{std::move(sharedHTs)} {
         tupleIdxPerBuildSide.resize(this->sharedHTs.size(), 0);
@@ -47,10 +47,8 @@ public:
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        std::vector<std::unique_ptr<PhysicalOperator>> childrenCopy;
-        childrenCopy.push_back(children[0]->copy());
         return std::make_unique<Intersect>(outputDataPos, intersectDataInfos, sharedHTs,
-            std::move(childrenCopy), id, printInfo->copy());
+            children[0]->copy(), id, printInfo->copy());
     }
 
 private:

--- a/src/include/processor/operator/order_by/order_by_merge.h
+++ b/src/include/processor/operator/order_by/order_by_merge.h
@@ -12,16 +12,6 @@ class OrderByMerge final : public Sink {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::ORDER_BY_MERGE;
 
 public:
-    // This constructor will only be called by the mapper when constructing the orderByMerge
-    // operator, because the mapper doesn't know the existence of keyBlockMergeTaskDispatcher
-    OrderByMerge(std::shared_ptr<SortSharedState> sharedState,
-        std::shared_ptr<KeyBlockMergeTaskDispatcher> sharedDispatcher,
-        std::unique_ptr<PhysicalOperator> child, uint32_t id,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : Sink{type_, std::move(child), id, std::move(printInfo)},
-          sharedState{std::move(sharedState)}, sharedDispatcher{std::move(sharedDispatcher)} {}
-
-    // This constructor is used for cloning only.
     OrderByMerge(std::shared_ptr<SortSharedState> sharedState,
         std::shared_ptr<KeyBlockMergeTaskDispatcher> sharedDispatcher, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)

--- a/src/include/processor/operator/order_by/order_by_scan.h
+++ b/src/include/processor/operator/order_by/order_by_scan.h
@@ -30,15 +30,6 @@ class OrderByScan final : public PhysicalOperator {
 
 public:
     OrderByScan(std::vector<DataPos> outVectorPos, std::shared_ptr<SortSharedState> sharedState,
-        std::unique_ptr<PhysicalOperator> child, uint32_t id,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : PhysicalOperator{type_, std::move(child), id, std::move(printInfo)},
-          outVectorPos{std::move(outVectorPos)},
-          localState{std::make_unique<OrderByScanLocalState>()},
-          sharedState{std::move(sharedState)} {}
-
-    // This constructor is used for cloning only.
-    OrderByScan(std::vector<DataPos> outVectorPos, std::shared_ptr<SortSharedState> sharedState,
         uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
         : PhysicalOperator{type_, id, std::move(printInfo)}, outVectorPos{std::move(outVectorPos)},
           localState{std::make_unique<OrderByScanLocalState>()},

--- a/src/include/processor/operator/order_by/top_k_scanner.h
+++ b/src/include/processor/operator/order_by/top_k_scanner.h
@@ -21,9 +21,8 @@ class TopKScan final : public PhysicalOperator {
 
 public:
     TopKScan(std::vector<DataPos> outVectorPos, std::shared_ptr<TopKSharedState> sharedState,
-        std::unique_ptr<PhysicalOperator> child, uint32_t id,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : PhysicalOperator{type_, std::move(child), id, std::move(printInfo)},
+         physical_op_id id, std::unique_ptr<OPPrintInfo> printInfo)
+        : PhysicalOperator{type_, id, std::move(printInfo)},
           outVectorPos{std::move(outVectorPos)}, localState{std::make_unique<TopKLocalScanState>()},
           sharedState{std::move(sharedState)} {}
 
@@ -36,7 +35,7 @@ public:
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<TopKScan>(outVectorPos, sharedState, children[0]->copy(), id,
+        return std::make_unique<TopKScan>(outVectorPos, sharedState, id,
             printInfo->copy());
     }
 

--- a/src/include/processor/operator/order_by/top_k_scanner.h
+++ b/src/include/processor/operator/order_by/top_k_scanner.h
@@ -21,10 +21,9 @@ class TopKScan final : public PhysicalOperator {
 
 public:
     TopKScan(std::vector<DataPos> outVectorPos, std::shared_ptr<TopKSharedState> sharedState,
-         physical_op_id id, std::unique_ptr<OPPrintInfo> printInfo)
-        : PhysicalOperator{type_, id, std::move(printInfo)},
-          outVectorPos{std::move(outVectorPos)}, localState{std::make_unique<TopKLocalScanState>()},
-          sharedState{std::move(sharedState)} {}
+        physical_op_id id, std::unique_ptr<OPPrintInfo> printInfo)
+        : PhysicalOperator{type_, id, std::move(printInfo)}, outVectorPos{std::move(outVectorPos)},
+          localState{std::make_unique<TopKLocalScanState>()}, sharedState{std::move(sharedState)} {}
 
     bool isSource() const override { return true; }
     // Ordered table should be scanned in single-thread mode.
@@ -35,8 +34,7 @@ public:
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<TopKScan>(outVectorPos, sharedState, id,
-            printInfo->copy());
+        return std::make_unique<TopKScan>(outVectorPos, sharedState, id, printInfo->copy());
     }
 
 private:

--- a/src/include/processor/operator/path_property_probe.h
+++ b/src/include/processor/operator/path_property_probe.h
@@ -75,12 +75,6 @@ class PathPropertyProbe : public PhysicalOperator {
 public:
     PathPropertyProbe(PathPropertyProbeInfo info,
         std::shared_ptr<PathPropertyProbeSharedState> sharedState,
-        std::vector<std::unique_ptr<PhysicalOperator>> children, uint32_t id,
-        std::unique_ptr<OPPrintInfo> printInfo)
-        : PhysicalOperator{type_, std::move(children), id, std::move(printInfo)},
-          info{std::move(info)}, sharedState{std::move(sharedState)} {}
-    PathPropertyProbe(PathPropertyProbeInfo info,
-        std::shared_ptr<PathPropertyProbeSharedState> sharedState,
         std::unique_ptr<PhysicalOperator> probeChild, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
         : PhysicalOperator{type_, std::move(probeChild), id, std::move(printInfo)},

--- a/src/include/processor/operator/persistent/set.h
+++ b/src/include/processor/operator/persistent/set.h
@@ -58,7 +58,7 @@ public:
         : PhysicalOperator{type_, std::move(child), id, std::move(printInfo)},
           executors{std::move(executors)} {}
 
-    inline bool isParallel() const override { return false; }
+    bool isParallel() const override { return false; }
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 

--- a/src/include/processor/operator/profile.h
+++ b/src/include/processor/operator/profile.h
@@ -18,23 +18,21 @@ class Profile final : public PhysicalOperator {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::PROFILE;
 
 public:
-    Profile(DataPos outputPos, ProfileInfo info, ProfileLocalState localState, uint32_t id,
-        std::unique_ptr<PhysicalOperator> child, std::unique_ptr<OPPrintInfo> printInfo)
-        : PhysicalOperator{type_, std::move(child), id, std::move(printInfo)}, outputPos{outputPos},
+    Profile(DataPos outputPos, ProfileInfo info, ProfileLocalState localState, uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
+        : PhysicalOperator{type_, id, std::move(printInfo)}, outputPos{outputPos},
           info{info}, localState{localState}, outputVector(nullptr) {}
 
     bool isSource() const override { return true; }
     bool isParallel() const override { return false; }
 
-    inline void setPhysicalPlan(PhysicalPlan* physicalPlan) { info.physicalPlan = physicalPlan; }
+    void setPhysicalPlan(PhysicalPlan* physicalPlan) { info.physicalPlan = physicalPlan; }
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<Profile>(outputPos, info, localState, id, children[0]->copy(),
-            printInfo->copy());
+        return std::make_unique<Profile>(outputPos, info, localState, id, printInfo->copy());
     }
 
 private:

--- a/src/include/processor/operator/profile.h
+++ b/src/include/processor/operator/profile.h
@@ -18,9 +18,10 @@ class Profile final : public PhysicalOperator {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::PROFILE;
 
 public:
-    Profile(DataPos outputPos, ProfileInfo info, ProfileLocalState localState, uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
-        : PhysicalOperator{type_, id, std::move(printInfo)}, outputPos{outputPos},
-          info{info}, localState{localState}, outputVector(nullptr) {}
+    Profile(DataPos outputPos, ProfileInfo info, ProfileLocalState localState, uint32_t id,
+        std::unique_ptr<OPPrintInfo> printInfo)
+        : PhysicalOperator{type_, id, std::move(printInfo)}, outputPos{outputPos}, info{info},
+          localState{localState}, outputVector(nullptr) {}
 
     bool isSource() const override { return true; }
     bool isParallel() const override { return false; }

--- a/src/include/processor/operator/table_function_call.h
+++ b/src/include/processor/operator/table_function_call.h
@@ -52,11 +52,11 @@ public:
           sharedState{std::move(sharedState)} {}
     // When exporting a kuzu database, we may have multiple copy to statements as children of the
     // FactorizedTableScan function.
-    TableFunctionCall(TableFunctionCallInfo info,
-        std::shared_ptr<function::TableFuncSharedState> sharedState, physical_op_vector_t children,
-        uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
-        : PhysicalOperator{type_, std::move(children), id, std::move(printInfo)},
-          info{std::move(info)}, sharedState{std::move(sharedState)} {}
+    // TableFunctionCall(TableFunctionCallInfo info,
+    //     std::shared_ptr<function::TableFuncSharedState> sharedState, physical_op_vector_t children,
+    //     uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
+    //     : PhysicalOperator{type_, std::move(children), id, std::move(printInfo)},
+    //       info{std::move(info)}, sharedState{std::move(sharedState)} {}
 
     const TableFunctionCallInfo& getInfo() const { return info; }
     std::shared_ptr<function::TableFuncSharedState> getSharedState() const { return sharedState; }

--- a/src/include/processor/operator/table_function_call.h
+++ b/src/include/processor/operator/table_function_call.h
@@ -50,13 +50,6 @@ public:
         std::unique_ptr<OPPrintInfo> printInfo)
         : PhysicalOperator{type_, id, std::move(printInfo)}, info{std::move(info)},
           sharedState{std::move(sharedState)} {}
-    // When exporting a kuzu database, we may have multiple copy to statements as children of the
-    // FactorizedTableScan function.
-    // TableFunctionCall(TableFunctionCallInfo info,
-    //     std::shared_ptr<function::TableFuncSharedState> sharedState, physical_op_vector_t children,
-    //     uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
-    //     : PhysicalOperator{type_, std::move(children), id, std::move(printInfo)},
-    //       info{std::move(info)}, sharedState{std::move(sharedState)} {}
 
     const TableFunctionCallInfo& getInfo() const { return info; }
     std::shared_ptr<function::TableFuncSharedState> getSharedState() const { return sharedState; }

--- a/src/include/processor/operator/table_scan/union_all_scan.h
+++ b/src/include/processor/operator/table_scan/union_all_scan.h
@@ -72,9 +72,8 @@ class UnionAllScan : public PhysicalOperator {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::UNION_ALL_SCAN;
 
 public:
-    UnionAllScan(UnionAllScanInfo info,
-        std::shared_ptr<UnionAllScanSharedState> sharedState, physical_op_id id,
-        std::unique_ptr<OPPrintInfo> printInfo)
+    UnionAllScan(UnionAllScanInfo info, std::shared_ptr<UnionAllScanSharedState> sharedState,
+        physical_op_id id, std::unique_ptr<OPPrintInfo> printInfo)
         : PhysicalOperator{type_, id, std::move(printInfo)}, info{std::move(info)},
           sharedState{std::move(sharedState)} {}
 

--- a/src/processor/map/create_factorized_table_scan.cpp
+++ b/src/processor/map/create_factorized_table_scan.cpp
@@ -28,12 +28,12 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createFTableScan(const expression_
     auto initInput = TableFuncInitSharedStateInput(info.bindData.get(), executionContext);
     auto sharedState = info.function.initSharedStateFunc(initInput);
     auto printInfo = std::make_unique<TableFunctionCallPrintInfo>(function->name, exprs);
-    if (children.size() == 0) {
-        return std::make_unique<TableFunctionCall>(std::move(info), sharedState, getOperatorID(),
+    auto result = std::make_unique<TableFunctionCall>(std::move(info), sharedState, getOperatorID(),
             std::move(printInfo));
+    for (auto& child : children) {
+        result->addChild(std::move(child));
     }
-    return std::make_unique<TableFunctionCall>(std::move(info), sharedState, std::move(children),
-        getOperatorID(), std::move(printInfo));
+    return result;
 }
 
 std::unique_ptr<PhysicalOperator> PlanMapper::createFTableScan(const expression_vector& exprs,

--- a/src/processor/map/create_factorized_table_scan.cpp
+++ b/src/processor/map/create_factorized_table_scan.cpp
@@ -29,7 +29,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createFTableScan(const expression_
     auto sharedState = info.function.initSharedStateFunc(initInput);
     auto printInfo = std::make_unique<TableFunctionCallPrintInfo>(function->name, exprs);
     auto result = std::make_unique<TableFunctionCall>(std::move(info), sharedState, getOperatorID(),
-            std::move(printInfo));
+        std::move(printInfo));
     for (auto& child : children) {
         result->addChild(std::move(child));
     }

--- a/src/processor/map/map_aggregate.cpp
+++ b/src/processor/map/map_aggregate.cpp
@@ -101,8 +101,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapAggregate(const LogicalOperator
     auto finalizer = std::make_unique<SimpleAggregateFinalize>(sharedState,
         std::move(aggregateInputInfos), getOperatorID(), printInfo->copy());
     finalizer->addChild(std::move(aggregate));
-    auto scan = std::make_unique<SimpleAggregateScan>(sharedState, aggOutputPos,
-        getOperatorID(), printInfo->copy());
+    auto scan = std::make_unique<SimpleAggregateScan>(sharedState, aggOutputPos, getOperatorID(),
+        printInfo->copy());
     scan->addChild(std::move(finalizer));
     return scan;
 }
@@ -181,11 +181,12 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createHashAggregate(const expressi
     outputExpressions.insert(outputExpressions.end(), unFlatKeys.begin(), unFlatKeys.end());
     outputExpressions.insert(outputExpressions.end(), payloads.begin(), payloads.end());
     auto aggOutputPos = getDataPos(aggregates, *outSchema);
-    auto finalizer = std::make_unique<HashAggregateFinalize>(sharedState, getOperatorID(), printInfo->copy());
+    auto finalizer =
+        std::make_unique<HashAggregateFinalize>(sharedState, getOperatorID(), printInfo->copy());
     finalizer->addChild(std::move(aggregate));
-    auto scan = std::make_unique<HashAggregateScan>(sharedState,
-        getDataPos(outputExpressions, *outSchema), std::move(aggOutputPos),
-        getOperatorID(), printInfo->copy());
+    auto scan =
+        std::make_unique<HashAggregateScan>(sharedState, getDataPos(outputExpressions, *outSchema),
+            std::move(aggOutputPos), getOperatorID(), printInfo->copy());
     scan->addChild(std::move(finalizer));
     return scan;
 }

--- a/src/processor/map/map_cross_product.cpp
+++ b/src/processor/map/map_cross_product.cpp
@@ -38,8 +38,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCrossProduct(
     auto localState = CrossProductLocalState(table, maxMorselSize);
     auto printInfo = std::make_unique<OPPrintInfo>();
     auto crossProduct = std::make_unique<CrossProduct>(std::move(info), std::move(localState),
-        std::move(probeSidePrevOperator), std::move(resultCollector), getOperatorID(),
+        std::move(probeSidePrevOperator), getOperatorID(),
         std::move(printInfo));
+    crossProduct->addChild(std::move(resultCollector));
     if (logicalCrossProduct.getSIPInfo().direction == SIPDirection::PROBE_TO_BUILD) {
         mapSIPJoin(crossProduct.get());
     }

--- a/src/processor/map/map_cross_product.cpp
+++ b/src/processor/map/map_cross_product.cpp
@@ -38,8 +38,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCrossProduct(
     auto localState = CrossProductLocalState(table, maxMorselSize);
     auto printInfo = std::make_unique<OPPrintInfo>();
     auto crossProduct = std::make_unique<CrossProduct>(std::move(info), std::move(localState),
-        std::move(probeSidePrevOperator), getOperatorID(),
-        std::move(printInfo));
+        std::move(probeSidePrevOperator), getOperatorID(), std::move(printInfo));
     crossProduct->addChild(std::move(resultCollector));
     if (logicalCrossProduct.getSIPInfo().direction == SIPDirection::PROBE_TO_BUILD) {
         mapSIPJoin(crossProduct.get());

--- a/src/processor/map/map_hash_join.cpp
+++ b/src/processor/map/map_hash_join.cpp
@@ -111,8 +111,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapHashJoin(const LogicalOperator*
     }
     auto probePrintInfo = std::make_unique<HashJoinProbePrintInfo>(probeKeys);
     auto hashJoinProbe = make_unique<HashJoinProbe>(sharedState, hashJoin->getJoinType(),
-        hashJoin->requireFlatProbeKeys(), probeDataInfo, std::move(probeSidePrevOperator),
-        std::move(hashJoinBuild), getOperatorID(), probePrintInfo->copy());
+        hashJoin->requireFlatProbeKeys(), probeDataInfo, std::move(probeSidePrevOperator), getOperatorID(), probePrintInfo->copy());
+    hashJoinProbe->addChild(std::move(hashJoinBuild));
     if (hashJoin->getSIPInfo().direction == SIPDirection::PROBE_TO_BUILD) {
         mapSIPJoin(hashJoinProbe.get());
     }

--- a/src/processor/map/map_hash_join.cpp
+++ b/src/processor/map/map_hash_join.cpp
@@ -111,7 +111,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapHashJoin(const LogicalOperator*
     }
     auto probePrintInfo = std::make_unique<HashJoinProbePrintInfo>(probeKeys);
     auto hashJoinProbe = make_unique<HashJoinProbe>(sharedState, hashJoin->getJoinType(),
-        hashJoin->requireFlatProbeKeys(), probeDataInfo, std::move(probeSidePrevOperator), getOperatorID(), probePrintInfo->copy());
+        hashJoin->requireFlatProbeKeys(), probeDataInfo, std::move(probeSidePrevOperator),
+        getOperatorID(), probePrintInfo->copy());
     hashJoinProbe->addChild(std::move(hashJoinBuild));
     if (hashJoin->getSIPInfo().direction == SIPDirection::PROBE_TO_BUILD) {
         mapSIPJoin(hashJoinProbe.get());

--- a/src/processor/map/map_intersect.cpp
+++ b/src/processor/map/map_intersect.cpp
@@ -16,11 +16,12 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapIntersect(const LogicalOperator
     auto logicalIntersect = logicalOperator->constPtrCast<LogicalIntersect>();
     auto intersectNodeID = logicalIntersect->getIntersectNodeID();
     auto outSchema = logicalIntersect->getSchema();
-    std::vector<std::unique_ptr<PhysicalOperator>> children;
-    children.resize(logicalOperator->getNumChildren());
+    // std::vector<std::unique_ptr<PhysicalOperator>> children;
+    // children.resize(logicalOperator->getNumChildren());
     std::vector<std::shared_ptr<HashJoinSharedState>> sharedStates;
     std::vector<IntersectDataInfo> intersectDataInfos;
     // Map build side children.
+    std::vector<std::unique_ptr<PhysicalOperator>> buildChildren;
     for (auto i = 1u; i < logicalIntersect->getNumChildren(); i++) {
         auto keyNodeID = logicalIntersect->getKeyNodeID(i - 1);
         auto keys = expression_vector{keyNodeID};
@@ -37,7 +38,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapIntersect(const LogicalOperator
         auto build = std::make_unique<IntersectBuild>(sharedState, std::move(buildInfo),
             std::move(buildPrevOperator), getOperatorID(), std::move(printInfo));
         build->setDescriptor(std::make_unique<ResultSetDescriptor>(buildSchema));
-        children[i] = std::move(build);
+        buildChildren.push_back(std::move(build));
         // Collect intersect info
         std::vector<DataPos> vectorsToScanPos;
         auto expressionsToScan = ExpressionUtil::excludeExpressions(
@@ -49,13 +50,16 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapIntersect(const LogicalOperator
         intersectDataInfos.push_back(info);
     }
     // Map probe side child.
-    children[0] = mapOperator(logicalIntersect->getChild(0).get());
+    auto probeChild = mapOperator(logicalIntersect->getChild(0).get());
     // Map intersect.
     auto outputDataPos =
         DataPos(outSchema->getExpressionPos(*logicalIntersect->getIntersectNodeID()));
     auto printInfo = std::make_unique<IntersectPrintInfo>(intersectNodeID);
     auto intersect = make_unique<Intersect>(outputDataPos, intersectDataInfos, sharedStates,
-        std::move(children), getOperatorID(), std::move(printInfo));
+        std::move(probeChild), getOperatorID(), std::move(printInfo));
+    for (auto& child : buildChildren) {
+        intersect->addChild(std::move(child));
+    }
     if (logicalIntersect->getSIPInfo().direction == SIPDirection::PROBE_TO_BUILD) {
         mapSIPJoin(intersect.get());
     }

--- a/src/processor/map/map_intersect.cpp
+++ b/src/processor/map/map_intersect.cpp
@@ -16,8 +16,6 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapIntersect(const LogicalOperator
     auto logicalIntersect = logicalOperator->constPtrCast<LogicalIntersect>();
     auto intersectNodeID = logicalIntersect->getIntersectNodeID();
     auto outSchema = logicalIntersect->getSchema();
-    // std::vector<std::unique_ptr<PhysicalOperator>> children;
-    // children.resize(logicalOperator->getNumChildren());
     std::vector<std::shared_ptr<HashJoinSharedState>> sharedStates;
     std::vector<IntersectDataInfo> intersectDataInfos;
     // Map build side children.

--- a/src/processor/map/map_order_by.cpp
+++ b/src/processor/map/map_order_by.cpp
@@ -83,8 +83,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapOrderBy(const LogicalOperator* 
         auto topK = make_unique<TopK>(std::move(orderByDataInfo), topKSharedState, skipNum,
             limitNum, std::move(prevOperator), getOperatorID(), printInfo->copy());
         topK->setDescriptor(std::make_unique<ResultSetDescriptor>(inSchema));
-        auto scan = std::make_unique<TopKScan>(outPos, topKSharedState, getOperatorID(),
-            printInfo->copy());
+        auto scan =
+            std::make_unique<TopKScan>(outPos, topKSharedState, getOperatorID(), printInfo->copy());
         scan->addChild(std::move(topK));
         return scan;
     }
@@ -97,7 +97,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapOrderBy(const LogicalOperator* 
     auto orderByMerge = make_unique<OrderByMerge>(orderBySharedState, std::move(dispatcher),
         getOperatorID(), printInfo->copy());
     orderByMerge->addChild(std::move(orderBy));
-    auto scan = std::make_unique<OrderByScan>(outPos, orderBySharedState, getOperatorID(), printInfo->copy());
+    auto scan = std::make_unique<OrderByScan>(outPos, orderBySharedState, getOperatorID(),
+        printInfo->copy());
     scan->addChild(std::move(orderByMerge));
     return scan;
 }

--- a/src/processor/map/map_path_property_probe.cpp
+++ b/src/processor/map/map_path_property_probe.cpp
@@ -150,17 +150,15 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPathPropertyProbe(
     pathProbeInfo.extendFromLeft = logicalProbe.extendFromLeft;
     auto pathProbeSharedState =
         std::make_shared<PathPropertyProbeSharedState>(nodeBuildSharedState, relBuildSharedState);
-    std::vector<std::unique_ptr<PhysicalOperator>> children;
-    children.push_back(std::move(prevOperator));
-    if (nodeBuild != nullptr) {
-        children.push_back(std::move(nodeBuild));
-    }
-    if (relBuild != nullptr) {
-        children.push_back(std::move(relBuild));
-    }
     auto printInfo = std::make_unique<OPPrintInfo>();
     auto pathPropertyProbe = std::make_unique<PathPropertyProbe>(std::move(pathProbeInfo),
-        pathProbeSharedState, std::move(children), getOperatorID(), std::move(printInfo));
+        pathProbeSharedState, std::move(prevOperator), getOperatorID(), std::move(printInfo));
+    if (nodeBuild != nullptr) {
+        pathPropertyProbe->addChild(std::move(nodeBuild));
+    }
+    if (relBuild != nullptr) {
+        pathPropertyProbe->addChild(std::move(relBuild));
+    }
     if (logicalProbe.getSIPInfo().direction == SIPDirection::PROBE_TO_BUILD) {
         mapSIPJoin(pathPropertyProbe.get());
     }

--- a/src/processor/map/map_union.cpp
+++ b/src/processor/map/map_union.cpp
@@ -37,8 +37,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapUnionAll(const LogicalOperator*
     auto maxMorselSize = tables[0]->hasUnflatCol() ? 1 : DEFAULT_VECTOR_CAPACITY;
     auto unionSharedState = make_shared<UnionAllScanSharedState>(std::move(tables), maxMorselSize);
     auto printInfo = std::make_unique<UnionAllScanPrintInfo>(expressionsToUnion);
-    auto scan = make_unique<UnionAllScan>(std::move(info), unionSharedState,
-        getOperatorID(), std::move(printInfo));
+    auto scan = make_unique<UnionAllScan>(std::move(info), unionSharedState, getOperatorID(),
+        std::move(printInfo));
     for (auto& child : prevOperators) {
         scan->addChild(std::move(child));
     }

--- a/src/processor/operator/table_scan/union_all_scan.cpp
+++ b/src/processor/operator/table_scan/union_all_scan.cpp
@@ -44,7 +44,7 @@ std::unique_ptr<UnionAllScanMorsel> UnionAllScanSharedState::getMorselNoLock(
 
 void UnionAllScan::initLocalStateInternal(ResultSet* /*resultSet_*/,
     ExecutionContext* /*context*/) {
-    for (auto& dataPos : info->outputPositions) {
+    for (auto& dataPos : info.outputPositions) {
         vectors.push_back(resultSet->getValueVector(dataPos).get());
     }
 }
@@ -54,7 +54,7 @@ bool UnionAllScan::getNextTuplesInternal(ExecutionContext* /*context*/) {
     if (morsel->numTuples == 0) {
         return false;
     }
-    morsel->table->scan(vectors, morsel->startTupleIdx, morsel->numTuples, info->columnIndices);
+    morsel->table->scan(vectors, morsel->startTupleIdx, morsel->numTuples, info.columnIndices);
     metrics->numOutputTuple.increase(morsel->numTuples);
     return true;
 }


### PR DESCRIPTION
# Description

When copying operator into pipeline for multithread execution, we have many unnecessary copies. A operator should either

- not copy any child if it's a source operator;
- or copy its pipeline child which guarantees to be its first children

I enforce the above rules to all our physical operators.

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).