### PR TITLE
build: allow system dependencies in cmake, refactor Makefile and CI

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Build
         run: make release
 
+      # Generate the binary db once to test that it can be read on all platforms.
       - name: Generate datasets
         run: bash scripts/generate_binary_demo.sh
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -80,17 +80,26 @@ jobs:
       - name: Generate datasets
         run: bash scripts/generate_binary_demo.sh
 
+      - name: Upload binary-demo
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-demo
+          path: dataset/binary-demo
+
       - name: Generate and upload tinysnb
         run: |
-          bash scripts/generate_binary_tinysnb.sh
-          s3cmd get s3://kuzu-test/tinysnb/version.txt || echo "0" > version.txt
-          s3cmd --access_key=${GCS_ACCESS_KEY_ID} --secret_key=${GCS_SECRET_ACCESS_KEY} --host=storage.googleapis.com --host-bucket="%(bucket)s.storage.googleapis.com" get s3://kuzudb-test/tinysnb/version.txt || echo "0" > version_gcs.txt
-          if [ "$(cat tinysnb/version.txt)" == "$(cat version.txt)" ] && [ "$(cat tinysnb/version.txt)" == "$(cat version_gcs.txt)" ]; then
+          version_current="$(python3 benchmark/version.py)"
+          echo "0" > version_s3.txt
+          echo "0" > version_gcs.txt
+          s3cmd get --force s3://kuzu-test/tinysnb/version.txt version_s3.txt || true
+          s3cmd --access_key=${GCS_ACCESS_KEY_ID} --secret_key=${GCS_SECRET_ACCESS_KEY} --host=storage.googleapis.com --host-bucket="%(bucket)s.storage.googleapis.com" get --force s3://kuzudb-test/tinysnb/version.txt version_gcs.txt || true
+          if [[ "$version_current" == "$(cat version_s3.txt)" ]] && [[ "$version_current" == "$(cat version_gcs.txt)" ]]; then
             echo "TinySNB dataset is up to date, skipping upload"
-            rm -rf tinysnb version.txt
+            rm -rf tinysnb version_s3.txt version_gcs.txt
             exit 0
           fi
           echo "TinySNB dataset is outdated, uploading..."
+          bash scripts/generate_binary_tinysnb.sh
           s3cmd del -r s3://kuzu-test/tinysnb/
           s3cmd sync ./tinysnb s3://kuzu-test/
           # s3cmd del -r doesn't work on GCS so we individually delete each object in the directory
@@ -99,27 +108,23 @@ jobs:
               s3cmd --access_key=${GCS_ACCESS_KEY_ID} --secret_key=${GCS_SECRET_ACCESS_KEY} --host=storage.googleapis.com --host-bucket="%(bucket)s.storage.googleapis.com" del ${gcs_file}
           done
           s3cmd --access_key=${GCS_ACCESS_KEY_ID} --secret_key=${GCS_SECRET_ACCESS_KEY} --host=storage.googleapis.com --host-bucket="%(bucket)s.storage.googleapis.com" sync ./tinysnb s3://kuzudb-test/
-          rm -rf tinysnb version.txt version_gcs.txt
+          rm -rf tinysnb version_s3.txt version_gcs.txt
 
       - name: Generate and upload ldbc-sf01
         run: |
-          bash scripts/generate_binary_ldbc-sf01.sh
-          s3cmd get s3://kuzu-test/ldbc01/version.txt || echo "0" > version.txt
-          if [ "$(cat ldbc01/version.txt)" == "$(cat version.txt)" ]; then
+          version_current="$(python3 benchmark/version.py)"
+          echo "0" > version_s3.txt
+          s3cmd get --force s3://kuzu-test/ldbc01/version.txt version_s3.txt || true
+          if [[ "$version_current" == "$(cat version_s3.txt)" ]]; then
             echo "LDBC-SF01 dataset is up to date, skipping upload"
-            rm -rf ldbc01 version.txt
+            rm -rf ldbc01 version_s3.txt
             exit 0
           fi
           echo "LDBC-SF01 dataset is outdated, uploading..."
+          bash scripts/generate_binary_ldbc-sf01.sh
           s3cmd del -r s3://kuzu-test/ldbc01/
           s3cmd sync ./ldbc01 s3://kuzu-test/
-          rm -rf ldbc01 version.txt
-
-      - name: Upload binary-demo
-        uses: actions/upload-artifact@v4
-        with:
-          name: binary-demo
-          path: dataset/binary-demo
+          rm -rf ldbc01 version_s3.txt
 
   gcc-build-test:
     name: gcc build & test

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -183,11 +183,17 @@ jobs:
         run: |
           make test
 
+      - name: Ensure Python dependencies
+        run: pip install --user -r tools/python_api/requirements_dev.txt
+
       - name: Python test
-        run: make pytest-venv
+        run: make pytest
+
+      - name: Ensure Node.js dependencies
+        run: make nodejs-deps
 
       - name: Node.js test
-        run: make nodejstest-deps
+        run: make nodejstest
 
       - name: Java test
         run: make javatest
@@ -462,11 +468,17 @@ jobs:
         run: |
           make test DEFAULT_REL_STORAGE_DIRECTION=BOTH
 
+      - name: Ensure Python dependencies
+        run: pip install --user -r tools/python_api/requirements_dev.txt
+
       - name: Python test
-        run: make pytest-venv
+        run: make pytest
+
+      - name: Ensure Node.js dependencies
+        run: make nodejs-deps
 
       - name: Node.js test
-        run: make nodejstest-deps
+        run: make nodejstest
 
       - name: Java test
         run: make javatest
@@ -640,17 +652,23 @@ jobs:
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
           make test
 
+      - name: Ensure Python dependencies
+        run: pip install --user -r tools/python_api/requirements_dev.txt
+
       - name: Python test
         shell: cmd
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-          make pytest-venv
+          make pytest
+
+      - name: Ensure Node.js dependencies
+        run: make nodejs-deps
 
       - name: Node.js test
         shell: cmd
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-          make nodejstest-deps
+          make nodejstest
 
       - name: Java test
         shell: cmd
@@ -880,22 +898,28 @@ jobs:
         run: |
           make test
 
-      - name: Python test
-        env:
-          PYBIND11_PYTHON_VERSION: 3.12
-        run: |
-          ulimit -n 10240
-          make pytest-venv
-
       - name: C and C++ Examples
         run: |
           ulimit -n 10240
           make example
 
+      - name: Ensure Python dependencies
+        run: pip install --user -r tools/python_api/requirements_dev.txt
+
+      - name: Python test
+        env:
+          PYBIND11_PYTHON_VERSION: 3.12
+        run: |
+          ulimit -n 10240
+          make pytest
+
+      - name: Ensure Node.js dependencies
+        run: make nodejs-deps
+
       - name: Node.js test
         run: |
           ulimit -n 10240
-          make nodejstest-deps
+          make nodejstest
 
       - name: Java test
         run: |
@@ -944,7 +968,9 @@ jobs:
 
       - name: Test
         working-directory: tools/shell/test
-        run: make test
+        run: |
+          pip3 install pytest pexpect
+          python3 -m pytest -v .
 
   linux-extension-test:
     name: linux extension test

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -185,12 +185,8 @@ jobs:
       - name: Python test
         run: make pytest-venv
 
-      - name: Ensure Node.js dependencies
-        run: npm install --include=dev
-        working-directory: tools/nodejs_api
-
       - name: Node.js test
-        run: make nodejstest
+        run: make nodejstest-deps
 
       - name: Java test
         run: make javatest
@@ -468,12 +464,8 @@ jobs:
       - name: Python test
         run: make pytest-venv
 
-      - name: Ensure Node.js dependencies
-        run: npm install --include=dev
-        working-directory: tools/nodejs_api
-
       - name: Node.js test
-        run: make nodejstest
+        run: make nodejstest-deps
 
       - name: Java test
         run: make javatest
@@ -653,15 +645,11 @@ jobs:
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
           make pytest-venv
 
-      - name: Ensure Node.js dependencies
-        run: npm install --include=dev
-        working-directory: tools/nodejs_api
-
       - name: Node.js test
         shell: cmd
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-          make nodejstest
+          make nodejstest-deps
 
       - name: Java test
         shell: cmd
@@ -746,10 +734,8 @@ jobs:
         run: python3 scripts/run-clang-format.py --in-place --clang-format-executable /usr/bin/clang-format-18 -r extension/
 
       - name: Format Python API
-        run: |
-          cd tools/python_api
-          make requirements
-          make format
+        working-directory: tools/python_api
+        run: make format
 
       - name: Update Rust
         run: rustup update
@@ -782,9 +768,7 @@ jobs:
 
       - name: Run Python lint
         working-directory: tools/python_api
-        run: |
-          make requirements
-          ./.venv/bin/ruff check src_py test --verbose
+        run: make check
 
   benchmark:
     name: benchmark
@@ -823,8 +807,7 @@ jobs:
 
       # For `napi.h` header.
       - name: Ensure Node.js dependencies
-        run: npm install --include=dev
-        working-directory: tools/nodejs_api
+        run: make nodejs-deps
 
       - name: Check for clangd diagnostics
         run: make clangd-diagnostics
@@ -908,14 +891,10 @@ jobs:
           ulimit -n 10240
           make example
 
-      - name: Ensure Node.js dependencies
-        run: npm install --include=dev
-        working-directory: tools/nodejs_api
-
       - name: Node.js test
         run: |
           ulimit -n 10240
-          make nodejstest
+          make nodejstest-deps
 
       - name: Java test
         run: |
@@ -929,8 +908,8 @@ jobs:
         run: |
           ulimit -n 10240
           source /Users/runner/.cargo/env
-          cmake -B build/release -DBUILD_EXAMPLES=OFF
-          make extension-release
+          # `extension-release` disables KUZU_BUILD, but it is a dependency of `BUILD_EXAMPLES`, so disable it too.
+          make extension-release EXTRA_CMAKE_FLAGS="-DBUILD_EXAMPLES=OFF"
           make rusttest
 
       - name: Rust test with pre-built library
@@ -942,7 +921,6 @@ jobs:
         run: |
           ulimit -n 10240
           source /Users/runner/.cargo/env
-          cmake -B build/release -DBUILD_EXAMPLES=OFF
           make extension-release
           make rusttest
 
@@ -965,9 +943,7 @@ jobs:
 
       - name: Test
         working-directory: tools/shell/test
-        run: |
-          pip3 install pytest pexpect
-          python3 -m pytest -v .
+        run: make test
 
   linux-extension-test:
     name: linux extension test

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -904,7 +904,7 @@ jobs:
           make example
 
       - name: Ensure Python dependencies
-        run: pip install --user -r tools/python_api/requirements_dev.txt
+        run: pip3 install --user -r tools/python_api/requirements_dev.txt
 
       - name: Python test
         env:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -154,11 +154,6 @@ jobs:
           name: binary-demo
           path: ${{ github.workspace }}/dataset/binary-demo
 
-      - name: Ensure Python dependencies
-        run: |
-          pip install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
-
       - name: Ensure Node.js dependencies
         run: npm install --include=dev
         working-directory: tools/nodejs_api
@@ -188,7 +183,7 @@ jobs:
           make test
 
       - name: Python test
-        run: make pytest
+        run: make pytest-venv
 
       - name: Node.js test
         run: make nodejstest
@@ -238,11 +233,6 @@ jobs:
         with:
           name: binary-demo
           path: ${{ github.workspace }}/dataset/binary-demo
-
-      - name: Ensure Python dependencies
-        run: |
-          pip install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
 
       - name: Ensure Node.js dependencies
         run: npm install --include=dev
@@ -410,11 +400,6 @@ jobs:
           name: binary-demo
           path: dataset/binary-demo
 
-      - name: Ensure Python dependencies
-        run: |
-          pip install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
-
       - name: Ensure Node.js dependencies
         run: npm install --include=dev
         working-directory: tools/nodejs_api
