### PR TITLE
Collect memory optimization

### DIFF
--- a/src/processor/operator/aggregate/simple_aggregate.cpp
+++ b/src/processor/operator/aggregate/simple_aggregate.cpp
@@ -152,6 +152,7 @@ void SimpleAggregateSharedState::finalizePartitions(storage::MemoryManager* memo
         return;
     }
     BaseAggregateSharedState::finalizePartitions(globalPartitions, [&](auto& partition) {
+        std::unique_lock lck{mtx};
         for (size_t i = 0; i < partition.distinctTables.size(); i++) {
             if (!aggregateFunctions[i].isDistinct) {
                 continue;

--- a/test/test_files/agg/distinct_agg.test
+++ b/test/test_files/agg/distinct_agg.test
@@ -122,3 +122,10 @@ Bob|Dan
 -STATEMENT MATCH (:person), (a:person)-[t:knows*2..2]->(b:person) RETURN count(*), count(DISTINCT t);
 ---- 1
 288|36
+
+-CASE Debug
+-STATEMENT UNWIND [1,1,3] AS x MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID=5 WITH COLLECT(DISTINCT e) AS es UNWIND es AS newE RETURN newE.date;
+---- 3
+1950-05-14
+2000-01-01
+2021-06-30

--- a/test/test_files/agg/hash_ldbc.test
+++ b/test/test_files/agg/hash_ldbc.test
@@ -49,8 +49,11 @@ Chrome|[Chrome,Firefox,Internet Explorer,Opera,Safari]
 Safari|[Chrome,Firefox,Internet Explorer,Opera,Safari]
 Opera|[Chrome,Firefox,Internet Explorer,Opera,Safari]
 
--CASE Debug
--STATEMENT MATCH (a:Comment)-[e:replyOf_Comment]->(b:Comment)
-            WITH b, collect(a) as aList
-            RETURN b, aList
----- ok
+-LOG TestCollectManyGroups
+-STATEMENT MATCH (a:Comment)-[e:replyOf_Comment]->(b:Comment) WITH b, collect(a) as aList RETURN b.id, size(aList) ORDER BY b.id DESC LIMIT 5;
+---- 5
+1099511998009|1
+1099511998014|4
+1099511998015|4
+1099511998020|1
+1099511998025|1

--- a/test/test_files/agg/hash_ldbc.test
+++ b/test/test_files/agg/hash_ldbc.test
@@ -48,3 +48,9 @@ Internet Explorer|[Chrome,Firefox,Internet Explorer,Opera,Safari]
 Chrome|[Chrome,Firefox,Internet Explorer,Opera,Safari]
 Safari|[Chrome,Firefox,Internet Explorer,Opera,Safari]
 Opera|[Chrome,Firefox,Internet Explorer,Opera,Safari]
+
+-CASE Debug
+-STATEMENT MATCH (a:Comment)-[e:replyOf_Comment]->(b:Comment)
+            WITH b, collect(a) as aList
+            RETURN b, aList
+---- ok


### PR DESCRIPTION
# Description

Closes https://github.com/kuzudb/kuzu/issues/5395 and https://github.com/kuzudb/kuzu/issues/5398

Instead of storing a `FactorizedTable` in each `CollectState`, we use the shared overflow buffer to allocate the elements in the collected list. 

The elements will form a linked list, with each element pointing to the memory in the shared overflow buffer containing the next element. This implementation was chosen over a simpler one (e.g. storing a vector of pointers in each `CollectState` to ensure that `CollectState` is trivially destructable, which is desired because the lifetimes of `CollectState` are difficult to manage (as they are stored in a FactorizedTable with their type casted away, which can prevent their destructor from being called).

Also fixes a concurrency bug where an unprotected shared overflow buffer is used in the finalizing the simple hash aggregates. Now, thread-local overflow buffers are used during finalization and the memory is merged into the shared buffer at the end of each thread's finalization.

# Microbenchmarks

First, we check to see the performance impact of the fix to the concurrency bug:

These benchmarks were done on clickbench.

Query | Execution time (master) | Execution time (new) | Peak memory usage (master) | Peak memory usage (new)
----|----|----|----|----
`MATCH (h:hits) RETURN COUNT(DISTINCT h.UserID);`|507ms|540ms|4458MB|4506MB
`MATCH (h:hits) RETURN COUNT(DISTINCT h.SearchPhrase);`|455ms|395ms|5270MB|5207MB
`MATCH (h:hits) RETURN h.RegionID, COUNT(DISTINCT h.UserID) AS u ORDER BY u DESC LIMIT 10;`|1850ms|1840ms|5388MB|5337MB

Next, we check the performance impact on collect:

These benchmarks were done on ldbc-sf01:

Dataset|Query | Execution time (master) | Execution time (new) | Peak memory usage (master) | Peak memory usage (new)
----|----|----|----|----|----
ldbc-sf01 replyOf_Comment (~77K edges) | `MATCH (a:Comment)-[e:replyOf_Comment]->(b:Comment) WITH b, collect(a) as aList RETURN b, aList;`|2.04s|0.38ms|9592MB|1261MB
twitter (~81K nodes, ~2.4M edges) | `MATCH (a:account)-[e:follows]->(b:account) return b.ID, collect(a);`|44s|1.05s|264GB|1.68GB

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).