### PR TITLE
Test Runner Write Mode

### DIFF
--- a/test/include/test_helper/test_helper.h
+++ b/test/include/test_helper/test_helper.h
@@ -25,6 +25,7 @@ struct TestQueryConfig {
 class TestHelper {
 public:
     inline static std::string E2E_TEST_FILES_DIRECTORY = "test/test_files";
+    inline static bool REWRITE_TESTS = false;
     static constexpr char SCHEMA_FILE_NAME[] = "schema.cypher";
     static constexpr char COPY_FILE_NAME[] = "copy.cypher";
     static constexpr char TEST_ANSWERS_PATH[] = "test/answers";
@@ -42,6 +43,11 @@ public:
     static void setE2ETestFilesDirectory(const std::string& directory) {
         E2E_TEST_FILES_DIRECTORY = directory;
     }
+
+    static void setRewriteTests(const bool rewrite_tests) {
+        REWRITE_TESTS = rewrite_tests;
+    }
+
 
     static std::vector<std::string> convertResultToString(main::QueryResult& queryResult,
         bool checkOutputOrder = false);

--- a/test/include/test_runner/test_group.h
+++ b/test/include/test_runner/test_group.h
@@ -66,6 +66,7 @@ struct TestStatement {
     std::string removeFilePath;
     // For rewriteTests
     std::string testFilePath;
+    std::string newOutput;
 };
 
 // Test group is a collection of test cases in a single file.

--- a/test/include/test_runner/test_group.h
+++ b/test/include/test_runner/test_group.h
@@ -64,6 +64,8 @@ struct TestStatement {
     std::string importFilePath;
     bool removeFileFlag = false;
     std::string removeFilePath;
+    // For rewriteTests
+    std::string testFilePath;
 };
 
 // Test group is a collection of test cases in a single file.

--- a/test/include/test_runner/test_group.h
+++ b/test/include/test_runner/test_group.h
@@ -65,7 +65,6 @@ struct TestStatement {
     bool removeFileFlag = false;
     std::string removeFilePath;
     // For rewriteTests
-    std::string testFilePath;
     std::string newOutput;
     ResultType testResultType;
 };

--- a/test/include/test_runner/test_group.h
+++ b/test/include/test_runner/test_group.h
@@ -67,6 +67,7 @@ struct TestStatement {
     // For rewriteTests
     std::string testFilePath;
     std::string newOutput;
+    ResultType testResultType;
 };
 
 // Test group is a collection of test cases in a single file.

--- a/test/include/test_runner/test_runner.h
+++ b/test/include/test_runner/test_runner.h
@@ -20,8 +20,6 @@ private:
         const std::string& databasePath);
     static void checkLogicalPlan(main::Connection& conn, main::QueryResult* queryResult,
         TestStatement* statement, size_t resultIdx);
-    static void writeLogicalPlan(main::Connection& conn, main::QueryResult* queryResult,
-        TestStatement* statement, size_t resultIdx);
     static bool checkResultNumeric(main::QueryResult& queryResult, const TestStatement* statement,
         size_t resultIdx);
     static std::vector<std::string> convertResultToString(main::QueryResult& queryResult,
@@ -31,7 +29,7 @@ private:
     static std::string convertResultColumnsToString(const main::QueryResult& queryResult);
     static void checkPlanResult(main::Connection& conn, main::QueryResult* result,
         TestStatement* statement, size_t resultIdx);
-    static void writePlanResult(main::Connection& conn, main::QueryResult* result,
+    static void writeOutput(main::QueryResult* result,
         TestStatement* statement, size_t resultIdx); 
 
 

--- a/test/include/test_runner/test_runner.h
+++ b/test/include/test_runner/test_runner.h
@@ -32,7 +32,7 @@ private:
     static void checkPlanResult(main::Connection& conn, main::QueryResult* result,
         TestStatement* statement, size_t resultIdx);
     static void writePlanResult(main::Connection& conn, main::QueryResult* result,
-        TestStatement* statement, size_t resultIdx, std::ofstream&);
+        TestStatement* statement, size_t resultIdx); 
 
 
     static void outputFailedPlan(main::Connection& conn, const TestStatement* statement);

--- a/test/include/test_runner/test_runner.h
+++ b/test/include/test_runner/test_runner.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <fstream>
 #include "main/connection.h"
 #include "test_runner/test_group.h"
 
@@ -31,7 +32,7 @@ private:
     static void checkPlanResult(main::Connection& conn, main::QueryResult* result,
         TestStatement* statement, size_t resultIdx);
     static void writePlanResult(main::Connection& conn, main::QueryResult* result,
-        TestStatement* statement, size_t resultIdx);
+        TestStatement* statement, size_t resultIdx, std::ofstream&);
 
 
     static void outputFailedPlan(main::Connection& conn, const TestStatement* statement);

--- a/test/include/test_runner/test_runner.h
+++ b/test/include/test_runner/test_runner.h
@@ -19,6 +19,8 @@ private:
         const std::string& databasePath);
     static void checkLogicalPlan(main::Connection& conn, main::QueryResult* queryResult,
         TestStatement* statement, size_t resultIdx);
+    static void writeLogicalPlan(main::Connection& conn, main::QueryResult* queryResult,
+        TestStatement* statement, size_t resultIdx);
     static bool checkResultNumeric(main::QueryResult& queryResult, const TestStatement* statement,
         size_t resultIdx);
     static std::vector<std::string> convertResultToString(main::QueryResult& queryResult,
@@ -28,6 +30,9 @@ private:
     static std::string convertResultColumnsToString(const main::QueryResult& queryResult);
     static void checkPlanResult(main::Connection& conn, main::QueryResult* result,
         TestStatement* statement, size_t resultIdx);
+    static void writePlanResult(main::Connection& conn, main::QueryResult* result,
+        TestStatement* statement, size_t resultIdx);
+
 
     static void outputFailedPlan(main::Connection& conn, const TestStatement* statement);
 };

--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -205,11 +205,9 @@ int main(int argc, char** argv) {
         }
         TestHelper::setE2ETestFilesDirectory(test_dir);
 
-        if (env_rewrite_tests != nullptr) {
-            rewrite_tests = env_rewrite_tests;
-        } else {
-            rewrite_tests = "test/test_files";
-        }
+        if (env_rewrite_tests != nullptr && std::string(env_rewrite_tests) != "FALSE" && std::string(env_rewrite_tests) != "OFF") {
+            rewrite_tests = true;
+        } 
         TestHelper::setRewriteTests(rewrite_tests);
 
 