@@ -468,11 +453,6 @@ jobs:
           name: binary-demo
           path: dataset/binary-demo
 
-      - name: Ensure Python dependencies
-        run: |
-          pip install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
-
       - name: Ensure Node.js dependencies
         run: npm install --include=dev
         working-directory: tools/nodejs_api
@@ -497,7 +477,7 @@ jobs:
           make test DEFAULT_REL_STORAGE_DIRECTION=BOTH
 
       - name: Python test
-        run: make pytest
+        run: make pytest-venv
 
       - name: Node.js test
         run: make nodejstest
@@ -541,15 +521,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Ensure Python dependencies
-        run: |
-          pip install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
-
-      - name: Ensure Node.js dependencies
-        run: npm install --include=dev
-        working-directory: tools/nodejs_api
-
       - name: Build
         run: |
           ln -s /home/runner/ldbc-1-csv dataset/ldbc-1/csv
@@ -587,15 +558,6 @@ jobs:
       BUFFER_POOL_SIZE: 1073741824
     steps:
       - uses: actions/checkout@v4
-
-      - name: Ensure Python dependencies
-        run: |
-          pip install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
-
-      - name: Ensure Node.js dependencies
-        run: npm install --include=dev
-        working-directory: tools/nodejs_api
 
       - name: Build
         run: |
@@ -649,11 +611,6 @@ jobs:
         with:
           name: binary-demo
           path: dataset/binary-demo
-
-      - name: Ensure Python dependencies
-        run: |
-          pip install torch~=2.0.0 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.0.0+cpu.html
 
       - name: Ensure Node.js dependencies
         run: npm install --include=dev
@@ -709,7 +666,7 @@ jobs:
         shell: cmd
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-          make pytest
+          make pytest-venv
 
       - name: Node.js test
         shell: cmd
@@ -931,11 +888,6 @@ jobs:
           name: binary-demo
           path: dataset/binary-demo
 
-      - name: Ensure Python dependencies
-        run: |
-          pip3 install torch~=2.2.0 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip3 install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
-
       - name: Ensure Node.js dependencies
         run: npm install --include=dev
         working-directory: tools/nodejs_api
@@ -970,7 +922,7 @@ jobs:
           PYBIND11_PYTHON_VERSION: 3.12
         run: |
           ulimit -n 10240
-          make pytest
+          make pytest-venv
 
       - name: C and C++ Examples
         run: |

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -700,17 +700,12 @@ jobs:
       - name: Check source headers for include guards
         run: ./scripts/check-include-guards.sh src/include
           ./scripts/check-include-guards.sh test/include
-          ./scripts/check-include-guards.sh extension/*/src/include
 
       - name: Check extension headers for include guards
-        run: ./scripts/check-include-guards.sh extension/delta/src/include
-          ./scripts/check-include-guards.sh extension/duckdb/src/include
-          ./scripts/check-include-guards.sh extension/fts/src/include
-          ./scripts/check-include-guards.sh extension/httpfs/src/include
-          ./scripts/check-include-guards.sh extension/iceberg/src/include
-          ./scripts/check-include-guards.sh extension/json/src/include
-          ./scripts/check-include-guards.sh extension/postgres/src/include
-          ./scripts/check-include-guards.sh extension/sqlite/src/include
+        run: |
+          for dir in extension/*/src/include ;do
+            ./scripts/check-include-guards.sh "$dir"
+          done
 
       - name: Checks source files for std::assert
         run: ./scripts/check-no-std-assert.sh src

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -127,7 +127,6 @@ jobs:
     runs-on: kuzu-self-hosted-testing
     env:
       NUM_THREADS: 32
-      CMAKE_BUILD_PARALLEL_LEVEL: 32
       TEST_JOBS: 16
       CLANGD_DIAGNOSTIC_JOBS: 32
       CLANGD_DIAGNOSTIC_INSTANCES: 6
@@ -153,10 +152,6 @@ jobs:
         with:
           name: binary-demo
           path: ${{ github.workspace }}/dataset/binary-demo
-
-      - name: Ensure Node.js dependencies
-        run: npm install --include=dev
-        working-directory: tools/nodejs_api
 
       - name: Test
         run: |
@@ -185,6 +180,10 @@ jobs:
       - name: Python test
         run: make pytest-venv
 
+      - name: Ensure Node.js dependencies
+        run: npm install --include=dev
+        working-directory: tools/nodejs_api
+
       - name: Node.js test
         run: make nodejstest
 
@@ -207,7 +206,6 @@ jobs:
     runs-on: kuzu-self-hosted-testing
     env:
       NUM_THREADS: 32
-      CMAKE_BUILD_PARALLEL_LEVEL: 32
       TEST_JOBS: 16
       CLANGD_DIAGNOSTIC_JOBS: 32
       CLANGD_DIAGNOSTIC_INSTANCES: 6
@@ -233,10 +231,6 @@ jobs:
         with:
           name: binary-demo
           path: ${{ github.workspace }}/dataset/binary-demo
-
-      - name: Ensure Node.js dependencies
-        run: npm install --include=dev
-        working-directory: tools/nodejs_api
 
       - name: Test vector 1024
         env:
@@ -360,7 +354,6 @@ jobs:
     env:
       # CARGO_BUILD_JOBS is set using this in the Makefile
       NUM_THREADS: 32
-      CMAKE_BUILD_PARALLEL_LEVEL: 32
       CC: gcc
       CXX: g++
       KUZU_LOCAL_EXTENSIONS: ${{ github.workspace }}/extension
@@ -400,10 +393,6 @@ jobs:
           name: binary-demo
           path: dataset/binary-demo
 
-      - name: Ensure Node.js dependencies
-        run: npm install --include=dev
-        working-directory: tools/nodejs_api
-
       - name: Test with ASAN
         run: |
           ln -s /home/runner/ldbc-1-csv dataset/ldbc-1/csv
@@ -430,7 +419,6 @@ jobs:
     runs-on: kuzu-self-hosted-testing
     env:
       NUM_THREADS: 32
-      CMAKE_BUILD_PARALLEL_LEVEL: 32
       TEST_JOBS: 16
       CC: clang
       CXX: clang++
@@ -453,10 +441,6 @@ jobs:
           name: binary-demo
           path: dataset/binary-demo
 
-      - name: Ensure Node.js dependencies
-        run: npm install --include=dev
-        working-directory: tools/nodejs_api
-
       - name: Test
         run: |
           ln -s /home/runner/ldbc-1-csv dataset/ldbc-1/csv
@@ -478,6 +462,10 @@ jobs:
 
       - name: Python test
         run: make pytest-venv
+
+      - name: Ensure Node.js dependencies
+        run: npm install --include=dev
+        working-directory: tools/nodejs_api
 
       - name: Node.js test
         run: make nodejstest
@@ -504,7 +492,6 @@ jobs:
     runs-on: kuzu-self-hosted-testing
     env:
       NUM_THREADS: 32
-      CMAKE_BUILD_PARALLEL_LEVEL: 32
       TEST_JOBS: 16
       CC: clang
       CXX: clang++
@@ -543,7 +530,6 @@ jobs:
     runs-on: kuzu-self-hosted-testing
     env:
       NUM_THREADS: 32
-      CMAKE_BUILD_PARALLEL_LEVEL: 32
       TEST_JOBS: 16
       CC: clang
       CXX: clang++
@@ -587,9 +573,7 @@ jobs:
     env:
       # Shorten build path as much as possible
       CARGO_TARGET_DIR: ${{ github.workspace }}/rs
-      CARGO_BUILD_JOBS: 18
       NUM_THREADS: 18
-      CMAKE_BUILD_PARALLEL_LEVEL: 18
       TEST_JOBS: 9
       UW_S3_ACCESS_KEY_ID: ${{ secrets.UW_S3_ACCESS_KEY_ID }}
       UW_S3_SECRET_ACCESS_KEY: ${{ secrets.UW_S3_SECRET_ACCESS_KEY }}
@@ -611,10 +595,6 @@ jobs:
         with:
           name: binary-demo
           path: dataset/binary-demo
-
-      - name: Ensure Node.js dependencies
-        run: npm install --include=dev
-        working-directory: tools/nodejs_api
 
       - name: Visual Studio Generator Build
         shell: cmd
@@ -667,6 +647,10 @@ jobs:
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
           make pytest-venv
+
+      - name: Ensure Node.js dependencies
+        run: npm install --include=dev
+        working-directory: tools/nodejs_api
 
       - name: Node.js test
         shell: cmd
@@ -879,7 +863,6 @@ jobs:
             export NUM_THREADS=12
           fi
           echo "NUM_THREADS=$NUM_THREADS" >> $GITHUB_ENV
-          echo "CMAKE_BUILD_PARALLEL_LEVEL=$NUM_THREADS" >> $GITHUB_ENV
           echo "NUM_THREADS=$NUM_THREADS"
 
       - name: Download binary-demo
@@ -887,10 +870,6 @@ jobs:
         with:
           name: binary-demo
           path: dataset/binary-demo
-
-      - name: Ensure Node.js dependencies
-        run: npm install --include=dev
-        working-directory: tools/nodejs_api
 
       - name: Test
         run: |
@@ -928,6 +907,10 @@ jobs:
         run: |
           ulimit -n 10240
           make example
+
+      - name: Ensure Node.js dependencies
+        run: npm install --include=dev
+        working-directory: tools/nodejs_api
 
       - name: Node.js test
         run: |
@@ -1117,7 +1100,6 @@ jobs:
     env:
       # Shorten build path as much as possible
       CARGO_TARGET_DIR: ${{ github.workspace }}/rs
-      CARGO_BUILD_JOBS: 18
       NUM_THREADS: 18
       TEST_JOBS: 9
       UW_S3_ACCESS_KEY_ID: ${{ secrets.UW_S3_ACCESS_KEY_ID }}

--- a/.github/workflows/multiplatform-build-test.yml
+++ b/.github/workflows/multiplatform-build-test.yml
@@ -83,19 +83,11 @@ jobs:
           make example NUM_THREADS=$(sysctl -n hw.physicalcpu)
           echo "C and C++ examples,$?" >> status.txt
 
-      - name: Ensure Python dependencies
-        continue-on-error: true
-        run: |
-          pip install torch~=2.6.0 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.6.0+cpu.html
-
       - name: Python test
         continue-on-error: true
         run: |
-          python --version
-          pip --version
           set +e
-          make pytest NUM_THREADS=$(sysctl -n hw.physicalcpu)
+          make pytest-venv NUM_THREADS=$(sysctl -n hw.physicalcpu)
           echo "Python test,$?" >> status.txt
 
       - name: Ensure Node.js dependencies
@@ -150,10 +142,11 @@ jobs:
 
       - name: Rename status.txt
         continue-on-error: true
-        run: mv status.txt ${{ matrix.runner }}.csv
+        run: |
+          cat status.txt
+          mv status.txt ${{ matrix.runner }}.csv
 
       - uses: actions/upload-artifact@v4
-        continue-on-error: true
         with:
           name: ${{ matrix.runner }}
           path: ${{ matrix.runner }}.csv
@@ -184,6 +177,9 @@ jobs:
           Set-MpPreference -DisableScriptScanning $true
           Set-MpPreference -SubmitSamplesConsent NeverSend
 
+      - uses: ilammy/msvc-dev-cmd@v1
+        continue-on-error: true
+
       - uses: actions/checkout@v4
         continue-on-error: true
 
@@ -192,9 +188,6 @@ jobs:
         with:
           name: binary-demo
           path: ${{ github.workspace }}/dataset/binary-demo
-
-      - uses: ilammy/msvc-dev-cmd@v1
-        continue-on-error: true
 
       - uses: actions/setup-python@v4
         continue-on-error: true
@@ -225,20 +218,11 @@ jobs:
           make example NUM_THREADS=%NUMBER_OF_PROCESSORS%
           echo C and C++ examples,%ERRORLEVEL% >> status.txt
 
