### PR TITLE
Clear logical plan

### DIFF
--- a/src/binder/expression/expression.cpp
+++ b/src/binder/expression/expression.cpp
@@ -7,7 +7,7 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace binder {
 
-Expression::~Expression() {}
+Expression::~Expression() = default;
 
 void Expression::cast(const LogicalType&) {
     // LCOV_EXCL_START

--- a/src/binder/expression/expression.cpp
+++ b/src/binder/expression/expression.cpp
@@ -7,6 +7,8 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace binder {
 
+Expression::~Expression() {}
+
 void Expression::cast(const LogicalType&) {
     // LCOV_EXCL_START
     throw BinderException(

--- a/src/include/binder/expression/expression.h
+++ b/src/include/binder/expression/expression.h
@@ -53,7 +53,7 @@ public:
         : Expression{expressionType, std::move(dataType), expression_vector{},
               std::move(uniqueName)} {}
     DELETE_COPY_DEFAULT_MOVE(Expression);
-    virtual ~Expression() = default;
+    virtual ~Expression();
 
     void setUniqueName(const std::string& name) { uniqueName = name; }
     std::string getUniqueName() const {

--- a/src/include/planner/join_order/cost_model.h
+++ b/src/include/planner/join_order/cost_model.h
@@ -17,7 +17,7 @@ public:
     static uint64_t computeMarkJoinCost(const binder::expression_vector& joinNodeIDs,
         const LogicalPlan& probe, const LogicalPlan& build);
     static uint64_t computeIntersectCost(const LogicalPlan& probePlan,
-        const std::vector<std::unique_ptr<LogicalPlan>>& buildPlans);
+        const std::vector<LogicalPlan>& buildPlans);
 };
 
 } // namespace planner

--- a/src/include/planner/join_order_enumerator_context.h
+++ b/src/include/planner/join_order_enumerator_context.h
@@ -22,11 +22,10 @@ public:
     bool containPlans(const binder::SubqueryGraph& subqueryGraph) const {
         return subPlansTable->containSubgraphPlans(subqueryGraph);
     }
-    std::vector<std::unique_ptr<LogicalPlan>>& getPlans(
-        const binder::SubqueryGraph& subqueryGraph) const {
+    const std::vector<LogicalPlan>& getPlans(const binder::SubqueryGraph& subqueryGraph) const {
         return subPlansTable->getSubgraphPlans(subqueryGraph);
     }
-    void addPlan(const binder::SubqueryGraph& subqueryGraph, std::unique_ptr<LogicalPlan> plan) {
+    void addPlan(const binder::SubqueryGraph& subqueryGraph, LogicalPlan plan) {
         subPlansTable->addPlan(subqueryGraph, std::move(plan));
     }
 

--- a/src/include/planner/operator/logical_plan.h
+++ b/src/include/planner/operator/logical_plan.h
@@ -13,6 +13,7 @@ class KUZU_API LogicalPlan {
 
 public:
     LogicalPlan() : cost{0} {}
+    LogicalPlan(const LogicalPlan& other) : lastOperator{other.lastOperator}, cost{other.cost} {}
     EXPLICIT_COPY_DEFAULT_MOVE(LogicalPlan);
 
     void setLastOperator(std::shared_ptr<LogicalOperator> op) { lastOperator = std::move(op); }
@@ -38,11 +39,6 @@ public:
 
     bool isProfile() const;
     bool hasUpdate() const;
-
-    std::unique_ptr<LogicalPlan> shallowCopy() const;
-
-private:
-    LogicalPlan(const LogicalPlan& other) : lastOperator{other.lastOperator}, cost{other.cost} {}
 
 private:
     std::shared_ptr<LogicalOperator> lastOperator;

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -261,7 +261,7 @@ public:
         LogicalPlan& buildPlan, LogicalPlan& resultPlan);
     void appendIntersect(const std::shared_ptr<binder::Expression>& intersectNodeID,
         binder::expression_vector& boundNodeIDs, LogicalPlan& probePlan,
-        std::vector<std::unique_ptr<LogicalPlan>>& buildPlans);
+        std::vector<LogicalPlan>& buildPlans);
 
     void appendCrossProduct(const LogicalPlan& probePlan, const LogicalPlan& buildPlan,
         LogicalPlan& resultPlan);

--- a/src/include/planner/subplans_table.h
+++ b/src/include/planner/subplans_table.h
@@ -25,11 +25,11 @@ class SubgraphPlans {
 public:
     explicit SubgraphPlans(const binder::SubqueryGraph& subqueryGraph);
 
-    inline uint64_t getMaxCost() const { return maxCost; }
+    uint64_t getMaxCost() const { return maxCost; }
 
-    void addPlan(std::unique_ptr<LogicalPlan> plan);
+    void addPlan(LogicalPlan plan);
 
-    std::vector<std::unique_ptr<LogicalPlan>>& getPlans() { return plans; }
+    const std::vector<LogicalPlan>& getPlans() const { return plans; }
 
 private:
     // To balance computation time, we encode plan by only considering the flat information of the
@@ -42,7 +42,7 @@ private:
 private:
     uint64_t maxCost = UINT64_MAX;
     binder::expression_vector nodeIDsToEncode;
-    std::vector<std::unique_ptr<LogicalPlan>> plans;
+    std::vector<LogicalPlan> plans;
     std::unordered_map<std::bitset<binder::MAX_NUM_QUERY_VARIABLES>, common::idx_t>
         encodedPlan2PlanIdx;
 };
@@ -51,25 +51,25 @@ private:
 // variables.
 class DPLevel {
 public:
-    inline bool contains(const binder::SubqueryGraph& subqueryGraph) {
+    bool contains(const binder::SubqueryGraph& subqueryGraph) const {
         return subgraph2Plans.contains(subqueryGraph);
     }
 
-    inline SubgraphPlans* getSubgraphPlans(const binder::SubqueryGraph& subqueryGraph) {
-        return subgraph2Plans.at(subqueryGraph).get();
+    const SubgraphPlans& getSubgraphPlans(const binder::SubqueryGraph& subqueryGraph) const {
+        return subgraph2Plans.at(subqueryGraph);
     }
 
     std::vector<binder::SubqueryGraph> getSubqueryGraphs();
 
-    void addPlan(const binder::SubqueryGraph& subqueryGraph, std::unique_ptr<LogicalPlan> plan);
+    void addPlan(const binder::SubqueryGraph& subqueryGraph, LogicalPlan plan);
 
-    inline void clear() { subgraph2Plans.clear(); }
+    void clear() { subgraph2Plans.clear(); }
 
 private:
     constexpr static uint32_t MAX_NUM_SUBGRAPH = 50;
 
 private:
-    binder::subquery_graph_V_map_t<std::unique_ptr<SubgraphPlans>> subgraph2Plans;
+    binder::subquery_graph_V_map_t<SubgraphPlans> subgraph2Plans;
 };
 
 class SubPlansTable {
@@ -80,22 +80,25 @@ public:
 
     bool containSubgraphPlans(const binder::SubqueryGraph& subqueryGraph) const;
 
-    std::vector<std::unique_ptr<LogicalPlan>>& getSubgraphPlans(
-        const binder::SubqueryGraph& subqueryGraph);
+    const std::vector<LogicalPlan>& getSubgraphPlans(
+        const binder::SubqueryGraph& subqueryGraph) const;
 
     std::vector<binder::SubqueryGraph> getSubqueryGraphs(uint32_t level);
 
-    void addPlan(const binder::SubqueryGraph& subqueryGraph, std::unique_ptr<LogicalPlan> plan);
+    void addPlan(const binder::SubqueryGraph& subqueryGraph, LogicalPlan plan);
 
     void clear();
 
 private:
-    DPLevel* getDPLevel(const binder::SubqueryGraph& subqueryGraph) const {
-        return dpLevels[subqueryGraph.getTotalNumVariables()].get();
+    const DPLevel& getDPLevel(const binder::SubqueryGraph& subqueryGraph) const {
+        return dpLevels[subqueryGraph.getTotalNumVariables()];
+    }
+    DPLevel& getDPLevelUnsafe(const binder::SubqueryGraph& subqueryGraph) {
+        return dpLevels[subqueryGraph.getTotalNumVariables()];
     }
 
 private:
-    std::vector<std::unique_ptr<DPLevel>> dpLevels;
+    std::vector<DPLevel> dpLevels;
 };
 
 } // namespace planner

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -518,7 +518,7 @@ std::unique_ptr<PreparedStatement> ClientContext::prepareNoLock(
                 auto bestPlan = planner.planStatement(*boundStatement);
                 // optimizing
                 optimizer::Optimizer::optimize(&bestPlan, this, planner.getCardinalityEstimator());
-                preparedStatement->logicalPlan = bestPlan.shallowCopy();
+                preparedStatement->logicalPlan = std::make_unique<LogicalPlan>(bestPlan);
             },
             preparedStatement->isReadOnly(), preparedStatement->isTransactionStatement(),
             TransactionHelper::getAction(shouldCommitNewTransaction,

--- a/src/planner/join_order/cost_model.cpp
+++ b/src/planner/join_order/cost_model.cpp
@@ -39,16 +39,16 @@ uint64_t CostModel::computeMarkJoinCost(const binder::expression_vector& joinNod
     return computeHashJoinCost(joinNodeIDs, probe, build);
 }
 
-uint64_t CostModel::computeIntersectCost(const kuzu::planner::LogicalPlan& probePlan,
-    const std::vector<std::unique_ptr<LogicalPlan>>& buildPlans) {
+uint64_t CostModel::computeIntersectCost(const LogicalPlan& probePlan,
+    const std::vector<LogicalPlan>& buildPlans) {
     uint64_t cost = 0ul;
     cost += probePlan.getCost();
     // TODO(Xiyang): think of how to calculate intersect cost such that it will be picked in worst
     // case.
     cost += probePlan.getCardinality();
     for (auto& buildPlan : buildPlans) {
-        KU_ASSERT(buildPlan->getCardinality() >= 1);
-        cost += buildPlan->getCost();
+        KU_ASSERT(buildPlan.getCardinality() >= 1);
+        cost += buildPlan.getCost();
     }
     return cost;
 }

--- a/src/planner/join_order/join_plan_solver.cpp
+++ b/src/planner/join_order/join_plan_solver.cpp
@@ -126,7 +126,7 @@ LogicalPlan JoinPlanSolver::solveMultiwayJoinTreeNode(const JoinTreeNode& treeNo
     KU_ASSERT(extraInfo.joinNodes.size() == 1);
     auto& joinNode = extraInfo.joinNodes[0]->constCast<NodeExpression>();
     auto probePlan = solveTreeNode(*treeNode.children[0], &treeNode);
-    std::vector<std::unique_ptr<LogicalPlan>> buildPlans;
+    std::vector<LogicalPlan> buildPlans;
     expression_vector boundNodeIDs;
     for (auto i = 1u; i < treeNode.children.size(); ++i) {
         auto child = treeNode.children[i];
@@ -134,7 +134,7 @@ LogicalPlan JoinPlanSolver::solveMultiwayJoinTreeNode(const JoinTreeNode& treeNo
         auto& childExtraInfo = child->extraInfo->constCast<ExtraScanTreeNodeInfo>();
         auto rel = std::static_pointer_cast<RelExpression>(childExtraInfo.relInfos[0].nodeOrRel);
         auto boundNode = *rel->getSrcNode() == joinNode ? rel->getDstNode() : rel->getSrcNode();
-        buildPlans.push_back(solveTreeNode(*child, &treeNode).shallowCopy());
+        buildPlans.push_back(solveTreeNode(*child, &treeNode).copy());
         boundNodeIDs.push_back(boundNode->constCast<NodeExpression>().getInternalID());
     }
     auto plan = LogicalPlan();

--- a/src/planner/operator/logical_plan.cpp
+++ b/src/planner/operator/logical_plan.cpp
@@ -15,12 +15,5 @@ bool LogicalPlan::hasUpdate() const {
     return lastOperator->hasUpdateRecursive();
 }
 
-std::unique_ptr<LogicalPlan> LogicalPlan::shallowCopy() const {
-    auto plan = std::make_unique<LogicalPlan>();
-    plan->lastOperator = lastOperator; // shallow copy sub-plan
-    plan->cost = cost;
-    return plan;
-}
-
 } // namespace planner
 } // namespace kuzu

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -131,14 +131,14 @@ void Planner::appendRecursiveExtend(const std::shared_ptr<NodeExpression>& bound
     // Scan path rel property pipeline
     std::shared_ptr<LogicalOperator> pathRelPropertyScanRoot = nullptr;
     if (!recursiveInfo->relProjectionList.empty()) {
-        auto pathRelPropertyScanPlan = std::make_unique<LogicalPlan>();
+        auto pathRelPropertyScanPlan = LogicalPlan();
         auto relProperties = recursiveInfo->relProjectionList;
         relProperties.push_back(recursiveInfo->rel->getInternalIDProperty());
         bool extendFromSource = *boundNode == *rel->getSrcNode();
         createPathRelPropertyScanPlan(recursiveInfo->node, recursiveInfo->nodeCopy,
             recursiveInfo->rel, direction, extendFromSource, relProperties,
-            *pathRelPropertyScanPlan);
-        pathRelPropertyScanRoot = pathRelPropertyScanPlan->getLastOperator();
+            pathRelPropertyScanPlan);
+        pathRelPropertyScanRoot = pathRelPropertyScanPlan.getLastOperator();
     }
     // Construct path by probing scanned properties
     auto pathPropertyProbe =

--- a/src/planner/query_planner.cpp
+++ b/src/planner/query_planner.cpp
@@ -9,7 +9,6 @@ namespace kuzu {
 namespace planner {
 
 LogicalPlan Planner::planQuery(const BoundStatement& boundStatement) {
-    std::unique_ptr<LogicalPlan> resultPlans;
     auto& regularQuery = boundStatement.constCast<BoundRegularQuery>();
     if (regularQuery.getNumSingleQueries() == 1) {
         return planSingleQuery(*regularQuery.getSingleQuery(0));

--- a/src/planner/subplans_table.cpp
+++ b/src/planner/subplans_table.cpp
@@ -5,7 +5,7 @@ using namespace kuzu::binder;
 namespace kuzu {
 namespace planner {
 
-SubgraphPlans::SubgraphPlans(const kuzu::binder::SubqueryGraph& subqueryGraph) {
+SubgraphPlans::SubgraphPlans(const SubqueryGraph& subqueryGraph) {
     for (auto i = 0u; i < subqueryGraph.queryGraph.getNumQueryNodes(); ++i) {
         if (subqueryGraph.queryNodesSelector[i]) {
             nodeIDsToEncode.push_back(subqueryGraph.queryGraph.getQueryNode(i)->getInternalID());
@@ -14,25 +14,25 @@ SubgraphPlans::SubgraphPlans(const kuzu::binder::SubqueryGraph& subqueryGraph) {
     maxCost = UINT64_MAX;
 }
 
-void SubgraphPlans::addPlan(std::unique_ptr<LogicalPlan> plan) {
+void SubgraphPlans::addPlan(LogicalPlan plan) {
     if (plans.size() > MAX_NUM_PLANS) {
         return;
     }
-    auto planCode = encodePlan(*plan);
+    auto planCode = encodePlan(plan);
     if (!encodedPlan2PlanIdx.contains(planCode)) {
         encodedPlan2PlanIdx.insert({planCode, plans.size()});
-        if (maxCost == UINT64_MAX || plan->getCost() > maxCost) { // update max cost
-            maxCost = plan->getCost();
+        if (maxCost == UINT64_MAX || plan.getCost() > maxCost) { // update max cost
+            maxCost = plan.getCost();
         }
         plans.push_back(std::move(plan));
     } else {
         auto planIdx = encodedPlan2PlanIdx.at(planCode);
-        if (plan->getCost() < plans[planIdx]->getCost()) {
-            if (plans[planIdx]->getCost() == maxCost) { // update max cost
+        if (plan.getCost() < plans[planIdx].getCost()) {
+            if (plans[planIdx].getCost() == maxCost) { // update max cost
                 maxCost = 0;
                 for (auto& plan_ : plans) {
-                    if (plan_->getCost() > maxCost) {
-                        maxCost = plan_->getCost();
+                    if (plan_.getCost() > maxCost) {
+                        maxCost = plan_.getCost();
                     }
                 }
             }
@@ -59,54 +59,53 @@ std::vector<SubqueryGraph> DPLevel::getSubqueryGraphs() {
     return result;
 }
 
-void DPLevel::addPlan(const kuzu::binder::SubqueryGraph& subqueryGraph,
-    std::unique_ptr<LogicalPlan> plan) {
+void DPLevel::addPlan(const SubqueryGraph& subqueryGraph, LogicalPlan plan) {
     if (subgraph2Plans.size() > MAX_NUM_SUBGRAPH) {
         return;
     }
     if (!contains(subqueryGraph)) {
-        subgraph2Plans.insert({subqueryGraph, std::make_unique<SubgraphPlans>(subqueryGraph)});
+        subgraph2Plans.insert({subqueryGraph, SubgraphPlans(subqueryGraph)});
     }
-    subgraph2Plans.at(subqueryGraph)->addPlan(std::move(plan));
+    subgraph2Plans.at(subqueryGraph).addPlan(std::move(plan));
 }
 
 void SubPlansTable::resize(uint32_t newSize) {
     auto prevSize = dpLevels.size();
     dpLevels.resize(newSize);
     for (auto i = prevSize; i < newSize; ++i) {
-        dpLevels[i] = std::make_unique<DPLevel>();
+        dpLevels[i] = DPLevel();
     }
 }
 
 uint64_t SubPlansTable::getMaxCost(const SubqueryGraph& subqueryGraph) const {
     return containSubgraphPlans(subqueryGraph) ?
-               getDPLevel(subqueryGraph)->getSubgraphPlans(subqueryGraph)->getMaxCost() :
+               getDPLevel(subqueryGraph).getSubgraphPlans(subqueryGraph).getMaxCost() :
                UINT64_MAX;
 }
 
 bool SubPlansTable::containSubgraphPlans(const SubqueryGraph& subqueryGraph) const {
-    return getDPLevel(subqueryGraph)->contains(subqueryGraph);
+    return getDPLevel(subqueryGraph).contains(subqueryGraph);
 }
 
-std::vector<std::unique_ptr<LogicalPlan>>& SubPlansTable::getSubgraphPlans(
-    const SubqueryGraph& subqueryGraph) {
-    auto dpLevel = getDPLevel(subqueryGraph);
-    KU_ASSERT(dpLevel->contains(subqueryGraph));
-    return dpLevel->getSubgraphPlans(subqueryGraph)->getPlans();
+const std::vector<LogicalPlan>& SubPlansTable::getSubgraphPlans(
+    const SubqueryGraph& subqueryGraph) const {
+    auto& dpLevel = getDPLevel(subqueryGraph);
+    KU_ASSERT(dpLevel.contains(subqueryGraph));
+    return dpLevel.getSubgraphPlans(subqueryGraph).getPlans();
 }
 
 std::vector<SubqueryGraph> SubPlansTable::getSubqueryGraphs(uint32_t level) {
-    return dpLevels[level]->getSubqueryGraphs();
+    return dpLevels[level].getSubqueryGraphs();
 }
 
-void SubPlansTable::addPlan(const SubqueryGraph& subqueryGraph, std::unique_ptr<LogicalPlan> plan) {
-    auto dpLevel = getDPLevel(subqueryGraph);
-    dpLevel->addPlan(subqueryGraph, std::move(plan));
+void SubPlansTable::addPlan(const SubqueryGraph& subqueryGraph, LogicalPlan plan) {
+    auto& dpLevel = getDPLevelUnsafe(subqueryGraph);
+    dpLevel.addPlan(subqueryGraph, std::move(plan));
 }
 
 void SubPlansTable::clear() {
     for (auto& dpLevel : dpLevels) {
-        dpLevel->clear();
+        dpLevel.clear();
     }
 }
 


### PR DESCRIPTION
# Description

Clear unnecessary use of smart pointers around LogicalPlan. Remove shallowCopy interface.

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).