--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -195,13 +195,23 @@ int main(int argc, char** argv) {
     try {
         // Main logic
         std::string test_dir;
+        bool rewrite_tests = false;
         char* env_test_dir = std::getenv("E2E_TEST_FILES_DIRECTORY");
+        char* env_rewrite_tests = std::getenv("E2E_REWRITE_TESTS");
         if (env_test_dir != nullptr) {
             test_dir = env_test_dir;
         } else {
             test_dir = "test/test_files";
         }
         TestHelper::setE2ETestFilesDirectory(test_dir);
+
+        if (env_rewrite_tests != nullptr) {
+            rewrite_tests = env_rewrite_tests;
+        } else {
+            rewrite_tests = "test/test_files";
+        }
+        TestHelper::setRewriteTests(rewrite_tests);
+
 
         checkGtestParams(argc, argv);
         testing::InitGoogleTest(&argc, argv);

--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -1,5 +1,6 @@
 #include <fstream>
 #include <string>
+#include <utility>
 #include "common/string_utils.h"
 #include "graph_test/graph_test.h"
 #include "test_runner/csv_converter.h"
@@ -30,10 +31,10 @@ public:
     explicit EndToEndTest(TestGroup::DatasetType datasetType, std::string dataset,
         std::optional<uint64_t> bufferPoolSize, uint64_t checkpointWaitTimeout,
         const std::set<std::string>& connNames,
-        std::vector<std::unique_ptr<TestStatement>> testStatements)
+        std::vector<std::unique_ptr<TestStatement>> testStatements, std::string  path)
         : datasetType{datasetType}, dataset{std::move(dataset)}, bufferPoolSize{bufferPoolSize},
           checkpointWaitTimeout{checkpointWaitTimeout}, testStatements{std::move(testStatements)},
-          connNames{connNames} {}
+          connNames{connNames}, testPath{std::move(path)} {}
 
     void SetUp() override {
         setUpDataset();
@@ -85,15 +86,16 @@ public:
             datasetType == TestGroup::DatasetType::CSV_TO_JSON) {
             std::filesystem::remove_all(tempDatasetPath);
         }
-        if (!TestHelper::REWRITE_TESTS || testStatements.empty())
+        if (!TestHelper::REWRITE_TESTS)
             return;
         std::fstream file;
         std::string f;
         std::string l;
-        file.open(testStatements.front()->testFilePath);
+        file.open(testPath);
         for(auto& statement : testStatements)
         {
             while(getline(file, l))
+            {
                 if (l != "-STATEMENT " + statement->query)
                     f += l + '\n';
                 else
@@ -106,14 +108,14 @@ public:
                         {
                             f += statement->newOutput;
                         }
-                        continue;
+                        break;
                         case ResultType::HASH:
                         {
                             f += l + '\n';
                             f += statement->newOutput;
                             getline(file, l);
                         }
-                        continue;
+                        break;
                         case ResultType::TUPLES:
                         {
                             int skip = std::stoi(l.substr(5));
@@ -121,15 +123,15 @@ public:
                                 getline(file, l);
                             f+=statement->newOutput;
                         }
-                        continue;
+                        break;
                         case ResultType::CSV_FILE: // TODO
-                        return;
+                        break;
                         case ResultType::ERROR_MSG:
                         {
                             f+=statement->newOutput;
                             getline(file, l);
                         }
-                        continue;
+                        break;
                         case ResultType::ERROR_REGEX:
                         {
                             f+=statement->newOutput;
@@ -137,13 +139,15 @@ public:
                             if (statement->newOutput != "ok\n")
                                 f += l + '\n';
                         }
-                        continue;
+                        break;
                     }
+                    break; // goto next statement
                 }
-            file.close();
-            file.open(statement->testFilePath, std::ios::trunc | std::ios::out);
-            file << f;
+            }
         }
+        file.close();
+        file.open(testPath, std::ios::trunc | std::ios::out);
+        file << f;
     }
 
     void TestBody() override { runTest(testStatements, checkpointWaitTimeout, connNames); }
@@ -157,6 +161,7 @@ private:
     uint64_t checkpointWaitTimeout;
     std::vector<std::unique_ptr<TestStatement>> testStatements;
     std::set<std::string> connNames;
+    std::string testPath;
 
     std::string generateTempDatasetPath() {
         std::string datasetName = dataset;
@@ -199,10 +204,10 @@ void parseAndRegisterTestGroup(const std::string& path, bool generateTestList = 
                     decltype(testStatements) testStatementsCopy;
                     for (const auto& testStatement : testStatements) {
                         testStatementsCopy.emplace_back(
-                            std::make_unique<TestStatement>(*testStatement))->testFilePath = path;
+                            std::make_unique<TestStatement>(*testStatement));
                     }
                     return new EndToEndTest(datasetType, dataset, bufferPoolSize,
-                        checkpointWaitTimeout, connNames, std::move(testStatementsCopy));
+                        checkpointWaitTimeout, connNames, std::move(testStatementsCopy), path);
                 });
         }
     } else {

--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -83,9 +83,78 @@ public:
             datasetType == TestGroup::DatasetType::CSV_TO_JSON) {
             std::filesystem::remove_all(tempDatasetPath);
         }
-        for(auto& t : testStatements)
-            std::cout << t->testFilePath << std::endl;
-        std::cout << "Test here " << std::endl;
+        if (!TestHelper::REWRITE_TESTS)
+            return;
+        for(auto& statement : testStatements)
+        {
+            TestQueryResult& testAnswer = statement->result[resultIdx];
+            std::string f;
+            std::string l;
+            std::fstream file;
+            file.open(statement->testFilePath);
+            while(getline(file, l))
+                if (l != "-STATEMENT " + statement->query)
+                    f+= l + '\n';
+                else
+                {
+                    f += l + '\n';
+                    getline(file, l); // result form specifier
+                    switch (testAnswer.type) 
+                    {
+                        case ResultType::OK:
+                        {
+                            f += "---- " + (result->isSuccess() ? std::string("ok") : std::string("error")) +'\n';
+                        }
+                        break;
+                        case ResultType::HASH:
+                        {
+                            f += l + '\n';
+                            std::string resultHash = convertResultToMD5Hash(*result, statement->checkOutputOrder, statement->checkColumnNames);
+                            f += resultHash;
+                            getline(file, l);
+                        }
+                        break;
+                        case ResultType::TUPLES:
+                        {
+                            f += "---- " + std::to_string(testAnswer.numTuples + statement->checkColumnNames) + '\n';
+                            std::vector<std::string> resultTuples = convertResultToString(*result, statement->checkOutputOrder, statement->checkColumnNames);
+                            for(auto result : resultTuples)
+                            {
+                                getline(file, l);
+                                f+= result + '\n';
+                            }
+                        }
+                        break;
+                        case ResultType::CSV_FILE: // TODO
+                        return;
+                        case ResultType::ERROR_MSG:
+                        {
+                            f += "---- " + (result->isSuccess() ? std::string("ok") : std::string("error")) +'\n';
+                            getline(file, l);
+                            f += result->getErrorMessage() + '\n';
+                        }
+                        break;
+                        case ResultType::ERROR_REGEX:
+                        {
+                            if (!result->isSuccess())
+                                    return;
+                            
+                            f += "---- ok";
+                        }
+                        break;
+                    }
+                }
+            file.close();
+            file.open(statement->testFilePath, std::ios::trunc | std::ios::out);
+            file << f;
+        }
+
+
+
+
+
+
+
     }
 
     void TestBody() override { runTest(testStatements, checkpointWaitTimeout, connNames); }

