### PR TITLE
Separate PrimaryKeyIndex constructor

### DIFF
--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -306,6 +306,10 @@ inline bool HashIndex<common::ku_string_t>::equals(const transaction::Transactio
 
 class PrimaryKeyIndex {
 public:
+    // Construct a new index
+    PrimaryKeyIndex(FileHandle* dataFH, bool inMemMode, common::PhysicalTypeID keyDataType,
+        MemoryManager& memoryManager, ShadowFile* shadowFile);
+    // Construct an existing index
     PrimaryKeyIndex(FileHandle* dataFH, bool inMemMode, common::PhysicalTypeID keyDataType,
         MemoryManager& memoryManager, ShadowFile* shadowFile, common::page_idx_t firstHeaderPage,
         common::page_idx_t overflowHeaderPage);
@@ -322,7 +326,7 @@ public:
         return common::ku_dynamic_cast<HashIndex<HashIndexType<T>>*>(hashIndices[indexPos].get());
     }
 
-    inline bool lookup(const transaction::Transaction* trx, common::ku_string_t key,
+    bool lookup(const transaction::Transaction* trx, common::ku_string_t key,
         common::offset_t& result, visible_func isVisible) {
         return lookup(trx, key.getAsStringView(), result, isVisible);
     }
@@ -336,7 +340,7 @@ public:
     bool lookup(const transaction::Transaction* trx, common::ValueVector* keyVector,
         uint64_t vectorPos, common::offset_t& result, visible_func isVisible);
 
-    inline bool insert(const transaction::Transaction* transaction, common::ku_string_t key,
+    bool insert(const transaction::Transaction* transaction, common::ku_string_t key,
         common::offset_t value, visible_func isVisible) {
         return insert(transaction, key.getAsStringView(), value, isVisible);
     }
@@ -371,7 +375,7 @@ public:
         }
     }
 
-    inline void delete_(common::ku_string_t key) { return delete_(key.getAsStringView()); }
+    void delete_(common::ku_string_t key) { return delete_(key.getAsStringView()); }
     template<common::IndexHashable T>
     inline void delete_(T key) {
         KU_ASSERT(keyDataTypeID == common::TypeUtils::getPhysicalTypeIDForType<T>());
@@ -392,6 +396,9 @@ public:
     void writeHeaders();
 
     void serialize(common::Serializer& serializer) const;
+
+private:
+    void initOverflowAndSubIndices(bool inMemMode, MemoryManager& mm);
 
 private:
     common::PhysicalTypeID keyDataTypeID;

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -149,7 +149,7 @@ void HashIndex<T>::splitSlots(const Transaction* transaction, HashIndexHeader& h
         Slot<T>* originalSlot = &*originalSlotIterator.seek(header.nextSplitSlotId);
         do {
             for (entry_pos_t originalEntryPos = 0; originalEntryPos < getSlotCapacity<T>();
-                 originalEntryPos++) {
+                originalEntryPos++) {
                 if (!originalSlot->header.isEntryValid(originalEntryPos)) {
                     continue; // Skip invalid entries.
                 }
@@ -296,10 +296,9 @@ void HashIndex<T>::mergeBulkInserts(const Transaction* transaction,
     // may not be consecutive, but we reduce the memory overhead for storing the information about
     // the sorted data and still just process each page once.
     for (uint64_t localSlotId = 0; localSlotId < insertLocalStorage.numPrimarySlots();
-         localSlotId += NUM_SLOTS_PER_PAGE) {
+        localSlotId += NUM_SLOTS_PER_PAGE) {
         for (size_t i = 0;
-             i < NUM_SLOTS_PER_PAGE && localSlotId + i < insertLocalStorage.numPrimarySlots();
-             i++) {
+            i < NUM_SLOTS_PER_PAGE && localSlotId + i < insertLocalStorage.numPrimarySlots(); i++) {
             auto localSlot =
                 typename InMemHashIndex<T>::SlotIterator(localSlotId + i, &insertLocalStorage);
             partitionedEntries[i].clear();
@@ -422,68 +421,68 @@ template class HashIndex<int128_t>;
 template class HashIndex<ku_string_t>;
 
 PrimaryKeyIndex::PrimaryKeyIndex(FileHandle* dataFH, bool inMemMode, PhysicalTypeID keyDataType,
+    MemoryManager& memoryManager, ShadowFile* shadowFile)
+    : keyDataTypeID(keyDataType), fileHandle{dataFH}, shadowFile{*shadowFile},
+      firstHeaderPage{INVALID_PAGE_IDX}, overflowHeaderPage{INVALID_PAGE_IDX} {
+    hashIndexHeadersForReadTrx.resize(NUM_HASH_INDEXES);
+    hashIndexHeadersForWriteTrx.resize(NUM_HASH_INDEXES);
+    hashIndexDiskArrays =
+        std::make_unique<DiskArrayCollection>(*fileHandle, *shadowFile, true /*bypassShadowing*/);
+    // Each index has a primary slot array and an overflow slot array
+    for (size_t i = 0; i < NUM_HASH_INDEXES * 2; i++) {
+        hashIndexDiskArrays->addDiskArray();
+    }
+    initOverflowAndSubIndices(inMemMode, memoryManager);
+}
+
+PrimaryKeyIndex::PrimaryKeyIndex(FileHandle* dataFH, bool inMemMode, PhysicalTypeID keyDataType,
     MemoryManager& memoryManager, ShadowFile* shadowFile, page_idx_t firstHeaderPage,
     page_idx_t overflowHeaderPage)
     : keyDataTypeID(keyDataType), fileHandle{dataFH}, shadowFile{*shadowFile},
       firstHeaderPage{firstHeaderPage}, overflowHeaderPage{overflowHeaderPage} {
-    bool newIndex = this->firstHeaderPage == INVALID_PAGE_IDX;
-
-    if (newIndex) {
-        hashIndexHeadersForReadTrx.resize(NUM_HASH_INDEXES);
-        hashIndexHeadersForWriteTrx.resize(NUM_HASH_INDEXES);
-
-        hashIndexDiskArrays = std::make_unique<DiskArrayCollection>(*fileHandle, *shadowFile,
-            true /*bypassShadowing*/);
-    } else {
-        size_t headerIdx = 0;
-        for (size_t headerPageIdx = 0; headerPageIdx < INDEX_HEADER_PAGES; headerPageIdx++) {
-            fileHandle->optimisticReadPage(this->firstHeaderPage + headerPageIdx, [&](auto* frame) {
-                const auto onDiskHeaders = reinterpret_cast<HashIndexHeaderOnDisk*>(frame);
-                for (size_t i = 0; i < INDEX_HEADERS_PER_PAGE && headerIdx < NUM_HASH_INDEXES;
-                     i++) {
-                    hashIndexHeadersForReadTrx.emplace_back(onDiskHeaders[i]);
-                    headerIdx++;
-                }
-            });
-        }
-        hashIndexHeadersForWriteTrx.assign(hashIndexHeadersForReadTrx.begin(),
-            hashIndexHeadersForReadTrx.end());
-        KU_ASSERT(headerIdx == NUM_HASH_INDEXES);
-        hashIndexDiskArrays = std::make_unique<DiskArrayCollection>(*fileHandle, *shadowFile,
-            firstHeaderPage +
-                INDEX_HEADER_PAGES /*firstHeaderPage for the DAC follows the index header pages*/,
-            true /*bypassShadowing*/);
+    size_t headerIdx = 0;
+    for (size_t headerPageIdx = 0; headerPageIdx < INDEX_HEADER_PAGES; headerPageIdx++) {
+        fileHandle->optimisticReadPage(this->firstHeaderPage + headerPageIdx, [&](auto* frame) {
+            const auto onDiskHeaders = reinterpret_cast<HashIndexHeaderOnDisk*>(frame);
+            for (size_t i = 0; i < INDEX_HEADERS_PER_PAGE && headerIdx < NUM_HASH_INDEXES; i++) {
+                hashIndexHeadersForReadTrx.emplace_back(onDiskHeaders[i]);
+                headerIdx++;
+            }
+        });
     }
+    hashIndexHeadersForWriteTrx.assign(hashIndexHeadersForReadTrx.begin(),
+        hashIndexHeadersForReadTrx.end());
+    KU_ASSERT(headerIdx == NUM_HASH_INDEXES);
+    hashIndexDiskArrays = std::make_unique<DiskArrayCollection>(*fileHandle, *shadowFile,
+        firstHeaderPage +
+            INDEX_HEADER_PAGES /*firstHeaderPage for the DAC follows the index header pages*/,
+        true /*bypassShadowing*/);
+    initOverflowAndSubIndices(inMemMode, memoryManager);
+}
 
+void PrimaryKeyIndex::initOverflowAndSubIndices(bool inMemMode, MemoryManager& memoryManager) {
     if (keyDataTypeID == PhysicalTypeID::STRING) {
         if (inMemMode) {
             overflowFile = std::make_unique<InMemOverflowFile>(memoryManager);
         } else {
-            overflowFile = std::make_unique<OverflowFile>(fileHandle, memoryManager, shadowFile,
+            overflowFile = std::make_unique<OverflowFile>(fileHandle, memoryManager, &shadowFile,
                 this->overflowHeaderPage);
         }
     }
-    if (newIndex) {
-        // Each index has a primary slot array and an overflow slot array
-        for (size_t i = 0; i < NUM_HASH_INDEXES * 2; i++) {
-            hashIndexDiskArrays->addDiskArray();
-        }
-    }
-
     hashIndices.reserve(NUM_HASH_INDEXES);
     TypeUtils::visit(
         keyDataTypeID,
         [&](ku_string_t) {
             for (auto i = 0u; i < NUM_HASH_INDEXES; i++) {
                 hashIndices.push_back(std::make_unique<HashIndex<ku_string_t>>(memoryManager,
-                    fileHandle, overflowFile->addHandle(), *hashIndexDiskArrays, i, shadowFile,
+                    fileHandle, overflowFile->addHandle(), *hashIndexDiskArrays, i, &shadowFile,
                     hashIndexHeadersForReadTrx[i], hashIndexHeadersForWriteTrx[i]));
             }
         },
         [&]<HashablePrimitive T>(T) {
             for (auto i = 0u; i < NUM_HASH_INDEXES; i++) {
                 hashIndices.push_back(std::make_unique<HashIndex<T>>(memoryManager, fileHandle,
-                    nullptr, *hashIndexDiskArrays, i, shadowFile, hashIndexHeadersForReadTrx[i],
+                    nullptr, *hashIndexDiskArrays, i, &shadowFile, hashIndexHeadersForReadTrx[i],
                     hashIndexHeadersForWriteTrx[i]));
             }
         },
@@ -562,7 +561,7 @@ void PrimaryKeyIndex::writeHeaders() {
             [&](auto* frame) {
                 auto onDiskFrame = reinterpret_cast<HashIndexHeaderOnDisk*>(frame);
                 for (size_t i = 0; i < INDEX_HEADERS_PER_PAGE && headerIdx < NUM_HASH_INDEXES;
-                     i++) {
+                    i++) {
                     hashIndexHeadersForWriteTrx[headerIdx++].write(onDiskFrame[i]);
                 }
             });

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -149,7 +149,7 @@ void HashIndex<T>::splitSlots(const Transaction* transaction, HashIndexHeader& h
         Slot<T>* originalSlot = &*originalSlotIterator.seek(header.nextSplitSlotId);
         do {
             for (entry_pos_t originalEntryPos = 0; originalEntryPos < getSlotCapacity<T>();
-                originalEntryPos++) {
+                 originalEntryPos++) {
                 if (!originalSlot->header.isEntryValid(originalEntryPos)) {
                     continue; // Skip invalid entries.
                 }
@@ -296,9 +296,10 @@ void HashIndex<T>::mergeBulkInserts(const Transaction* transaction,
     // may not be consecutive, but we reduce the memory overhead for storing the information about
     // the sorted data and still just process each page once.
     for (uint64_t localSlotId = 0; localSlotId < insertLocalStorage.numPrimarySlots();
-        localSlotId += NUM_SLOTS_PER_PAGE) {
+         localSlotId += NUM_SLOTS_PER_PAGE) {
         for (size_t i = 0;
-            i < NUM_SLOTS_PER_PAGE && localSlotId + i < insertLocalStorage.numPrimarySlots(); i++) {
+             i < NUM_SLOTS_PER_PAGE && localSlotId + i < insertLocalStorage.numPrimarySlots();
+             i++) {
             auto localSlot =
                 typename InMemHashIndex<T>::SlotIterator(localSlotId + i, &insertLocalStorage);
             partitionedEntries[i].clear();
@@ -561,7 +562,7 @@ void PrimaryKeyIndex::writeHeaders() {
             [&](auto* frame) {
                 auto onDiskFrame = reinterpret_cast<HashIndexHeaderOnDisk*>(frame);
                 for (size_t i = 0; i < INDEX_HEADERS_PER_PAGE && headerIdx < NUM_HASH_INDEXES;
-                    i++) {
+                     i++) {
                     hashIndexHeadersForWriteTrx[headerIdx++].write(onDiskFrame[i]);
                 }
             });

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -485,7 +485,7 @@ void NodeTable::commit(Transaction* transaction, TableCatalogEntry* tableEntry,
     // 2. Set deleted flag for tuples that are deleted in local storage.
     row_idx_t numLocalRows = 0u;
     for (auto localNodeGroupIdx = 0u; localNodeGroupIdx < localNodeTable.getNumNodeGroups();
-        localNodeGroupIdx++) {
+         localNodeGroupIdx++) {
         const auto localNodeGroup = localNodeTable.getNodeGroup(localNodeGroupIdx);
         if (localNodeGroup->hasDeletions(transaction)) {
             // TODO(Guodong): Assume local storage is small here. Should optimize the loop away by
@@ -619,7 +619,7 @@ void NodeTable::scanPKColumn(const Transaction* transaction, PKColumnScanHelper&
 
     const auto numNodeGroups = nodeGroups_.getNumNodeGroups();
     for (node_group_idx_t nodeGroupToScan = 0u; nodeGroupToScan < numNodeGroups;
-        ++nodeGroupToScan) {
+         ++nodeGroupToScan) {
         scanState->nodeGroup = nodeGroups_.getNodeGroupNoLock(nodeGroupToScan);
 
         // It is possible for the node group to have no chunked groups if we are rolling back due to


### PR DESCRIPTION
# Description

Simplify the constructor of `PrimaryKeyIndex` a bit by breaking it into two, one for creating an empty one from scratch , and one for creating from an existing one.