-      - name: Ensure Python dependencies
-        continue-on-error: true
-        shell: cmd
-        run: |
-          pip install torch~=2.6.0 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --user -r tools\python_api\requirements_dev.txt -f https://data.pyg.org/whl/torch-2.6.0+cpu.html
-
       - name: Python test
         continue-on-error: true
         shell: cmd
         run: |
-          python --version
-          pip --version
-          make pytest NUM_THREADS=%NUMBER_OF_PROCESSORS%
+          make pytest-venv NUM_THREADS=%NUMBER_OF_PROCESSORS%
           echo Python test,%ERRORLEVEL% >> status.txt
 
       - name: Ensure Node.js dependencies
@@ -304,10 +288,10 @@ jobs:
         continue-on-error: true
         shell: cmd
         run: |
+          cat status.txt
           rename status.txt ${{ matrix.runner }}.csv
 
       - uses: actions/upload-artifact@v4
-        continue-on-error: true
         with:
           name: ${{ matrix.runner }}
           path: ${{ matrix.runner }}.csv
@@ -341,7 +325,7 @@ jobs:
         continue-on-error: true
         run: |
           apt-get update
-          apt-get install -y git build-essential cmake python3 python3-dev python3-venv python3-pip openjdk-17-jdk ca-certificates curl gnupg ${{ matrix.image == 'ubuntu:22.04' && 'gcc-12 g++-12' || 'gcc g++' }} ${{ (matrix.image == 'debian:sid' || matrix.image == 'ubuntu:25.04') && 'nodejs npm' || 'nodejs' }}
+          apt-get install -y git build-essential cmake python3 python3-dev python3-venv openjdk-17-jdk ca-certificates curl gnupg ${{ matrix.image == 'ubuntu:22.04' && 'gcc-12 g++-12' || 'gcc g++' }} ${{ (matrix.image == 'debian:sid' || matrix.image == 'ubuntu:25.04') && 'nodejs npm' || 'nodejs' }}
 
       - name: Setup gcc 12
         if: ${{ matrix.image == 'ubuntu:22.04' }}
@@ -383,22 +367,11 @@ jobs:
           make example NUM_THREADS=$(nproc)
           echo "C and C++ examples,$?" >> status.txt
 
-      - name: Ensure Python dependencies
-        continue-on-error: true
-        run: |
-          python3 -m venv /opt/venv
-          . /opt/venv/bin/activate
-          pip install torch~=2.6.0 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.6.0+cpu.html
-
       - name: Python test
         continue-on-error: true
         run: |
-          . /opt/venv/bin/activate
-          python --version
-          pip --version
           set +e
-          make pytest NUM_THREADS=$(nproc)
+          make pytest-venv NUM_THREADS=$(nproc)
           echo "Python test,$?" >> status.txt
 
       - name: Ensure Node.js dependencies
@@ -461,12 +434,12 @@ jobs:
       - name: Rename status.txt
         continue-on-error: true
         run: |
+          cat status.txt
           PLATFORM=$(echo ${{ matrix.image }} | tr ':' '-')
           echo "PLATFORM=$PLATFORM" >> $GITHUB_ENV
           mv status.txt $PLATFORM.csv
 
       - uses: actions/upload-artifact@v4
-        continue-on-error: true
         with:
           name: ${{env.PLATFORM}}
           path: ${{env.PLATFORM}}.csv
@@ -551,22 +524,11 @@ jobs:
           make example NUM_THREADS=$(nproc)
           echo "C and C++ examples,$?" >> status.txt
 
-      - name: Ensure Python dependencies
-        continue-on-error: true
-        run: |
-          python3 -m venv /opt/venv
-          source /opt/venv/bin/activate
-          pip3 install torch~=2.6.0 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip3 install -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.6.0+cpu.html
-
       - name: Python test
         continue-on-error: true
         run: |
-          source /opt/venv/bin/activate
-          python --version
-          pip --version
           set +e
-          make pytest NUM_THREADS=$(nproc)
+          make pytest-venv NUM_THREADS=$(nproc)
           echo "Python test,$?" >> status.txt
 
       - name: Ensure Node.js dependencies
@@ -629,12 +591,12 @@ jobs:
       - name: Rename status.txt
         continue-on-error: true
         run: |
+          cat status.txt
           PLATFORM=$(echo ${{ matrix.image }} | tr ':' '-')
           echo "PLATFORM=$PLATFORM" >> $GITHUB_ENV
           mv status.txt $PLATFORM.csv
 
       - uses: actions/upload-artifact@v4
-        continue-on-error: true
         with:
           name: ${{env.PLATFORM}}
           path: ${{env.PLATFORM}}.csv
@@ -654,7 +616,7 @@ jobs:
         continue-on-error: true
         run: |
           pacman -Syu --noconfirm
-          pacman -S --needed --noconfirm git base-devel cmake gcc python python-pip npm jdk17-openjdk
+          pacman -S --needed --noconfirm git base-devel cmake gcc python npm jdk17-openjdk
 
       - uses: actions/checkout@v4
         continue-on-error: true
@@ -689,22 +651,11 @@ jobs:
           make example NUM_THREADS=$(nproc)
           echo "C and C++ examples,$?" >> status.txt
 
-      - name: Ensure Python dependencies
-        continue-on-error: true
-        run: |
-          python3 -m venv /opt/venv
-          source /opt/venv/bin/activate
-          pip install torch~=2.6.0 --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.6.0+cpu.html
-
       - name: Python test
         continue-on-error: true
         run: |
-          source /opt/venv/bin/activate
-          python --version
-          pip --version
           set +e
-          make pytest NUM_THREADS=$(nproc)
+          make pytest-venv NUM_THREADS=$(nproc)
           echo "Python test,$?" >> status.txt
 
       - name: Ensure Node.js dependencies
@@ -767,10 +718,10 @@ jobs:
       - name: Rename status.txt
         continue-on-error: true
         run: |
+          cat status.txt
           mv status.txt archlinux.csv
 
       - uses: actions/upload-artifact@v4
-        continue-on-error: true
         with:
           name: archlinux
           path: archlinux.csv

--- a/.github/workflows/multiplatform-build-test.yml
+++ b/.github/workflows/multiplatform-build-test.yml
@@ -3,6 +3,7 @@ name: Multiplatform Build and Test
 env:
   USE_EXISTING_BINARY_DATASET: 1
   WERROR: 1
+  BUILD_TYPE: Release
 
 on:
   workflow_dispatch:
@@ -669,7 +670,7 @@ jobs:
         run: |
           set +e
           echo NUM_THREADS=$(nproc)
-          make test NUM_THREADS=$(nproc) USE_STD_FORMAT=1
+          make test NUM_THREADS=$(nproc)
           echo "Test,$?" >> status.txt
           make clean
           rm -rf dataset/ldbc-1

--- a/.github/workflows/multiplatform-build-test.yml
+++ b/.github/workflows/multiplatform-build-test.yml
@@ -11,6 +11,29 @@ on:
     - cron: "0 8 * * *"
 
 jobs:
+  # Generate the binary db once to test that it can be read on all platforms.
+  generate-binary-demo:
+    runs-on: kuzu-self-hosted-testing
+    env:
+      NUM_THREADS: 32
+      GEN: Ninja
+      CC: gcc
+      CXX: g++
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: make release
+
+      - name: Generate datasets
+        run: bash scripts/generate_binary_demo.sh
+
+      - name: Upload binary-demo
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-demo
+          path: dataset/binary-demo
+
   macos-build-test:
     strategy:
       matrix:
@@ -18,12 +41,19 @@ jobs:
       fail-fast: false
     name: ${{ matrix.runner }}
     runs-on: ${{ matrix.runner }}
+    needs: [ generate-binary-demo ]
     defaults:
       run:
         shell: bash
     steps:
       - uses: actions/checkout@v4
         continue-on-error: true
+
+      - name: Download binary-demo
+        uses: actions/download-artifact@v4
+        with:
+          name: binary-demo
+          path: ${{ github.workspace }}/dataset/binary-demo
 
       - uses: actions/setup-python@v4
         continue-on-error: true
@@ -128,6 +158,7 @@ jobs:
         runner: [ windows-2022, windows-2025 ]
       fail-fast: false
     name: ${{ matrix.runner }}
+    needs: [ generate-binary-demo ]
     runs-on: ${{ matrix.runner }}
     env:
       WERROR: 0
@@ -151,6 +182,15 @@ jobs:
         continue-on-error: true
 
       - uses: actions/checkout@v4
+        continue-on-error: true
+
+      - name: Download binary-demo
+        uses: actions/download-artifact@v4
+        with:
+          name: binary-demo
+          path: ${{ github.workspace }}/dataset/binary-demo
+
+      - uses: ilammy/msvc-dev-cmd@v1
         continue-on-error: true
 
       - uses: actions/setup-python@v4
@@ -268,6 +308,7 @@ jobs:
         image: [ "ubuntu:22.04", "ubuntu:24.04", "ubuntu:25.04", "debian:12", "debian:sid" ]
       fail-fast: false
     name: ${{ matrix.image }}
+    needs: [ generate-binary-demo ]
     runs-on: ubuntu-24.04
     container:
       image: ${{ matrix.image }}
@@ -301,6 +342,12 @@ jobs:
 
       - uses: actions/checkout@v4
         continue-on-error: true
+
+      - name: Download binary-demo
+        uses: actions/download-artifact@v4
+        with:
+          name: binary-demo
+          path: ${{ github.workspace }}/dataset/binary-demo
 
       - name: Determine NUM_THREADS
         run: |
@@ -409,6 +456,7 @@ jobs:
         image: [ "rockylinux:8", "rockylinux:9", "fedora:41", "fedora:42" ]
       fail-fast: false
     name: ${{ matrix.image }}
+    needs: [ generate-binary-demo ]
     runs-on: ubuntu-24.04
     container:
       image: ${{ matrix.image }}
@@ -425,7 +473,7 @@ jobs:
           dnf update -y
           dnf install -y epel-release
           dnf update -y
-          dnf config-manager --set-enabled ${{ matrix.image == 'rockylinux:8' && 'powertools' || 'crb' }}
+          dnf config-manager --set-enabled ${{ matrix.image == 'rockylinux:8' && 'powertools' || 'crb' }} # For ninja.
 
       - name: Enable SHA-1 on Rocky Linux 9
         continue-on-error: true
@@ -452,6 +500,12 @@ jobs:
 
       - uses: actions/checkout@v4
         continue-on-error: true
+
+      - name: Download binary-demo
+        uses: actions/download-artifact@v4
+        with:
+          name: binary-demo
+          path: ${{ github.workspace }}/dataset/binary-demo
 
       - name: Determine NUM_THREADS
         run: |
@@ -557,6 +611,7 @@ jobs:
   archlinux-build-test:
     name: archlinux
     runs-on: ubuntu-24.04
+    needs: [ generate-binary-demo ]
     container:
       image: archlinux:latest
     env:
@@ -572,6 +627,12 @@ jobs:
 
       - uses: actions/checkout@v4
         continue-on-error: true
+
+      - name: Download binary-demo
+        uses: actions/download-artifact@v4
+        with:
+          name: binary-demo
+          path: ${{ github.workspace }}/dataset/binary-demo
 
       - name: Determine NUM_THREADS
         run: |

--- a/.github/workflows/multiplatform-build-test.yml
+++ b/.github/workflows/multiplatform-build-test.yml
@@ -1,7 +1,6 @@
 name: Multiplatform Build and Test
 
 env:
-  USE_EXISTING_BINARY_DATASET: 1
   WERROR: 1
   BUILD_TYPE: Release
   GEN: Ninja
@@ -12,27 +11,6 @@ on:
     - cron: "0 8 * * *"
 
 jobs:
-  generate-binary-demo:
-    runs-on: kuzu-self-hosted-testing
-    env:
-      NUM_THREADS: 32
-      CC: gcc
-      CXX: g++
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build
-        run: make release
-
-      - name: Generate datasets
-        run: bash scripts/generate_binary_demo.sh
-
-      - name: Upload binary-demo
-        uses: actions/upload-artifact@v4
-        with:
-          name: binary-demo
-          path: dataset/binary-demo
-
   macos-build-test:
     strategy:
       matrix:
