### PR TITLE
Avoid reserializing catalog/storage metadata if there are no changes since last checkpoint

### DIFF
--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -177,6 +177,7 @@ public:
 
     void incrementVersion() { version++; }
     uint64_t getVersion() const { return version; }
+    void setVersion(uint64_t newVersion) { version = newVersion; }
 
     void serialize(common::Serializer& ser) const;
     void deserialize(common::Deserializer& deSer);

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -177,7 +177,8 @@ public:
 
     void incrementVersion() { version++; }
     uint64_t getVersion() const { return version; }
-    void setVersion(uint64_t newVersion) { version = newVersion; }
+    bool changedSinceLastCheckpoint() const { return version != 0; }
+    void resetVersion() { version = 0; }
 
     void serialize(common::Serializer& ser) const;
     void deserialize(common::Deserializer& deSer);
@@ -216,6 +217,8 @@ private:
     std::unique_ptr<CatalogSet> internalSequences;
     std::unique_ptr<CatalogSet> internalFunctions;
 
+    // incremented whenever a change is made to the catalog
+    // reset to 0 at the end of each checkpoint
     uint64_t version;
 };
 

--- a/src/include/storage/checkpointer.h
+++ b/src/include/storage/checkpointer.h
@@ -13,8 +13,8 @@ namespace storage {
 struct DatabaseHeader {
     PageRange catalogPageRange;
     PageRange metadataPageRange;
-    uint64_t catalogVersion;
-    uint64_t pageManagerVersion;
+    uint64_t catalogVersion{};
+    uint64_t pageManagerVersion{};
 };
 
 class Checkpointer {

--- a/src/include/storage/checkpointer.h
+++ b/src/include/storage/checkpointer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "main/client_context.h"
+#include "storage/page_range.h"
 
 namespace kuzu {
 namespace main {
@@ -9,7 +10,12 @@ class AttachedKuzuDatabase;
 
 namespace storage {
 
-struct PageRange;
+struct DatabaseHeader {
+    PageRange catalogPageRange;
+    PageRange metadataPageRange;
+    uint64_t catalogVersion;
+    uint64_t pageManagerVersion;
+};
 
 class Checkpointer {
     friend class main::AttachedKuzuDatabase;
@@ -29,7 +35,10 @@ private:
         common::VirtualFileSystem* vfs, catalog::Catalog* catalog, StorageManager* storageManager);
 
 private:
-    void writeDatabaseHeader(const PageRange& catalogPageRange, const PageRange& metadataPageRange);
+    void writeDatabaseHeader(const DatabaseHeader& header);
+    DatabaseHeader getCurrentDatabaseHeader() const;
+    PageRange serializeCatalog(catalog::Catalog& catalog, StorageManager& storageManager);
+    PageRange serializeMetadata(catalog::Catalog& catalog, StorageManager& storageManager);
 
 private:
     main::ClientContext& clientContext;

--- a/src/include/storage/checkpointer.h
+++ b/src/include/storage/checkpointer.h
@@ -13,8 +13,6 @@ namespace storage {
 struct DatabaseHeader {
     PageRange catalogPageRange;
     PageRange metadataPageRange;
-    uint64_t catalogVersion{};
-    uint64_t pageManagerVersion{};
 };
 
 class Checkpointer {

--- a/src/include/storage/page_manager.h
+++ b/src/include/storage/page_manager.h
@@ -23,7 +23,8 @@ public:
           version(0) {}
 
     uint64_t getVersion() const { return version; }
-    void setVersion(uint64_t newVersion) { version = newVersion; }
+    bool changedSinceLastCheckpoint() const { return version != 0; }
+    void resetVersion() { version = 0; }
 
     PageRange allocatePageRange(common::page_idx_t numPages);
     void freePageRange(PageRange block);

--- a/src/include/storage/page_manager.h
+++ b/src/include/storage/page_manager.h
@@ -19,7 +19,10 @@ class FileHandle;
 class PageManager {
 public:
     explicit PageManager(FileHandle* fileHandle)
-        : freeSpaceManager(std::make_unique<FreeSpaceManager>()), fileHandle(fileHandle) {}
+        : freeSpaceManager(std::make_unique<FreeSpaceManager>()), fileHandle(fileHandle),
+          version(0) {}
+
+    uint64_t getVersion() const { return version; }
 
     PageRange allocatePageRange(common::page_idx_t numPages);
     void freePageRange(PageRange block);
@@ -39,6 +42,7 @@ private:
     std::unique_ptr<FreeSpaceManager> freeSpaceManager;
     std::mutex mtx;
     FileHandle* fileHandle;
+    uint64_t version;
 };
 } // namespace storage
 } // namespace kuzu

--- a/src/include/storage/page_manager.h
+++ b/src/include/storage/page_manager.h
@@ -23,6 +23,7 @@ public:
           version(0) {}
 
     uint64_t getVersion() const { return version; }
+    void setVersion(uint64_t newVersion) { version = newVersion; }
 
     PageRange allocatePageRange(common::page_idx_t numPages);
     void freePageRange(PageRange block);

--- a/src/include/storage/page_range.h
+++ b/src/include/storage/page_range.h
@@ -5,7 +5,7 @@
 namespace kuzu::storage {
 
 struct PageRange {
-    PageRange() = default;
+    PageRange() : startPageIdx(common::INVALID_PAGE_IDX), numPages(0) {};
     PageRange(common::page_idx_t startPageIdx, common::page_idx_t numPages)
         : startPageIdx(startPageIdx), numPages(numPages) {}
 

--- a/src/include/storage/page_range.h
+++ b/src/include/storage/page_range.h
@@ -5,7 +5,7 @@
 namespace kuzu::storage {
 
 struct PageRange {
-    PageRange() : startPageIdx(common::INVALID_PAGE_IDX), numPages(0) {};
+    PageRange() : startPageIdx(common::INVALID_PAGE_IDX), numPages(0){};
     PageRange(common::page_idx_t startPageIdx, common::page_idx_t numPages)
         : startPageIdx(startPageIdx), numPages(numPages) {}
 

--- a/src/include/storage/storage_manager.h
+++ b/src/include/storage/storage_manager.h
@@ -36,7 +36,7 @@ public:
 
     void createTable(catalog::TableCatalogEntry* entry);
 
-    void checkpoint(const catalog::Catalog& catalog);
+    bool checkpoint(const catalog::Catalog& catalog);
     void finalizeCheckpoint();
     void rollbackCheckpoint(const catalog::Catalog& catalog);
 

--- a/src/include/storage/table/node_table.h
+++ b/src/include/storage/table/node_table.h
@@ -159,7 +159,7 @@ public:
 
     void commit(transaction::Transaction* transaction, catalog::TableCatalogEntry* tableEntry,
         LocalTable* localTable) override;
-    void checkpoint(catalog::TableCatalogEntry* tableEntry) override;
+    bool checkpoint(catalog::TableCatalogEntry* tableEntry) override;
     void rollbackCheckpoint() override;
     void reclaimStorage(FileHandle& dataFH) override;
 

--- a/src/include/storage/table/rel_table.h
+++ b/src/include/storage/table/rel_table.h
@@ -175,8 +175,7 @@ public:
     }
     common::column_id_t getNumColumns() const {
         KU_ASSERT(directedRelData.size() >= 1);
-        RUNTIME_CHECK(for (const auto& relData
-                           : directedRelData) {
+        RUNTIME_CHECK(for (const auto& relData : directedRelData) {
             KU_ASSERT(relData->getNumColumns() == directedRelData[0]->getNumColumns());
         });
         return directedRelData[0]->getNumColumns();
@@ -190,7 +189,7 @@ public:
 
     void commit(transaction::Transaction* transaction, catalog::TableCatalogEntry* tableEntry,
         LocalTable* localTable) override;
-    void checkpoint(catalog::TableCatalogEntry* tableEntry) override;
+    bool checkpoint(catalog::TableCatalogEntry* tableEntry) override;
     void rollbackCheckpoint() override {};
     void reclaimStorage(FileHandle& dataFH) override;
 

--- a/src/include/storage/table/rel_table.h
+++ b/src/include/storage/table/rel_table.h
@@ -175,7 +175,8 @@ public:
     }
     common::column_id_t getNumColumns() const {
         KU_ASSERT(directedRelData.size() >= 1);
-        RUNTIME_CHECK(for (const auto& relData : directedRelData) {
+        RUNTIME_CHECK(for (const auto& relData
+                           : directedRelData) {
             KU_ASSERT(relData->getNumColumns() == directedRelData[0]->getNumColumns());
         });
         return directedRelData[0]->getNumColumns();

--- a/src/include/storage/table/table.h
+++ b/src/include/storage/table/table.h
@@ -167,7 +167,7 @@ public:
 
     virtual void commit(transaction::Transaction* transaction,
         catalog::TableCatalogEntry* tableEntry, LocalTable* localTable) = 0;
-    virtual void checkpoint(catalog::TableCatalogEntry* tableEntry) = 0;
+    virtual bool checkpoint(catalog::TableCatalogEntry* tableEntry) = 0;
     virtual void rollbackCheckpoint() = 0;
     virtual void reclaimStorage(FileHandle& dataFH) = 0;
 

--- a/src/storage/checkpointer.cpp
+++ b/src/storage/checkpointer.cpp
@@ -50,11 +50,13 @@ void Checkpointer::writeCheckpoint() {
     auto* dataFH = storageManager->getDataFH();
 
     // Serialize the catalog if there are changes
-    if (catalog->changedSinceLastCheckpoint()) {
+    if (databaseHeader.catalogPageRange.startPageIdx == common::INVALID_PAGE_IDX ||
+        catalog->changedSinceLastCheckpoint()) {
         databaseHeader.catalogPageRange = serializeCatalog(*catalog, *storageManager);
     }
     // Serialize the storage metadata if there are changes
-    if (hasStorageChanges || catalog->changedSinceLastCheckpoint() ||
+    if (databaseHeader.metadataPageRange.startPageIdx == common::INVALID_PAGE_IDX ||
+        hasStorageChanges || catalog->changedSinceLastCheckpoint() ||
         dataFH->getPageManager()->changedSinceLastCheckpoint()) {
         databaseHeader.metadataPageRange = serializeMetadata(*catalog, *storageManager);
     }

--- a/src/storage/page_manager.cpp
+++ b/src/storage/page_manager.cpp
@@ -12,6 +12,7 @@ PageRange PageManager::allocatePageRange(common::page_idx_t numPages) {
         common::UniqLock lck{mtx};
         auto allocatedFreeChunk = freeSpaceManager->popFreePages(numPages);
         if (allocatedFreeChunk.has_value()) {
+            ++version;
             return {*allocatedFreeChunk};
         }
     }
@@ -26,6 +27,7 @@ void PageManager::freePageRange(PageRange entry) {
         // Freed pages cannot be immediately reused to ensure checkpoint recovery works
         // Instead they are reusable after the end of the next checkpoint
         freeSpaceManager->addUncheckpointedFreePages(entry);
+        ++version;
     }
 }
 

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -478,7 +478,7 @@ void NodeTable::commit(Transaction* transaction, TableCatalogEntry* tableEntry,
     // 2. Set deleted flag for tuples that are deleted in local storage.
     row_idx_t numLocalRows = 0u;
     for (auto localNodeGroupIdx = 0u; localNodeGroupIdx < localNodeTable.getNumNodeGroups();
-        localNodeGroupIdx++) {
+         localNodeGroupIdx++) {
         const auto localNodeGroup = localNodeTable.getNodeGroup(localNodeGroupIdx);
         if (localNodeGroup->hasDeletions(transaction)) {
             // TODO(Guodong): Assume local storage is small here. Should optimize the loop away by
@@ -611,7 +611,7 @@ void NodeTable::scanPKColumn(const Transaction* transaction, PKColumnScanHelper&
 
     const auto numNodeGroups = nodeGroups_.getNumNodeGroups();
     for (node_group_idx_t nodeGroupToScan = 0u; nodeGroupToScan < numNodeGroups;
-        ++nodeGroupToScan) {
+         ++nodeGroupToScan) {
         scanState->nodeGroup = nodeGroups_.getNodeGroupNoLock(nodeGroupToScan);
 
         // It is possible for the node group to have no chunked groups if we are rolling back due to

--- a/src/storage/table/rel_table.cpp
+++ b/src/storage/table/rel_table.cpp
@@ -481,7 +481,8 @@ void RelTable::prepareCommitForNodeGroup(const Transaction* transaction,
     }
 }
 
-void RelTable::checkpoint(TableCatalogEntry* tableEntry) {
+bool RelTable::checkpoint(TableCatalogEntry* tableEntry) {
+    bool ret = hasChanges;
     if (hasChanges) {
         // Deleted columns are vacuumed and not checkpointed or serialized.
         std::vector<column_id_t> columnIDs;
@@ -494,6 +495,7 @@ void RelTable::checkpoint(TableCatalogEntry* tableEntry) {
         }
         hasChanges = false;
     }
+    return ret;
 }
 
 row_idx_t RelTable::getNumTotalRows(const Transaction* transaction) {

--- a/test/test_files/function/call/call.test
+++ b/test/test_files/function/call/call.test
@@ -392,14 +392,18 @@ Binder exception: Unknown table function output variable name: destination table
 Binder exception: The number of variables in the yield clause exceeds the number of output variables of the table function.
 
 -CASE CallCatalogVersion
+-STATEMENT CALL auto_checkpoint=false;
+---- ok
+-STATEMENT CHECKPOINT;
+---- ok
 -STATEMENT CALL catalog_version() return *;
 ---- 1
-8
+0
 -STATEMENT CREATE NODE TABLE test(id INT64 PRIMARY KEY);
 ---- ok
 -STATEMENT CALL catalog_version() return *;
 ---- 1
-9
+1
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT CREATE REL TABLE testRel(FROM test TO test);
@@ -408,7 +412,7 @@ Binder exception: The number of variables in the yield clause exceeds the number
 ---- ok
 -STATEMENT CALL catalog_version() return *;
 ---- 1
-9
+1
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT CREATE REL TABLE testRel(FROM test TO test);
@@ -417,7 +421,7 @@ Binder exception: The number of variables in the yield clause exceeds the number
 ---- ok
 -STATEMENT CALL catalog_version() return *;
 ---- 1
-10
+2
 
 -CASE CacheArrayColumn
 -STATEMENT CREATE NODE TABLE testArray(id INT64 PRIMARY KEY, arr INT64[8]);

--- a/test/test_files/function/call/call.test
+++ b/test/test_files/function/call/call.test
@@ -392,6 +392,7 @@ Binder exception: Unknown table function output variable name: destination table
 Binder exception: The number of variables in the yield clause exceeds the number of output variables of the table function.
 
 -CASE CallCatalogVersion
+-SKIP_IN_MEM
 -STATEMENT CALL auto_checkpoint=false;
 ---- ok
 -STATEMENT CHECKPOINT;


### PR DESCRIPTION
# Description

Detects if any changes were made to the catalog/storage metadata since the last checkpoint. If not, skips serializing and reuses the same pages + serialized data from the last checkpoint (as stored in the DB header).

- `Table::checkpoint` now returns a boolean that says whether there are any checkpointed changes for the current table
- Added a version for `PageManager` that increments on each FSM modification. This together with the catalog version helps determine if there are any changes in the current checkpoint
- When writing a checkpoint now reads the database header from the previous checkpoint. This data is used in case we skip serializing in the current checkpoint.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).