### PR TITLE
Fix unwind with null value

### DIFF
--- a/dataset/csv-edge-case-tests/null-field.csv
+++ b/dataset/csv-edge-case-tests/null-field.csv
@@ -1,0 +1,3 @@
+col1,col2,col3
+5,,abc
+3,[],def

--- a/src/binder/bind/read/bind_unwind.cpp
+++ b/src/binder/bind/read/bind_unwind.cpp
@@ -26,8 +26,15 @@ std::unique_ptr<BoundReadingClause> Binder::bindUnwindClause(const ReadingClause
         boundExpression = expressionBinder.implicitCast(boundExpression, targetType);
     }
     if (!skipDataTypeValidation(*boundExpression)) {
-        ExpressionUtil::validateDataType(*boundExpression, LogicalTypeID::LIST);
-        alias = createVariable(aliasName, ListType::getChildType(boundExpression->dataType));
+        if (ExpressionUtil::isNullLiteral(*boundExpression)) {
+            // For the `unwind NULL` clause, we assign the STRING[] type to the NULL literal.
+            alias = createVariable(aliasName, LogicalType::STRING());
+            boundExpression = expressionBinder.implicitCast(boundExpression,
+                LogicalType::LIST(LogicalType::STRING()));
+        } else {
+            ExpressionUtil::validateDataType(*boundExpression, LogicalTypeID::LIST);
+            alias = createVariable(aliasName, ListType::getChildType(boundExpression->dataType));
+        }
     } else {
         alias = createVariable(aliasName, LogicalType::ANY());
     }

--- a/test/test_files/unwind/unwind.test
+++ b/test/test_files/unwind/unwind.test
@@ -234,3 +234,14 @@ Aida|Alice|Bob|Dan
 -STATEMENT MATCH (a:N) RETURN a.id
 ---- 1
 1
+
+-CASE UnwindNull
+-STATEMENT UNWIND NULL AS t RETURN t
+---- 0
+-STATEMENT UNWIND [] AS t RETURN t
+---- 0
+-STATEMENT UNWIND [NULL] AS t RETURN t
+---- 1
+
+-STATEMENT LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/csv-edge-case-tests/null-field.csv"(header=true) UNWIND col2 AS t RETURN t
+---- 0


### PR DESCRIPTION
Handle unwind with null values.
The unwind casts the literal null value to `STRING[]` in such case.