@@ -40,20 +18,12 @@ jobs:
       fail-fast: false
     name: ${{ matrix.runner }}
     runs-on: ${{ matrix.runner }}
-    needs: [ generate-binary-demo ]
     defaults:
       run:
         shell: bash
     steps:
       - uses: actions/checkout@v4
         continue-on-error: true
-
-      - name: Download binary-demo
-        uses: actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          name: binary-demo
-          path: ${{ github.workspace }}/dataset/binary-demo
 
       - uses: actions/setup-python@v4
         continue-on-error: true
@@ -163,7 +133,6 @@ jobs:
         runner: [ windows-2022, windows-2025 ]
       fail-fast: false
     name: ${{ matrix.runner }}
-    needs: [ generate-binary-demo ]
     runs-on: ${{ matrix.runner }}
     env:
       WERROR: 0
@@ -188,13 +157,6 @@ jobs:
 
       - uses: actions/checkout@v4
         continue-on-error: true
-
-      - name: Download binary-demo
-        uses: actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          name: binary-demo
-          path: ${{ github.workspace }}/dataset/binary-demo
 
       - uses: actions/setup-python@v4
         continue-on-error: true
@@ -317,7 +279,6 @@ jobs:
         image: [ "ubuntu:22.04", "ubuntu:24.04", "ubuntu:25.04", "debian:12", "debian:sid" ]
       fail-fast: false
     name: ${{ matrix.image }}
-    needs: [ generate-binary-demo ]
     runs-on: ubuntu-24.04
     container:
       image: ${{ matrix.image }}
@@ -351,13 +312,6 @@ jobs:
 
       - uses: actions/checkout@v4
         continue-on-error: true
-
-      - name: Download binary-demo
-        uses: actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          name: binary-demo
-          path: ${{ github.workspace }}/dataset/binary-demo
 
       - name: Determine NUM_THREADS
         run: |
@@ -471,7 +425,6 @@ jobs:
         image: [ "rockylinux:8", "rockylinux:9", "fedora:41", "fedora:42" ]
       fail-fast: false
     name: ${{ matrix.image }}
-    needs: [ generate-binary-demo ]
     runs-on: ubuntu-24.04
     container:
       image: ${{ matrix.image }}
@@ -515,13 +468,6 @@ jobs:
 
       - uses: actions/checkout@v4
         continue-on-error: true
-
-      - name: Download binary-demo
-        uses: actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          name: binary-demo
-          path: ${{ github.workspace }}/dataset/binary-demo
 
       - name: Determine NUM_THREADS
         run: |
@@ -632,7 +578,6 @@ jobs:
   archlinux-build-test:
     name: archlinux
     runs-on: ubuntu-24.04
-    needs: [ generate-binary-demo ]
     container:
       image: archlinux:latest
     env:
@@ -648,13 +593,6 @@ jobs:
 
       - uses: actions/checkout@v4
         continue-on-error: true
-
-      - name: Download binary-demo
-        uses: actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          name: binary-demo
-          path: ${{ github.workspace }}/dataset/binary-demo
 
       - name: Determine NUM_THREADS
         run: |

--- a/.github/workflows/multiplatform-build-test.yml
+++ b/.github/workflows/multiplatform-build-test.yml
@@ -4,6 +4,7 @@ env:
   USE_EXISTING_BINARY_DATASET: 1
   WERROR: 1
   BUILD_TYPE: Release
+  GEN: Ninja
 
 on:
   workflow_dispatch:
@@ -15,7 +16,6 @@ jobs:
     runs-on: kuzu-self-hosted-testing
     env:
       NUM_THREADS: 32
-      GEN: Ninja
       CC: gcc
       CXX: g++
     steps:
@@ -60,12 +60,19 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Determine NUM_THREADS
+        run: |
+          export NUM_THREADS=$(sysctl -n hw.physicalcpu)
+          echo "NUM_THREADS=$NUM_THREADS" >> $GITHUB_ENV
+          echo "TEST_JOBS=$NUM_THREADS" >> $GITHUB_ENV
+          echo "CARGO_BUILD_JOBS=$NUM_THREADS" >> $GITHUB_ENV
+          echo "NUM_THREADS=$NUM_THREADS"
+
       - name: Test
         continue-on-error: true
         run: |
           set +e
-          echo NUM_THREADS=$(sysctl -n hw.physicalcpu)
-          make test NUM_THREADS=$(sysctl -n hw.physicalcpu)
+          make test
           echo "Test,$?" >> status.txt
           make clean
           rm -rf dataset/ldbc-1
@@ -74,21 +81,21 @@ jobs:
         continue-on-error: true
         run: |
           set +e
-          make release NUM_THREADS=$(sysctl -n hw.physicalcpu)
+          make release
           echo "Build,$?" >> status.txt
 
       - name: C and C++ examples
         continue-on-error: true
         run: |
           set +e
-          make example NUM_THREADS=$(sysctl -n hw.physicalcpu)
+          make example
           echo "C and C++ examples,$?" >> status.txt
 
       - name: Python test
         continue-on-error: true
         run: |
           set +e
-          make pytest-venv NUM_THREADS=$(sysctl -n hw.physicalcpu)
+          make pytest-venv
           echo "Python test,$?" >> status.txt
 
       - name: Ensure Node.js dependencies
@@ -102,7 +109,7 @@ jobs:
           node --version
           npm --version
           set +e
-          make nodejstest NUM_THREADS=$(sysctl -n hw.physicalcpu)
+          make nodejstest
           echo "Node.js test,$?" >> status.txt
 
       - name: Java test
@@ -110,7 +117,7 @@ jobs:
         run: |
           java --version
           set +e
-          make javatest NUM_THREADS=$(sysctl -n hw.physicalcpu)
+          make javatest
           echo "Java test,$?" >> status.txt
 
       - name: Cleanup
@@ -120,10 +127,6 @@ jobs:
       - name: Rust share build
         continue-on-error: true
         run: echo $'[workspace]\nmembers = ["tools/rust_api","examples/rust"]\nresolver = "2"' > Cargo.toml
-
-      - name: Rust set env
-        continue-on-error: true
-        run: echo "CARGO_BUILD_JOBS=$(sysctl -n hw.physicalcpu)" >> $GITHUB_ENV
 
       - name: Rust test
         continue-on-error: true
@@ -143,11 +146,13 @@ jobs:
           echo "Rust example,$?" >> ../../status.txt
 
       - name: Rename status.txt
+        if: ${{ always() }}
         run: |
           cat status.txt
           mv status.txt ${{ matrix.runner }}.csv
 
       - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
         with:
           name: ${{ matrix.runner }}
           path: ${{ matrix.runner }}.csv
@@ -196,12 +201,20 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Determine NUM_THREADS
+        shell: powershell
+        run: |
+          $numThreads = $env:NUMBER_OF_PROCESSORS
+          "NUM_THREADS=$numThreads" >> $env:GITHUB_ENV
+          "TEST_JOBS=$numThreads" >> $env:GITHUB_ENV
+          "CARGO_BUILD_JOBS=$numThreads" >> $env:GITHUB_ENV
+          Write-Host "NUMBER_OF_PROCESSORS=$numThreads"
+
       - name: Test
         continue-on-error: true
         shell: cmd
         run: |
-          echo NUMBER_OF_PROCESSORS=%NUMBER_OF_PROCESSORS%
-          make test NUM_THREADS=%NUMBER_OF_PROCESSORS%
+          make test
           echo Test,%ERRORLEVEL% >> status.txt
           make clean
           rm -rf dataset/ldbc-1
@@ -210,21 +223,21 @@ jobs:
         continue-on-error: true
         shell: cmd
         run: |
-          make release NUM_THREADS=%NUMBER_OF_PROCESSORS%
+          make release
           echo Build,%ERRORLEVEL% >> status.txt
 
       - name: C and C++ examples
         continue-on-error: true
         shell: cmd
         run: |
-          make example NUM_THREADS=%NUMBER_OF_PROCESSORS%
+          make example
           echo C and C++ examples,%ERRORLEVEL% >> status.txt
 
       - name: Python test
         continue-on-error: true
         shell: cmd
         run: |
-          make pytest-venv NUM_THREADS=%NUMBER_OF_PROCESSORS%
+          make pytest-venv
           echo Python test,%ERRORLEVEL% >> status.txt
 
       - name: Ensure Node.js dependencies
@@ -237,7 +250,7 @@ jobs:
         continue-on-error: true
         shell: cmd
         run: |
-          make nodejstest NUM_THREADS=%NUMBER_OF_PROCESSORS%
+          make nodejstest
           echo Node.js test,%ERRORLEVEL% >> status.txt
 
       - name: Set up JDK 11
@@ -253,7 +266,7 @@ jobs:
         shell: cmd
         run: |
           java --version
-          make javatest NUM_THREADS=%NUMBER_OF_PROCESSORS%
+          make javatest
           echo Java test,%ERRORLEVEL% >> status.txt
 
       - name: Cleanup
@@ -273,7 +286,6 @@ jobs:
           cargo --version
           set OPENSSL_DIR=C:\Program Files\OpenSSL-Win64
           set CXXFLAGS=/std:c++20
-          set CARGO_BUILD_JOBS=%NUMBER_OF_PROCESSORS%
           cargo test --release --features arrow
           echo Rust test,%ERRORLEVEL% >> status.txt
 
@@ -283,17 +295,18 @@ jobs:
         run: |
           set OPENSSL_DIR=C:\Program Files\OpenSSL-Win64
           set CXXFLAGS=/std:c++20
-          set CARGO_BUILD_JOBS=%NUMBER_OF_PROCESSORS%
           cargo build --release --features arrow
           echo Rust example,%ERRORLEVEL% >> status.txt
 
       - name: Rename status.txt
+        if: ${{ always() }}
         shell: cmd
         run: |
           cat status.txt
           rename status.txt ${{ matrix.runner }}.csv
 
       - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
         with:
           name: ${{ matrix.runner }}
           path: ${{ matrix.runner }}.csv
@@ -327,7 +340,7 @@ jobs:
         continue-on-error: true
         run: |
           apt-get update
-          apt-get install -y git build-essential cmake python3 python3-dev python3-venv openjdk-17-jdk ca-certificates curl gnupg ${{ matrix.image == 'ubuntu:22.04' && 'gcc-12 g++-12' || 'gcc g++' }} ${{ (matrix.image == 'debian:sid' || matrix.image == 'ubuntu:25.04') && 'nodejs npm' || 'nodejs' }}
+          apt-get install -y git build-essential cmake ninja-build python3 python3-dev python3-venv openjdk-17-jdk ca-certificates curl gnupg ${{ matrix.image == 'ubuntu:22.04' && 'gcc-12 g++-12' || 'gcc g++' }} ${{ (matrix.image == 'debian:sid' || matrix.image == 'ubuntu:25.04') && 'nodejs npm' || 'nodejs' }}
 
       - name: Setup gcc 12
         if: ${{ matrix.image == 'ubuntu:22.04' }}
@@ -346,12 +359,19 @@ jobs:
           name: binary-demo
           path: ${{ github.workspace }}/dataset/binary-demo
 
+      - name: Determine NUM_THREADS
+        run: |
+          export NUM_THREADS=$(nproc)
+          echo "NUM_THREADS=$NUM_THREADS" >> $GITHUB_ENV
+          echo "TEST_JOBS=$NUM_THREADS" >> $GITHUB_ENV
+          echo "CARGO_BUILD_JOBS=$NUM_THREADS" >> $GITHUB_ENV
+          echo "NUM_THREADS=$NUM_THREADS"
+
       - name: Test
         continue-on-error: true
         run: |
           set +e