--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -133,12 +133,12 @@ void parseAndRegisterTestGroup(const std::string& path, bool generateTestList = 
             auto connNames = testGroup->testCasesConnNames[testCaseName];
             testing::RegisterTest(testGroup->group.c_str(), testCaseName.c_str(), nullptr, nullptr,
                 __FILE__, __LINE__,
-                [datasetType, dataset, bufferPoolSize, checkpointWaitTimeout, connNames,
+                [filename, datasetType, dataset, bufferPoolSize, checkpointWaitTimeout, connNames,
                     testStatements = std::move(testStatements)]() mutable -> DBTest* {
                     decltype(testStatements) testStatementsCopy;
                     for (const auto& testStatement : testStatements) {
                         testStatementsCopy.emplace_back(
-                            std::make_unique<TestStatement>(*testStatement));
+                            std::make_unique<TestStatement>(*testStatement))->testFilePath = filename;
                     }
                     return new EndToEndTest(datasetType, dataset, bufferPoolSize,
                         checkpointWaitTimeout, connNames, std::move(testStatementsCopy));

--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -1,6 +1,7 @@
 #include <fstream>
 #include <string>
 #include <utility>
+#include "alp/state.hpp"
 #include "common/string_utils.h"
 #include "graph_test/graph_test.h"
 #include "test_runner/csv_converter.h"
@@ -86,6 +87,7 @@ public:
             datasetType == TestGroup::DatasetType::CSV_TO_JSON) {
             std::filesystem::remove_all(tempDatasetPath);
         }
+
         if (!TestHelper::REWRITE_TESTS)
             return;
         std::fstream file;
@@ -93,16 +95,56 @@ public:
         std::string l;
         file.open(testPath);
 
+        std::streampos pos;
         for(auto& statement : testStatements)
         {
-            while(getline(file, l))
+            while(pos = file.tellg(), getline(file, l))
             {
-                if (l != "-STATEMENT " + statement->query)
+                if (!l.starts_with("-STATEMENT"))
+                {
                     f += l + '\n';
+                    continue;
+                }
+
+                std::string stmt = l;
+                while(getline(file, l))
+                    if (l.starts_with("----"))
+                        break;
+                    else 
+                        stmt += l;
+
+                auto normalize = [](const std::string& s)
+                {
+                    std::string result;
+                    bool in_space = false;
+                    for (char c : s) {
+                        if (std::isspace(static_cast<unsigned char>(c))) {
+                            if (!in_space) {
+                                result += ' ';
+                                in_space = true;
+                            }
+                        } else {
+                            result += c;
+                            in_space = false;
+                        }
+                    }
+                    return result;
+                };
+
+                if (normalize(stmt) != (normalize("-STATEMENT " + statement->query))) 
+                {
+                    std::cout << "GOT HERE ON" << std::endl;
+                    std::cout << stmt << std::endl;
+                    std::cout << "-STATEMENT " + statement->query << std::endl;
+                    file.seekg(pos);
+                    getline(file, l);
+                    f += l + '\n';
+                    continue;
+                }
+
                 else
                 {
-                    f += l + '\n'; // Add statement back
-                    getline(file, l); // get result form specifier
+                    f += stmt + '\n'; // Add statement back
                     switch (statement->testResultType) 
                     {
                         case ResultType::OK:

--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -1,3 +1,5 @@
+#include <fstream>
+#include <string>
 #include "common/string_utils.h"
 #include "graph_test/graph_test.h"
 #include "test_runner/csv_converter.h"
@@ -83,78 +85,65 @@ public:
             datasetType == TestGroup::DatasetType::CSV_TO_JSON) {
             std::filesystem::remove_all(tempDatasetPath);
         }
-        if (!TestHelper::REWRITE_TESTS)
+        if (!TestHelper::REWRITE_TESTS || testStatements.empty())
             return;
+        std::fstream file;
+        std::string f;
+        std::string l;
+        file.open(testStatements.front()->testFilePath);
         for(auto& statement : testStatements)
         {
-            TestQueryResult& testAnswer = statement->result[resultIdx];
-            std::string f;
-            std::string l;
-            std::fstream file;
-            file.open(statement->testFilePath);
             while(getline(file, l))
                 if (l != "-STATEMENT " + statement->query)
-                    f+= l + '\n';
+                    f += l + '\n';
                 else
                 {
                     f += l + '\n';
                     getline(file, l); // result form specifier
-                    switch (testAnswer.type) 
+                    switch (statement->testResultType) 
                     {
                         case ResultType::OK:
                         {
-                            f += "---- " + (result->isSuccess() ? std::string("ok") : std::string("error")) +'\n';
+                            f += statement->newOutput;
                         }
-                        break;
+                        continue;
                         case ResultType::HASH:
                         {
                             f += l + '\n';
-                            std::string resultHash = convertResultToMD5Hash(*result, statement->checkOutputOrder, statement->checkColumnNames);
-                            f += resultHash;
+                            f += statement->newOutput;
                             getline(file, l);
                         }
-                        break;
+                        continue;
                         case ResultType::TUPLES:
                         {
-                            f += "---- " + std::to_string(testAnswer.numTuples + statement->checkColumnNames) + '\n';
-                            std::vector<std::string> resultTuples = convertResultToString(*result, statement->checkOutputOrder, statement->checkColumnNames);
-                            for(auto result : resultTuples)
-                            {
+                            int skip = std::stoi(l.substr(5));
+                            for(int i = 0; i < skip; ++i)
                                 getline(file, l);
-                                f+= result + '\n';
-                            }
+                            f+=statement->newOutput;
                         }
-                        break;
+                        continue;
                         case ResultType::CSV_FILE: // TODO
                         return;
                         case ResultType::ERROR_MSG:
                         {
-                            f += "---- " + (result->isSuccess() ? std::string("ok") : std::string("error")) +'\n';
+                            f+=statement->newOutput;
                             getline(file, l);
-                            f += result->getErrorMessage() + '\n';
                         }
-                        break;
+                        continue;
                         case ResultType::ERROR_REGEX:
                         {
-                            if (!result->isSuccess())
-                                    return;
-                            
-                            f += "---- ok";
+                            f+=statement->newOutput;
+                            getline(file, l);
+                            if (statement->newOutput != "ok\n")
+                                f += l + '\n';
                         }
-                        break;
+                        continue;
                     }
                 }
             file.close();
             file.open(statement->testFilePath, std::ios::trunc | std::ios::out);
             file << f;
         }
-
-
-
-
-
-
-
     }
 
     void TestBody() override { runTest(testStatements, checkpointWaitTimeout, connNames); }

--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -133,12 +133,12 @@ void parseAndRegisterTestGroup(const std::string& path, bool generateTestList = 
             auto connNames = testGroup->testCasesConnNames[testCaseName];
             testing::RegisterTest(testGroup->group.c_str(), testCaseName.c_str(), nullptr, nullptr,
                 __FILE__, __LINE__,
-                [filename, datasetType, dataset, bufferPoolSize, checkpointWaitTimeout, connNames,
+                [path, datasetType, dataset, bufferPoolSize, checkpointWaitTimeout, connNames,
                     testStatements = std::move(testStatements)]() mutable -> DBTest* {
                     decltype(testStatements) testStatementsCopy;
                     for (const auto& testStatement : testStatements) {
                         testStatementsCopy.emplace_back(
-                            std::make_unique<TestStatement>(*testStatement))->testFilePath = filename;
+                            std::make_unique<TestStatement>(*testStatement))->testFilePath = path;
                     }
                     return new EndToEndTest(datasetType, dataset, bufferPoolSize,
                         checkpointWaitTimeout, connNames, std::move(testStatementsCopy));

--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -92,6 +92,7 @@ public:
         std::string f;
         std::string l;
         file.open(testPath);
+
         for(auto& statement : testStatements)
         {
             while(getline(file, l))
@@ -100,8 +101,8 @@ public:
                     f += l + '\n';
                 else
                 {
-                    f += l + '\n';
-                    getline(file, l); // result form specifier
+                    f += l + '\n'; // Add statement back
+                    getline(file, l); // get result form specifier
                     switch (statement->testResultType) 
                     {
                         case ResultType::OK:
@@ -111,25 +112,25 @@ public:
                         break;
                         case ResultType::HASH:
                         {
-                            f += l + '\n';
-                            f += statement->newOutput;
-                            getline(file, l);
+                            f += l + '\n'; // Add result specifier
+                            f += statement->newOutput; // Add produced hash
+                            getline(file, l); // Ignore expected hash
                         }
                         break;
                         case ResultType::TUPLES:
                         {
-                            int skip = std::stoi(l.substr(5));
+                            int skip = std::stoi(l.substr(5)); // Ignore expected tuples
                             for(int i = 0; i < skip; ++i)
                                 getline(file, l);
-                            f+=statement->newOutput;
+                            f+=statement->newOutput; // Add actual output
                         }
                         break;
                         case ResultType::CSV_FILE: // TODO
                         break;
                         case ResultType::ERROR_MSG:
                         {
-                            f+=statement->newOutput;
-                            getline(file, l);
+                            f+=statement->newOutput; // Add actual output (result and error msg)
+                            getline(file, l); //Ignore produced error msg 
                         }
                         break;
                         case ResultType::ERROR_REGEX:

--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -164,7 +164,7 @@ public:
                             f+=statement->newOutput; // Add actual output
                         }
                         break;
-                        case ResultType::CSV_FILE: // TODO
+                        case ResultType::CSV_FILE: // not supported yet
                         break;
                         case ResultType::ERROR_MSG:
                         {

--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -83,6 +83,9 @@ public:
             datasetType == TestGroup::DatasetType::CSV_TO_JSON) {
             std::filesystem::remove_all(tempDatasetPath);
         }
+        for(auto& t : testStatements)
+            std::cout << t->testFilePath << std::endl;
+        std::cout << "Test here " << std::endl;
     }
 
     void TestBody() override { runTest(testStatements, checkpointWaitTimeout, connNames); }

--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -95,10 +95,9 @@ public:
         std::string l;
         file.open(testPath);
 
-        std::streampos pos;
         for(auto& statement : testStatements)
         {
-            while(pos = file.tellg(), getline(file, l))
+            while(getline(file, l))
             {
                 if (!l.starts_with("-STATEMENT"))
                 {
@@ -106,12 +105,16 @@ public:
                     continue;
                 }
 
+                f += l + '\n';
                 std::string stmt = l;
                 while(getline(file, l))
                     if (l.starts_with("----"))
                         break;
                     else 
+                    {
+                        f += l + '\n';
                         stmt += l;
+                    }
 
                 auto normalize = [](const std::string& s)
                 {
@@ -133,18 +136,12 @@ public:
 
                 if (normalize(stmt) != (normalize("-STATEMENT " + statement->query))) 
                 {
-                    std::cout << "GOT HERE ON" << std::endl;
-                    std::cout << stmt << std::endl;
-                    std::cout << "-STATEMENT " + statement->query << std::endl;
-                    file.seekg(pos);
-                    getline(file, l);
                     f += l + '\n';
                     continue;
                 }
 
                 else
                 {
-                    f += stmt + '\n'; // Add statement back
                     switch (statement->testResultType) 
                     {
                         case ResultType::OK:
@@ -188,6 +185,9 @@ public:
                 }
             }
         }
+
+        while(getline(file, l)) // get any remaining lines in the file, could be comments or anything else
+            f+=l + '\n';
         file.close();
         file.open(testPath, std::ios::trunc | std::ios::out);
         file << f;

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -68,7 +68,7 @@ void TestRunner::testStatement(TestStatement* statement, Connection& conn,
     QueryResult* currentQueryResult = actualResult.get();
     idx_t resultIdx = 0u;
     do {
-        checkLogicalPlan(conn, currentQueryResult, statement, resultIdx);
+        TestHelper::REWRITE_TESTS ? writeLogicalPlan(conn, currentQueryResult, statement, resultIdx) : checkLogicalPlan(conn, currentQueryResult, statement, resultIdx);
         currentQueryResult = currentQueryResult->getNextQueryResult();
         resultIdx++;
     } while (currentQueryResult);
@@ -102,6 +102,11 @@ void TestRunner::checkLogicalPlan(Connection& conn, QueryResult* queryResult,
         checkPlanResult(conn, queryResult, statement, resultIdx);
     }
     }
+}
+
+void TestRunner::writeLogicalPlan(Connection& conn, QueryResult* queryResult,
+    TestStatement* statement, size_t resultIdx) {
+    /* TODO */
 }
 
 void TestRunner::checkPlanResult(Connection& conn, QueryResult* result, TestStatement* statement,
@@ -171,6 +176,13 @@ void TestRunner::checkPlanResult(Connection& conn, QueryResult* result, TestStat
         }
     }
 }
+
+
+void TestRunner::writePlanResult(Connection& conn, QueryResult* result, TestStatement* statement,
+    size_t resultIdx) {
+    /* TODO */
+}
+
 
 void TestRunner::outputFailedPlan(Connection& conn, const TestStatement* statement) {
     spdlog::error("QUERY FAILED.");

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -190,12 +190,15 @@ void TestRunner::checkPlanResult(Connection& conn, QueryResult* result, TestStat
 void TestRunner::writePlanResult(Connection& /**/, QueryResult* result, TestStatement* statement,
     size_t resultIdx) {
     TestQueryResult& testAnswer = statement->result[resultIdx];
+    statement->testResultType = testAnswer.type;
     std::string f;
     switch (testAnswer.type) 
     {
         case ResultType::OK:
         {
             f += "---- " + (result->isSuccess() ? std::string("ok") : std::string("error")) +'\n';
+            if (!result->isSuccess())
+                    f+=result->getErrorMessage() + '\n';
         }
         break;
         case ResultType::HASH:
@@ -224,10 +227,7 @@ void TestRunner::writePlanResult(Connection& /**/, QueryResult* result, TestStat
         break;
         case ResultType::ERROR_REGEX:
         {
-            if (!result->isSuccess())
-                    return;
-            
-            f += "---- ok";
+            f += "---- " + (result->isSuccess() ? std::string("ok") : std::string("error(regex)")) +'\n';
         }
         break;
     }

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -187,6 +187,92 @@ void TestRunner::checkPlanResult(Connection& conn, QueryResult* result, TestStat
     }
 }
 
+//void TestRunner::writePlanResult(Connection& /**/, QueryResult* result, TestStatement* statement,
+//    size_t resultIdx) {
+//    TestQueryResult& testAnswer = statement->result[resultIdx];
+//    std::string f;
+//    std::string l;
+//    std::fstream file;
+//    file.open(statement->testFilePath);
+//    while(getline(file, l))
+//        if (l != "-STATEMENT " + statement->query)
+//            f+= l + '\n';
+//        else 
+//        {
+//            f+= l + '\n'; // Add statement (Got in while loop)
+//            getline(file, l); // Get current result specifier
+//            switch (testAnswer.type) 
+//            {
+//
+//                case ResultType::TUPLES:
+//                {
+//                        // PUT RESULT SPECIFIER
+//                        f += "---- " + std::to_string(testAnswer.numTuples + statement->checkColumnNames) + '\n'; // we update tuple count if needed
+//                        // ADD ACTUAL OUTPUT
+//                        std::vector<std::string> resultTuples = convertResultToString(*result, statement->checkOutputOrder, statement->checkColumnNames);
+//
+//                        for(auto& testOutput : resultTuples)
+//                        {
+//                            getline(file, l); // Ignore existing output
+//                            f+= testOutput + '\n';
+//                        }
+//                }
+//                break;
+//
+//                case ResultType::OK:
+//                {
+//                        // GET RESULT SPECIFIER
+//                        f += "---- " + (result->isSuccess() ? std::string("ok") : std::string("error")) +'\n';
+//                }
+//                break;
+//
+//                case ResultType::ERROR_MSG:
+//                {
+//                        // GET RESULT SPECIFIER
+//                        f += "---- " + (result->isSuccess() ? std::string("ok") : std::string("error")) +'\n';
+//                        // IGNORE EXISTING OUTPUT
+//                        getline(file, l);
+//                        // ADD ACTUAL OUTPUT
+//                        f += result->getErrorMessage() + '\n';
+//                }
+//                break;
+//
+//                case ResultType::ERROR_REGEX:
+//                {
+//                        // GET RESULT SPECIFIER
+//                        f += l + '\n';
+//                        // IGNORE EXISTING OUTPUT (non trivial in this case,
+//                        // want to keep the original regex)
+//
+//                        // ADD ACTUAL OUTPUT
+//                        getline(file, l);
+//                        f += l + '\n';
+//                }
+//                break;
+//
+//                case ResultType::HASH:
+//                {
+//                        return;
+//                        // GET RESULT SPECIFIER
+//                        f += l + '\n';
+//                        // IGNORE EXISTING OUTPUT
+//                        getline(file, l);
+//                        // ADD ACTUAL OUTPUT
+//                        std::string resultHash = convertResultToMD5Hash(*result, statement->checkOutputOrder, statement->checkColumnNames);
+//                        f += resultHash;
+//                }
+//                break;
+//
+//                case ResultType::CSV_FILE:
+//                return;
+//            }
+//        }
+//
+//    file.close();
+//    file.open(statement->testFilePath, std::ios::trunc | std::ios::out);
+//    file << f;
+//}
+
 
 void TestRunner::writePlanResult(Connection& /**/, QueryResult* result, TestStatement* statement,
     size_t resultIdx) {

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -191,64 +191,47 @@ void TestRunner::writePlanResult(Connection& /**/, QueryResult* result, TestStat
     size_t resultIdx) {
     TestQueryResult& testAnswer = statement->result[resultIdx];
     std::string f;
-    std::string l;
-    std::fstream file;
-    file.open(statement->testFilePath);
-    while(getline(file, l))
-        if (l != "-STATEMENT " + statement->query)
-            f+= l + '\n';
-        else
+    switch (testAnswer.type) 
+    {
+        case ResultType::OK:
         {
-            f += l + '\n';
-            getline(file, l); // result form specifier
-            switch (testAnswer.type) 
+            f += "---- " + (result->isSuccess() ? std::string("ok") : std::string("error")) +'\n';
+        }
+        break;
+        case ResultType::HASH:
+        {
+            std::string resultHash = convertResultToMD5Hash(*result, statement->checkOutputOrder, statement->checkColumnNames);
+            f += resultHash;
+        }
+        break;
+        case ResultType::TUPLES:
+        {
+            f += "---- " + std::to_string(testAnswer.numTuples + statement->checkColumnNames) + '\n';
+            std::vector<std::string> resultTuples = convertResultToString(*result, statement->checkOutputOrder, statement->checkColumnNames);
+            for(auto result : resultTuples)
             {
-                case ResultType::OK:
-                {
-                    f += "---- " + (result->isSuccess() ? std::string("ok") : std::string("error")) +'\n';
-                }
-                break;
-                case ResultType::HASH:
-                {
-                    f += l + '\n';
-                    std::string resultHash = convertResultToMD5Hash(*result, statement->checkOutputOrder, statement->checkColumnNames);
-                    f += resultHash;
-                    getline(file, l);
-                }
-                break;
-                case ResultType::TUPLES:
-                {
-                    f += "---- " + std::to_string(testAnswer.numTuples + statement->checkColumnNames) + '\n';
-                    std::vector<std::string> resultTuples = convertResultToString(*result, statement->checkOutputOrder, statement->checkColumnNames);
-                    for(auto result : resultTuples)
-                    {
-                        getline(file, l);
-                        f+= result + '\n';
-                    }
-                }
-                break;
-                case ResultType::CSV_FILE: // TODO
-                return;
-                case ResultType::ERROR_MSG:
-                {
-                    f += "---- " + (result->isSuccess() ? std::string("ok") : std::string("error")) +'\n';
-                    getline(file, l);
-                    f += result->getErrorMessage() + '\n';
-                }
-                break;
-                case ResultType::ERROR_REGEX:
-                {
-                    if (!result->isSuccess())
-                            return;
-                    
-                    f += "---- ok";
-                }
-                break;
+                f+= result + '\n';
             }
         }
-    file.close();
-    file.open(statement->testFilePath, std::ios::trunc | std::ios::out);
-    file << f;
+        break;
+        case ResultType::CSV_FILE: // TODO
+        return;
+        case ResultType::ERROR_MSG:
+        {
+            f += "---- " + (result->isSuccess() ? std::string("ok") : std::string("error")) +'\n';
+            f += result->getErrorMessage() + '\n';
+        }
+        break;
+        case ResultType::ERROR_REGEX:
+        {
+            if (!result->isSuccess())
+                    return;
+            
+            f += "---- ok";
+        }
+        break;
+    }
+    statement->newOutput = f;
 }
 
 void TestRunner::outputFailedPlan(Connection& conn, const TestStatement* statement) {

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -233,11 +233,13 @@ void TestRunner::writePlanResult(Connection& /**/, QueryResult* result, TestStat
         /*TODO*/
         return;
     }
-    if (testAnswer.type == ResultType::HASH) {
+    else if (testAnswer.type == ResultType::HASH) {
         std::string resultHash = convertResultToMD5Hash(*result, statement->checkOutputOrder,
             statement->checkColumnNames);
         outFile << resultHash << std::endl;
+        return;
     } 
+    KU_ASSERT(testAnswer.type == ResultType::HASH);
     std::vector<std::string> resultTuples =
         convertResultToString(*result, statement->checkOutputOrder, statement->checkColumnNames);
     for(auto testOutput : resultTuples)

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -187,122 +187,84 @@ void TestRunner::checkPlanResult(Connection& conn, QueryResult* result, TestStat
     }
 }
 
-//void TestRunner::writePlanResult(Connection& /**/, QueryResult* result, TestStatement* statement,
-//    size_t resultIdx) {
-//    TestQueryResult& testAnswer = statement->result[resultIdx];
-//    std::string f;
-//    std::string l;
-//    std::fstream file;
-//    file.open(statement->testFilePath);
-//    while(getline(file, l))
-//        if (l != "-STATEMENT " + statement->query)
-//            f+= l + '\n';
-//        else 
-//        {
-//            f+= l + '\n'; // Add statement (Got in while loop)
-//            getline(file, l); // Get current result specifier
-//            switch (testAnswer.type) 
-//            {
-//
-//                case ResultType::TUPLES:
-//                {
-//                        // PUT RESULT SPECIFIER
-//                        f += "---- " + std::to_string(testAnswer.numTuples + statement->checkColumnNames) + '\n'; // we update tuple count if needed
-//                        // ADD ACTUAL OUTPUT
-//                        std::vector<std::string> resultTuples = convertResultToString(*result, statement->checkOutputOrder, statement->checkColumnNames);
-//
-//                        for(auto& testOutput : resultTuples)
-//                        {
-//                            getline(file, l); // Ignore existing output
-//                            f+= testOutput + '\n';
-//                        }
-//                }
-//                break;
-//
-//                case ResultType::OK:
-//                {
-//                        // GET RESULT SPECIFIER
-//                        f += "---- " + (result->isSuccess() ? std::string("ok") : std::string("error")) +'\n';
-//                }
-//                break;
-//
-//                case ResultType::ERROR_MSG:
-//                {
-//                        // GET RESULT SPECIFIER
-//                        f += "---- " + (result->isSuccess() ? std::string("ok") : std::string("error")) +'\n';
-//                        // IGNORE EXISTING OUTPUT
-//                        getline(file, l);
-//                        // ADD ACTUAL OUTPUT
-//                        f += result->getErrorMessage() + '\n';
-//                }
-//                break;
-//
-//                case ResultType::ERROR_REGEX:
-//                {
-//                        // GET RESULT SPECIFIER
-//                        f += l + '\n';
-//                        // IGNORE EXISTING OUTPUT (non trivial in this case,
-//                        // want to keep the original regex)
-//
-//                        // ADD ACTUAL OUTPUT
-//                        getline(file, l);
-//                        f += l + '\n';
-//                }
-//                break;
-//
-//                case ResultType::HASH:
-//                {
-//                        return;
-//                        // GET RESULT SPECIFIER
-//                        f += l + '\n';
-//                        // IGNORE EXISTING OUTPUT
-//                        getline(file, l);
-//                        // ADD ACTUAL OUTPUT
-//                        std::string resultHash = convertResultToMD5Hash(*result, statement->checkOutputOrder, statement->checkColumnNames);
-//                        f += resultHash;
-//                }
-//                break;
-//
-//                case ResultType::CSV_FILE:
-//                return;
-//            }
-//        }
-//
-//    file.close();
-//    file.open(statement->testFilePath, std::ios::trunc | std::ios::out);
-//    file << f;
-//}
-
-
 void TestRunner::writePlanResult(Connection& /**/, QueryResult* result, TestStatement* statement,
     size_t resultIdx) {
-    std::fstream file;
+    TestQueryResult& testAnswer = statement->result[resultIdx];
     std::string f;
     std::string l;
+    std::fstream file;
     file.open(statement->testFilePath);
     while(getline(file, l))
         if (l != "-STATEMENT " + statement->query)
             f+= l + '\n';
         else 
         {
-            f+= l + '\n'; // Add statement
-            getline(file, l); // Add result specifier
-            f+= l + '\n';
-            TestQueryResult& testAnswer = statement->result[resultIdx];
-            if (testAnswer.type == ResultType::HASH) 
+            f+= l + '\n'; // Add statement (Got in while loop)
+            getline(file, l); // Get current result specifier
+            switch (testAnswer.type) 
             {
-                std::string resultHash = convertResultToMD5Hash(*result, statement->checkOutputOrder,
-                                                                statement->checkColumnNames);
-                f += resultHash;
-                getline(file, l); //ignore Expected
-            } 
-            KU_ASSERT(testAnswer.type == ResultType::TUPLES);
-            std::vector<std::string> resultTuples =
-                convertResultToString(*result, statement->checkOutputOrder, statement->checkColumnNames);
-            for(auto testOutput : resultTuples)
-            {
-                getline(file, l); //ignore Expected
-                f += testOutput + '\n';
+
+                case ResultType::TUPLES:
+                {
+                        // PUT RESULT SPECIFIER
+                        f += "---- " + std::to_string(testAnswer.numTuples + statement->checkColumnNames) + '\n'; // we update tuple count if needed
+                        // ADD ACTUAL OUTPUT
+                        std::vector<std::string> resultTuples = convertResultToString(*result, statement->checkOutputOrder, statement->checkColumnNames);
+
+                        for(auto& testOutput : resultTuples)
+                        {
+                            getline(file, l); // Ignore existing output
+                            f+= testOutput + '\n';
+                        }
+                }
+                break;
+
+                case ResultType::OK:
+                {
+                        // GET RESULT SPECIFIER
+                        f += "---- " + (result->isSuccess() ? std::string("ok") : std::string("error")) +'\n';
+                }
+                break;
+
+                case ResultType::ERROR_MSG:
+                {
+                        // GET RESULT SPECIFIER
+                        f += "---- " + (result->isSuccess() ? std::string("ok") : std::string("error")) +'\n';
+                        // IGNORE EXISTING OUTPUT
+                        getline(file, l);
+                        // ADD ACTUAL OUTPUT
+                        f += result->getErrorMessage() + '\n';
+                }
+                break;
+
+                case ResultType::ERROR_REGEX:
+                {
+                        // GET RESULT SPECIFIER
+                        f += l + '\n';
+                        // IGNORE EXISTING OUTPUT (non trivial in this case,
+                        // want to keep the original regex)
+
+                        // ADD ACTUAL OUTPUT
+                        getline(file, l);
+                        f += l + '\n';
+                }
+                break;
+
+                case ResultType::HASH:
+                {
+                        return;
+                        // GET RESULT SPECIFIER
+                        f += l + '\n';
+                        // IGNORE EXISTING OUTPUT
+                        getline(file, l);
+                        // ADD ACTUAL OUTPUT
+                        std::string resultHash = convertResultToMD5Hash(*result, statement->checkOutputOrder, statement->checkColumnNames);
+                        f += resultHash;
+                }
+                break;
+
+                case ResultType::CSV_FILE:
+                return;
             }
         }
 
@@ -310,8 +272,6 @@ void TestRunner::writePlanResult(Connection& /**/, QueryResult* result, TestStat
     file.open(statement->testFilePath, std::ios::trunc | std::ios::out);
     file << f;
 }
-
-
 
 void TestRunner::outputFailedPlan(Connection& conn, const TestStatement* statement) {
     spdlog::error("QUERY FAILED.");

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -240,11 +240,10 @@ void TestRunner::writePlanResult(Connection& /**/, QueryResult* result, TestStat
     } 
     std::vector<std::string> resultTuples =
         convertResultToString(*result, statement->checkOutputOrder, statement->checkColumnNames);
-    for(size_t i = 0; i < resultTuples.size() - 1; ++i)
-        outFile << resultTuples[i] << '|';
-    if (resultTuples.size())
-        outFile << resultTuples[resultTuples.size() - 1] << std::endl;
-}
+    for(auto testOutput : resultTuples)
+        outFile << testOutput << std::endl;
+    outFile << std::endl;
+ }
 
 
 void TestRunner::outputFailedPlan(Connection& conn, const TestStatement* statement) {

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -203,7 +203,7 @@ void TestRunner::writeOutput(QueryResult* result, TestStatement* statement,
         break;
         case ResultType::TUPLES:
         {
-            f += "---- " + std::to_string(testAnswer.numTuples + statement->checkColumnNames) + '\n';
+            f += "---- " + std::to_string(result->getNumTuples()) + '\n';
             std::vector<std::string> resultTuples = convertResultToString(*result, statement->checkOutputOrder, statement->checkColumnNames);
             for(auto result : resultTuples)
             {
@@ -211,7 +211,7 @@ void TestRunner::writeOutput(QueryResult* result, TestStatement* statement,
             }
         }
         break;
-        case ResultType::CSV_FILE: // TODO
+        case ResultType::CSV_FILE: // not supported yet...
         return;
         case ResultType::ERROR_MSG:
         {

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -199,8 +199,7 @@ void TestRunner::writePlanResult(Connection& /**/, QueryResult* result, TestStat
             f+= l + '\n';
         else 
         {
-            getline(file, l); // Add statement
-            f+= l + '\n';
+            f+= l + '\n'; // Add statement
             getline(file, l); // Add result specifier
             f+= l + '\n';
             TestQueryResult& testAnswer = statement->result[resultIdx];
@@ -219,7 +218,7 @@ void TestRunner::writePlanResult(Connection& /**/, QueryResult* result, TestStat
         }
 
     file.close();
-    file.open(statement->testFilePath, std::ios::trunc);
+    file.open(statement->testFilePath, std::ios::trunc | std::ios::out);
     file << f;
 }
 

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -111,7 +111,7 @@ void TestRunner::checkLogicalPlan(Connection& conn, QueryResult* queryResult,
 void TestRunner::writeLogicalPlan(Connection& conn, QueryResult* queryResult,
     TestStatement* statement, size_t resultIdx) {
     std::ofstream outFile;
-    outFile.open(statement->testFilePath, std::ios::app);
+    outFile.open(statement->testFilePath.substr(0, statement->testFilePath.length() - 4) + "out", std::ios::app);
     if (!outFile.is_open())
     {
         throw TestException("Cannot open file: " + statement->testFilePath);

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -68,7 +68,10 @@ void TestRunner::testStatement(TestStatement* statement, Connection& conn,
     QueryResult* currentQueryResult = actualResult.get();
     idx_t resultIdx = 0u;
     do {
-        TestHelper::REWRITE_TESTS ? writeLogicalPlan(conn, currentQueryResult, statement, resultIdx) : checkLogicalPlan(conn, currentQueryResult, statement, resultIdx);
+        TestHelper::REWRITE_TESTS ?
+            writeLogicalPlan(conn, currentQueryResult, statement, resultIdx) :
+            checkLogicalPlan(conn, currentQueryResult, statement, resultIdx);
+
         currentQueryResult = currentQueryResult->getNextQueryResult();
         resultIdx++;
     } while (currentQueryResult);

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -116,6 +116,7 @@ void TestRunner::writeLogicalPlan(Connection& conn, QueryResult* queryResult,
     {
         throw TestException("Cannot open file: " + statement->testFilePath);
     }
+    outFile << statement->query << std::endl;
     const TestQueryResult& testAnswer =
         statement->result[std::min(resultIdx, statement->result.size() - 1)];
     outFile << "---- ";
@@ -225,15 +226,8 @@ void TestRunner::checkPlanResult(Connection& conn, QueryResult* result, TestStat
 
 
 void TestRunner::writePlanResult(Connection& /**/, QueryResult* result, TestStatement* statement,
-    size_t resultIdx) {
+    size_t resultIdx, std::ofstream& outFile) {
     /* TODO */
-    std::ofstream outFile;
-    outFile.open(statement->testFilePath, std::ios::app);
-    if (!outFile.is_open())
-    {
-        throw TestException("Cannot open file: " + statement->testFilePath);
-    }
-
     TestQueryResult& testAnswer = statement->result[resultIdx];
     if (testAnswer.type == ResultType::CSV_FILE) {
         /*TODO*/

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -239,7 +239,7 @@ void TestRunner::writePlanResult(Connection& /**/, QueryResult* result, TestStat
         outFile << resultHash << std::endl;
         return;
     } 
-    KU_ASSERT(testAnswer.type == ResultType::HASH);
+    KU_ASSERT(testAnswer.type == ResultType::TUPLES);
     std::vector<std::string> resultTuples =
         convertResultToString(*result, statement->checkOutputOrder, statement->checkColumnNames);
     for(auto testOutput : resultTuples)

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -70,7 +70,11 @@ void TestRunner::testStatement(TestStatement* statement, Connection& conn,
     QueryResult* currentQueryResult = actualResult.get();
     idx_t resultIdx = 0u;
     if (TestHelper::REWRITE_TESTS)
+        do {
             writeOutput(currentQueryResult, statement, resultIdx);
+            currentQueryResult = currentQueryResult->getNextQueryResult();
+            resultIdx++;
+        } while (currentQueryResult);
     else
         do {
             checkLogicalPlan(conn, currentQueryResult, statement, resultIdx);
@@ -221,7 +225,7 @@ void TestRunner::writeOutput(QueryResult* result, TestStatement* statement,
         }
         break;
     }
-    statement->newOutput = f;
+    statement->newOutput += f;
 }
 
 void TestRunner::outputFailedPlan(Connection& conn, const TestStatement* statement) {

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -207,14 +207,17 @@ void TestRunner::writePlanResult(Connection& /**/, QueryResult* result, TestStat
             {
                 std::string resultHash = convertResultToMD5Hash(*result, statement->checkOutputOrder,
                                                                 statement->checkColumnNames);
-                f += resultHash + '\n';
+                f += resultHash;
+                getline(file, l); //ignore Expected
             } 
             KU_ASSERT(testAnswer.type == ResultType::TUPLES);
             std::vector<std::string> resultTuples =
                 convertResultToString(*result, statement->checkOutputOrder, statement->checkColumnNames);
             for(auto testOutput : resultTuples)
+            {
+                getline(file, l); //ignore Expected
                 f += testOutput + '\n';
-            f += '\n';
+            }
         }
 
     file.close();

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -197,77 +197,28 @@ void TestRunner::writePlanResult(Connection& /**/, QueryResult* result, TestStat
     while(getline(file, l))
         if (l != "-STATEMENT " + statement->query)
             f+= l + '\n';
-        else 
+        else
         {
-            f+= l + '\n'; // Add statement (Got in while loop)
-            getline(file, l); // Get current result specifier
-            switch (testAnswer.type) 
+            f += l + '\n';
+            getline(file, l); // result form specifier
+            f += l + '\n';
+            if (testAnswer.type == ResultType::TUPLES)
             {
-
-                case ResultType::TUPLES:
+                std::vector<std::string> resultTuples = convertResultToString(*result, statement->checkOutputOrder, statement->checkColumnNames);
+                for(auto result : resultTuples)
                 {
-                        // PUT RESULT SPECIFIER
-                        f += "---- " + std::to_string(testAnswer.numTuples + statement->checkColumnNames) + '\n'; // we update tuple count if needed
-                        // ADD ACTUAL OUTPUT
-                        std::vector<std::string> resultTuples = convertResultToString(*result, statement->checkOutputOrder, statement->checkColumnNames);
-
-                        for(auto& testOutput : resultTuples)
-                        {
-                            getline(file, l); // Ignore existing output
-                            f+= testOutput + '\n';
-                        }
+                    getline(file, l);
+                    f+= result + '\n';
                 }
-                break;
-
-                case ResultType::OK:
-                {
-                        // GET RESULT SPECIFIER
-                        f += "---- " + (result->isSuccess() ? std::string("ok") : std::string("error")) +'\n';
-                }
-                break;
-
-                case ResultType::ERROR_MSG:
-                {
-                        // GET RESULT SPECIFIER
-                        f += "---- " + (result->isSuccess() ? std::string("ok") : std::string("error")) +'\n';
-                        // IGNORE EXISTING OUTPUT
-                        getline(file, l);
-                        // ADD ACTUAL OUTPUT
-                        f += result->getErrorMessage() + '\n';
-                }
-                break;
-
-                case ResultType::ERROR_REGEX:
-                {
-                        // GET RESULT SPECIFIER
-                        f += l + '\n';
-                        // IGNORE EXISTING OUTPUT (non trivial in this case,
-                        // want to keep the original regex)
-
-                        // ADD ACTUAL OUTPUT
-                        getline(file, l);
-                        f += l + '\n';
-                }
-                break;
-
-                case ResultType::HASH:
-                {
-                        return;
-                        // GET RESULT SPECIFIER
-                        f += l + '\n';
-                        // IGNORE EXISTING OUTPUT
-                        getline(file, l);
-                        // ADD ACTUAL OUTPUT
-                        std::string resultHash = convertResultToMD5Hash(*result, statement->checkOutputOrder, statement->checkColumnNames);
-                        f += resultHash;
-                }
-                break;
-
-                case ResultType::CSV_FILE:
-                return;
+                f += '\n';
+            }
+            else if (testAnswer.type == ResultType::HASH)
+            {
+                std::string resultHash = convertResultToMD5Hash(*result, statement->checkOutputOrder, statement->checkColumnNames);
+                f += resultHash;
+                getline(file, l);
             }
         }
-
     file.close();
     file.open(statement->testFilePath, std::ios::trunc | std::ios::out);
     file << f;

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -70,7 +70,7 @@ void TestRunner::testStatement(TestStatement* statement, Connection& conn,
     QueryResult* currentQueryResult = actualResult.get();
     idx_t resultIdx = 0u;
     if (TestHelper::REWRITE_TESTS)
-            writeLogicalPlan(conn, currentQueryResult, statement, resultIdx);
+            writeOutput(currentQueryResult, statement, resultIdx);
     else
         do {
             checkLogicalPlan(conn, currentQueryResult, statement, resultIdx);
@@ -108,16 +108,6 @@ void TestRunner::checkLogicalPlan(Connection& conn, QueryResult* queryResult,
     }
     }
 }
-
-void TestRunner::writeLogicalPlan(Connection& conn, QueryResult* queryResult,
-    TestStatement* statement, size_t resultIdx) {
-    (void)conn;
-    (void)queryResult;
-    (void)statement;
-    (void)resultIdx;
-    writePlanResult(conn, queryResult, statement, resultIdx);
-}
-
 
 void TestRunner::checkPlanResult(Connection& conn, QueryResult* result, TestStatement* statement,
     size_t resultIdx) {
@@ -187,7 +177,7 @@ void TestRunner::checkPlanResult(Connection& conn, QueryResult* result, TestStat
     }
 }
 
-void TestRunner::writePlanResult(Connection& /**/, QueryResult* result, TestStatement* statement,
+void TestRunner::writeOutput(QueryResult* result, TestStatement* statement,
     size_t resultIdx) {
     TestQueryResult& testAnswer = statement->result[resultIdx];
     statement->testResultType = testAnswer.type;


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue (if applicable). Please also include
relevant motivation and context.

This PR proposes an augmentation to the test runner. Providing the flag E2E_REWRITE_TESTS=1 (or equivalent) will change the functionality of the runner. Rather than running a diff after a test is complete, the runner will save the produced output and write it back out to the test file after tests are done. This process should simplify test writing. 

Fixes #5188 

# Contributor agreement

- [X] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).