### PR TITLE
Add ADLS support to Azure extension

### DIFF
--- a/extension/azure/test/test_files/azure.test
+++ b/extension/azure/test/test_files/azure.test
@@ -6,9 +6,12 @@
 ---- error
 Binder exception: Cannot load from file type azure. If this file type is part of a kuzu extension please load the extension then try again.
 
--CASE AzureScan
+-CASE AzureScanBlob
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/azure/build/libazure.kuzu_extension';
 ---- ok
+-STATEMENT LOAD FROM "az://kuzu-test/vPerson.csv" RETURN *;
+---- error
+IO exception: Cannot open file az://kuzu-test/vPerson.csv: No such file or directory
 -STATEMENT CALL current_setting('AZURE_CONNECTION_STRING') return *;
 ---- ok
 -STATEMENT CREATE NODE TABLE Person AS LOAD FROM "az://kuzu-test/vPerson.csv" (file_format='azure') RETURN *;
@@ -44,3 +47,10 @@ Alice|Bob
 Bob|Dan
 Bob|Carol
 Bob|Alice
+
+-CASE AzureScanADLS
+-STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/azure/build/libazure.kuzu_extension';
+---- ok
+-STATEMENT LOAD FROM "abfss://kuzu-test/vPerson.csv" RETURN *;
+---- error
+IO exception: Cannot open file abfss://kuzu-test/vPerson.csv: No such file or directory

--- a/extension/azure/test/test_files/azure.test
+++ b/extension/azure/test/test_files/azure.test
@@ -6,7 +6,7 @@
 ---- error
 Binder exception: Cannot load from file type azure. If this file type is part of a kuzu extension please load the extension then try again.
 
--CASE AzureScanBlob
+-CASE AzureScan
 -STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/azure/build/libazure.kuzu_extension';
 ---- ok
 -STATEMENT LOAD FROM "az://kuzu-test/vPerson.csv" RETURN *;
@@ -47,10 +47,21 @@ Alice|Bob
 Bob|Dan
 Bob|Carol
 Bob|Alice
-
--CASE AzureScanADLS
--STATEMENT LOAD EXTENSION '${KUZU_ROOT_DIRECTORY}/extension/azure/build/libazure.kuzu_extension';
+-STATEMENT COPY Knows FROM (LOAD FROM "abfss://kuzu-test/dirA/dirB/eKnows_2.csv" (file_format='azure') RETURN *);
 ---- ok
--STATEMENT LOAD FROM "abfss://kuzu-test/vPerson.csv" RETURN *;
----- error
-IO exception: Cannot open file abfss://kuzu-test/vPerson.csv: No such file or directory
+-STATEMENT MATCH (a:Person)-[e:Knows]->(b:Person) RETURN a.fname, b.fname;
+---- 14
+Alice|Bob
+Alice|Carol
+Alice|Dan
+Bob|Alice
+Bob|Carol
+Bob|Dan
+Carol|Alice
+Carol|Bob
+Carol|Dan
+Dan|Alice
+Dan|Bob
+Dan|Carol
+Elizabeth|Farooq
+Elizabeth|Greg

--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -341,7 +341,8 @@ std::string LocalFileSystem::expandPath(main::ClientContext* context,
 bool LocalFileSystem::isLocalPath(const std::string& path) {
     return path.rfind("s3://", 0) != 0 && path.rfind("gs://", 0) != 0 &&
            path.rfind("gcs://", 0) != 0 && path.rfind("http://", 0) != 0 &&
-           path.rfind("https://", 0) != 0 && path.rfind("az://", 0) != 0;
+           path.rfind("https://", 0) != 0 && path.rfind("az://", 0) != 0 &&
+           path.rfind("abfss://", 0) != 0;
 }
 
 void LocalFileSystem::readFromFile(FileInfo& fileInfo, void* buffer, uint64_t numBytes,


### PR DESCRIPTION
I believe ADLS support was already working since we use DuckDB under the hood. All this PR really does is add support for the "abfss://" URI scheme, and some new tests.