-          echo NUM_THREADS=$(nproc)
-          make test NUM_THREADS=$(nproc)
+          make test
           echo "Test,$?" >> status.txt
           make clean
           rm -rf dataset/ldbc-1
@@ -360,21 +380,21 @@ jobs:
         continue-on-error: true
         run: |
           set +e
-          make release NUM_THREADS=$(nproc)
+          make release
           echo "Build,$?" >> status.txt
 
       - name: C and C++ examples
         continue-on-error: true
         run: |
           set +e
-          make example NUM_THREADS=$(nproc)
+          make example
           echo "C and C++ examples,$?" >> status.txt
 
       - name: Python test
         continue-on-error: true
         run: |
           set +e
-          make pytest-venv NUM_THREADS=$(nproc)
+          make pytest-venv
           echo "Python test,$?" >> status.txt
 
       - name: Ensure Node.js dependencies
@@ -388,7 +408,7 @@ jobs:
           node --version
           npm --version
           set +e
-          make nodejstest NUM_THREADS=$(nproc)
+          make nodejstest
           echo "Node.js test,$?" >> status.txt
 
       - name: Java test
@@ -396,7 +416,7 @@ jobs:
         run: |
           java --version
           set +e
-          make javatest NUM_THREADS=$(nproc)
+          make javatest
           echo "Java test,$?" >> status.txt
 
       - name: Cleanup
@@ -413,10 +433,6 @@ jobs:
       - name: Rust share build
         continue-on-error: true
         run: echo '[workspace]\nmembers = ["tools/rust_api","examples/rust"]\nresolver = "2"' > Cargo.toml
-
-      - name: Rust set env
-        continue-on-error: true
-        run: echo "CARGO_BUILD_JOBS=$(nproc)" >> $GITHUB_ENV
 
       - name: Rust test
         continue-on-error: true
@@ -436,6 +452,7 @@ jobs:
           echo "Rust example,$?" >> ../../status.txt
 
       - name: Rename status.txt
+        if: ${{ always() }}
         run: |
           cat status.txt
           PLATFORM=$(echo ${{ matrix.image }} | tr ':' '-')
@@ -443,6 +460,7 @@ jobs:
           mv status.txt $PLATFORM.csv
 
       - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
         with:
           name: ${{env.PLATFORM}}
           path: ${{env.PLATFORM}}.csv
@@ -463,13 +481,14 @@ jobs:
       JAVA_HOME: /usr/lib/jvm/java-${{ matrix.image == 'fedora:42' && '21' || '17' }}-openjdk
       HOME: /root
     steps:
-      - name: Enable EPEL
+      - name: Enable EPEL on Rocky Linux
         continue-on-error: true
         if: ${{ matrix.image == 'rockylinux:8' || matrix.image ==  'rockylinux:9' }}
         run: |
           dnf update -y
           dnf install -y epel-release
           dnf update -y
+          dnf config-manager --set-enabled ${{ matrix.image == 'rockylinux:8' && 'powertools' || 'crb' }}
 
       - name: Enable SHA-1 on Rocky Linux 9
         continue-on-error: true
@@ -480,7 +499,7 @@ jobs:
         continue-on-error: true
         run: |
           curl -fsSL https://rpm.nodesource.com/setup_20.x | bash -
-          dnf install -y git cmake nodejs ${{ (matrix.image == 'rockylinux:8' || matrix.image ==  'rockylinux:9') && 'gcc-toolset-12 python3.11 python3.11-devel' || 'gcc gcc-c++ python3-devel' }} ${{ matrix.image == 'fedora:42' && 'java-21-openjdk-devel' || 'java-17-openjdk-devel' }}
+          dnf install -y git cmake ninja-build nodejs ${{ (matrix.image == 'rockylinux:8' || matrix.image ==  'rockylinux:9') && 'gcc-toolset-12 python3.11 python3.11-devel' || 'gcc gcc-c++ python3-devel' }} ${{ matrix.image == 'fedora:42' && 'java-21-openjdk-devel' || 'java-17-openjdk-devel' }}
           dnf clean all
 
       - name: Enable gcc-toolset-12 and python3.11 on Rocky Linux
@@ -504,12 +523,19 @@ jobs:
           name: binary-demo
           path: ${{ github.workspace }}/dataset/binary-demo
 
+      - name: Determine NUM_THREADS
+        run: |
+          export NUM_THREADS=$(nproc)
+          echo "NUM_THREADS=$NUM_THREADS" >> $GITHUB_ENV
+          echo "TEST_JOBS=$NUM_THREADS" >> $GITHUB_ENV
+          echo "CARGO_BUILD_JOBS=$NUM_THREADS" >> $GITHUB_ENV
+          echo "NUM_THREADS=$NUM_THREADS"
+
       - name: Test
         continue-on-error: true
         run: |
           set +e
-          echo NUM_THREADS=$(nproc)
-          make test NUM_THREADS=$(nproc)
+          make test
           echo "Test,$?" >> status.txt
           make clean
           rm -rf dataset/ldbc-1
@@ -518,21 +544,21 @@ jobs:
         continue-on-error: true
         run: |
           set +e
-          make release NUM_THREADS=$(nproc)
+          make release
           echo "Build,$?" >> status.txt
 
       - name: C and C++ examples
         continue-on-error: true
         run: |
           set +e
-          make example NUM_THREADS=$(nproc)
+          make example
           echo "C and C++ examples,$?" >> status.txt
 
       - name: Python test
         continue-on-error: true
         run: |
           set +e
-          make pytest-venv NUM_THREADS=$(nproc)
+          make pytest-venv
           echo "Python test,$?" >> status.txt
 
       - name: Ensure Node.js dependencies
@@ -546,7 +572,7 @@ jobs:
           node --version
           npm --version
           set +e
-          make nodejstest NUM_THREADS=$(nproc)
+          make nodejstest
           echo "Node.js test,$?" >> status.txt
 
       - name: Java test
@@ -554,7 +580,7 @@ jobs:
         run: |
           java --version
           set +e
-          make javatest NUM_THREADS=$(nproc)
+          make javatest
           echo "Java test,$?" >> status.txt
 
       - name: Cleanup
@@ -571,10 +597,6 @@ jobs:
       - name: Rust share build
         continue-on-error: true
         run: echo $'[workspace]\nmembers = ["tools/rust_api","examples/rust"]\nresolver = "2"' > Cargo.toml
-
-      - name: Rust set env
-        continue-on-error: true
-        run: echo "CARGO_BUILD_JOBS=$(nproc)" >> $GITHUB_ENV
 
       - name: Rust test
         continue-on-error: true
@@ -594,6 +616,7 @@ jobs:
           echo "Rust example,$?" >> ../../status.txt
 
       - name: Rename status.txt
+        if: ${{ always() }}
         run: |
           cat status.txt
           PLATFORM=$(echo ${{ matrix.image }} | tr ':' '-')
@@ -601,6 +624,7 @@ jobs:
           mv status.txt $PLATFORM.csv
 
       - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
         with:
           name: ${{env.PLATFORM}}
           path: ${{env.PLATFORM}}.csv
@@ -620,7 +644,7 @@ jobs:
         continue-on-error: true
         run: |
           pacman -Syu --noconfirm
-          pacman -S --needed --noconfirm git base-devel cmake gcc python npm jdk17-openjdk
+          pacman -S --needed --noconfirm git base-devel cmake ninja gcc python npm jdk17-openjdk
 
       - uses: actions/checkout@v4
         continue-on-error: true
@@ -632,12 +656,19 @@ jobs:
           name: binary-demo
           path: ${{ github.workspace }}/dataset/binary-demo
 
+      - name: Determine NUM_THREADS
+        run: |
+          export NUM_THREADS=$(nproc)
+          echo "NUM_THREADS=$NUM_THREADS" >> $GITHUB_ENV
+          echo "TEST_JOBS=$NUM_THREADS" >> $GITHUB_ENV
+          echo "CARGO_BUILD_JOBS=$NUM_THREADS" >> $GITHUB_ENV
+          echo "NUM_THREADS=$NUM_THREADS"
+
       - name: Test
         continue-on-error: true
         run: |
           set +e
-          echo NUM_THREADS=$(nproc)
-          make test NUM_THREADS=$(nproc)
+          make test
           echo "Test,$?" >> status.txt
           make clean
           rm -rf dataset/ldbc-1
@@ -646,21 +677,21 @@ jobs:
         continue-on-error: true
         run: |
           set +e
-          make release NUM_THREADS=$(nproc)
+          make release
           echo "Build,$?" >> status.txt
 
       - name: C and C++ examples
         continue-on-error: true
         run: |
           set +e
-          make example NUM_THREADS=$(nproc)
+          make example
           echo "C and C++ examples,$?" >> status.txt
 
       - name: Python test
         continue-on-error: true
         run: |
           set +e
-          make pytest-venv NUM_THREADS=$(nproc)
+          make pytest-venv
           echo "Python test,$?" >> status.txt
 
       - name: Ensure Node.js dependencies
@@ -674,7 +705,7 @@ jobs:
           node --version
           npm --version
           set +e
-          make nodejstest NUM_THREADS=$(nproc)
+          make nodejstest
           echo "Node.js test,$?" >> status.txt
 
       - name: Java test
@@ -682,7 +713,7 @@ jobs:
         run: |
           java --version
           set +e
-          make javatest NUM_THREADS=$(nproc)
+          make javatest
           echo "Java test,$?" >> status.txt
 
       - name: Cleanup
@@ -699,10 +730,6 @@ jobs:
       - name: Rust share build
         continue-on-error: true
         run: echo $'[workspace]\nmembers = ["tools/rust_api","examples/rust"]\nresolver = "2"' > Cargo.toml
-
-      - name: Rust set env
-        continue-on-error: true
-        run: echo "CARGO_BUILD_JOBS=$(nproc)" >> $GITHUB_ENV
 
       - name: Rust test
         working-directory: tools/rust_api
@@ -722,11 +749,13 @@ jobs:
           echo "Rust example,$?" >> ../../status.txt
 
       - name: Rename status.txt
+        if: ${{ always() }}
         run: |
           cat status.txt
           mv status.txt archlinux.csv
 
       - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
         with:
           name: archlinux
           path: archlinux.csv

--- a/.github/workflows/multiplatform-build-test.yml
+++ b/.github/workflows/multiplatform-build-test.yml
@@ -50,6 +50,7 @@ jobs:
 
       - name: Download binary-demo
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: binary-demo
           path: ${{ github.workspace }}/dataset/binary-demo
@@ -113,6 +114,7 @@ jobs:
           echo "Java test,$?" >> status.txt
 
       - name: Cleanup
+        continue-on-error: true
         run: make clean
 
       - name: Rust share build
@@ -141,7 +143,6 @@ jobs:
           echo "Rust example,$?" >> ../../status.txt
 
       - name: Rename status.txt
-        continue-on-error: true
         run: |
           cat status.txt
           mv status.txt ${{ matrix.runner }}.csv
@@ -185,6 +186,7 @@ jobs:
 
       - name: Download binary-demo
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: binary-demo
           path: ${{ github.workspace }}/dataset/binary-demo
@@ -256,6 +258,7 @@ jobs:
 
       - name: Cleanup
         shell: cmd
+        continue-on-error: true
         run: make clean
 
       - name: Rust share build
@@ -285,7 +288,6 @@ jobs:
           echo Rust example,%ERRORLEVEL% >> status.txt
 
       - name: Rename status.txt
-        continue-on-error: true
         shell: cmd
         run: |
           cat status.txt
@@ -339,6 +341,7 @@ jobs:
 
       - name: Download binary-demo
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: binary-demo
           path: ${{ github.workspace }}/dataset/binary-demo
@@ -397,6 +400,7 @@ jobs:
           echo "Java test,$?" >> status.txt
 
       - name: Cleanup
+        continue-on-error: true
         run: make clean
 
       - name: Install Rust
@@ -432,7 +436,6 @@ jobs:
           echo "Rust example,$?" >> ../../status.txt
 
       - name: Rename status.txt
