### PR TITLE
Reclaim space for all structures in data.kz file

### DIFF
--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -36,22 +36,23 @@ namespace kuzu {
 namespace function {
 
 #define SCALAR_FUNCTION_BASE(_PARAM, _NAME)                                                        \
-    {_PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
 #define SCALAR_FUNCTION(_PARAM) SCALAR_FUNCTION_BASE(_PARAM, _PARAM::name)
 #define SCALAR_FUNCTION_ALIAS(_PARAM) SCALAR_FUNCTION_BASE(_PARAM::alias, _PARAM::name)
 #define REWRITE_FUNCTION_BASE(_PARAM, _NAME)                                                       \
-    {_PARAM::getFunctionSet, _NAME, CatalogEntryType::REWRITE_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _NAME, CatalogEntryType::REWRITE_FUNCTION_ENTRY }
 #define REWRITE_FUNCTION(_PARAM) REWRITE_FUNCTION_BASE(_PARAM, _PARAM::name)
 #define REWRITE_FUNCTION_ALIAS(_PARAM) REWRITE_FUNCTION_BASE(_PARAM::alias, _PARAM::name)
 #define AGGREGATE_FUNCTION(_PARAM)                                                                 \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY }
 #define EXPORT_FUNCTION(_PARAM)                                                                    \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY }
 #define TABLE_FUNCTION(_PARAM)                                                                     \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY }
 #define STANDALONE_TABLE_FUNCTION(_PARAM)                                                          \
-    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY}
-#define FINAL_FUNCTION {nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
+    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY }
+#define FINAL_FUNCTION                                                                             \
+    { nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
 
 FunctionCollection* FunctionCollection::getFunctions() {
     static FunctionCollection functions[] = {

--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -36,23 +36,22 @@ namespace kuzu {
 namespace function {
 
 #define SCALAR_FUNCTION_BASE(_PARAM, _NAME)                                                        \
-    { _PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
 #define SCALAR_FUNCTION(_PARAM) SCALAR_FUNCTION_BASE(_PARAM, _PARAM::name)
 #define SCALAR_FUNCTION_ALIAS(_PARAM) SCALAR_FUNCTION_BASE(_PARAM::alias, _PARAM::name)
 #define REWRITE_FUNCTION_BASE(_PARAM, _NAME)                                                       \
-    { _PARAM::getFunctionSet, _NAME, CatalogEntryType::REWRITE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _NAME, CatalogEntryType::REWRITE_FUNCTION_ENTRY}
 #define REWRITE_FUNCTION(_PARAM) REWRITE_FUNCTION_BASE(_PARAM, _PARAM::name)
 #define REWRITE_FUNCTION_ALIAS(_PARAM) REWRITE_FUNCTION_BASE(_PARAM::alias, _PARAM::name)
 #define AGGREGATE_FUNCTION(_PARAM)                                                                 \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY}
 #define EXPORT_FUNCTION(_PARAM)                                                                    \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY}
 #define TABLE_FUNCTION(_PARAM)                                                                     \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY}
 #define STANDALONE_TABLE_FUNCTION(_PARAM)                                                          \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY }
-#define FINAL_FUNCTION                                                                             \
-    { nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY}
+#define FINAL_FUNCTION {nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
 
 FunctionCollection* FunctionCollection::getFunctions() {
     static FunctionCollection functions[] = {
@@ -226,7 +225,7 @@ FunctionCollection* FunctionCollection::getFunctions() {
         TABLE_FUNCTION(StatsInfoFunction), TABLE_FUNCTION(StorageInfoFunction),
         TABLE_FUNCTION(ShowAttachedDatabasesFunction), TABLE_FUNCTION(ShowSequencesFunction),
         TABLE_FUNCTION(ShowFunctionsFunction), TABLE_FUNCTION(BMInfoFunction),
-        TABLE_FUNCTION(ShowLoadedExtensionsFunction),
+        TABLE_FUNCTION(FileInfoFunction), TABLE_FUNCTION(ShowLoadedExtensionsFunction),
         TABLE_FUNCTION(ShowOfficialExtensionsFunction), TABLE_FUNCTION(ShowIndexesFunction),
         TABLE_FUNCTION(ShowProjectedGraphsFunction),
 

--- a/src/function/table/CMakeLists.txt
+++ b/src/function/table/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(kuzu_table_function
         current_setting.cpp
         db_version.cpp
         drop_project_graph.cpp
+        file_info.cpp
         free_space_info.cpp
         show_attached_databases.cpp
         show_connection.cpp

--- a/src/function/table/file_info.cpp
+++ b/src/function/table/file_info.cpp
@@ -1,0 +1,54 @@
+#include "binder/binder.h"
+#include "function/table/bind_data.h"
+#include "function/table/simple_table_function.h"
+#include "main/client_context.h"
+#include "main/database.h"
+#include "storage/storage_manager.h"
+
+namespace kuzu {
+namespace function {
+
+struct FileInfoBindData final : TableFuncBindData {
+    uint64_t numPages;
+
+    FileInfoBindData(uint64_t numPages, binder::expression_vector columns)
+        : TableFuncBindData{std::move(columns), 1}, numPages(numPages) {}
+
+    std::unique_ptr<TableFuncBindData> copy() const override {
+        return std::make_unique<FileInfoBindData>(numPages, columns);
+    }
+};
+
+static common::offset_t internalTableFunc(const TableFuncMorsel& /*morsel*/,
+    const TableFuncInput& input, common::DataChunk& output) {
+    KU_ASSERT(output.getNumValueVectors() == 1);
+    auto fileInfoBindData = input.bindData->constPtrCast<FileInfoBindData>();
+    output.getValueVectorMutable(0).setValue<uint64_t>(0, fileInfoBindData->numPages);
+    return 1;
+}
+
+static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* context,
+    const TableFuncBindInput* input) {
+    auto numPages = context->getStorageManager()->getDataFH()->getNumPages();
+    std::vector<common::LogicalType> returnTypes;
+    returnTypes.emplace_back(common::LogicalType::UINT64());
+    auto returnColumnNames = std::vector<std::string>{"num_pages"};
+    returnColumnNames =
+        TableFunction::extractYieldVariables(returnColumnNames, input->yieldVariables);
+    auto columns = input->binder->createVariables(returnColumnNames, returnTypes);
+    return std::make_unique<FileInfoBindData>(numPages, columns);
+}
+
+function_set FileInfoFunction::getFunctionSet() {
+    function_set functionSet;
+    auto function = std::make_unique<TableFunction>(name, std::vector<common::LogicalTypeID>{});
+    function->tableFunc = SimpleTableFunc::getTableFunc(internalTableFunc);
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = SimpleTableFunc::initSharedState;
+    function->initLocalStateFunc = TableFunction::initEmptyLocalState;
+    functionSet.push_back(std::move(function));
+    return functionSet;
+}
+
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/table/simple_table_function.h
+++ b/src/include/function/table/simple_table_function.h
@@ -122,6 +122,12 @@ struct BMInfoFunction final {
     static function_set getFunctionSet();
 };
 
+struct FileInfoFunction final {
+    static constexpr const char* name = "FILE_INFO";
+
+    static function_set getFunctionSet();
+};
+
 struct ShowAttachedDatabasesFunction final {
     static constexpr const char* name = "SHOW_ATTACHED_DATABASES";
 

--- a/src/include/storage/checkpointer.h
+++ b/src/include/storage/checkpointer.h
@@ -10,9 +10,14 @@ class AttachedKuzuDatabase;
 
 namespace storage {
 
+class PageManager;
+
 struct DatabaseHeader {
     PageRange catalogPageRange;
     PageRange metadataPageRange;
+
+    void updateCatalogPageRange(PageManager& pageManager, PageRange newPageRange);
+    void updateMetadataPageRange(PageManager& pageManager, PageRange newPageRange);
 };
 
 class Checkpointer {

--- a/src/include/storage/disk_array.h
+++ b/src/include/storage/disk_array.h
@@ -17,7 +17,7 @@
 
 namespace kuzu {
 namespace storage {
-
+class PageManager;
 class FileHandle;
 class BufferManager;
 
@@ -46,7 +46,11 @@ struct PageStorageInfo {
 
 // TODO(bmwinger): this should use the memoryManager
 struct PIP {
-    PIP() : nextPipPageIdx{ShadowUtils::NULL_PAGE_IDX}, pageIdxs{} {}
+    PIP() : nextPipPageIdx{ShadowUtils::NULL_PAGE_IDX}, pageIdxs{} {
+        for (auto& pageIdx : pageIdxs) {
+            pageIdx = ShadowUtils::NULL_PAGE_IDX;
+        }
+    }
 
     common::page_idx_t nextPipPageIdx;
     common::page_idx_t pageIdxs[NUM_PAGE_IDXS_PER_PIP];
@@ -132,6 +136,8 @@ public:
     }
 
     void checkpoint();
+
+    void reclaimStorage(PageManager& pageManager) const;
 
     // Write WriteIterator for making fast bulk changes to the disk array
     // The pages are cached while the elements are stored on the same page
@@ -298,6 +304,9 @@ public:
     inline void checkpointInMemoryIfNecessary() { diskArray.checkpointInMemoryIfNecessary(); }
     inline void rollbackInMemoryIfNecessary() { diskArray.rollbackInMemoryIfNecessary(); }
     inline void checkpoint() { diskArray.checkpoint(); }
+    inline void reclaimStorage(PageManager& pageManager) const {
+        diskArray.reclaimStorage(pageManager);
+    }
 
     class WriteIterator {
     public:

--- a/src/include/storage/disk_array_collection.h
+++ b/src/include/storage/disk_array_collection.h
@@ -47,6 +47,8 @@ public:
         }
     }
 
+    void reclaimStorage(PageManager& pageManager, common::page_idx_t firstHeaderPage) const;
+
     template<typename T>
     std::unique_ptr<DiskArray<T>> getDiskArray(uint32_t idx) {
         KU_ASSERT(idx < numHeaders);

--- a/src/include/storage/file_handle.h
+++ b/src/include/storage/file_handle.h
@@ -78,8 +78,11 @@ public:
     uint8_t* getFrame(common::page_idx_t pageIdx);
     PageState* getPageState(common::page_idx_t pageIdx) { return &pageStates[pageIdx]; }
 
+    // Pages added through these APIs are not tracked by the FSM
+    // If allocating pages from the data.kz file it's recommended to do so using the PageManager
     common::page_idx_t addNewPage();
     common::page_idx_t addNewPages(common::page_idx_t numNewPages);
+
     void removePageIdxAndTruncateIfNecessary(common::page_idx_t pageIdx);
     void removePageFromFrameIfNecessary(common::page_idx_t pageIdx);
     void flushAllDirtyPagesInFrames();

--- a/src/include/storage/local_storage/local_node_table.h
+++ b/src/include/storage/local_storage/local_node_table.h
@@ -53,7 +53,7 @@ private:
 private:
     PageCursor overflowCursor;
     std::unique_ptr<OverflowFile> overflowFile;
-    std::unique_ptr<OverflowFileHandle> overflowFileHandle;
+    OverflowFileHandle* overflowFileHandle;
     std::unique_ptr<LocalHashIndex> hashIndex;
     NodeGroupCollection nodeGroups;
 };

--- a/src/include/storage/page_manager.h
+++ b/src/include/storage/page_manager.h
@@ -27,7 +27,9 @@ public:
     void resetVersion() { version = 0; }
 
     PageRange allocatePageRange(common::page_idx_t numPages);
+    common::page_idx_t allocatePage() { return allocatePageRange(1).startPageIdx; }
     void freePageRange(PageRange block);
+    void freePage(common::page_idx_t pageIdx) { freePageRange(PageRange(pageIdx, 1)); }
 
     void serialize(common::Serializer& serializer);
     void deserialize(common::Deserializer& deSer);

--- a/src/include/storage/table/chunked_node_group.h
+++ b/src/include/storage/table/chunked_node_group.h
@@ -153,8 +153,7 @@ public:
         common::transaction_t commitTS);
     void rollbackDelete(common::row_idx_t startRow, common::row_idx_t numRows_,
         common::transaction_t commitTS);
-    virtual void reclaimStorage(FileHandle& dataFH);
-    void reclaimColumn(FileHandle& dataFH, common::column_id_t columnID);
+    virtual void reclaimStorage(PageManager& pageManager) const;
 
     uint64_t getEstimatedMemoryUsage() const;
 

--- a/src/include/storage/table/column_chunk.h
+++ b/src/include/storage/table/column_chunk.h
@@ -101,7 +101,7 @@ public:
     MergedColumnChunkStats getMergedColumnChunkStats(
         const transaction::Transaction* transaction) const;
 
-    void reclaimStorage(FileHandle& dataFH);
+    void reclaimStorage(PageManager& pageManager) const;
 
 private:
     void scanCommittedUpdates(const transaction::Transaction* transaction, ColumnChunkData& output,

--- a/src/include/storage/table/column_chunk_data.h
+++ b/src/include/storage/table/column_chunk_data.h
@@ -17,6 +17,9 @@
 #include "storage/table/column_reader_writer.h"
 #include "storage/table/in_memory_exception_chunk.h"
 
+namespace kuzu::storage {
+class PageManager;
+}
 namespace kuzu {
 namespace evaluator {
 class ExpressionEvaluator;
@@ -236,7 +239,7 @@ public:
 
     void updateStats(const common::ValueVector* vector, const common::SelectionView& selVector);
 
-    virtual void reclaimStorage(FileHandle& dataFH);
+    virtual void reclaimStorage(PageManager& pageManager);
 
 protected:
     // Initializes the data buffer and functions. They are (and should be) only called in

--- a/src/include/storage/table/csr_chunked_node_group.h
+++ b/src/include/storage/table/csr_chunked_node_group.h
@@ -130,7 +130,7 @@ public:
         transaction::Transaction* transaction, FileHandle& dataFH) const override;
 
     void flush(FileHandle& dataFH) override;
-    void reclaimStorage(FileHandle& dataFH) override;
+    void reclaimStorage(PageManager& pageManager) const override;
 
     // this does not override ChunkedNodeGroup::merge() since clang-tidy analyzer
     // seems to struggle with detecting the std::move of the header unless this is inlined

--- a/src/include/storage/table/csr_node_group.h
+++ b/src/include/storage/table/csr_node_group.h
@@ -210,7 +210,7 @@ public:
         FileHandle* dataFH, ColumnStats* newColumnStats) override;
 
     void checkpoint(MemoryManager& memoryManager, NodeGroupCheckpointState& state) override;
-    void reclaimStorage(FileHandle& dataFH, const common::UniqLock& lock) const override;
+    void reclaimStorage(PageManager& pageManager, const common::UniqLock& lock) const override;
 
     bool isEmpty() const override { return !persistentChunkGroup && NodeGroup::isEmpty(); }
 

--- a/src/include/storage/table/list_chunk_data.h
+++ b/src/include/storage/table/list_chunk_data.h
@@ -107,7 +107,7 @@ public:
     static void deserialize(common::Deserializer& deSer, ColumnChunkData& chunkData);
 
     void flush(FileHandle& dataFH) override;
-    void reclaimStorage(FileHandle& dataFH) override;
+    void reclaimStorage(PageManager& pageManager) override;
 
 protected:
     void copyListValues(const common::list_entry_t& entry, common::ValueVector* dataVector);

--- a/src/include/storage/table/node_group.h
+++ b/src/include/storage/table/node_group.h
@@ -159,8 +159,8 @@ public:
     void applyFuncToChunkedGroups(version_record_handler_op_t func, common::row_idx_t startRow,
         common::row_idx_t numRows, common::transaction_t commitTS) const;
     void rollbackInsert(common::row_idx_t startRow);
-    void reclaimStorage(FileHandle& dataFH);
-    virtual void reclaimStorage(FileHandle& dataFH, const common::UniqLock& lock) const;
+    void reclaimStorage(PageManager& pageManager) const;
+    virtual void reclaimStorage(PageManager& pageManager, const common::UniqLock& lock) const;
 
     virtual void checkpoint(MemoryManager& memoryManager, NodeGroupCheckpointState& state);
 

--- a/src/include/storage/table/node_group_collection.h
+++ b/src/include/storage/table/node_group_collection.h
@@ -76,7 +76,7 @@ public:
     uint64_t getEstimatedMemoryUsage() const;
 
     void checkpoint(MemoryManager& memoryManager, NodeGroupCheckpointState& state);
-    void reclaimStorage(FileHandle& dataFH);
+    void reclaimStorage(PageManager& pageManager) const;
 
     TableStats getStats() const {
         auto lock = nodeGroups.lock();

--- a/src/include/storage/table/node_table.h
+++ b/src/include/storage/table/node_table.h
@@ -193,7 +193,7 @@ public:
         LocalTable* localTable) override;
     bool checkpoint(catalog::TableCatalogEntry* tableEntry) override;
     void rollbackCheckpoint() override;
-    void reclaimStorage(FileHandle& dataFH) override;
+    void reclaimStorage(PageManager& pageManager) const override;
 
     void rollbackPKIndexInsert(transaction::Transaction* transaction, common::row_idx_t startRow,
         common::row_idx_t numRows_, common::node_group_idx_t nodeGroupIdx_);

--- a/src/include/storage/table/rel_table.h
+++ b/src/include/storage/table/rel_table.h
@@ -198,7 +198,7 @@ public:
         LocalTable* localTable) override;
     bool checkpoint(catalog::TableCatalogEntry* tableEntry) override;
     void rollbackCheckpoint() override {};
-    void reclaimStorage(FileHandle& dataFH) override;
+    void reclaimStorage(PageManager& pageManager) const override;
 
     common::row_idx_t getNumTotalRows(const transaction::Transaction* transaction) override;
 

--- a/src/include/storage/table/rel_table_data.h
+++ b/src/include/storage/table/rel_table_data.h
@@ -97,7 +97,7 @@ public:
 
     TableStats getStats() const { return nodeGroups->getStats(); }
 
-    void reclaimStorage(FileHandle& dataFH);
+    void reclaimStorage(PageManager& pageManager) const;
     void checkpoint(const std::vector<common::column_id_t>& columnIDs);
 
     void pushInsertInfo(const transaction::Transaction* transaction, const CSRNodeGroup& nodeGroup,

--- a/src/include/storage/table/string_chunk_data.h
+++ b/src/include/storage/table/string_chunk_data.h
@@ -61,7 +61,7 @@ public:
     void finalize() override;
 
     void flush(FileHandle& dataFH) override;
-    void reclaimStorage(FileHandle& dataFH) override;
+    void reclaimStorage(PageManager& pageManager) override;
 
     void resetNumValuesFromMetadata() override;
     void syncNumValues() override {

--- a/src/include/storage/table/struct_chunk_data.h
+++ b/src/include/storage/table/struct_chunk_data.h
@@ -49,7 +49,7 @@ public:
     }
 
     void flush(FileHandle& dataFH) override;
-    void reclaimStorage(FileHandle& dataFH) override;
+    void reclaimStorage(PageManager& pageManager) override;
 
 protected:
     void append(ColumnChunkData* other, common::offset_t startPosInOtherChunk,

--- a/src/include/storage/table/table.h
+++ b/src/include/storage/table/table.h
@@ -169,7 +169,7 @@ public:
         catalog::TableCatalogEntry* tableEntry, LocalTable* localTable) = 0;
     virtual bool checkpoint(catalog::TableCatalogEntry* tableEntry) = 0;
     virtual void rollbackCheckpoint() = 0;
-    virtual void reclaimStorage(FileHandle& dataFH) = 0;
+    virtual void reclaimStorage(PageManager& pageManager) const = 0;
 
     virtual common::row_idx_t getNumTotalRows(const transaction::Transaction* transaction) = 0;
 

--- a/src/storage/disk_array.cpp
+++ b/src/storage/disk_array.cpp
@@ -223,9 +223,6 @@ void DiskArrayInternal::checkpointOrRollbackInMemoryIfNecessaryNoLock(bool isChe
         clearWALPageVersionAndRemovePageFromFrameIfNecessary(newPIP.pipPageIdx);
         if (isCheckpoint) {
             pips.emplace_back(newPIP);
-        } else {
-            // These are newly inserted pages, so we can truncate the file handle.
-            this->fileHandle.removePageIdxAndTruncateIfNecessary(newPIP.pipPageIdx);
         }
     }
     // Note that we already updated the header to its correct state above.

--- a/src/storage/free_space_manager.cpp
+++ b/src/storage/free_space_manager.cpp
@@ -16,7 +16,7 @@ static FreeSpaceManager::sorted_free_list_t& getFreeList(
     return freeLists[level];
 }
 
-FreeSpaceManager::FreeSpaceManager() : freeLists{}, numEntries(0){};
+FreeSpaceManager::FreeSpaceManager() : freeLists{}, numEntries(0) {};
 
 common::idx_t FreeSpaceManager::getLevel(common::page_idx_t numPages) {
     // level is exponent of largest power of 2 that is <= numPages
@@ -162,6 +162,7 @@ void FreeSpaceManager::mergePageRanges(free_list_t newInitialEntries, FileHandle
     PageRange prevEntry = allEntries[0];
     for (common::row_idx_t i = 1; i < allEntries.size(); ++i) {
         const auto& entry = allEntries[i];
+        KU_ASSERT(prevEntry.startPageIdx + prevEntry.numPages <= entry.startPageIdx);
         if (prevEntry.startPageIdx + prevEntry.numPages == entry.startPageIdx) {
             prevEntry.numPages += entry.numPages;
         } else {

--- a/src/storage/free_space_manager.cpp
+++ b/src/storage/free_space_manager.cpp
@@ -16,7 +16,7 @@ static FreeSpaceManager::sorted_free_list_t& getFreeList(
     return freeLists[level];
 }
 
-FreeSpaceManager::FreeSpaceManager() : freeLists{}, numEntries(0) {};
+FreeSpaceManager::FreeSpaceManager() : freeLists{}, numEntries(0){};
 
 common::idx_t FreeSpaceManager::getLevel(common::page_idx_t numPages) {
     // level is exponent of largest power of 2 that is <= numPages

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -676,7 +676,9 @@ void PrimaryKeyIndex::reclaimStorage(PageManager& pageManager) const {
 }
 
 page_idx_t PrimaryKeyIndex::getDiskArrayFirstHeaderPage() const {
-    return getFirstHeaderPage() + NUM_HEADER_PAGES;
+    const auto firstHeaderPage = getFirstHeaderPage();
+    return firstHeaderPage == INVALID_PAGE_IDX ? INVALID_PAGE_IDX :
+                                                 firstHeaderPage + NUM_HEADER_PAGES;
 }
 
 page_idx_t PrimaryKeyIndex::getFirstHeaderPage() const {

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -673,7 +673,10 @@ void PrimaryKeyIndex::reclaimStorage(PageManager& pageManager) const {
     if (overflowFile) {
         overflowFile->reclaimStorage(pageManager);
     }
-    fileHandle->getPageManager()->freePageRange({getFirstHeaderPage(), NUM_HEADER_PAGES});
+    const auto firstHeaderPage = getFirstHeaderPage();
+    if (firstHeaderPage != INVALID_PAGE_IDX) {
+        fileHandle->getPageManager()->freePageRange({getFirstHeaderPage(), NUM_HEADER_PAGES});
+    }
 }
 
 page_idx_t PrimaryKeyIndex::getDiskArrayFirstHeaderPage() const {

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -155,7 +155,7 @@ void HashIndex<T>::splitSlots(const Transaction* transaction, HashIndexHeader& h
         Slot<T>* originalSlot = &*originalSlotIterator.seek(header.nextSplitSlotId);
         do {
             for (entry_pos_t originalEntryPos = 0; originalEntryPos < getSlotCapacity<T>();
-                originalEntryPos++) {
+                 originalEntryPos++) {
                 if (!originalSlot->header.isEntryValid(originalEntryPos)) {
                     continue; // Skip invalid entries.
                 }
@@ -301,9 +301,10 @@ void HashIndex<T>::mergeBulkInserts(const Transaction* transaction,
     // may not be consecutive, but we reduce the memory overhead for storing the information about
     // the sorted data and still just process each page once.
     for (uint64_t localSlotId = 0; localSlotId < insertLocalStorage.numPrimarySlots();
-        localSlotId += NUM_SLOTS_PER_PAGE) {
+         localSlotId += NUM_SLOTS_PER_PAGE) {
         for (size_t i = 0;
-            i < NUM_SLOTS_PER_PAGE && localSlotId + i < insertLocalStorage.numPrimarySlots(); i++) {
+             i < NUM_SLOTS_PER_PAGE && localSlotId + i < insertLocalStorage.numPrimarySlots();
+             i++) {
             auto localSlot =
                 typename InMemHashIndex<T>::SlotIterator(localSlotId + i, &insertLocalStorage);
             partitionedEntries[i].clear();
@@ -464,7 +465,7 @@ PrimaryKeyIndex::PrimaryKeyIndex(IndexInfo indexInfo, std::unique_ptr<IndexStora
                 [&](auto* frame) {
                     const auto onDiskHeaders = reinterpret_cast<HashIndexHeaderOnDisk*>(frame);
                     for (size_t i = 0; i < INDEX_HEADERS_PER_PAGE && headerIdx < NUM_HASH_INDEXES;
-                        i++) {
+                         i++) {
                         hashIndexHeadersForReadTrx.emplace_back(onDiskHeaders[i]);
                         headerIdx++;
                     }
@@ -608,7 +609,7 @@ void PrimaryKeyIndex::writeHeaders() const {
             [&](auto* frame) {
                 const auto onDiskFrame = reinterpret_cast<HashIndexHeaderOnDisk*>(frame);
                 for (size_t i = 0; i < INDEX_HEADERS_PER_PAGE && headerIdx < NUM_HASH_INDEXES;
-                    i++) {
+                     i++) {
                     hashIndexHeadersForWriteTrx[headerIdx++].write(onDiskFrame[i]);
                 }
             });

--- a/src/storage/overflow_file.cpp
+++ b/src/storage/overflow_file.cpp
@@ -158,15 +158,12 @@ void OverflowFileHandle::reclaimStorage(PageManager& pageManager) {
             break;
         }
 
-        if (pageWriteCache.contains(pageIdx)) {
-            pageIdx =
-                *reinterpret_cast<page_idx_t*>(pageWriteCache.at(pageIdx)->getData() + END_OF_PAGE);
-        } else {
-            overflowFile.readFromDisk(TransactionType::CHECKPOINT, pageIdx,
-                [&pageIdx](auto* frame) {
-                    pageIdx = *reinterpret_cast<page_idx_t*>(frame + END_OF_PAGE);
-                });
-        }
+        // reclaimStorage() is only called after the hash index is checkpointed
+        // so the page write cache should always be cleared
+        KU_ASSERT(!pageWriteCache.contains(pageIdx));
+        overflowFile.readFromDisk(TransactionType::CHECKPOINT, pageIdx, [&pageIdx](auto* frame) {
+            pageIdx = *reinterpret_cast<page_idx_t*>(frame + END_OF_PAGE);
+        });
     }
 }
 

--- a/src/storage/overflow_file.cpp
+++ b/src/storage/overflow_file.cpp
@@ -74,6 +74,9 @@ uint8_t* OverflowFileHandle::addANewPage() {
         memcpy(pageWriteCache[nextPosToWriteTo.pageIdx]->getData() + END_OF_PAGE, &newPageIdx,
             sizeof(page_idx_t));
     }
+    if (startPageIdx == INVALID_PAGE_IDX) {
+        startPageIdx = newPageIdx;
+    }
     pageWriteCache.emplace(newPageIdx,
         overflowFile.memoryManager.allocateBuffer(true /*initializeToZero*/, KUZU_PAGE_SIZE));
     nextPosToWriteTo.elemPosInPage = 0;
@@ -138,6 +141,35 @@ void OverflowFileHandle::checkpoint() {
     }
 }
 
+void OverflowFileHandle::reclaimStorage(PageManager& pageManager) {
+    if (startPageIdx == INVALID_PAGE_IDX) {
+        return;
+    }
+
+    auto pageIdx = startPageIdx;
+    while (true) {
+        if (pageIdx == 0 || pageIdx == INVALID_PAGE_IDX) [[unlikely]] {
+            throw RuntimeException(
+                "The overflow file has been corrupted, this should never happen.");
+        }
+        pageManager.freePage(pageIdx);
+
+        if (pageIdx == nextPosToWriteTo.pageIdx) {
+            break;
+        }
+
+        if (pageWriteCache.contains(pageIdx)) {
+            pageIdx =
+                *reinterpret_cast<page_idx_t*>(pageWriteCache.at(pageIdx)->getData() + END_OF_PAGE);
+        } else {
+            overflowFile.readFromDisk(TransactionType::CHECKPOINT, pageIdx,
+                [&pageIdx](auto* frame) {
+                    pageIdx = *reinterpret_cast<page_idx_t*>(frame + END_OF_PAGE);
+                });
+        }
+    }
+}
+
 void OverflowFileHandle::read(TransactionType trxType, page_idx_t pageIdx,
     const std::function<void(uint8_t*)>& func) const {
     auto cachedPage = pageWriteCache.find(pageIdx);
@@ -169,7 +201,7 @@ OverflowFile::OverflowFile(FileHandle* dataFH, MemoryManager& memoryManager)
         numPagesOnDisk = fileHandle->getNumPages();
     }
     // Reserve a page for the header
-    getNewPageIdx();
+    this->headerPageIdx = getNewPageIdx();
     header = StringOverflowFileHeader();
 }
 
@@ -221,7 +253,16 @@ void OverflowFile::rollbackInMemory() {
     }
     for (auto i = 0u; i < handles.size(); i++) {
         auto& handle = handles[i];
-        handle->rollbackInMemory(header.cursors[i]);
+        handle->rollbackInMemory(header.entries[i].cursor);
+    }
+}
+
+void OverflowFile::reclaimStorage(PageManager& pageManager) const {
+    for (auto& handle : handles) {
+        handle->reclaimStorage(pageManager);
+    }
+    if (headerPageIdx != INVALID_PAGE_IDX) {
+        fileHandle->getPageManager()->freePage(headerPageIdx);
     }
 }
 

--- a/src/storage/page_manager.cpp
+++ b/src/storage/page_manager.cpp
@@ -2,7 +2,6 @@
 
 #include "common/uniq_lock.h"
 #include "storage/file_handle.h"
-#include "storage/shadow_utils.h"
 
 namespace kuzu::storage {
 static constexpr bool ENABLE_FSM = true;

--- a/src/storage/shadow_utils.cpp
+++ b/src/storage/shadow_utils.cpp
@@ -51,7 +51,7 @@ std::pair<FileHandle*, page_idx_t> ShadowUtils::getFileHandleAndPhysicalPageIdxT
 page_idx_t ShadowUtils::insertNewPage(FileHandle& fileHandle, ShadowFile& shadowFile,
     const std::function<void(uint8_t*)>& insertOp) {
     KU_ASSERT(!fileHandle.isInMemoryMode());
-    const auto newOriginalPage = fileHandle.addNewPage();
+    const auto newOriginalPage = fileHandle.getPageManager()->allocatePage();
     KU_ASSERT(!shadowFile.hasShadowPage(fileHandle.getFileIndex(), newOriginalPage));
     const auto shadowPage =
         shadowFile.getOrCreateShadowPage(fileHandle.getFileIndex(), newOriginalPage);

--- a/src/storage/table/chunked_node_group.cpp
+++ b/src/storage/table/chunked_node_group.cpp
@@ -498,16 +498,12 @@ void ChunkedNodeGroup::rollbackDelete(row_idx_t startRow, row_idx_t numRows_, tr
     versionInfo->rollbackDelete(startRow, numRows_);
 }
 
-void ChunkedNodeGroup::reclaimStorage(FileHandle& dataFH) {
+void ChunkedNodeGroup::reclaimStorage(PageManager& pageManager) const {
     for (auto& columnChunk : chunks) {
         if (columnChunk) {
-            columnChunk->reclaimStorage(dataFH);
+            columnChunk->reclaimStorage(pageManager);
         }
     }
-}
-
-void ChunkedNodeGroup::reclaimColumn(FileHandle& dataFH, common::column_id_t columnID) {
-    chunks[columnID]->reclaimStorage(dataFH);
 }
 
 void ChunkedNodeGroup::serialize(Serializer& serializer) const {

--- a/src/storage/table/column_chunk.cpp
+++ b/src/storage/table/column_chunk.cpp
@@ -262,8 +262,8 @@ std::pair<std::unique_ptr<ColumnChunk>, std::unique_ptr<ColumnChunk>> ColumnChun
     return {std::move(updatedRows), std::move(updatedData)};
 }
 
-void ColumnChunk::reclaimStorage(FileHandle& dataFH) {
-    data->reclaimStorage(dataFH);
+void ColumnChunk::reclaimStorage(PageManager& pageManager) const {
+    data->reclaimStorage(pageManager);
 }
 
 } // namespace storage

--- a/src/storage/table/column_chunk_data.cpp
+++ b/src/storage/table/column_chunk_data.cpp
@@ -1008,13 +1008,13 @@ uint64_t ColumnChunkData::spillToDisk() {
     return spilledBytes;
 }
 
-void ColumnChunkData::reclaimStorage(FileHandle& dataFH) {
+void ColumnChunkData::reclaimStorage(PageManager& pageManager) {
     if (nullData) {
-        nullData->reclaimStorage(dataFH);
+        nullData->reclaimStorage(pageManager);
     }
     if (residencyState == ResidencyState::ON_DISK) {
         if (metadata.getStartPageIdx() != INVALID_PAGE_IDX) {
-            dataFH.getPageManager()->freePageRange(metadata.pageRange);
+            pageManager.freePageRange(metadata.pageRange);
         }
     }
 }

--- a/src/storage/table/csr_chunked_node_group.cpp
+++ b/src/storage/table/csr_chunked_node_group.cpp
@@ -260,13 +260,13 @@ void ChunkedCSRNodeGroup::flush(FileHandle& dataFH) {
     }
 }
 
-void ChunkedCSRNodeGroup ::reclaimStorage(FileHandle& dataFH) {
-    ChunkedNodeGroup::reclaimStorage(dataFH);
+void ChunkedCSRNodeGroup ::reclaimStorage(PageManager& pageManager) const {
+    ChunkedNodeGroup::reclaimStorage(pageManager);
     if (csrHeader.offset) {
-        csrHeader.offset->reclaimStorage(dataFH);
+        csrHeader.offset->reclaimStorage(pageManager);
     }
     if (csrHeader.length) {
-        csrHeader.length->reclaimStorage(dataFH);
+        csrHeader.length->reclaimStorage(pageManager);
     }
 }
 

--- a/src/storage/table/csr_node_group.cpp
+++ b/src/storage/table/csr_node_group.cpp
@@ -2,6 +2,7 @@
 
 #include "common/constants.h"
 #include "storage/buffer_manager/memory_manager.h"
+#include "storage/file_handle.h"
 #include "storage/storage_utils.h"
 #include "storage/table/rel_table.h"
 #include "transaction/transaction.h"
@@ -469,10 +470,10 @@ void CSRNodeGroup::checkpoint(MemoryManager&, NodeGroupCheckpointState& state) {
     checkpointDataTypesNoLock(state);
 }
 
-void CSRNodeGroup::reclaimStorage(FileHandle& dataFH, const common::UniqLock& lock) const {
-    NodeGroup::reclaimStorage(dataFH, lock);
+void CSRNodeGroup::reclaimStorage(PageManager& pageManager, const UniqLock& lock) const {
+    NodeGroup::reclaimStorage(pageManager, lock);
     if (persistentChunkGroup) {
-        persistentChunkGroup->reclaimStorage(dataFH);
+        persistentChunkGroup->reclaimStorage(pageManager);
     }
 }
 
@@ -481,7 +482,7 @@ static std::unique_ptr<ChunkedCSRNodeGroup> createNewPersistentChunkGroup(
     auto newGroup =
         std::make_unique<ChunkedCSRNodeGroup>(oldPersistentChunkGroup, csrState.columnIDs);
     // checkpointed columns have been moved to the new group, reclaim storage for dropped column
-    oldPersistentChunkGroup.reclaimStorage(csrState.dataFH);
+    oldPersistentChunkGroup.reclaimStorage(*csrState.dataFH.getPageManager());
     return newGroup;
 }
 
@@ -533,7 +534,7 @@ void CSRNodeGroup::checkpointInMemAndOnDisk(const UniqLock& lock, NodeGroupCheck
         }
     }
     if (numTuplesAfterCheckpoint == 0) {
-        reclaimStorage(csrState.dataFH, lock);
+        reclaimStorage(*csrState.dataFH.getPageManager(), lock);
         persistentChunkGroup = nullptr;
     } else {
         KU_ASSERT(csrState.newHeader->sanityCheck());

--- a/src/storage/table/list_chunk_data.cpp
+++ b/src/storage/table/list_chunk_data.cpp
@@ -441,11 +441,11 @@ void ListChunkData::flush(FileHandle& dataFH) {
     offsetColumnChunk->flush(dataFH);
 }
 
-void ListChunkData::reclaimStorage(FileHandle& dataFH) {
-    ColumnChunkData::reclaimStorage(dataFH);
-    sizeColumnChunk->reclaimStorage(dataFH);
-    dataColumnChunk->reclaimStorage(dataFH);
-    offsetColumnChunk->reclaimStorage(dataFH);
+void ListChunkData::reclaimStorage(PageManager& pageManager) {
+    ColumnChunkData::reclaimStorage(pageManager);
+    sizeColumnChunk->reclaimStorage(pageManager);
+    dataColumnChunk->reclaimStorage(pageManager);
+    offsetColumnChunk->reclaimStorage(pageManager);
 }
 
 } // namespace storage

--- a/src/storage/table/node_group_collection.cpp
+++ b/src/storage/table/node_group_collection.cpp
@@ -208,10 +208,10 @@ void NodeGroupCollection::checkpoint(MemoryManager& memoryManager,
     types = std::move(typesAfterCheckpoint);
 }
 
-void NodeGroupCollection::reclaimStorage(FileHandle& dataFH) {
+void NodeGroupCollection::reclaimStorage(PageManager& pageManager) const {
     const auto lock = nodeGroups.lock();
     for (auto& nodeGroup : nodeGroups.getAllGroups(lock)) {
-        nodeGroup->reclaimStorage(dataFH);
+        nodeGroup->reclaimStorage(pageManager);
     }
 }
 

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -509,7 +509,7 @@ void NodeTable::commit(Transaction* transaction, TableCatalogEntry* tableEntry,
     // 2. Set deleted flag for tuples that are deleted in local storage.
     row_idx_t numLocalRows = 0u;
     for (auto localNodeGroupIdx = 0u; localNodeGroupIdx < localNodeTable.getNumNodeGroups();
-        localNodeGroupIdx++) {
+         localNodeGroupIdx++) {
         const auto localNodeGroup = localNodeTable.getNodeGroup(localNodeGroupIdx);
         if (localNodeGroup->hasDeletions(transaction)) {
             // TODO(Guodong): Assume local storage is small here. Should optimize the loop away by

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -509,7 +509,7 @@ void NodeTable::commit(Transaction* transaction, TableCatalogEntry* tableEntry,
     // 2. Set deleted flag for tuples that are deleted in local storage.
     row_idx_t numLocalRows = 0u;
     for (auto localNodeGroupIdx = 0u; localNodeGroupIdx < localNodeTable.getNumNodeGroups();
-         localNodeGroupIdx++) {
+        localNodeGroupIdx++) {
         const auto localNodeGroup = localNodeTable.getNodeGroup(localNodeGroupIdx);
         if (localNodeGroup->hasDeletions(transaction)) {
             // TODO(Guodong): Assume local storage is small here. Should optimize the loop away by
@@ -601,8 +601,9 @@ void NodeTable::rollbackCheckpoint() {
     }
 }
 
-void NodeTable::reclaimStorage(FileHandle& dataFH) {
-    nodeGroups->reclaimStorage(dataFH);
+void NodeTable::reclaimStorage(PageManager& pageManager) const {
+    nodeGroups->reclaimStorage(pageManager);
+    getPKIndex()->reclaimStorage(pageManager);
 }
 
 TableStats NodeTable::getStats(const Transaction* transaction) const {

--- a/src/storage/table/rel_table.cpp
+++ b/src/storage/table/rel_table.cpp
@@ -439,9 +439,9 @@ void RelTable::commit(Transaction* transaction, TableCatalogEntry* tableEntry,
     localRelTable.clear();
 }
 
-void RelTable::reclaimStorage(FileHandle& dataFH) {
+void RelTable::reclaimStorage(PageManager& pageManager) const {
     for (auto& relData : directedRelData) {
-        relData->reclaimStorage(dataFH);
+        relData->reclaimStorage(pageManager);
     }
 }
 

--- a/src/storage/table/rel_table_data.cpp
+++ b/src/storage/table/rel_table_data.cpp
@@ -288,8 +288,8 @@ void RelTableData::rollbackGroupCollectionInsert(row_idx_t numRows_, bool isPers
     nodeGroups->rollbackInsert(numRows_, !isPersistent);
 }
 
-void RelTableData::reclaimStorage(FileHandle& dataFH) {
-    nodeGroups->reclaimStorage(dataFH);
+void RelTableData::reclaimStorage(PageManager& pageManager) const {
+    nodeGroups->reclaimStorage(pageManager);
 }
 
 } // namespace storage

--- a/src/storage/table/string_chunk_data.cpp
+++ b/src/storage/table/string_chunk_data.cpp
@@ -256,11 +256,11 @@ void StringChunkData::flush(FileHandle& dataFH) {
     dictionaryChunk->flush(dataFH);
 }
 
-void StringChunkData::reclaimStorage(FileHandle& dataFH) {
-    ColumnChunkData::reclaimStorage(dataFH);
-    indexColumnChunk->reclaimStorage(dataFH);
-    dictionaryChunk->getOffsetChunk()->reclaimStorage(dataFH);
-    dictionaryChunk->getStringDataChunk()->reclaimStorage(dataFH);
+void StringChunkData::reclaimStorage(PageManager& pageManager) {
+    ColumnChunkData::reclaimStorage(pageManager);
+    indexColumnChunk->reclaimStorage(pageManager);
+    dictionaryChunk->getOffsetChunk()->reclaimStorage(pageManager);
+    dictionaryChunk->getStringDataChunk()->reclaimStorage(pageManager);
 }
 
 uint64_t StringChunkData::getEstimatedMemoryUsage() const {

--- a/src/storage/table/struct_chunk_data.cpp
+++ b/src/storage/table/struct_chunk_data.cpp
@@ -87,10 +87,10 @@ void StructChunkData::flush(FileHandle& dataFH) {
     }
 }
 
-void StructChunkData::reclaimStorage(FileHandle& dataFH) {
-    ColumnChunkData::reclaimStorage(dataFH);
+void StructChunkData::reclaimStorage(PageManager& pageManager) {
+    ColumnChunkData::reclaimStorage(pageManager);
     for (const auto& childChunk : childChunks) {
-        childChunk->reclaimStorage(dataFH);
+        childChunk->reclaimStorage(pageManager);
     }
 }
 

--- a/test/storage/local_hash_index_test.cpp
+++ b/test/storage/local_hash_index_test.cpp
@@ -12,14 +12,13 @@ bool isVisible(offset_t) {
 }
 
 TEST(LocalHashIndexTests, LocalInserts) {
-    PageCursor dummyCursor{0, 0};
     BufferManager bm(":memory:", "", 256 * 1024 * 1024 /*bufferPoolSize*/,
         512 * 1024 * 1024 /*maxDBSize*/, nullptr, true);
     MemoryManager memoryManager(&bm, nullptr);
     auto overflowFile = std::make_unique<InMemOverflowFile>(memoryManager);
-    auto overflowFileHandle = std::make_unique<OverflowFileHandle>(*overflowFile, dummyCursor);
-    auto hashIndex = std::make_unique<LocalHashIndex>(memoryManager, PhysicalTypeID::INT64,
-        overflowFileHandle.get());
+    auto* overflowFileHandle = overflowFile->addHandle();
+    auto hashIndex =
+        std::make_unique<LocalHashIndex>(memoryManager, PhysicalTypeID::INT64, overflowFileHandle);
 
     for (int64_t i = 0u; i < 100000; i++) {
         ASSERT_TRUE(hashIndex->insert(i, i * 2, isVisible));
@@ -51,14 +50,13 @@ std::string gen_random(const int len) {
 }
 
 TEST(LocalHashIndexTests, LocalStringInserts) {
-    PageCursor dummyCursor{INVALID_PAGE_IDX, 0};
     BufferManager bm(":memory:", "", 256 * 1024 * 1024 /*bufferPoolSize*/,
         512 * 1024 * 1024 /*maxDBSize*/, nullptr, true);
     MemoryManager memoryManager(&bm, nullptr);
     auto overflowFile = std::make_unique<InMemOverflowFile>(memoryManager);
-    auto overflowFileHandle = std::make_unique<OverflowFileHandle>(*overflowFile, dummyCursor);
-    auto hashIndex = std::make_unique<LocalHashIndex>(memoryManager, PhysicalTypeID::STRING,
-        overflowFileHandle.get());
+    auto* overflowFileHandle = overflowFile->addHandle();
+    auto hashIndex =
+        std::make_unique<LocalHashIndex>(memoryManager, PhysicalTypeID::STRING, overflowFileHandle);
 
     std::vector<std::string> keys;
     for (int64_t i = 0u; i < 100; i++) {

--- a/test/test_files/dml_node/delete/delete_empty.test
+++ b/test/test_files/dml_node/delete/delete_empty.test
@@ -97,28 +97,29 @@
 -STATEMENT create node table other(id INT64, PRIMARY KEY (id))
 ---- ok
 # table used to store some intermediate results
--STATEMENT create node table stats(id SERIAL, numPages INT64, PRIMARY KEY(id))
----- ok
-# pre-allocate rows so that it doesn't affect storage allocations later
--STATEMENT create (:stats)
+-STATEMENT create node table stats(startPageIdx INT64, numPages INT64, PRIMARY KEY(startPageIdx))
 ---- ok
 -STATEMENT COPY Post FROM "${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Post.csv"(parallel=false)
 -PARALLELISM 1
----- ok
-# store number of pages in the DB before the delete
--STATEMENT CALL file_info() with num_pages match (s:stats) where s.id = 0 set s.numPages = num_pages
 ---- ok
 -STATEMENT call storage_info('Post') where node_group_id = 0 with num_values as node_group_capacity limit 1
            match (p:Post) where ID(p) < internal_id(0, node_group_capacity) delete p with count(*) as num_deleted, node_group_capacity
            return num_deleted = node_group_capacity
 ---- 1
 True
-# on the next allocation the pages for the deleted node group should be reused so the number of pages in the DB shouldn't increase
--STATEMENT copy other from (unwind range(1, 100000) as i return i)
----- ok
--STATEMENT call file_info() with num_pages match (s:stats) return num_pages <= s.numPages
+# store free pages before re-copy
+-STATEMENT call fsm_info() return sum(num_pages) > 0
 ---- 1
 True
+-STATEMENT call fsm_info() with start_page_idx, num_pages create (s:stats {startPageIdx: start_page_idx, numPages: num_pages})
+---- ok
+# on the next allocation the pages for the deleted node group should be reused
+-STATEMENT copy other from (unwind range(1, 100000) as i return i)
+---- ok
+-STATEMENT call storage_info('other') where num_pages > 0 with column_name, start_page_idx, num_pages
+            where count { match (s:stats) where s.startPageIdx <= start_page_idx and s.startPageIdx + s.numPages >= start_page_idx + num_pages } = 0
+            return column_name, start_page_idx, num_pages
+---- 0
 
 -STATEMENT match (p:Post) with count(*) as remaining
            optional match (p:Post) where p.ID = 1030792523231 with p.imageFile as imageFile, remaining
@@ -135,9 +136,6 @@ True
 # table used to store some intermediate results
 -STATEMENT create node table stats(startPageIdx INT64, numPages INT64, PRIMARY KEY(startPageIdx))
 ---- ok
-# pre-allocate rows so that it doesn't affect storage allocations later
--STATEMENT unwind range(1, 10000) as i create (:stats {startPageIdx: i, numPages: 0})
----- ok
 -STATEMENT COPY Post FROM "${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Post.csv"(parallel=false)
 -PARALLELISM 1
 ---- ok
@@ -147,17 +145,23 @@ True
 -STATEMENT call fsm_info() return sum(num_pages) > 0
 ---- 1
 True
--STATEMENT call fsm_info() with start_page_idx, num_pages match (s:stats) where s.startPageIdx = start_page_idx set s.numPages = num_pages
+-STATEMENT call fsm_info() with start_page_idx, num_pages create (s:stats {startPageIdx: start_page_idx, numPages: num_pages})
 ---- ok
 # copy again, the storage pages should be reallocated
 # the number of pages in the DB can still increase because of the hash index
 -STATEMENT COPY Post FROM "${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Post.csv"(parallel=false)
 -PARALLELISM 1
 ---- ok
--STATEMENT call storage_info('Post') where num_pages > 0 with column_name, start_page_idx, num_pages
-                where count { match (s:stats) where s.startPageIdx <= start_page_idx and s.startPageIdx + s.numPages >= start_page_idx + num_pages } = 0
-                return column_name, start_page_idx, num_pages
----- 0
+# the re-copying won't be perfect because we don't reset the nodeOffset to be inserted to for Post
+# the "stats" table also uses up some storage
+# so we leave some margin of error when checking to see if all pages have been reallocated
+-STATEMENT call storage_info('Post') with sum(num_pages) as total_num_pages
+            call storage_info('Post') where num_pages > 0 with column_name, start_page_idx, num_pages, total_num_pages
+            where count { match (s:stats) where s.startPageIdx <= start_page_idx and s.startPageIdx + s.numPages >= start_page_idx + num_pages } = 0
+            with sum(num_pages) as new_pages, total_num_pages
+            return new_pages * 10 < total_num_pages
+---- 1
+True
 -RELOADDB
 # try some queries
 -STATEMENT match(p:Post) return count(*)

--- a/test/test_files/dml_node/delete/delete_empty.test
+++ b/test/test_files/dml_node/delete/delete_empty.test
@@ -157,9 +157,9 @@ True
 # so we leave some margin of error when checking to see if all pages have been reallocated
 -STATEMENT call storage_info('Post') with sum(num_pages) as total_num_pages
             call storage_info('Post') where num_pages > 0 with column_name, start_page_idx, num_pages, total_num_pages
-            where count { match (s:stats) where s.startPageIdx <= start_page_idx and s.startPageIdx + s.numPages >= start_page_idx + num_pages } = 0
-            with sum(num_pages) as new_pages, total_num_pages
-            return new_pages * 10 < total_num_pages
+            where count { match (s:stats) where s.startPageIdx <= start_page_idx and s.startPageIdx + s.numPages >= start_page_idx + num_pages } > 0
+            with sum(num_pages) as num_reused_pages, total_num_pages
+            return (total_num_pages - num_reused_pages) * 10 < total_num_pages
 ---- 1
 True
 -RELOADDB

--- a/test/test_files/dml_node/delete/delete_empty.test
+++ b/test/test_files/dml_node/delete/delete_empty.test
@@ -94,10 +94,14 @@
 ---- ok
 -STATEMENT create node table Post (id INT64, imageFile STRING, creationDate INT64, locationIP STRING, browserUsed STRING, language STRING, content STRING, length INT32, PRIMARY KEY (id));
 ---- ok
--STATEMENT create node table other(id INT64, PRIMARY KEY (id))
+-STATEMENT create node table other(id serial, val INT64, PRIMARY KEY (id))
+---- ok
+# preallocate rows for other table so that hash index storage isn't allocated later
+# the val column will be constant so will take up no space
+-STATEMENT unwind range(1, 100000) as i create (:other)
 ---- ok
 # table used to store some intermediate results
--STATEMENT create node table stats(startPageIdx INT64, numPages INT64, PRIMARY KEY(startPageIdx))
+-STATEMENT create node table stats(id SERIAL, numPages INT64, PRIMARY KEY(id))
 ---- ok
 -STATEMENT COPY Post FROM "${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Post.csv"(parallel=false)
 -PARALLELISM 1
@@ -108,18 +112,16 @@
 ---- 1
 True
 # store free pages before re-copy
--STATEMENT call fsm_info() return sum(num_pages) > 0
+-STATEMENT call file_info() with num_pages create (s:stats {numPages: num_pages})
+---- ok
+# set values for the val column, it will now need some pages for storage
+# on the next allocation the pages for the deleted node group should be reused
+# so the DB shouldn't grow by much
+-STATEMENT match (o:other) set o.val = o.id
+---- ok
+-STATEMENT call file_info() with num_pages match (s:stats) return num_pages <= s.numPages
 ---- 1
 True
--STATEMENT call fsm_info() with start_page_idx, num_pages create (s:stats {startPageIdx: start_page_idx, numPages: num_pages})
----- ok
-# on the next allocation the pages for the deleted node group should be reused
--STATEMENT copy other from (unwind range(1, 100000) as i return i)
----- ok
--STATEMENT call storage_info('other') where num_pages > 0 with column_name, start_page_idx, num_pages
-            where count { match (s:stats) where s.startPageIdx <= start_page_idx and s.startPageIdx + s.numPages >= start_page_idx + num_pages } = 0
-            return column_name, start_page_idx, num_pages
----- 0
 
 -STATEMENT match (p:Post) with count(*) as remaining
            optional match (p:Post) where p.ID = 1030792523231 with p.imageFile as imageFile, remaining
@@ -159,7 +161,7 @@ True
             call storage_info('Post') where num_pages > 0 with column_name, start_page_idx, num_pages, total_num_pages
             where count { match (s:stats) where s.startPageIdx <= start_page_idx and s.startPageIdx + s.numPages >= start_page_idx + num_pages } > 0
             with sum(num_pages) as num_reused_pages, total_num_pages
-            return (total_num_pages - num_reused_pages) * 10 < total_num_pages
+            return (total_num_pages - num_reused_pages) * 5 < total_num_pages
 ---- 1
 True
 -RELOADDB

--- a/test/test_files/dml_node/delete/delete_empty.test
+++ b/test/test_files/dml_node/delete/delete_empty.test
@@ -94,32 +94,31 @@
 ---- ok
 -STATEMENT create node table Post (id INT64, imageFile STRING, creationDate INT64, locationIP STRING, browserUsed STRING, language STRING, content STRING, length INT32, PRIMARY KEY (id));
 ---- ok
+-STATEMENT create node table other(id INT64, PRIMARY KEY (id))
+---- ok
+# table used to store some intermediate results
+-STATEMENT create node table stats(id SERIAL, numPages INT64, PRIMARY KEY(id))
+---- ok
+# pre-allocate rows so that it doesn't affect storage allocations later
+-STATEMENT create (:stats)
+---- ok
 -STATEMENT COPY Post FROM "${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Post.csv"(parallel=false)
 -PARALLELISM 1
 ---- ok
--STATEMENT call fsm_info() return COUNT(*)
----- 1
-0
+# store number of pages in the DB before the delete
+-STATEMENT CALL file_info() with num_pages match (s:stats) where s.id = 0 set s.numPages = num_pages
+---- ok
 -STATEMENT call storage_info('Post') where node_group_id = 0 with num_values as node_group_capacity limit 1
            match (p:Post) where ID(p) < internal_id(0, node_group_capacity) delete p with count(*) as num_deleted, node_group_capacity
            return num_deleted = node_group_capacity
 ---- 1
 True
-
-# on the next allocation the pages for the deleted node group should be reused
--STATEMENT create node table other(id INT64, primary key(id))
+# on the next allocation the pages for the deleted node group should be reused so the number of pages in the DB shouldn't increase
+-STATEMENT copy other from (unwind range(1, 100000) as i return i)
 ---- ok
--STATEMENT begin transaction;
-        create (:other{id: 1});
-        create (:other{id: 2});
-        commit;
----- ok
----- ok
----- ok
----- ok
--STATEMENT call storage_info('other') return count (*)
+-STATEMENT call file_info() with num_pages match (s:stats) return num_pages <= s.numPages
 ---- 1
-2
+True
 
 -STATEMENT match (p:Post) with count(*) as remaining
            optional match (p:Post) where p.ID = 1030792523231 with p.imageFile as imageFile, remaining
@@ -133,22 +132,32 @@ True
 ---- ok
 -STATEMENT create node table Post (id INT64, imageFile STRING, creationDate INT64, locationIP STRING, browserUsed STRING, language STRING, content STRING, length INT32, PRIMARY KEY (id));
 ---- ok
--STATEMENT COPY Post FROM "${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Post.csv"(parallel=false)
+# table used to store some intermediate results
+-STATEMENT create node table stats(startPageIdx INT64, numPages INT64, PRIMARY KEY(startPageIdx))
 ---- ok
--STATEMENT call fsm_info() return *
----- 0
+# pre-allocate rows so that it doesn't affect storage allocations later
+-STATEMENT unwind range(1, 10000) as i create (:stats {startPageIdx: i, numPages: 0})
+---- ok
+-STATEMENT COPY Post FROM "${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Post.csv"(parallel=false)
+-PARALLELISM 1
+---- ok
 -STATEMENT match (p:Post) delete p
 ---- ok
-# copy again, page allocation should start from 0 as the dropped pages are reclaimed + truncated
--STATEMENT COPY Post FROM "${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Post.csv"(parallel=false)
----- ok
-# TODO(Guodong): Revisit when reclaiming pages for hash indexes.
-# -STATEMENT call fsm_info() return count(*)
-# ---- 1
-# 1
--STATEMENT CALL storage_info('Post') where start_page_idx = 0 return count(*)
+# store free pages after the delete for later comparison
+-STATEMENT call fsm_info() return sum(num_pages) > 0
 ---- 1
-0
+True
+-STATEMENT call fsm_info() with start_page_idx, num_pages match (s:stats) where s.startPageIdx = start_page_idx set s.numPages = num_pages
+---- ok
+# copy again, the storage pages should be reallocated
+# the number of pages in the DB can still increase because of the hash index
+-STATEMENT COPY Post FROM "${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Post.csv"(parallel=false)
+-PARALLELISM 1
+---- ok
+-STATEMENT call storage_info('Post') where num_pages > 0 with column_name, start_page_idx, num_pages
+                where count { match (s:stats) where s.startPageIdx <= start_page_idx and s.startPageIdx + s.numPages >= start_page_idx + num_pages } = 0
+                return column_name, start_page_idx, num_pages
+---- 0
 -RELOADDB
 # try some queries
 -STATEMENT match(p:Post) return count(*)

--- a/test/test_files/dml_node/delete/delete_empty.test
+++ b/test/test_files/dml_node/delete/delete_empty.test
@@ -96,15 +96,16 @@
 ---- ok
 -STATEMENT create node table other(id serial, val INT64, PRIMARY KEY (id))
 ---- ok
-# preallocate rows for other table so that hash index storage isn't allocated later
-# the val column will be constant so will take up no space
--STATEMENT unwind range(1, 100000) as i create (:other)
----- ok
 # table used to store some intermediate results
 -STATEMENT create node table stats(id SERIAL, numPages INT64, PRIMARY KEY(id))
 ---- ok
 -STATEMENT COPY Post FROM "${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Post.csv"(parallel=false)
 -PARALLELISM 1
+---- ok
+# preallocate rows for other table so that hash index storage isn't allocated later
+# the val column will be constant so will take up no space
+-STATEMENT call storage_info('Post') where node_group_id = 0 with num_values as node_group_capacity limit 1
+    unwind range(1, node_group_capacity) as i create (:other)
 ---- ok
 -STATEMENT call storage_info('Post') where node_group_id = 0 with num_values as node_group_capacity limit 1
            match (p:Post) where ID(p) < internal_id(0, node_group_capacity) delete p with count(*) as num_deleted, node_group_capacity

--- a/test/test_files/function/call/fsm_info.test
+++ b/test/test_files/function/call/fsm_info.test
@@ -61,6 +61,8 @@ True
 True
 
 -CASE FSMEmptyAfterFirstCopy
+-STATEMENT begin transaction
+---- ok
 -STATEMENT create node table person (ID INt64, fName StRING, gender INT64, isStudent BoOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration interval, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
 ---- ok
 -STATEMENT create rel table knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, comments STRING[], summary STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[])), notes UNION(firstmet DATE, type INT16, comment STRING), someMap MAP(STRING, STRING), MANY_MAnY);
@@ -68,6 +70,8 @@ True
 -STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv";
 ---- ok
 -STATEMENT COPY knows FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv";
+---- ok
+-STATEMENT commit
 ---- ok
 -STATEMENT call fsm_info() return *
 ---- 0

--- a/test/test_files/function/call/fsm_info.test
+++ b/test/test_files/function/call/fsm_info.test
@@ -104,8 +104,9 @@ True
 # copying the same initial data to a new table should reuse most of the pages so the db should not grow by much
 -STATEMENT COPY knows1 FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv";
 ---- ok
-# leave some margin for rewriting storage metadata but most free pages should be used
--STATEMENT call fsm_info() return sum(num_pages) < 5
+# allow margin equal to the largest page range for a column chunk in the table
+-STATEMENT CALL fsm_info() with sum(num_pages) as num_free_pages call storage_info('knows1') with num_free_pages, max(num_pages) as largest_range
+            return num_free_pages is null or largest_range >= num_free_pages or 5 >= num_free_pages
 ---- 1
 True
 

--- a/test/test_files/function/call/fsm_info.test
+++ b/test/test_files/function/call/fsm_info.test
@@ -79,6 +79,8 @@ True
 -CASE FSMReclaimRelNewTable
 -STATEMENT CALL threads=1
 ---- ok
+-STATEMENT begin transaction
+---- ok
 -STATEMENT create node table person (ID INt64, fName StRING, gender INT64, isStudent BoOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration interval, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
 ---- ok
 -STATEMENT create rel table knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, comments STRING[], summary STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[])), notes UNION(firstmet DATE, type INT16, comment STRING), someMap MAP(STRING, STRING), MANY_MAnY);
@@ -87,6 +89,8 @@ True
 ---- ok
 -STATEMENT copy person from ["${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv", "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson2.csv"](ignore_errors=true);
 ---- ok
+-STATEMENT commit
+---- ok
 -STATEMENT call fsm_info() return *
 ---- 0
 -STATEMENT COPY knows FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv";
@@ -94,14 +98,14 @@ True
 # second copy should trigger space reclaiming
 -STATEMENT COPY knows FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows_2.csv";
 ---- ok
--STATEMENT CALL fsm_info() return sum(num_pages) > 0
+-STATEMENT call fsm_info() return sum(num_pages) >= 10
 ---- 1
 True
-# copying the same initial data to a new table should reuse most of the pages
+# copying the same initial data to a new table should reuse most of the pages so the db should not grow by much
 -STATEMENT COPY knows1 FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv";
 ---- ok
-# allow margin equal to the largest page range for a column chunk in the table
--STATEMENT CALL fsm_info() with sum(num_pages) as num_free_pages call storage_info('knows1') with num_free_pages, max(num_pages) as largest_range return num_free_pages is null or largest_range >= num_free_pages
+# leave some margin for rewriting storage metadata but most free pages should be used
+-STATEMENT call fsm_info() return sum(num_pages) < 5
 ---- 1
 True
 

--- a/test/test_files/transaction/ddl/ddl_empty.test
+++ b/test/test_files/transaction/ddl/ddl_empty.test
@@ -631,6 +631,12 @@ True
 ---- ok
 -STATEMENT create rel table knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, comments STRING[], summary STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[])), notes UNION(firstmet DATE, type INT16, comment STRING), someMap MAP(STRING, STRING), MANY_MAnY);
 ---- ok
+# table used to store some intermediate results
+-STATEMENT create node table stats(id SERIAL, numPages INT64, PRIMARY KEY(id))
+---- ok
+# pre-allocate rows so that it doesn't affect storage allocations later
+-STATEMENT create (:stats)
+---- ok
 -STATEMENT copy person from ["${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv", "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson2.csv"](ignore_errors=true)
 ---- ok
 -STATEMENT COPY knows FROM ["${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv", "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows_2.csv"];
@@ -639,23 +645,25 @@ True
 ---- ok
 -STATEMENT checkpoint
 ---- ok
--STATEMENT match (a)-[k:knows]->(b) return a.id, b.id
+-STATEMENT match (a:person)-[k:knows]->(b:person) return a.id, b.id
 ---- error
 Binder exception: Table knows does not exist.
 
+-STATEMENT call file_info() with num_pages match (s:stats) where s.id = 0 set s.numPages = num_pages
+---- ok
 -STATEMENT create rel table knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, comments STRING[], summary STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[])), notes UNION(firstmet DATE, type INT16, comment STRING), someMap MAP(STRING, STRING), MANY_MAnY);
 ---- ok
 -STATEMENT COPY knows FROM ["${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv", "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows_2.csv"];
 ---- ok
--STATEMENT call fsm_info() return *
----- 0
--STATEMENT CALL storage_info('person') where start_page_idx < 4294967295 with max(start_page_idx + num_pages) as expected_start_page_idx
-        CALL storage_info('knows') where start_page_idx = expected_start_page_idx return count(*)
+# The DB shouldn't grow after the recopy
+-STATEMENT CALL file_info() with num_pages match (s:stats) return num_pages <= s.numPages
 ---- 1
-0
+True
 
 -CASE DropRelTableRollbackRecovery
 -SKIP_IN_MEM
+-STATEMENT begin transaction
+---- ok
 -STATEMENT create node table person (ID INt64, fName StRING, gender INT64, isStudent BoOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration interval, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID, PRIMARY KEY (ID));
 ---- ok
 -STATEMENT create node table organisation (ID INT64, name STRING, orgCode INT64, mark DOUBLE, score INT64, history STRING, licenseValidInterval INTERVAL, rating DOUBLE, state STRUCT(revenue INT16, location STRING[], stock STRUCT(price INT64[], volume INT64)), info UNION(price FLOAT, movein DATE, note STRING),PRIMARY KEY (ID));
@@ -667,6 +675,10 @@ Binder exception: Table knows does not exist.
 -STATEMENT COPY organisation FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vOrganisation.csv";
 ---- ok
 -STATEMENT COPY studyAt FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eStudyAt.csv";
+---- ok
+-STATEMENT commit;
+         checkpoint;
+---- ok
 ---- ok
 -STATEMENT call fsm_info() return *
 ---- 0

--- a/test/test_files/transaction/ddl/ddl_empty.test
+++ b/test/test_files/transaction/ddl/ddl_empty.test
@@ -586,6 +586,11 @@ Binder exception: Cannot find property since for k.
 -STATEMENT CALL storage_info('movies') where start_page_idx = 0 return count(*)
 ---- 1
 0
+-STATEMENT match (m:movies) return m.name, m.length
+---- 3
+Sóló cón tu párejâ|126
+The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie|2544
+Roma|298
 
 -CASE DropNodeTableRollbackRecovery
 -SKIP_IN_MEM

--- a/test/test_files/transaction/ddl/ddl_empty.test
+++ b/test/test_files/transaction/ddl/ddl_empty.test
@@ -570,7 +570,15 @@ Binder exception: Cannot find property since for k.
 -SKIP_IN_MEM
 -STATEMENT create node table movies (name STRING, length INT32, note STRING, description STRUCT(rating DOUBLE, stars INT8, views INT64, release TIMESTAMP, release_ns TIMESTAMP_NS, release_ms TIMESTAMP_MS, release_sec TIMESTAMP_SEC, release_tz TIMESTAMP_TZ, film DATE, u8 UINT8, u16 UINT16, u32 UINT32, u64 UINT64, hugedata INT128), content BYTEA, audience MAP(STRING, INT64), grade union(credit boolean, grade1 double, grade2 int64), PRIMARY KEY (name));
 ---- ok
+# table used to store some intermediate results
+-STATEMENT create node table stats(id SERIAL, numPages INT64, PRIMARY KEY(id))
+---- ok
+# preallocate storage for stats table
+-STATEMENT create (:stats)
+---- ok
 -STATEMENT COPY movies FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vMovies.csv";
+---- ok
+-STATEMENT call file_info() with num_pages match (s:stats) where s.id = 0 set s.numPages = num_pages
 ---- ok
 -STATEMENT drop table movies
 ---- ok
@@ -581,11 +589,9 @@ Binder exception: Cannot find property since for k.
 ---- ok
 -STATEMENT COPY movies FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vMovies.csv";
 ---- ok
--STATEMENT call fsm_info() return *
----- 0
--STATEMENT CALL storage_info('movies') where start_page_idx = 0 return count(*)
+-STATEMENT call file_info() with num_pages match (s:stats) where s.id = 0 return num_pages <= s.numPages
 ---- 1
-0
+True
 -STATEMENT match (m:movies) return m.name, m.length
 ---- 3
 Sóló cón tu párejâ|126
@@ -594,9 +600,13 @@ Roma|298
 
 -CASE DropNodeTableRollbackRecovery
 -SKIP_IN_MEM
+-STATEMENT begin transaction
+---- ok
 -STATEMENT create node table movies (name STRING, length INT32, note STRING, description STRUCT(rating DOUBLE, stars INT8, views INT64, release TIMESTAMP, release_ns TIMESTAMP_NS, release_ms TIMESTAMP_MS, release_sec TIMESTAMP_SEC, release_tz TIMESTAMP_TZ, film DATE, u8 UINT8, u16 UINT16, u32 UINT32, u64 UINT64, hugedata INT128), content BYTEA, audience MAP(STRING, INT64), grade union(credit boolean, grade1 double, grade2 int64), PRIMARY KEY (name));
 ---- ok
 -STATEMENT COPY movies FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vMovies.csv";
+---- ok
+-STATEMENT commit
 ---- ok
 -STATEMENT call fsm_info() return *
 ---- 0
@@ -634,7 +644,7 @@ True
 # table used to store some intermediate results
 -STATEMENT create node table stats(id SERIAL, numPages INT64, PRIMARY KEY(id))
 ---- ok
-# pre-allocate rows so that it doesn't affect storage allocations later
+# preallocate storage for stats table
 -STATEMENT create (:stats)
 ---- ok
 -STATEMENT copy person from ["${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv", "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson2.csv"](ignore_errors=true)
@@ -648,7 +658,6 @@ True
 -STATEMENT match (a:person)-[k:knows]->(b:person) return a.id, b.id
 ---- error
 Binder exception: Table knows does not exist.
-
 -STATEMENT call file_info() with num_pages match (s:stats) where s.id = 0 set s.numPages = num_pages
 ---- ok
 -STATEMENT create rel table knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, comments STRING[], summary STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[])), notes UNION(firstmet DATE, type INT16, comment STRING), someMap MAP(STRING, STRING), MANY_MAnY);

--- a/test/test_files/transaction/ddl/ddl_empty.test
+++ b/test/test_files/transaction/ddl/ddl_empty.test
@@ -598,6 +598,32 @@ Sóló cón tu párejâ|126
 The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie|2544
 Roma|298
 
+-CASE DropNodeTableManyLargePKString
+-SKIP_IN_MEM
+-STATEMENT call checkpoint_threshold=0
+---- ok
+-STATEMENT create node table tab (id STRING, PRIMARY KEY (id));
+---- ok
+# table used to store some intermediate results
+-STATEMENT create node table stats(id SERIAL, numPages INT64, PRIMARY KEY(id))
+---- ok
+# preallocate storage for stats table
+-STATEMENT create (:stats)
+---- ok
+-STATEMENT COPY tab FROM (unwind range(1, 100000) as i return concat("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", cast(i, "string")));
+---- ok
+-STATEMENT call file_info() with num_pages match (s:stats) where s.id = 0 set s.numPages = num_pages
+---- ok
+-STATEMENT drop table tab
+---- ok
+-STATEMENT create node table tab (id STRING, PRIMARY KEY (id));
+---- ok
+-STATEMENT COPY tab FROM (unwind range(1, 100000) as i return concat("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", cast(i, "string")));
+---- ok
+-STATEMENT call file_info() with num_pages match (s:stats) where s.id = 0 return num_pages <= s.numPages
+---- 1
+True
+
 -CASE DropNodeTableRollbackRecovery
 -SKIP_IN_MEM
 -STATEMENT begin transaction


### PR DESCRIPTION
# Description

Allocations for the following structures are now tracked + freed with the page manager:
- hash index + overflow file + disk arrays
- catalog
- storage metadata

Also added a table function `FILE_INFO` for testing purposes. It returns the number of total pages in the data.kz file handle.