### PR TITLE
Fix export database with json type in schema

### DIFF
--- a/extension/json/test/export_db.test
+++ b/extension/json/test/export_db.test
@@ -1,0 +1,23 @@
+-DATASET CSV empty
+-BUFFER_POOL_SIZE 5000000
+
+--
+
+-CASE ExportDBTest
+-STATEMENT LOAD EXTENSION "${KUZU_ROOT_DIRECTORY}/extension/json/build/libjson.kuzu_extension";
+---- ok
+-STATEMENT create node table person (id INT64, description json, primary key(id));
+---- ok
+-STATEMENT CREATE (p:person {id: 5, description: 6})
+---- ok
+-STATEMENT CREATE (p:person {id: 8, description: to_json({"family": "anatidae", "species": [ "duck", "goose", "swan", null]})})
+---- ok
+-STATEMENT EXPORT DATABASE '${KUZU_EXPORT_DB_DIRECTORY}_json/export'
+---- ok
+-IMPORT_DATABASE '${KUZU_EXPORT_DB_DIRECTORY}_json/export'
+-STATEMENT IMPORT DATABASE '${KUZU_EXPORT_DB_DIRECTORY}_json/export';
+---- ok
+-STATEMENT MATCH (p:person) return p.*
+---- 2
+5|6
+8|{"family":"anatidae","species":["duck","goose","swan",null]}

--- a/src/processor/operator/simple/export_db.cpp
+++ b/src/processor/operator/simple/export_db.cpp
@@ -78,8 +78,16 @@ static void writeCopyStatement(stringstream& ss, const TableCatalogEntry* entry,
     }
 }
 
+static void exportLoadedExtensions(stringstream& ss, ClientContext* clientContext) {
+    auto extensionCypher = clientContext->getExtensionManager()->toCypher();
+    if (!extensionCypher.empty()) {
+        ss << extensionCypher << std::endl;
+    }
+}
+
 std::string getSchemaCypher(ClientContext* clientContext) {
     stringstream ss;
+    exportLoadedExtensions(ss, clientContext);
     const auto catalog = clientContext->getCatalog();
     auto transaction = clientContext->getTransaction();
     ToCypherInfo toCypherInfo;
@@ -104,10 +112,6 @@ std::string getSchemaCypher(ClientContext* clientContext) {
     for (auto macroName : catalog->getMacroNames(transaction)) {
         ss << catalog->getScalarMacroFunction(transaction, macroName)->toCypher(macroName)
            << std::endl;
-    }
-    auto extensionCypher = clientContext->getExtensionManager()->toCypher();
-    if (!extensionCypher.empty()) {
-        ss << extensionCypher << std::endl;
     }
     return ss.str();
 }


### PR DESCRIPTION
Closes #5435 
Fixes the ordering of `load extension` statements and `ddl` statements when exporting the database.