-        continue-on-error: true
         run: |
           cat status.txt
           PLATFORM=$(echo ${{ matrix.image }} | tr ':' '-')
@@ -496,6 +499,7 @@ jobs:
 
       - name: Download binary-demo
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: binary-demo
           path: ${{ github.workspace }}/dataset/binary-demo
@@ -554,6 +558,7 @@ jobs:
           echo "Java test,$?" >> status.txt
 
       - name: Cleanup
+        continue-on-error: true
         run: make clean
 
       - name: Install Rust
@@ -589,7 +594,6 @@ jobs:
           echo "Rust example,$?" >> ../../status.txt
 
       - name: Rename status.txt
-        continue-on-error: true
         run: |
           cat status.txt
           PLATFORM=$(echo ${{ matrix.image }} | tr ':' '-')
@@ -623,6 +627,7 @@ jobs:
 
       - name: Download binary-demo
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: binary-demo
           path: ${{ github.workspace }}/dataset/binary-demo
@@ -681,6 +686,7 @@ jobs:
           echo "Java test,$?" >> status.txt
 
       - name: Cleanup
+        continue-on-error: true
         run: make clean
 
       - name: Install Rust
@@ -716,7 +722,6 @@ jobs:
           echo "Rust example,$?" >> ../../status.txt
 
       - name: Rename status.txt
-        continue-on-error: true
         run: |
           cat status.txt
           mv status.txt archlinux.csv

--- a/.github/workflows/multiplatform-build-test.yml
+++ b/.github/workflows/multiplatform-build-test.yml
@@ -68,18 +68,13 @@ jobs:
           make pytest-venv
           echo "Python test,$?" >> status.txt
 
-      - name: Ensure Node.js dependencies
-        continue-on-error: true
-        working-directory: tools/nodejs_api
-        run: npm install --include=dev
-
       - name: Node.js test
         continue-on-error: true
         run: |
           node --version
           npm --version
           set +e
-          make nodejstest
+          make nodejstest-deps
           echo "Node.js test,$?" >> status.txt
 
       - name: Java test
@@ -202,17 +197,11 @@ jobs:
           make pytest-venv
           echo Python test,%ERRORLEVEL% >> status.txt
 
-      - name: Ensure Node.js dependencies
-        continue-on-error: true
-        shell: cmd
-        working-directory: .\tools\nodejs_api
-        run: npm install --include=dev
-
       - name: Node.js test
         continue-on-error: true
         shell: cmd
         run: |
-          make nodejstest
+          make nodejstest-deps
           echo Node.js test,%ERRORLEVEL% >> status.txt
 
       - name: Set up JDK 11
@@ -351,18 +340,13 @@ jobs:
           make pytest-venv
           echo "Python test,$?" >> status.txt
 
-      - name: Ensure Node.js dependencies
-        working-directory: tools/nodejs_api
-        continue-on-error: true
-        run: npm install --include=dev
-
       - name: Node.js test
         continue-on-error: true
         run: |
           node --version
           npm --version
           set +e
-          make nodejstest
+          make nodejstest-deps
           echo "Node.js test,$?" >> status.txt
 
       - name: Java test
@@ -507,18 +491,13 @@ jobs:
           make pytest-venv
           echo "Python test,$?" >> status.txt
 
-      - name: Ensure Node.js dependencies
-        continue-on-error: true
-        working-directory: tools/nodejs_api
-        run: npm install --include=dev
-
       - name: Node.js test
         continue-on-error: true
         run: |
           node --version
           npm --version
           set +e
-          make nodejstest
+          make nodejstest-deps
           echo "Node.js test,$?" >> status.txt
 
       - name: Java test
@@ -632,18 +611,11 @@ jobs:
           make pytest-venv
           echo "Python test,$?" >> status.txt
 
-      - name: Ensure Node.js dependencies
-        continue-on-error: true
-        working-directory: tools/nodejs_api
-        run: npm install --include=dev
-
       - name: Node.js test
         continue-on-error: true
         run: |
-          node --version
-          npm --version
           set +e
-          make nodejstest
+          make nodejstest-deps
           echo "Node.js test,$?" >> status.txt
 
       - name: Java test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,13 +280,16 @@ endif()
 
 if (ENABLE_BACKTRACES)
     find_package(cpptrace QUIET)
-    if (NOT cpptrace_FOUND)
+    if(cpptrace_FOUND)
+        message(STATUS "Using system cpptrace")
+    else()
+        message(STATUS "cpptrace not found. Fetching from GitHub...")
         include(FetchContent)
         FetchContent_Declare(
-          cpptrace
-          GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
-          GIT_TAG        v0.8.3
-          GIT_SHALLOW    TRUE
+            cpptrace
+            GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
+            GIT_TAG        v0.8.3
+            GIT_SHALLOW    TRUE
         )
         FetchContent_MakeAvailable(cpptrace)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ if(SINGLE_THREADED)
     add_compile_definitions(__SINGLE_THREADED__)
     message(STATUS "Single-threaded mode is enabled")
 else()
+    message(STATUS "Multi-threaded mode is enabled: CMAKE_BUILD_PARALLEL_LEVEL=$ENV{CMAKE_BUILD_PARALLEL_LEVEL}")
     find_package(Threads REQUIRED)
 endif()
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@
 
 BUILD_TYPE ?=
 BUILD_PATH ?=
+EXTRA_CMAKE_FLAGS ?=
 CLANGD_DIAGNOSTIC_INSTANCES ?= 4
 PREFIX ?= install
 TEST_JOBS ?= 10
@@ -177,8 +178,13 @@ endif
 nodejs:
 	$(call run-cmake-release, -DBUILD_NODEJS=TRUE)
 
+nodejs-deps:
+	cd tools/nodejs_api && npm install --include=dev
+
 nodejstest: nodejs
 	cd tools/nodejs_api && npm test
+
+nodejstest-deps: nodejs-deps nodejstest
 
 python:
 	$(call run-cmake-release, -DBUILD_PYTHON=TRUE -DBUILD_SHELL=FALSE)
@@ -309,7 +315,7 @@ get-build-type = $(if $(BUILD_TYPE),$(BUILD_TYPE),$1)
 get-build-path = $(if $(BUILD_PATH),$(BUILD_PATH),$(call lowercase,$(call get-build-type,$(1))))
 
 define config-cmake
-	cmake -B build/$(call get-build-path,$1) -DCMAKE_BUILD_TYPE=$(call get-build-type,$1) $2 $(CMAKE_FLAGS) .
+	cmake -B build/$(call get-build-path,$1) -DCMAKE_BUILD_TYPE=$(call get-build-type,$1) $2 $(CMAKE_FLAGS) $(EXTRA_CMAKE_FLAGS) .
 endef
 
 define build-cmake

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,18 @@
 BUILD_TYPE ?=
 BUILD_PATH ?=
 CLANGD_DIAGNOSTIC_INSTANCES ?= 4
-NUM_THREADS ?= 1
 PREFIX ?= install
 TEST_JOBS ?= 10
 EXTENSION_LIST ?= httpfs;duckdb;json;postgres;sqlite;fts;delta;iceberg;azure;unity_catalog;vector;neo4j;algo;llm
 EXTENSION_TEST_EXCLUDE_FILTER ?= ""
 
+ifeq ($(shell uname -s 2>/dev/null),Linux)
+	NUM_THREADS ?= $(shell expr $(shell nproc) \* 2 / 3)
+else ifeq ($(shell uname -s 2>/dev/null),Darwin)
+	NUM_THREADS ?= $(shell expr $(shell sysctl -n hw.ncpu) \* 2 / 3)
+else
+	NUM_THREADS ?= 1
+endif
 export CMAKE_BUILD_PARALLEL_LEVEL=$(NUM_THREADS)
 
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,25 @@
+.DEFAULT_GOAL := release
+# Declare explicit build targets to avoid conflict with files of the same name.
 .PHONY: \
-	release debug all alldebug \
-	test lcov \
-	java nodejs python rust \
-	javatest nodejstest pytest rusttest \
+	release relwithdebinfo debug all allconfig alldebug \
+	test-build test lcov \
+	java_native_header java javatest \
+	nodejs nodejstest \
+	python python-debug pytest pytest-debug \
+	wasm wasmtest \
+	rusttest \
 	benchmark example \
-	clangd tidy clangd-diagnostics \
+	extension-test-build extension-test extension-json-test-build extension-json-test \
+	extension-debug extension-release \
+	shell-test \
+	tidy tidy-analyzer clangd-diagnostics \
 	install \
-	clean-extension clean-python-api clean-java clean \
-	extension-test shell-test
-
+	clean-extension clean-python-api clean-java clean
 .ONESHELL:
 .SHELLFLAGS = -ec
 
+BUILD_TYPE ?=
+BUILD_PATH ?=
 CLANGD_DIAGNOSTIC_INSTANCES ?= 4
 NUM_THREADS ?= 1
 PREFIX ?= install
@@ -82,9 +90,14 @@ ifdef WASM_NODEFS
 	CMAKE_FLAGS += -DWASM_NODEFS=$(WASM_NODEFS)
 endif
 
-CMAKE_FLAGS += -DUSE_STD_FORMAT=$(if $(USE_STD_FORMAT),TRUE,FALSE)
+ifdef USE_STD_FORMAT
+	CMAKE_FLAGS += -DUSE_STD_FORMAT=$(USE_STD_FORMAT)
+endif
 
-# Must be first in the Makefile so that it is the default target.
+ifdef EXTRA_CMAKE_FLAGS
+	CMAKE_FLAGS += $(EXTRA_CMAKE_FLAGS)
+endif
+
 release:
 	$(call run-cmake-release,)
 
@@ -127,37 +140,22 @@ test-build:
 
 test: test-build
 	python3 dataset/ldbc-1/download_data.py
-	ctest --test-dir build/relwithdebinfo/test --output-on-failure -j ${TEST_JOBS}
+	ctest --test-dir build/$(call get-build-path,RelWithDebInfo)/test --output-on-failure -j ${TEST_JOBS}
 
 lcov:
 	python3 dataset/ldbc-1/download_data.py
 	$(call run-cmake-release, -DBUILD_TESTS=TRUE -DBUILD_LCOV=TRUE)
-	ctest --test-dir build/release/test --output-on-failure -j ${TEST_JOBS}
+	ctest --test-dir build/$(call get-build-path,Release)/test --output-on-failure -j ${TEST_JOBS}
 
 # Language APIs
 
 # Required for clangd-related tools.
 java_native_header:
-	cmake --build build/release --target kuzu_java
+	cmake --build build/$(call get-build-path,Release) --target kuzu_java
 
 java:
 	$(call run-cmake-release, -DBUILD_JAVA=TRUE)
 
-nodejs:
-	$(call run-cmake-release, -DBUILD_NODEJS=TRUE)
-
-python:
-	$(call run-cmake-release, -DBUILD_PYTHON=TRUE -DBUILD_SHELL=FALSE)
-
-python-debug:
-	$(call run-cmake-debug, -DBUILD_PYTHON=TRUE)
-
-wasm:
-	mkdir -p build/wasm && cd build/wasm &&\
-	emcmake cmake $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=Release -DBUILD_WASM=TRUE -DBUILD_BENCHMARK=FALSE -DBUILD_TESTS=FALSE -DBUILD_SHELL=FALSE  ../.. && \
-	cmake --build . --config Release -j $(NUM_THREADS)
-
-# Language API tests
 javatest:
 ifeq ($(OS),Windows_NT)
 	cd tools/java_api &&\
@@ -167,14 +165,34 @@ else
 	./gradlew test -i
 endif
 
+nodejs:
+	$(call run-cmake-release, -DBUILD_NODEJS=TRUE)
+
 nodejstest: nodejs
 	cd tools/nodejs_api && npm test
+
+python:
+	$(call run-cmake-release, -DBUILD_PYTHON=TRUE -DBUILD_SHELL=FALSE)
+
+python-debug:
+	$(call run-cmake-debug, -DBUILD_PYTHON=TRUE)
 
 pytest: python
 	cmake -E env PYTHONPATH=tools/python_api/build python3 -m pytest -vv tools/python_api/test
 
 pytest-debug: python-debug
 	cmake -E env PYTHONPATH=tools/python_api/build python3 -m pytest -vv tools/python_api/test
+
+wasm:
+	mkdir -p build/wasm && cd build/wasm &&\
+	emcmake cmake $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=$(call get-build-type,Release) -DBUILD_WASM=TRUE -DBUILD_BENCHMARK=FALSE -DBUILD_TESTS=FALSE -DBUILD_SHELL=FALSE  ../.. && \
+	cmake --build . --config $(call get-build-type,Release) -j $(NUM_THREADS)
+
+wasmtest:
+	mkdir -p build/wasm && cd build/wasm &&\
+	emcmake cmake $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=$(call get-build-type,Release) -DBUILD_WASM=TRUE -DBUILD_BENCHMARK=FALSE -DBUILD_TESTS=TRUE -DBUILD_SHELL=FALSE  ../.. && \
+	cmake --build . --config $(call get-build-type,Release) -j $(NUM_THREADS) &&\
+	cd ../.. && ctest --test-dir  build/wasm/test/ --output-on-failure -j ${TEST_JOBS} --timeout 600
 
 rusttest:
 ifeq ($(OS),Windows_NT)
@@ -183,12 +201,6 @@ else
 	export CARGO_BUILD_JOBS=$(NUM_THREADS)
 endif
 	cd tools/rust_api && cargo test --release --locked --all-features
-
-wasmtest:
-	mkdir -p build/wasm && cd build/wasm &&\
-	emcmake cmake $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=Release -DBUILD_WASM=TRUE -DBUILD_BENCHMARK=FALSE -DBUILD_TESTS=TRUE -DBUILD_SHELL=FALSE  ../.. && \
-	cmake --build . --config Release -j $(NUM_THREADS) &&\
-	cd ../.. && ctest --test-dir  build/wasm/test/ --output-on-failure -j ${TEST_JOBS} --timeout 600
 
 # Other misc build targets
 benchmark:
@@ -204,6 +216,13 @@ extension-test-build:
 		-DBUILD_TESTS=TRUE \
 	)
 
+extension-test: extension-test-build
+	$(if $(filter Windows_NT,$(OS)),\
+		set "E2E_TEST_FILES_DIRECTORY=extension" &&,\
+		E2E_TEST_FILES_DIRECTORY=extension) \
+    ctest --test-dir build/$(call get-build-path,RelWithDebInfo)/test/runner --output-on-failure -j ${TEST_JOBS} --exclude-regex "${EXTENSION_TEST_EXCLUDE_FILTER}"
+	aws s3 rm s3://kuzu-dataset-us/${RUN_ID}/ --recursive
+
 extension-json-test-build:
 	$(call run-cmake-relwithdebinfo, \
 		-DBUILD_EXTENSIONS="json" \
@@ -211,17 +230,8 @@ extension-json-test-build:
 		-DENABLE_ADDRESS_SANITIZER=TRUE \
 	)
 
-# This should be removed and be replaced with something more flexible with any given extension names.
-extension-test: extension-test-build
-ifeq ($(OS),Windows_NT)
-	set "E2E_TEST_FILES_DIRECTORY=extension" && ctest --test-dir build/relwithdebinfo/test/runner --output-on-failure -j ${TEST_JOBS} --exclude-regex "${EXTENSION_TEST_EXCLUDE_FILTER}"
-else
-	E2E_TEST_FILES_DIRECTORY=extension ctest --test-dir build/relwithdebinfo/test/runner --output-on-failure -j ${TEST_JOBS} --exclude-regex "${EXTENSION_TEST_EXCLUDE_FILTER}"
-endif
-	aws s3 rm s3://kuzu-dataset-us/${RUN_ID}/ --recursive
-
 extension-json-test: extension-json-test-build
-	ctest --test-dir build/relwithdebinfo/extension --output-on-failure -j ${TEST_JOBS} -R json
+	ctest --test-dir build/$(call get-build-path,RelWithDebInfo)/extension --output-on-failure -j ${TEST_JOBS} -R json
 	aws s3 rm s3://kuzu-dataset-us/${RUN_ID}/ --recursive
 
 extension-debug:
@@ -236,8 +246,9 @@ extension-release:
 		-DBUILD_KUZU=FALSE \
 	)
 
+# pytest expects a `Release` build path.
 shell-test:
-	$(call run-cmake-relwithdebinfo, \
+	$(call run-cmake-release, \
 		-DBUILD_SHELL=TRUE \
 	)
 	cd tools/shell/test && python3 -m pytest -v
@@ -248,40 +259,27 @@ shell-test:
 # `|` ensures these targets build in this order, even in the presence of
 # parallelism.
 tidy: | allconfig java_native_header
-	run-clang-tidy -p build/release -quiet -j $(NUM_THREADS) \
+	run-clang-tidy -p build/$(call get-build-path,Release) -quiet -j $(NUM_THREADS) \
 		"^$(realpath src)|$(realpath extension)/(?!fts/third_party/snowball/)|$(realpath tools)/(?!shell/linenoise.cpp)"
 
 tidy-analyzer: | allconfig java_native_header
-	run-clang-tidy -config-file .clang-tidy-analyzer -p build/release -quiet -j $(NUM_THREADS) \
+	run-clang-tidy -config-file .clang-tidy-analyzer -p build/$(call get-build-path,Release) -quiet -j $(NUM_THREADS) \
 		"^$(realpath src)/(?!function/vector_cast_functions.cpp)|$(realpath extension)/(?!fts/third_party/snowball/)|$(realpath tools)/(?!shell/linenoise.cpp)"
 
 clangd-diagnostics: | allconfig java_native_header
 	find src -name *.h -or -name *.cpp | xargs \
-		./scripts/get-clangd-diagnostics.py --compile-commands-dir build/release \
+		./scripts/get-clangd-diagnostics.py --compile-commands-dir build/$(call get-build-path,Release) \
 		-j $(NUM_THREADS) --instances $(CLANGD_DIAGNOSTIC_INSTANCES)
 
 
 # Installation
 install:
-	cmake --install build/release --prefix $(PREFIX)
+	cmake --install build/$(call get-build-path,Release) --prefix $(PREFIX)
 
 
 # Cleaning
 clean-extension:
-	cmake -E rm -rf extension/algo/build
-	cmake -E rm -rf extension/httpfs/build
-	cmake -E rm -rf extension/duckdb/build
-	cmake -E rm -rf extension/postgres/build
-	cmake -E rm -rf extension/sqlite/build
-	cmake -E rm -rf extension/fts/build
-	cmake -E rm -rf extension/delta/build
-	cmake -E rm -rf extension/iceberg/build
-	cmake -E rm -rf extension/azure/build
-	cmake -E rm -rf extension/llm/build
-	cmake -E rm -rf extension/unity_catalog/build
-	cmake -E rm -rf extension/vector/build
-	cmake -E rm -rf extension/neo4j/build
-	cmake -E rm -rf extension/gds/build
+	cmake -E rm -rf extension/*/build
 
 clean-python-api:
 	cmake -E rm -rf tools/python_api/build
@@ -294,37 +292,41 @@ clean: clean-extension clean-python-api clean-java
 
 
 # Utils
+lowercase = $(if $(filter Release,$(1)),release,$(if $(filter RelWithDebInfo,$(1)),relwithdebinfo,$(if $(filter Debug,$(1)),debug,$(1))))
+get-build-type = $(if $(BUILD_TYPE),$(BUILD_TYPE),$1)
+get-build-path = $(if $(BUILD_PATH),$(BUILD_PATH),$(call lowercase,$(call get-build-type,$(1))))
+
 define config-cmake
-	cmake -B build/$1 $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=$2 $3 .
+	cmake -B build/$(call get-build-path,$1) -DCMAKE_BUILD_TYPE=$(call get-build-type,$1) $2 $(CMAKE_FLAGS) .
 endef
 
 define build-cmake
-	cmake --build build/$1 --config $2
+	cmake --build build/$(call get-build-path,$1) --config $(call get-build-type,$1)
 endef
 
 define run-cmake
-	$(call config-cmake,$1,$2,$3)
-	$(call build-cmake,$1,$2)
+	$(call config-cmake,$1,$2)
+	$(call build-cmake,$1)
 endef
 
 define run-cmake-debug
-	$(call run-cmake,debug,Debug,$1)
+	$(call run-cmake,Debug,$1)
 endef
 
 define build-cmake-release
-	$(call build-cmake,release,Release,$1)
+	$(call build-cmake,Release,$1)
 endef
 
 define build-cmake-relwithdebinfo
-	$(call build-cmake,relwithdebinfo,RelWithDebInfo,$1)
+	$(call build-cmake,RelWithDebInfo,$1)
 endef
 
 define config-cmake-release
-	$(call config-cmake,release,Release,$1)
+	$(call config-cmake,Release,$1)
 endef
 
 define config-cmake-relwithdebinfo
-	$(call config-cmake,relwithdebinfo,RelWithDebInfo,$1)
+	$(call config-cmake,RelWithDebInfo,$1)
 endef
 
 define run-cmake-release

--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,9 @@ benchmark:
 example:
 	$(call run-cmake-release, -DBUILD_EXAMPLES=TRUE)
 
+extension-build:
+	$(call run-cmake-relwithdebinfo,-DBUILD_EXTENSIONS="$(EXTENSION_LIST)")
+
 extension-test-build:
 	$(call run-cmake-relwithdebinfo, \
 		-DBUILD_EXTENSIONS="$(EXTENSION_LIST)" \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
+# Helper frontend to cmake.
+# Tip: to see the actual commands that will be run for any target, use `make -n <target>`.
+
 .DEFAULT_GOAL := release
-# Declare explicit build targets to avoid conflict with files of the same name.
+# Explicit targets to avoid conflict with files of the same name.
 .PHONY: \
 	release relwithdebinfo debug all allconfig alldebug \
 	test-build test lcov \

--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,9 @@ python-debug:
 pytest: python
 	cmake -E env PYTHONPATH=tools/python_api/build python3 -m pytest -vv tools/python_api/test
 
+pytest-venv: python
+	$(MAKE) -C tools/python_api pytest
+
 pytest-debug: python-debug
 	cmake -E env PYTHONPATH=tools/python_api/build python3 -m pytest -vv tools/python_api/test
 

--- a/benchmark/serializer.py
+++ b/benchmark/serializer.py
@@ -6,16 +6,9 @@ import shutil
 import subprocess
 import sys
 
+from version import _get_kuzu_version
+
 base_dir = os.path.dirname(os.path.realpath(__file__))
-
-
-def _get_kuzu_version():
-    cmake_file = os.path.join(base_dir, '..', 'CMakeLists.txt')
-    with open(cmake_file) as f:
-        for line in f:
-            if line.startswith('project(Kuzu VERSION'):
-                return line.split(' ')[2].strip()
-
 
 def serialize(kuzu_exec_path, dataset_name, dataset_path, serialized_graph_path, benchmark_copy_log_dir,
               single_thread: bool = False):
@@ -96,7 +89,7 @@ def serialize(kuzu_exec_path, dataset_name, dataset_path, serialized_graph_path,
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(description='Serializes dataset to a kuzu database')
-    parser.add_argument("dataset_name", help="Name of the dataset for dispay purposes")
+    parser.add_argument("dataset_name", help="Name of the dataset for display purposes")
     parser.add_argument("dataset_path", help="Input path of the dataset to serialize")
     parser.add_argument("serialized_graph_path",
                         help="Output path of the database. Will be created if it does not exist already")
@@ -113,7 +106,6 @@ if __name__ == '__main__':
     parser.add_argument("--kuzu-shell",
                         help="Path of the kuzu shell executable. Defaults to the path as built in the default release build directory",
                         default=default_kuzu_exec_path)
-    args = parser.parse_args()
     args = parser.parse_args()
 
     try:

--- a/benchmark/version.py
+++ b/benchmark/version.py
@@ -1,0 +1,14 @@
+import os
+
+base_dir = os.path.dirname(os.path.realpath(__file__))
+
+def _get_kuzu_version():
+    cmake_file = os.path.join(base_dir, '..', 'CMakeLists.txt')
+    with open(cmake_file) as f:
+        for line in f:
+            if line.startswith('project(Kuzu VERSION'):
+                return line.split(' ')[2].strip()
+    return "0"
+
+if __name__ == "__main__":
+    print(_get_kuzu_version())

--- a/scripts/multiplatform-test-helper/notify-discord.py
+++ b/scripts/multiplatform-test-helper/notify-discord.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
                     stages.append(r['stage'])
                 if r['status'] != "✅":
                     failures.setdefault(platform, list()).append(r)
-        message += f"- Platforms:\n  - {', '.join(result.keys())}\n"
+        message += f"- Platforms:\n  - {', '.join(sorted(result.keys()))}\n"
         message += f"- Stages:\n  - {', '.join(stages)}\n"
         # Add only the failures.
         if len(failures) > 0:

--- a/scripts/multiplatform-test-helper/notify-discord.py
+++ b/scripts/multiplatform-test-helper/notify-discord.py
@@ -37,26 +37,22 @@ if __name__ == "__main__":
                 sys.exit(1)
         await client.close()
 
-    message = ""
-    message += "## Multiplatform test result:\n"
+    message = "## Multiplatform test result:\n"
     with open(sys.argv[1], "r") as f:
         result = json.load(f)
         failures = {}
-        message += "### Success:\n"
+        stages = []
         for platform in sorted(result.keys()):
-            if len(message) >= 1500:
-                messages.append(message)
-                message = ""
-            message += f"- **{platform}**:\n"
             for r in result[platform]:
-                # Only show success status first.
-                if r['status'] == "✅":
-                    message += f"  - {r['stage']}: {r['status']}\n"
-                else:
+                if r['stage'] not in stages:
+                    stages.append(r['stage'])
+                if r['status'] != "✅":
                     failures.setdefault(platform, list()).append(r)
+        message += f"- Platforms:\n  - {', '.join(result.keys())}\n"
+        message += f"- Stages:\n  - {', '.join(stages)}\n"
+        # Add only the failures.
         if len(failures) > 0:
-            # Show all failures at the end.
-            message += "### Failure:\n"
+            message += "### Failures:\n"
             for platform in sorted(failures.keys()):
                 if len(message) >= 1500:
                     messages.append(message)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,8 +3,8 @@ add_subdirectory(gtest EXCLUDE_FROM_ALL)
 
 # Make gtest available to subdirectories.
 add_library(GTest::GTest INTERFACE IMPORTED)
-target_link_libraries(GTest::GTest INTERFACE gtest_main)
-target_link_libraries(GTest::GTest INTERFACE gmock_main)
+target_link_libraries(GTest::GTest INTERFACE gtest gtest_main)
+target_link_libraries(GTest::GTest INTERFACE gmock gmock_main)
 
 enable_testing()
 add_subdirectory(test_helper)

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -1,14 +1,20 @@
-include(FetchContent)
-
 # Disable WERROR for gtest.
 set(CMAKE_COMPILE_WARNING_AS_ERROR FALSE)
-# Disable LTO for gtest, since it uses an older version of CMake.
-set(CMAKE_INTERPROCEDURAL_OPTIMIZATION FALSE)
 
-FetchContent_Declare(
+find_package(GTest QUIET)
+if(GTest_FOUND)
+    message(STATUS "Using system GTest")
+else()
+    message(STATUS "GTest not found. Fetching from GitHub...")
+    include(FetchContent)
+    FetchContent_Declare(
         googletest
         GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG v1.13.0
-)
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
+        GIT_TAG        v1.17.0
+        GIT_SHALLOW    TRUE
+    )
+    if(WIN32)
+        set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    endif()
+    FetchContent_MakeAvailable(googletest)
+endif()

--- a/tools/python_api/Makefile
+++ b/tools/python_api/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-# Declare explicit build targets to avoid conflict with files of the same name.
+# Explicit targets to avoid conflict with files of the same name.
 .PHONY: \
 	requirements \
 	lint check format \

--- a/tools/python_api/Makefile
+++ b/tools/python_api/Makefile
@@ -20,12 +20,12 @@ endif
 	python3 -m venv $(VENV)
 	$(MAKE) requirements
 
-requirements: .venv  ## Install/update Python dev packages
+requirements:  ## Install/update Python dev packages
 	@unset CONDA_PREFIX \
-	&& $(VENV_BIN)/python -m pip install -U "uv==0.7.9" \
+	&& $(VENV_BIN)/python -m pip install -U uv \
 	&& $(VENV_BIN)/uv pip install --upgrade -r requirements_dev.txt
 
-pytest: requirements
+pytest: .venv
 ifeq ($(OS),Windows_NT)
 	set PYTHONPATH=./build
 else
@@ -39,7 +39,7 @@ lint: .venv  ## Apply autoformatting and linting rules
 	-$(VENV_BIN)/mypy src_py test
 
 check: .venv
-	$(VENV_BIN)/ruff check src_py test
+	$(VENV_BIN)/ruff check src_py test --verbose
 
 format: .venv
 	$(VENV_BIN)/ruff format src_py test

--- a/tools/python_api/Makefile
+++ b/tools/python_api/Makefile
@@ -1,4 +1,10 @@
 .DEFAULT_GOAL := help
+# Declare explicit build targets to avoid conflict with files of the same name.
+.PHONY: \
+	requirements \
+	lint check format \
+	build test \
+	help
 
 PYTHONPATH=
 SHELL=/usr/bin/env bash
@@ -14,37 +20,38 @@ endif
 	python3 -m venv $(VENV)
 	$(MAKE) requirements
 
-.PHONY: requirements
 requirements: .venv  ## Install/update Python dev packages
 	@unset CONDA_PREFIX \
-	&& $(VENV_BIN)/python -m pip install -U uv \
-	&& $(VENV_BIN)/uv pip install --upgrade -r requirements_dev.txt \
+	&& $(VENV_BIN)/python -m pip install -U "uv==0.7.9" \
+	&& $(VENV_BIN)/uv pip install --upgrade -r requirements_dev.txt
 
-.PHONY: lint
-lint:  ## Apply autoformatting and linting rules
+pytest: requirements
+ifeq ($(OS),Windows_NT)
+	set PYTHONPATH=./build
+else
+	export PYTHONPATH=./build
+endif
+	$(VENV_BIN)/python -m pytest -vv ./test
+
+lint: .venv  ## Apply autoformatting and linting rules
 	$(VENV_BIN)/ruff check src_py test
 	$(VENV_BIN)/ruff format src_py test
 	-$(VENV_BIN)/mypy src_py test
 
-.PHONY: check
-check:
+check: .venv
 	$(VENV_BIN)/ruff check src_py test
 
-.PHONY: format
-format:
+format: .venv
 	$(VENV_BIN)/ruff format src_py test
 
-.PHONY: build
 build:  ## Compile kuzu (and install in 'build') for Python
 	$(MAKE) -C ../../ python
 	cp src_py/*.py build/kuzu/
 
-.PHONY: test
-test:  ## Run the Python unit tests
+test: .venv  ## Run the Python unit tests
 	cp src_py/*.py build/kuzu/ && cd build
 	$(VENV_BIN)/pytest test
 
-.PHONY: help
 help:  ## Display this help information
 	@echo -e "\033[1mAvailable commands:\033[0m"
 	@grep -E '^[a-z.A-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}' | sort

--- a/tools/python_api/requirements_dev.txt
+++ b/tools/python_api/requirements_dev.txt
@@ -12,7 +12,6 @@ setuptools~=70.2
 # required for lint/formatting
 ruff==0.11.12
 mypy==1.16.0
-uv==0.7.9
 
 # cpu version of torch
 --find-links https://data.pyg.org/whl/torch-2.2.0+cpu.html

--- a/tools/python_api/requirements_dev.txt
+++ b/tools/python_api/requirements_dev.txt
@@ -1,17 +1,21 @@
 # required for tests
 networkx~=3.0
-numpy~=1.26
+numpy~=2.0
 pandas~=2.2
 polars~=1.30
 pyarrow~=20.0
 pybind11~=2.13
 pytest
-torch
-torch-geometric~=2.3.0
-setuptools~=80.8
 pytest-asyncio~=1.0
+setuptools~=70.2
 
 # required for lint/formatting
 ruff==0.11.12
 mypy==1.16.0
-uv==0.7.8
+uv==0.7.9
+
+# cpu version of torch
+--find-links https://data.pyg.org/whl/torch-2.2.0+cpu.html
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch
+torch-geometric~=2.3.0

--- a/tools/python_api/test/test_issue.py
+++ b/tools/python_api/test/test_issue.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from tools.python_api.test.type_aliases import ConnDB
+try:
+    from tools.python_api.test.type_aliases import ConnDB
+except ImportError:
+    from type_aliases import ConnDB
 
 # required by python-lint
 

--- a/tools/python_api/test/test_wal.py
+++ b/tools/python_api/test/test_wal.py
@@ -28,6 +28,8 @@ def run_query_then_kill(tmp_path: Path, build_dir: Path, queries: str):
     time.sleep(5)
     proc.kill()
     proc.wait(5)
+    # Force remove the lock file. Safe since proc.wait() ensures the process has terminated.
+    Path(f"{tmp_path!s}/.lock").unlink(missing_ok=True)
 
 
 # Kill the database while it's in the middle of executing a long persistent query

--- a/tools/shell/test/Makefile
+++ b/tools/shell/test/Makefile
@@ -1,0 +1,24 @@
+.DEFAULT_GOAL := help
+# Explicit targets to avoid conflict with files of the same name.
+.PHONY: requirements test
+
+PYTHONPATH=
+SHELL=/usr/bin/env bash
+VENV=.venv
+
+ifeq ($(OS),Windows_NT)
+	VENV_BIN=$(VENV)/Scripts
+else
+	VENV_BIN=$(VENV)/bin
+endif
+
+.venv:
+	python3 -m venv $(VENV)
+	$(MAKE) requirements
+
+requirements:
+	$(VENV_BIN)/python -m pip install -U uv \
+	&& $(VENV_BIN)/uv pip install pytest pexpect
+
+test: .venv
+	$(VENV_BIN)/python3 -m pytest -v .


### PR DESCRIPTION
CMake:
* Currently, `gtest` is downloaded from their release (as per their recommendation). However, when packaging Kuzu, this causes an issue in `nixpkgs` because networks calls are not allowed during builds. This PR first looks for a system `gtest` and downloads only if that is not found, similar to how `cpptrace` works currently.

Makefile:
* Refactor to be able to override the BUILD_TYPE and BUILD_PATH from the cli. Otherwise currently each rule makes its own decision on whether to build Kuzu in Release or RelWithDebInfo mode with no way to override, for example to share build artifacts. The semantics of all the rules have been kept the same. A future PR could make the list of rules simpler, such as removing `make release` and `make relwithdebinfo` and having a single `make build`.
* Add ability to append more CMAKE flags.
* Sort the targets.
* Add `pytest-venv` and `nodejstest-deps` to make it easy to run tests locally and have a way to run exactly what the CI uses.

ci-workflow:
* Fix `Generate and upload` to properly check existing dataset before uploading a new one. Fixes [a bug](https://github.com/kuzudb/kuzu/actions/runs/15558886039/job/43806101704#step:5:372).
* Use `pytest-venv`, `nodejstest-deps`, `shell-test` to avoid using system pip installations.
* Make `Check extension headers` more generic.
* Python dependencies are now all moved to the `requirements-dev.txt` file.

multiplatform-build-test.yml:
* Use ninja.
* Set number of threads globally.