### PR TITLE
Loadable index

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(Kuzu VERSION 0.10.0.4 LANGUAGES CXX C)
+project(Kuzu VERSION 0.10.0.5 LANGUAGES CXX C)
 
 option(SINGLE_THREADED "Single-threaded mode" FALSE)
 if(SINGLE_THREADED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(Kuzu VERSION 0.10.0.3 LANGUAGES CXX C)
+project(Kuzu VERSION 0.10.0.4 LANGUAGES CXX C)
 
 option(SINGLE_THREADED "Single-threaded mode" FALSE)
 if(SINGLE_THREADED)

--- a/extension/vector/src/catalog/hnsw_index_catalog_entry.cpp
+++ b/extension/vector/src/catalog/hnsw_index_catalog_entry.cpp
@@ -16,28 +16,15 @@ namespace vector_extension {
 std::shared_ptr<common::BufferedSerializer> HNSWIndexAuxInfo::serialize() const {
     auto bufferWriter = std::make_shared<common::BufferedSerializer>();
     auto serializer = common::Serializer(bufferWriter);
-    serializer.serializeValue(upperRelTableID);
-    serializer.serializeValue(lowerRelTableID);
-    serializer.serializeValue(upperEntryPoint);
-    serializer.serializeValue(lowerEntryPoint);
     config.serialize(serializer);
     return bufferWriter;
 }
 
 std::unique_ptr<HNSWIndexAuxInfo> HNSWIndexAuxInfo::deserialize(
     std::unique_ptr<common::BufferReader> reader) {
-    common::table_id_t upperRelTableID = common::INVALID_TABLE_ID;
-    common::table_id_t lowerRelTableID = common::INVALID_TABLE_ID;
-    common::offset_t upperEntryPoint = common::INVALID_OFFSET;
-    common::offset_t lowerEntryPoint = common::INVALID_OFFSET;
     common::Deserializer deSer{std::move(reader)};
-    deSer.deserializeValue(upperRelTableID);
-    deSer.deserializeValue(lowerRelTableID);
-    deSer.deserializeValue(upperEntryPoint);
-    deSer.deserializeValue(lowerEntryPoint);
     auto config = HNSWIndexConfig::deserialize(deSer);
-    return std::make_unique<HNSWIndexAuxInfo>(upperRelTableID, lowerRelTableID, upperEntryPoint,
-        lowerEntryPoint, std::move(config));
+    return std::make_unique<HNSWIndexAuxInfo>(std::move(config));
 }
 
 std::string HNSWIndexAuxInfo::toCypher(const IndexCatalogEntry& indexEntry,

--- a/extension/vector/src/function/create_hnsw_index.cpp
+++ b/extension/vector/src/function/create_hnsw_index.cpp
@@ -27,8 +27,8 @@ namespace vector_extension {
 CreateInMemHNSWSharedState::CreateInMemHNSWSharedState(const CreateHNSWIndexBindData& bindData)
     : SimpleTableFuncSharedState{bindData.numRows}, name{bindData.indexName},
       nodeTable{bindData.context->getStorageManager()
-              ->getTable(bindData.tableEntry->getTableID())
-              ->cast<storage::NodeTable>()},
+                    ->getTable(bindData.tableEntry->getTableID())
+                    ->cast<storage::NodeTable>()},
       numNodes{bindData.numRows}, bindData{&bindData} {
     storage::IndexInfo dummyIndexInfo{"", "", bindData.tableEntry->getTableID(),
         {bindData.tableEntry->getColumnID(bindData.propertyID)}, {PhysicalTypeID::ARRAY}, false,

--- a/extension/vector/src/function/create_hnsw_index.cpp
+++ b/extension/vector/src/function/create_hnsw_index.cpp
@@ -30,7 +30,9 @@ CreateInMemHNSWSharedState::CreateInMemHNSWSharedState(const CreateHNSWIndexBind
               ->getTable(bindData.tableEntry->getTableID())
               ->cast<storage::NodeTable>()},
       numNodes{bindData.numRows}, bindData{&bindData} {
-    storage::IndexInfo dummyIndexInfo;
+    storage::IndexInfo dummyIndexInfo{"", "", bindData.tableEntry->getTableID(),
+        {bindData.tableEntry->getColumnID(bindData.propertyID)}, {PhysicalTypeID::ARRAY}, false,
+        false};
     hnswIndex = std::make_shared<InMemHNSWIndex>(bindData.context, dummyIndexInfo,
         std::make_unique<storage::IndexStorageInfo>(), nodeTable,
         bindData.tableEntry->getColumnID(bindData.propertyID), bindData.config.copy());
@@ -271,8 +273,8 @@ static void finalizeHNSWTableFinalizeFunc(const ExecutionContext* context,
         clientContext->getStorageManager()->getTable(nodeTableID)->ptrCast<storage::NodeTable>();
     auto columnID = bindData->tableEntry->getColumnID(bindData->propertyID);
     auto hnswIndexType = OnDiskHNSWIndex::getIndexType();
-    storage::IndexInfo indexInfo{bindData->indexName, hnswIndexType.typeName, nodeTableID, columnID,
-        PhysicalTypeID::ARRAY,
+    storage::IndexInfo indexInfo{bindData->indexName, hnswIndexType.typeName, nodeTableID,
+        {columnID}, {PhysicalTypeID::ARRAY},
         hnswIndexType.constraintType == storage::IndexConstraintType::PRIMARY,
         hnswIndexType.definitionType == storage::IndexDefinitionType::BUILTIN};
     auto storageInfo = std::make_unique<HNSWStorageInfo>(upperTable->getTableID(),

--- a/extension/vector/src/function/create_hnsw_index.cpp
+++ b/extension/vector/src/function/create_hnsw_index.cpp
@@ -270,10 +270,11 @@ static void finalizeHNSWTableFinalizeFunc(const ExecutionContext* context,
     auto nodeTable =
         clientContext->getStorageManager()->getTable(nodeTableID)->ptrCast<storage::NodeTable>();
     auto columnID = bindData->tableEntry->getColumnID(bindData->propertyID);
-    storage::IndexInfo indexInfo{bindData->indexName, HNSW_INDEX_TYPE.typeName, nodeTableID,
-        columnID, PhysicalTypeID::ARRAY,
-        HNSW_INDEX_TYPE.constraintType == storage::IndexConstraintType::PRIMARY,
-        HNSW_INDEX_TYPE.definitionType == storage::IndexDefinitionType::BUILTIN};
+    auto hnswIndexType = OnDiskHNSWIndex::getIndexType();
+    storage::IndexInfo indexInfo{bindData->indexName, hnswIndexType.typeName, nodeTableID, columnID,
+        PhysicalTypeID::ARRAY,
+        hnswIndexType.constraintType == storage::IndexConstraintType::PRIMARY,
+        hnswIndexType.definitionType == storage::IndexDefinitionType::BUILTIN};
     auto storageInfo = std::make_unique<HNSWStorageInfo>(upperTable->getTableID(),
         lowerTable->getTableID(), index->getUpperEntryPoint(), index->getLowerEntryPoint());
     auto onDiskIndex = std::make_unique<OnDiskHNSWIndex>(context->clientContext, indexInfo,

--- a/extension/vector/src/function/create_hnsw_index.cpp
+++ b/extension/vector/src/function/create_hnsw_index.cpp
@@ -27,10 +27,12 @@ namespace vector_extension {
 CreateInMemHNSWSharedState::CreateInMemHNSWSharedState(const CreateHNSWIndexBindData& bindData)
     : SimpleTableFuncSharedState{bindData.numRows}, name{bindData.indexName},
       nodeTable{bindData.context->getStorageManager()
-                    ->getTable(bindData.tableEntry->getTableID())
-                    ->cast<storage::NodeTable>()},
+              ->getTable(bindData.tableEntry->getTableID())
+              ->cast<storage::NodeTable>()},
       numNodes{bindData.numRows}, bindData{&bindData} {
-    hnswIndex = std::make_shared<InMemHNSWIndex>(bindData.context, nodeTable,
+    storage::IndexInfo dummyIndexInfo;
+    hnswIndex = std::make_shared<InMemHNSWIndex>(bindData.context, dummyIndexInfo,
+        std::make_unique<storage::IndexStorageInfo>(), nodeTable,
         bindData.tableEntry->getColumnID(bindData.propertyID), bindData.config.copy());
 }
 
@@ -260,13 +262,23 @@ static void finalizeHNSWTableFinalizeFunc(const ExecutionContext* context,
         HNSWIndexUtils::getUpperGraphTableName(nodeTableID, bindData->indexName));
     const auto lowerTable = catalog->getTableCatalogEntry(transaction,
         HNSWIndexUtils::getLowerGraphTableName(nodeTableID, bindData->indexName));
-    auto auxInfo =
-        std::make_unique<HNSWIndexAuxInfo>(upperTable->getTableID(), lowerTable->getTableID(),
-            index->getUpperEntryPoint(), index->getLowerEntryPoint(), bindData->config.copy());
+    auto auxInfo = std::make_unique<HNSWIndexAuxInfo>(bindData->config.copy());
     auto indexEntry = std::make_unique<catalog::IndexCatalogEntry>(HNSWIndexCatalogEntry::TYPE_NAME,
         bindData->tableEntry->getTableID(), bindData->indexName, std::vector{bindData->propertyID},
         std::move(auxInfo));
     catalog->createIndex(transaction, std::move(indexEntry));
+    auto nodeTable =
+        clientContext->getStorageManager()->getTable(nodeTableID)->ptrCast<storage::NodeTable>();
+    auto columnID = bindData->tableEntry->getColumnID(bindData->propertyID);
+    storage::IndexInfo indexInfo{bindData->indexName, HNSW_INDEX_TYPE, columnID,
+        PhysicalTypeID::ARRAY};
+    auto storageInfo = std::make_unique<HNSWStorageInfo>(upperTable->getTableID(),
+        lowerTable->getTableID(), index->getUpperEntryPoint(), index->getLowerEntryPoint());
+    auto onDiskIndex = std::make_unique<OnDiskHNSWIndex>(context->clientContext, indexInfo,
+        std::move(storageInfo), bindData->tableEntry->ptrCast<catalog::NodeTableCatalogEntry>(),
+        upperTable->ptrCast<catalog::RelGroupCatalogEntry>(),
+        lowerTable->ptrCast<catalog::RelGroupCatalogEntry>(), bindData->config.copy());
+    nodeTable->addIndex(std::move(onDiskIndex));
 }
 
 static double finalizeHNSWProgressFunc(TableFuncSharedState* sharedState) {

--- a/extension/vector/src/function/create_hnsw_index.cpp
+++ b/extension/vector/src/function/create_hnsw_index.cpp
@@ -270,8 +270,10 @@ static void finalizeHNSWTableFinalizeFunc(const ExecutionContext* context,
     auto nodeTable =
         clientContext->getStorageManager()->getTable(nodeTableID)->ptrCast<storage::NodeTable>();
     auto columnID = bindData->tableEntry->getColumnID(bindData->propertyID);
-    storage::IndexInfo indexInfo{bindData->indexName, HNSW_INDEX_TYPE, columnID,
-        PhysicalTypeID::ARRAY};
+    storage::IndexInfo indexInfo{bindData->indexName, HNSW_INDEX_TYPE.typeName, nodeTableID,
+        columnID, PhysicalTypeID::ARRAY,
+        HNSW_INDEX_TYPE.constraintType == storage::IndexConstraintType::PRIMARY,
+        HNSW_INDEX_TYPE.definitionType == storage::IndexDefinitionType::BUILTIN};
     auto storageInfo = std::make_unique<HNSWStorageInfo>(upperTable->getTableID(),
         lowerTable->getTableID(), index->getUpperEntryPoint(), index->getLowerEntryPoint());
     auto onDiskIndex = std::make_unique<OnDiskHNSWIndex>(context->clientContext, indexInfo,

--- a/extension/vector/src/include/catalog/hnsw_index_catalog_entry.h
+++ b/extension/vector/src/include/catalog/hnsw_index_catalog_entry.h
@@ -12,22 +12,11 @@ namespace vector_extension {
 
 struct HNSWIndexAuxInfo final : catalog::IndexAuxInfo {
 
-    common::table_id_t upperRelTableID = common::INVALID_TABLE_ID;
-    common::table_id_t lowerRelTableID = common::INVALID_TABLE_ID;
-    common::offset_t upperEntryPoint = common::INVALID_OFFSET;
-    common::offset_t lowerEntryPoint = common::INVALID_OFFSET;
     HNSWIndexConfig config;
 
-    HNSWIndexAuxInfo(common::table_id_t upperRelTableID, common::table_id_t lowerRelTableID,
-        common::offset_t upperEntryPoint, common::offset_t lowerEntryPoint, HNSWIndexConfig config)
-        : upperRelTableID{upperRelTableID}, lowerRelTableID{lowerRelTableID},
-          upperEntryPoint{upperEntryPoint}, lowerEntryPoint{lowerEntryPoint},
-          config{std::move(config)} {}
+    HNSWIndexAuxInfo(HNSWIndexConfig config) : config{std::move(config)} {}
 
-    HNSWIndexAuxInfo(const HNSWIndexAuxInfo& other)
-        : upperRelTableID{other.upperRelTableID}, lowerRelTableID{other.lowerRelTableID},
-          upperEntryPoint{other.upperEntryPoint}, lowerEntryPoint{other.lowerEntryPoint},
-          config{other.config.copy()} {}
+    HNSWIndexAuxInfo(const HNSWIndexAuxInfo& other) : config{other.config.copy()} {}
 
     std::shared_ptr<common::BufferedSerializer> serialize() const override;
     static std::unique_ptr<HNSWIndexAuxInfo> deserialize(

--- a/extension/vector/src/include/catalog/hnsw_index_catalog_entry.h
+++ b/extension/vector/src/include/catalog/hnsw_index_catalog_entry.h
@@ -14,7 +14,7 @@ struct HNSWIndexAuxInfo final : catalog::IndexAuxInfo {
 
     HNSWIndexConfig config;
 
-    HNSWIndexAuxInfo(HNSWIndexConfig config) : config{std::move(config)} {}
+    explicit HNSWIndexAuxInfo(HNSWIndexConfig config) : config{std::move(config)} {}
 
     HNSWIndexAuxInfo(const HNSWIndexAuxInfo& other) : config{other.config.copy()} {}
 

--- a/extension/vector/src/include/function/hnsw_index_functions.h
+++ b/extension/vector/src/include/function/hnsw_index_functions.h
@@ -65,8 +65,6 @@ struct QueryHNSWIndexBindData final : function::TableFuncBindData {
     catalog::NodeTableCatalogEntry* nodeTableEntry = nullptr;
     catalog::IndexCatalogEntry* indexEntry = nullptr;
     common::column_id_t indexColumnID = common::INVALID_COLUMN_ID;
-    catalog::RelGroupCatalogEntry* upperRelTableEntry = nullptr;
-    catalog::RelGroupCatalogEntry* lowerRelTableEntry = nullptr;
     std::shared_ptr<binder::Expression> queryExpression;
     std::shared_ptr<binder::Expression> kExpression;
     std::shared_ptr<binder::NodeExpression> outputNode;

--- a/extension/vector/src/include/index/hnsw_graph.h
+++ b/extension/vector/src/include/index/hnsw_graph.h
@@ -114,6 +114,7 @@ public:
     compressed_offsets_t getNeighbors(common::offset_t nodeOffset, common::offset_t maxDegree,
         common::offset_t numNbrs) const;
 
+    // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const function.
     void setNodeOffset(common::offset_t csrOffset, common::offset_t nodeOffset) {
         view->setNodeOffsetAtomic(csrOffset, nodeOffset);
     }
@@ -154,9 +155,9 @@ public:
         KU_ASSERT(length <= maxDegree);
         csrLengths[nodeOffset].store(length);
     }
-    // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const function.
     // Note: when the incremented csr length hits maxDegree, this function will block until there is
     // a shrink happening.
+    // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const function.
     uint16_t incrementCSRLength(common::offset_t nodeOffset) {
         KU_ASSERT(nodeOffset < numNodes);
         while (true) {
@@ -175,7 +176,7 @@ public:
     void finalize(storage::MemoryManager& mm, common::node_group_idx_t nodeGroupIdx,
         const processor::PartitionerSharedState& partitionerSharedState);
 
-    // In the current implementation race conditions can result in dstNode entries being skipped
+    // In the current implementation, race conditions can result in dstNode entries being skipped
     // during insertion. Skipped entries will be marked with this value
     common::offset_t getInvalidOffset() const { return invalidOffset; }
 

--- a/extension/vector/src/include/index/hnsw_index.h
+++ b/extension/vector/src/include/index/hnsw_index.h
@@ -241,7 +241,8 @@ public:
     std::vector<NodeWithDistance> search(transaction::Transaction* transaction,
         const void* queryVector, HNSWSearchState& searchState) const;
 
-    static std::unique_ptr<Index> load(main::ClientContext* context, storage::IndexInfo indexInfo,
+    static std::unique_ptr<Index> load(main::ClientContext* context,
+        storage::StorageManager* storageManager, storage::IndexInfo indexInfo,
         std::span<uint8_t> storageInfoBuffer);
 
     static storage::IndexType getIndexType() {

--- a/extension/vector/src/include/index/hnsw_index.h
+++ b/extension/vector/src/include/index/hnsw_index.h
@@ -9,6 +9,9 @@
 #include "index/hnsw_index_utils.h"
 
 namespace kuzu {
+namespace catalog {
+class IndexCatalogEntry;
+}
 namespace function {
 struct HNSWSearchState;
 struct QueryHNSWLocalState;
@@ -72,17 +75,38 @@ struct VisitedState {
     bool contains(common::offset_t offset) const { return visited[offset]; }
 };
 
-class HNSWIndex {
+struct HNSWStorageInfo final : storage::IndexStorageInfo {
+    common::table_id_t upperRelTableID;
+    common::table_id_t lowerRelTableID;
+    common::offset_t upperEntryPoint;
+    common::offset_t lowerEntryPoint;
+
+    HNSWStorageInfo()
+        : upperRelTableID{common::INVALID_TABLE_ID}, lowerRelTableID{common::INVALID_TABLE_ID},
+          upperEntryPoint{common::INVALID_OFFSET}, lowerEntryPoint{common::INVALID_OFFSET} {}
+    HNSWStorageInfo(const common::table_id_t& upperRelTableID,
+        const common::table_id_t& lowerRelTableID, common::offset_t upperEntryPoint,
+        common::offset_t lowerEntryPoint)
+        : upperRelTableID{upperRelTableID}, lowerRelTableID{lowerRelTableID},
+          upperEntryPoint{upperEntryPoint}, lowerEntryPoint{lowerEntryPoint} {}
+
+    std::shared_ptr<common::BufferedSerializer> serialize() const override;
+
+    static std::unique_ptr<IndexStorageInfo> deserialize(
+        std::unique_ptr<common::BufferReader> reader);
+};
+
+class HNSWIndex : public storage::Index {
 public:
-    explicit HNSWIndex(HNSWIndexConfig config, common::ArrayTypeInfo typeInfo)
-        : config{std::move(config)}, typeInfo{std::move(typeInfo)} {
+    explicit HNSWIndex(storage::IndexInfo indexInfo,
+        std::unique_ptr<storage::IndexStorageInfo> storageInfo, HNSWIndexConfig config,
+        common::ArrayTypeInfo typeInfo)
+        : Index{indexInfo, std::move(storageInfo)}, config{std::move(config)},
+          typeInfo{std::move(typeInfo)} {
         metricFunc =
             HNSWIndexUtils::getMetricsFunction(this->config.metric, this->typeInfo.getChildType());
     }
-    virtual ~HNSWIndex() = default;
-
-    virtual common::offset_t getUpperEntryPoint() const = 0;
-    virtual common::offset_t getLowerEntryPoint() const = 0;
+    ~HNSWIndex() override = default;
 
     common::LogicalType getElementType() const { return typeInfo.getChildType().copy(); }
 
@@ -146,13 +170,17 @@ private:
     InMemHNSWLayerInfo info;
 };
 
+static constexpr storage::IndexType HNSW_INDEX_TYPE{"HNSW",
+    storage::IndexConstraintType::SECONDARY_NON_UNIQUE, storage::IndexDefinitionType::EXTENSION};
+
 class InMemHNSWIndex final : public HNSWIndex {
 public:
-    InMemHNSWIndex(const main::ClientContext* context, storage::NodeTable& table,
+    InMemHNSWIndex(const main::ClientContext* context, storage::IndexInfo indexInfo,
+        std::unique_ptr<storage::IndexStorageInfo> storageInfo, storage::NodeTable& table,
         common::column_id_t columnID, HNSWIndexConfig config);
 
-    common::offset_t getUpperEntryPoint() const override { return upperLayer->getEntryPoint(); }
-    common::offset_t getLowerEntryPoint() const override { return lowerLayer->getEntryPoint(); }
+    common::offset_t getUpperEntryPoint() const { return upperLayer->getEntryPoint(); }
+    common::offset_t getLowerEntryPoint() const { return lowerLayer->getEntryPoint(); }
 
     // Note that the input is only `offset`, as we assume embeddings are already cached in memory.
     bool insert(common::offset_t offset, VisitedState& upperVisited, VisitedState& lowerVisited);
@@ -207,21 +235,18 @@ struct HNSWSearchState {
 
 class OnDiskHNSWIndex final : public HNSWIndex {
 public:
-    OnDiskHNSWIndex(main::ClientContext* context, catalog::NodeTableCatalogEntry* nodeTableEntry,
-        common::column_id_t columnID, catalog::RelGroupCatalogEntry* upperRelTableEntry,
+    OnDiskHNSWIndex(main::ClientContext* context, storage::IndexInfo indexInfo,
+        std::unique_ptr<storage::IndexStorageInfo> storageInfo,
+        catalog::NodeTableCatalogEntry* nodeTableEntry,
+        catalog::RelGroupCatalogEntry* upperRelTableEntry,
         catalog::RelGroupCatalogEntry* lowerRelTableEntry, HNSWIndexConfig config);
-
-    void setDefaultUpperEntryPoint(common::offset_t offset) {
-        defaultUpperEntryPoint.store(offset);
-    }
-    void setDefaultLowerEntryPoint(common::offset_t offset) {
-        defaultLowerEntryPoint.store(offset);
-    }
-    common::offset_t getUpperEntryPoint() const override { return defaultUpperEntryPoint.load(); }
-    common::offset_t getLowerEntryPoint() const override { return defaultLowerEntryPoint.load(); }
 
     std::vector<NodeWithDistance> search(transaction::Transaction* transaction,
         const void* queryVector, HNSWSearchState& searchState) const;
+
+    static std::unique_ptr<Index> load(main::ClientContext* context, storage::IndexInfo indexInfo,
+        const catalog::Catalog& catalog, const catalog::IndexCatalogEntry* indexEntry,
+        std::span<uint8_t> storageInfoBuffer);
 
 private:
     common::offset_t searchNNInUpperLayer(transaction::Transaction* transaction,
@@ -279,8 +304,8 @@ private:
     // The search starts in the upper layer to find the closest node, which serves as the entry
     // point for the lower layer search. If the upper layer does not return a valid entry point,
     // the search falls back to the defaultLowerEntryPoint in the lower layer.
-    std::atomic<common::offset_t> defaultUpperEntryPoint;
-    std::atomic<common::offset_t> defaultLowerEntryPoint;
+    // std::atomic<common::offset_t> defaultUpperEntryPoint;
+    // std::atomic<common::offset_t> defaultLowerEntryPoint;
     std::unique_ptr<graph::OnDiskGraph> upperGraph;
     std::unique_ptr<graph::OnDiskGraph> lowerGraph;
     std::unique_ptr<OnDiskEmbeddings> embeddings;

--- a/extension/vector/src/include/index/hnsw_index.h
+++ b/extension/vector/src/include/index/hnsw_index.h
@@ -170,9 +170,6 @@ private:
     InMemHNSWLayerInfo info;
 };
 
-static constexpr storage::IndexType HNSW_INDEX_TYPE{"HNSW",
-    storage::IndexConstraintType::SECONDARY_NON_UNIQUE, storage::IndexDefinitionType::EXTENSION};
-
 class InMemHNSWIndex final : public HNSWIndex {
 public:
     InMemHNSWIndex(const main::ClientContext* context, storage::IndexInfo indexInfo,
@@ -245,7 +242,6 @@ public:
         const void* queryVector, HNSWSearchState& searchState) const;
 
     static std::unique_ptr<Index> load(main::ClientContext* context, storage::IndexInfo indexInfo,
-        const catalog::Catalog& catalog, const catalog::IndexCatalogEntry* indexEntry,
         std::span<uint8_t> storageInfoBuffer);
 
 private:
@@ -310,6 +306,10 @@ private:
     std::unique_ptr<graph::OnDiskGraph> lowerGraph;
     std::unique_ptr<OnDiskEmbeddings> embeddings;
 };
+
+static const storage::IndexType HNSW_INDEX_TYPE{"HNSW",
+    storage::IndexConstraintType::SECONDARY_NON_UNIQUE, storage::IndexDefinitionType::EXTENSION,
+    OnDiskHNSWIndex::load};
 
 } // namespace vector_extension
 } // namespace kuzu

--- a/extension/vector/src/include/index/hnsw_index.h
+++ b/extension/vector/src/include/index/hnsw_index.h
@@ -244,6 +244,13 @@ public:
     static std::unique_ptr<Index> load(main::ClientContext* context, storage::IndexInfo indexInfo,
         std::span<uint8_t> storageInfoBuffer);
 
+    static storage::IndexType getIndexType() {
+        static const storage::IndexType HNSW_INDEX_TYPE{"HNSW",
+            storage::IndexConstraintType::SECONDARY_NON_UNIQUE,
+            storage::IndexDefinitionType::EXTENSION, load};
+        return HNSW_INDEX_TYPE;
+    }
+
 private:
     common::offset_t searchNNInUpperLayer(transaction::Transaction* transaction,
         const void* queryVector, storage::NodeTableScanState& embeddingScanState) const;
@@ -306,10 +313,6 @@ private:
     std::unique_ptr<graph::OnDiskGraph> lowerGraph;
     std::unique_ptr<OnDiskEmbeddings> embeddings;
 };
-
-static const storage::IndexType HNSW_INDEX_TYPE{"HNSW",
-    storage::IndexConstraintType::SECONDARY_NON_UNIQUE, storage::IndexDefinitionType::EXTENSION,
-    OnDiskHNSWIndex::load};
 
 } // namespace vector_extension
 } // namespace kuzu

--- a/extension/vector/src/index/hnsw_index.cpp
+++ b/extension/vector/src/index/hnsw_index.cpp
@@ -301,12 +301,13 @@ OnDiskHNSWIndex::OnDiskHNSWIndex(main::ClientContext* context, IndexInfo indexIn
           getArrayTypeInfo(context->getStorageManager()
                                ->getTable(nodeTableEntry->getTableID())
                                ->cast<NodeTable>(),
-              indexInfo.columnID)},
+              indexInfo.columnIDs[0])},
       nodeTableID{nodeTableEntry->getTableID()}, upperRelTableEntry{upperRelTableEntry},
       lowerRelTableEntry{lowerRelTableEntry} {
     auto& nodeTable =
         context->getStorageManager()->getTable(nodeTableEntry->getTableID())->cast<NodeTable>();
-    KU_ASSERT(nodeTable.getColumn(indexInfo.columnID).getDataType().getLogicalTypeID() ==
+    KU_ASSERT(this->indexInfo.columnIDs.size() == 1);
+    KU_ASSERT(nodeTable.getColumn(this->indexInfo.columnIDs[0]).getDataType().getLogicalTypeID() ==
               common::LogicalTypeID::ARRAY);
     embeddings = std::make_unique<OnDiskEmbeddings>(
         common::ArrayTypeInfo{typeInfo.getChildType().copy(), typeInfo.getNumElements()},
@@ -317,8 +318,8 @@ OnDiskHNSWIndex::OnDiskHNSWIndex(main::ClientContext* context, IndexInfo indexIn
     upperGraph = std::make_unique<graph::OnDiskGraph>(context, std::move(upperGraphEntry));
 }
 
-std::unique_ptr<Index> OnDiskHNSWIndex::load(main::ClientContext* context, IndexInfo indexInfo,
-    std::span<uint8_t> storageInfoBuffer) {
+std::unique_ptr<Index> OnDiskHNSWIndex::load(main::ClientContext* context, StorageManager*,
+    IndexInfo indexInfo, std::span<uint8_t> storageInfoBuffer) {
     auto reader =
         std::make_unique<common::BufferReader>(storageInfoBuffer.data(), storageInfoBuffer.size());
     auto storageInfo = HNSWStorageInfo::deserialize(std::move(reader));

--- a/extension/vector/src/main/vector_extension.cpp
+++ b/extension/vector/src/main/vector_extension.cpp
@@ -37,7 +37,7 @@ void VectorExtension::load(main::ClientContext* context) {
     extension::ExtensionUtils::addStandaloneTableFunc<CreateVectorIndexFunction>(db);
     extension::ExtensionUtils::addInternalStandaloneTableFunc<InternalDropHNSWIndexFunction>(db);
     extension::ExtensionUtils::addStandaloneTableFunc<DropVectorIndexFunction>(db);
-    extension::ExtensionUtils::registerIndexType(db, HNSW_INDEX_TYPE);
+    extension::ExtensionUtils::registerIndexType(db, OnDiskHNSWIndex::getIndexType());
     initHNSWEntries(context);
 }
 

--- a/extension/vector/src/main/vector_extension.cpp
+++ b/extension/vector/src/main/vector_extension.cpp
@@ -4,16 +4,27 @@
 #include "function/hnsw_index_functions.h"
 #include "main/client_context.h"
 #include "main/database.h"
+#include "storage/storage_manager.h"
 
 namespace kuzu {
 namespace vector_extension {
 
-static void initHNSWEntries(const transaction::Transaction* transaction,
-    catalog::Catalog& catalog) {
-    for (auto& indexEntry : catalog.getIndexEntries(transaction)) {
+static void initHNSWEntries(main::ClientContext* context) {
+    auto catalog = context->getCatalog();
+    auto storageManager = context->getStorageManager();
+    for (auto& indexEntry : catalog->getIndexEntries(&transaction::DUMMY_TRANSACTION)) {
         if (indexEntry->getIndexType() == HNSWIndexCatalogEntry::TYPE_NAME &&
             !indexEntry->isLoaded()) {
             indexEntry->setAuxInfo(HNSWIndexAuxInfo::deserialize(indexEntry->getAuxBufferReader()));
+            // Should load the index in storage side as well.
+            auto& nodeTable =
+                storageManager->getTable(indexEntry->getTableID())->cast<storage::NodeTable>();
+            auto optionalIndex = nodeTable.getIndex(indexEntry->getIndexName());
+            KU_ASSERT(optionalIndex.has_value() && !optionalIndex.value()->isLoaded());
+            auto unloadedIndex = optionalIndex.value();
+            auto loadedIndex = OnDiskHNSWIndex::load(context, unloadedIndex->getIndexInfo(),
+                *catalog, indexEntry, unloadedIndex->getStorageBuffer());
+            nodeTable.addOrReplaceIndex(std::move(loadedIndex));
         }
     }
 }
@@ -27,7 +38,7 @@ void VectorExtension::load(main::ClientContext* context) {
     extension::ExtensionUtils::addStandaloneTableFunc<CreateVectorIndexFunction>(db);
     extension::ExtensionUtils::addInternalStandaloneTableFunc<InternalDropHNSWIndexFunction>(db);
     extension::ExtensionUtils::addStandaloneTableFunc<DropVectorIndexFunction>(db);
-    initHNSWEntries(&transaction::DUMMY_TRANSACTION, *db.getCatalog());
+    initHNSWEntries(context);
 }
 
 } // namespace vector_extension

--- a/extension/vector/src/main/vector_extension.cpp
+++ b/extension/vector/src/main/vector_extension.cpp
@@ -23,7 +23,7 @@ static void initHNSWEntries(main::ClientContext* context) {
             KU_ASSERT_UNCONDITIONAL(
                 optionalIndex.has_value() && !optionalIndex.value().get().isLoaded());
             auto& unloadedIndex = optionalIndex.value().get();
-            unloadedIndex.load(context);
+            unloadedIndex.load(context, storageManager);
         }
     }
 }

--- a/src/extension/extension.cpp
+++ b/src/extension/extension.cpp
@@ -5,6 +5,8 @@
 #include "common/string_utils.h"
 #include "common/system_message.h"
 #include "main/client_context.h"
+#include "storage/storage_manager.h"
+
 #ifdef _WIN32
 
 #include "windows.h"
@@ -155,6 +157,10 @@ bool ExtensionUtils::isOfficialExtension(const std::string& extension) {
         }
     }
     return false;
+}
+
+void ExtensionUtils::registerIndexType(main::Database& database, storage::IndexType type) {
+    database.storageManager->registerIndexType(std::move(type));
 }
 
 ExtensionLibLoader::ExtensionLibLoader(const std::string& extensionName, const std::string& path)

--- a/src/include/catalog/catalog_entry/index_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/index_catalog_entry.h
@@ -95,7 +95,7 @@ public:
 
     bool isLoaded() const { return auxBuffer == nullptr; }
 
-    TableCatalogEntry* getTableEntryToExport(main::ClientContext* context) {
+    TableCatalogEntry* getTableEntryToExport(main::ClientContext* context) const {
         return isLoaded() ? auxInfo->getTableEntryToExport(context) : nullptr;
     }
 

--- a/src/include/common/serializer/serializer.h
+++ b/src/include/common/serializer/serializer.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>

--- a/src/include/extension/extension.h
+++ b/src/include/extension/extension.h
@@ -15,6 +15,9 @@
 #define ADD_CONFIDENTIAL_EXTENSION_OPTION(OPTION)                                                  \
     db->addExtensionOption(OPTION::NAME, OPTION::TYPE, OPTION::getDefaultValue(), true)
 
+namespace kuzu::storage {
+struct IndexType;
+}
 namespace kuzu {
 namespace function {
 struct TableFunction;
@@ -144,6 +147,8 @@ struct KUZU_API ExtensionUtils {
         addFunc<typename T::alias>(database, T::name,
             catalog::CatalogEntryType::SCALAR_FUNCTION_ENTRY);
     }
+
+    static void registerIndexType(main::Database& database, storage::IndexType type);
 };
 
 class KUZU_API ExtensionLibLoader {

--- a/src/include/extension/extension.h
+++ b/src/include/extension/extension.h
@@ -77,8 +77,6 @@ struct KUZU_API ExtensionUtils {
 
     static constexpr const char* EXTENSION_INSTALLER_SUFFIX = "_installer";
 
-    static bool isFullPath(const std::string& extension);
-
     static ExtensionRepoInfo getExtensionLibRepoInfo(const std::string& extensionName,
         const std::string& extensionRepo);
 

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -188,8 +188,6 @@ private:
 
     static std::unique_ptr<QueryResult> queryResultWithError(std::string_view errMsg);
     static std::unique_ptr<PreparedStatement> preparedStatementWithError(std::string_view errMsg);
-    static void validatePrepareParams(const PreparedStatement* preparedStatement,
-        const std::unordered_map<std::string, std::shared_ptr<common::Value>>& inputParams);
     static void bindParametersNoLock(const PreparedStatement* preparedStatement,
         const std::unordered_map<std::string, std::unique_ptr<common::Value>>& inputParams);
     void validateTransaction(const PreparedStatement& preparedStatement) const;

--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -332,6 +332,8 @@ struct PrimaryKeyIndexStorageInfo final : IndexStorageInfo {
 
 class PrimaryKeyIndex final : public Index {
 public:
+    static constexpr const char* name = "_PK";
+
     // Construct an existing index
     PrimaryKeyIndex(IndexInfo indexInfo, std::unique_ptr<IndexStorageInfo> storageInfo,
         bool inMemMode, MemoryManager& memoryManager, FileHandle* dataFH, ShadowFile* shadowFile);

--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -1,16 +1,17 @@
 #pragma once
 
 #include <algorithm>
-#include <cstdint>
 #include <string_view>
 #include <type_traits>
 
 #include "common/cast.h"
+#include "common/serializer/serializer.h"
 #include "common/type_utils.h"
 #include "common/types/ku_string.h"
 #include "common/types/types.h"
 #include "hash_index_header.h"
 #include "hash_index_slot.h"
+#include "index.h"
 #include "storage/buffer_manager/memory_manager.h"
 #include "storage/index/hash_index_utils.h"
 #include "storage/index/in_mem_hash_index.h"
@@ -304,17 +305,36 @@ inline bool HashIndex<common::ku_string_t>::equals(const transaction::Transactio
     return false;
 }
 
-class PrimaryKeyIndex {
-public:
-    // Construct a new index
-    PrimaryKeyIndex(FileHandle* dataFH, bool inMemMode, common::PhysicalTypeID keyDataType,
-        MemoryManager& memoryManager, ShadowFile* shadowFile);
-    // Construct an existing index
-    PrimaryKeyIndex(FileHandle* dataFH, bool inMemMode, common::PhysicalTypeID keyDataType,
-        MemoryManager& memoryManager, ShadowFile* shadowFile, common::page_idx_t firstHeaderPage,
-        common::page_idx_t overflowHeaderPage);
+struct PrimaryKeyIndexStorageInfo final : IndexStorageInfo {
+    common::page_idx_t firstHeaderPage;
+    common::page_idx_t overflowHeaderPage;
 
-    ~PrimaryKeyIndex();
+    PrimaryKeyIndexStorageInfo()
+        : firstHeaderPage{common::INVALID_PAGE_IDX}, overflowHeaderPage{common::INVALID_PAGE_IDX} {}
+    PrimaryKeyIndexStorageInfo(common::page_idx_t firstHeaderPage,
+        common::page_idx_t overflowHeaderPage)
+        : firstHeaderPage{firstHeaderPage}, overflowHeaderPage{overflowHeaderPage} {}
+
+    std::shared_ptr<common::BufferedSerializer> serialize() const override {
+        auto bufferWriter = std::make_shared<common::BufferedSerializer>();
+        auto serializer = common::Serializer(bufferWriter);
+        serializer.write<common::page_idx_t>(firstHeaderPage);
+        serializer.write<common::page_idx_t>(overflowHeaderPage);
+        return bufferWriter;
+    }
+
+    static std::unique_ptr<IndexStorageInfo> deserialize(common::Deserializer& deSer);
+};
+
+class PrimaryKeyIndex final : public Index {
+public:
+    // Construct an existing index
+    PrimaryKeyIndex(IndexInfo indexInfo, std::unique_ptr<IndexStorageInfo> storageInfo,
+        bool inMemMode, MemoryManager& memoryManager, FileHandle* dataFH, ShadowFile* shadowFile);
+    ~PrimaryKeyIndex() override;
+
+    static std::unique_ptr<PrimaryKeyIndex> createNewIndex(IndexInfo indexInfo, bool inMemMode,
+        MemoryManager& memoryManager, FileHandle* dataFH, ShadowFile* shadowFile);
 
     template<typename T>
     inline HashIndex<HashIndexType<T>>* getTypedHashIndex(T key) {
@@ -333,7 +353,7 @@ public:
     template<common::IndexHashable T>
     inline bool lookup(const transaction::Transaction* trx, T key, common::offset_t& result,
         visible_func isVisible) {
-        KU_ASSERT(keyDataTypeID == common::TypeUtils::getPhysicalTypeIDForType<T>());
+        KU_ASSERT(indexInfo.keyDataType == common::TypeUtils::getPhysicalTypeIDForType<T>());
         return getTypedHashIndex(key)->lookupInternal(trx, key, result, isVisible);
     }
 
@@ -347,7 +367,7 @@ public:
     template<common::IndexHashable T>
     inline bool insert(const transaction::Transaction* transaction, T key, common::offset_t value,
         visible_func isVisible) {
-        KU_ASSERT(keyDataTypeID == common::TypeUtils::getPhysicalTypeIDForType<T>());
+        KU_ASSERT(indexInfo.keyDataType == common::TypeUtils::getPhysicalTypeIDForType<T>());
         return getTypedHashIndex(key)->insertInternal(transaction, key, value, isVisible);
     }
     bool insert(const transaction::Transaction* transaction, const common::ValueVector* keyVector,
@@ -360,7 +380,7 @@ public:
     size_t appendWithIndexPos(const transaction::Transaction* transaction,
         const IndexBuffer<T>& buffer, uint64_t bufferOffset, uint64_t indexPos,
         visible_func isVisible) {
-        KU_ASSERT(keyDataTypeID == common::TypeUtils::getPhysicalTypeIDForType<T>());
+        KU_ASSERT(indexInfo.keyDataType == common::TypeUtils::getPhysicalTypeIDForType<T>());
         KU_ASSERT(std::all_of(buffer.begin(), buffer.end(), [&](auto& elem) {
             return HashIndexUtils::getHashIndexPosition(elem.first) == indexPos;
         }));
@@ -378,30 +398,32 @@ public:
     void delete_(common::ku_string_t key) { return delete_(key.getAsStringView()); }
     template<common::IndexHashable T>
     inline void delete_(T key) {
-        KU_ASSERT(keyDataTypeID == common::TypeUtils::getPhysicalTypeIDForType<T>());
+        KU_ASSERT(indexInfo.keyDataType == common::TypeUtils::getPhysicalTypeIDForType<T>());
         return getTypedHashIndex(key)->deleteInternal(key);
     }
 
     void delete_(common::ValueVector* keyVector);
 
-    void checkpointInMemory();
-    void checkpoint(bool forceCheckpointAll = false);
+    void checkpointInMemory() override;
+    void checkpoint(bool forceCheckpointAll = false) override;
     FileHandle* getFileHandle() const { return fileHandle; }
     OverflowFile* getOverflowFile() const { return overflowFile.get(); }
 
-    void rollbackCheckpoint();
+    void rollbackCheckpoint() override;
 
-    common::PhysicalTypeID keyTypeID() const { return keyDataTypeID; }
+    common::PhysicalTypeID keyTypeID() const { return indexInfo.keyDataType; }
 
     void writeHeaders();
 
-    void serialize(common::Serializer& serializer) const;
+    // Construct a new index
+    PrimaryKeyIndex(IndexInfo indexInfo, bool inMemMode, MemoryManager& memoryManager,
+        FileHandle* dataFH, ShadowFile* shadowFile);
 
 private:
-    void initOverflowAndSubIndices(bool inMemMode, MemoryManager& mm);
+    void initOverflowAndSubIndices(bool inMemMode, MemoryManager& mm,
+        PrimaryKeyIndexStorageInfo& storageInfo);
 
 private:
-    common::PhysicalTypeID keyDataTypeID;
     FileHandle* fileHandle;
     std::unique_ptr<OverflowFile> overflowFile;
     std::vector<std::unique_ptr<OnDiskHashIndex>> hashIndices;
@@ -410,8 +432,6 @@ private:
     ShadowFile& shadowFile;
     // Stores both primary and overflow slots
     std::unique_ptr<DiskArrayCollection> hashIndexDiskArrays;
-    common::page_idx_t firstHeaderPage;
-    common::page_idx_t overflowHeaderPage;
 };
 
 } // namespace storage

--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -332,7 +332,7 @@ struct PrimaryKeyIndexStorageInfo final : IndexStorageInfo {
 
 class PrimaryKeyIndex final : public Index {
 public:
-    static constexpr const char* name = "_PK";
+    static constexpr const char* DEFAULT_NAME = "_PK";
 
     // Construct an existing index
     PrimaryKeyIndex(IndexInfo indexInfo, std::unique_ptr<IndexStorageInfo> storageInfo,
@@ -421,6 +421,9 @@ public:
 
     void writeHeaders();
 
+    static KUZU_API std::unique_ptr<Index> load(main::ClientContext* context, IndexInfo indexInfo,
+        std::span<uint8_t> storageInfoBuffer);
+
 private:
     void initOverflowAndSubIndices(bool inMemMode, MemoryManager& mm,
         PrimaryKeyIndexStorageInfo& storageInfo);
@@ -435,6 +438,9 @@ private:
     // Stores both primary and overflow slots
     std::unique_ptr<DiskArrayCollection> hashIndexDiskArrays;
 };
+
+static const IndexType HASH_INDEX_TYPE{"HASH", IndexConstraintType::PRIMARY,
+    IndexDefinitionType::BUILTIN, PrimaryKeyIndex::load};
 
 } // namespace storage
 } // namespace kuzu

--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -424,6 +424,12 @@ public:
     static KUZU_API std::unique_ptr<Index> load(main::ClientContext* context, IndexInfo indexInfo,
         std::span<uint8_t> storageInfoBuffer);
 
+    static IndexType getIndexType() {
+        static const IndexType HASH_INDEX_TYPE{"HASH", IndexConstraintType::PRIMARY,
+            IndexDefinitionType::BUILTIN, load};
+        return HASH_INDEX_TYPE;
+    }
+
 private:
     void initOverflowAndSubIndices(bool inMemMode, MemoryManager& mm,
         PrimaryKeyIndexStorageInfo& storageInfo);
@@ -438,9 +444,6 @@ private:
     // Stores both primary and overflow slots
     std::unique_ptr<DiskArrayCollection> hashIndexDiskArrays;
 };
-
-static const IndexType HASH_INDEX_TYPE{"HASH", IndexConstraintType::PRIMARY,
-    IndexDefinitionType::BUILTIN, PrimaryKeyIndex::load};
 
 } // namespace storage
 } // namespace kuzu

--- a/src/include/storage/index/index.h
+++ b/src/include/storage/index/index.h
@@ -42,6 +42,7 @@ struct IndexInfo {
 struct IndexStorageInfo {
     IndexStorageInfo() {}
     virtual ~IndexStorageInfo() = default;
+    DELETE_COPY_DEFAULT_MOVE(IndexStorageInfo);
 
     virtual std::shared_ptr<common::BufferedSerializer> serialize() const;
 

--- a/src/include/storage/index/index.h
+++ b/src/include/storage/index/index.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "common/serializer/buffered_serializer.h"
 #include "common/types/types.h"
 #include <span>

--- a/src/include/storage/index/index.h
+++ b/src/include/storage/index/index.h
@@ -7,33 +7,36 @@
 namespace kuzu {
 namespace storage {
 
-enum class IndexConstraintType : uint8_t {
-    PRIMARY = 0, // Primary key index
-    SECONDARY_NON_UNIQUE = 1,
+enum class KUZU_API IndexConstraintType : uint8_t {
+    PRIMARY = 0,              // Primary key index
+    SECONDARY_NON_UNIQUE = 1, // Secondary index that is not unique
 };
 
-enum class IndexDefinitionType : uint8_t {
+enum class KUZU_API IndexDefinitionType : uint8_t {
     BUILTIN = 0,
     EXTENSION = 1,
 };
 
-struct IndexType {
+class Index;
+struct IndexInfo;
+using index_load_func_t = std::function<std::unique_ptr<Index>(main::ClientContext* context,
+    IndexInfo, std::span<uint8_t>)>;
+
+struct KUZU_API IndexType {
     std::string typeName;
     IndexConstraintType constraintType;
     IndexDefinitionType definitionType;
-
-    void serialize(common::Serializer& ser) const;
-    static IndexType deserialize(common::Deserializer& deSer);
+    index_load_func_t loadFunc;
 };
 
-static constexpr IndexType HASH_INDEX_TYPE{"HASH", IndexConstraintType::PRIMARY,
-    IndexDefinitionType::BUILTIN};
-
-struct IndexInfo {
+struct KUZU_API IndexInfo {
     std::string name;
-    IndexType indexType;
+    std::string indexType;
+    common::table_id_t tableID;
     common::column_id_t columnID;
     common::PhysicalTypeID keyDataType;
+    bool isPrimary;
+    bool isBuiltin;
 
     void serialize(common::Serializer& ser) const;
     static IndexInfo deserialize(common::Deserializer& deSer);
@@ -65,12 +68,8 @@ public:
 
     DELETE_COPY_AND_MOVE(Index);
 
-    bool isPrimary() const {
-        return indexInfo.indexType.constraintType == IndexConstraintType::PRIMARY;
-    }
-    bool isExtension() const {
-        return indexInfo.indexType.definitionType == IndexDefinitionType::EXTENSION;
-    }
+    bool isPrimary() const { return indexInfo.isPrimary; }
+    bool isExtension() const { return indexInfo.isBuiltin; }
     bool isLoaded() const { return loaded; }
     std::string getName() const { return indexInfo.name; }
     IndexInfo getIndexInfo() const { return indexInfo; }
@@ -100,6 +99,45 @@ protected:
     std::unique_ptr<uint8_t[]> storageInfoBuffer;
     uint64_t storageInfoBufferSize;
     bool loaded;
+};
+
+class IndexHolder {
+public:
+    explicit IndexHolder(std::unique_ptr<Index> loadedIndex);
+    IndexHolder(IndexInfo indexInfo, std::unique_ptr<uint8_t[]> storageInfoBuffer,
+        uint32_t storageInfoBufferSize);
+
+    std::string getName() const { return indexInfo.name; }
+    bool isLoaded() const { return loaded; }
+
+    void serialize(common::Serializer& ser) const;
+    KUZU_API void load(main::ClientContext* context);
+    void checkpoint() {
+        if (loaded) {
+            KU_ASSERT(index);
+            index->checkpoint();
+        }
+    }
+    void rollbackCheckpoint() {
+        if (loaded) {
+            KU_ASSERT(index);
+            index->rollbackCheckpoint();
+        }
+    }
+
+    Index* getIndex() const {
+        KU_ASSERT(index);
+        return index.get();
+    }
+
+private:
+    IndexInfo indexInfo;
+    std::unique_ptr<uint8_t[]> storageInfoBuffer;
+    uint64_t storageInfoBufferSize;
+    bool loaded;
+
+    // Loaded index structure.
+    std::unique_ptr<Index> index;
 };
 
 } // namespace storage

--- a/src/include/storage/index/index.h
+++ b/src/include/storage/index/index.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "common/serializer/buffered_serializer.h"
+#include "common/types/types.h"
+#include "storage/storage_utils.h"
+
+namespace kuzu {
+namespace storage {
+
+enum class IndexConstraintType : uint8_t {
+    PRIMARY = 0, // Primary key index
+    SECONDARY_NON_UNIQUE = 1,
+};
+
+enum class IndexDefinitionType : uint8_t {
+    BUILTIN = 0,
+    EXTENSION = 1,
+};
+
+struct IndexType {
+    std::string typeName;
+    IndexConstraintType constraintType;
+    IndexDefinitionType definitionType;
+
+    void serialize(common::Serializer& ser) const;
+    static IndexType deserialize(common::Deserializer& deSer);
+};
+
+static constexpr IndexType HASH_INDEX_TYPE{"DEFAULT", IndexConstraintType::PRIMARY,
+    IndexDefinitionType::BUILTIN};
+
+struct IndexInfo {
+    std::string name;
+    IndexType indexType;
+    common::column_id_t columnID;
+    common::PhysicalTypeID keyDataType;
+
+    void serialize(common::Serializer& ser) const;
+    static IndexInfo deserialize(common::Deserializer& deSer);
+};
+
+struct IndexStorageInfo {
+    IndexStorageInfo() {}
+    virtual ~IndexStorageInfo() = default;
+
+    virtual std::shared_ptr<common::BufferedSerializer> serialize() const;
+
+    template<typename TARGET>
+    TARGET& cast() {
+        return common::ku_dynamic_cast<TARGET&>(*this);
+    }
+};
+
+class Index {
+public:
+    Index(IndexInfo indexInfo, std::unique_ptr<IndexStorageInfo> storageInfo)
+        : indexInfo{std::move(indexInfo)}, storageInfo{std::move(storageInfo)},
+          storageInfoBuffer{nullptr}, storageInfoBufferSize{0}, loaded{true} {}
+    Index(IndexInfo indexInfo, std::unique_ptr<uint8_t[]> storageBuffer, uint32_t storageBufferSize)
+        : indexInfo{std::move(indexInfo)}, storageInfo{nullptr},
+          storageInfoBuffer{std::move(storageBuffer)}, storageInfoBufferSize{storageBufferSize},
+          loaded{false} {}
+    virtual ~Index() = default;
+
+    DELETE_COPY_AND_MOVE(Index);
+
+    bool isPrimary() const {
+        return indexInfo.indexType.constraintType == IndexConstraintType::PRIMARY;
+    }
+    bool isExtension() const {
+        return indexInfo.indexType.definitionType == IndexDefinitionType::EXTENSION;
+    }
+    bool isLoaded() const { return loaded; }
+
+    virtual void checkpointInMemory() {};
+    virtual void checkpoint(bool forceCheckpointAll = false) { KU_UNUSED(forceCheckpointAll); }
+    virtual void rollbackCheckpoint() {}
+
+    virtual void serialize(common::Serializer& ser) const;
+
+    template<typename TARGET>
+    TARGET& cast() {
+        return common::ku_dynamic_cast<TARGET&>(*this);
+    }
+
+protected:
+    IndexInfo indexInfo;
+    std::unique_ptr<IndexStorageInfo> storageInfo;
+    std::unique_ptr<uint8_t[]> storageInfoBuffer;
+    uint64_t storageInfoBufferSize;
+    bool loaded;
+};
+
+} // namespace storage
+} // namespace kuzu

--- a/src/include/storage/index/index.h
+++ b/src/include/storage/index/index.h
@@ -2,7 +2,7 @@
 
 #include "common/serializer/buffered_serializer.h"
 #include "common/types/types.h"
-#include "storage/storage_utils.h"
+#include <span>
 
 namespace kuzu {
 namespace storage {
@@ -27,6 +27,11 @@ struct KUZU_API IndexType {
     IndexConstraintType constraintType;
     IndexDefinitionType definitionType;
     index_load_func_t loadFunc;
+
+    IndexType(std::string typeName, IndexConstraintType constraintType,
+        IndexDefinitionType definitionType, index_load_func_t loadFunc)
+        : typeName{std::move(typeName)}, constraintType{constraintType},
+          definitionType{definitionType}, loadFunc{std::move(loadFunc)} {}
 };
 
 struct KUZU_API IndexInfo {

--- a/src/include/storage/shadow_file.h
+++ b/src/include/storage/shadow_file.h
@@ -43,9 +43,6 @@ public:
     void clearAll(main::ClientContext& context);
 
 private:
-    static std::unique_ptr<common::FileInfo> getDataFileInfo(const main::ClientContext& context);
-
-private:
     FileHandle* shadowingFH;
     // The map caches shadow page idxes for pages in original files.
     std::unordered_map<common::file_idx_t,

--- a/src/include/storage/storage_manager.h
+++ b/src/include/storage/storage_manager.h
@@ -55,7 +55,10 @@ public:
         const std::string& typeName) const;
 
     void serialize(const catalog::Catalog& catalog, common::Serializer& ser);
-    void deserialize(main::ClientContext* context, common::Deserializer& deSer);
+    // We need to pass in the catalog and storageManager explicitly as they can be from
+    // attachedDatabase.
+    void deserialize(main::ClientContext* context, const catalog::Catalog* catalog,
+        common::Deserializer& deSer);
 
 private:
     void initDataFileHandle(common::VirtualFileSystem* vfs, main::ClientContext* context);

--- a/src/include/storage/storage_manager.h
+++ b/src/include/storage/storage_manager.h
@@ -51,9 +51,11 @@ public:
     void registerIndexType(IndexType indexType) {
         registeredIndexTypes.push_back(std::move(indexType));
     }
+    std::optional<std::reference_wrapper<const IndexType>> getIndexType(
+        const std::string& typeName) const;
 
     void serialize(const catalog::Catalog& catalog, common::Serializer& ser);
-    void deserialize(const catalog::Catalog& catalog, common::Deserializer& deSer);
+    void deserialize(main::ClientContext* context, common::Deserializer& deSer);
 
 private:
     void initDataFileHandle(common::VirtualFileSystem* vfs, main::ClientContext* context);

--- a/src/include/storage/storage_manager.h
+++ b/src/include/storage/storage_manager.h
@@ -4,7 +4,7 @@
 
 #include "catalog/catalog.h"
 #include "shadow_file.h"
-#include "storage/index/hash_index.h"
+#include "storage/index/index.h"
 #include "storage/wal/wal.h"
 
 namespace kuzu {
@@ -48,6 +48,10 @@ public:
     bool compressionEnabled() const { return enableCompression; }
     bool isInMemory() const { return inMemory; }
 
+    void registerIndexType(IndexType indexType) {
+        registeredIndexTypes.push_back(std::move(indexType));
+    }
+
     void serialize(const catalog::Catalog& catalog, common::Serializer& ser);
     void deserialize(const catalog::Catalog& catalog, common::Deserializer& deSer);
 
@@ -70,6 +74,7 @@ private:
     std::unique_ptr<ShadowFile> shadowFile;
     bool enableCompression;
     bool inMemory;
+    std::vector<IndexType> registeredIndexTypes;
 };
 
 } // namespace storage

--- a/src/include/storage/storage_utils.h
+++ b/src/include/storage/storage_utils.h
@@ -16,9 +16,9 @@ namespace kuzu {
 namespace storage {
 
 struct PageCursor {
+    PageCursor() : PageCursor{UINT32_MAX, UINT16_MAX} {};
     PageCursor(common::page_idx_t pageIdx, uint32_t posInPage)
         : pageIdx{pageIdx}, elemPosInPage{posInPage} {};
-    PageCursor() : PageCursor{UINT32_MAX, UINT16_MAX} {};
 
     void nextPage() {
         pageIdx++;

--- a/src/include/storage/table/node_table.h
+++ b/src/include/storage/table/node_table.h
@@ -217,7 +217,8 @@ public:
     }
 
     void serialize(common::Serializer& serializer) const override;
-    void deserialize(main::ClientContext* context, common::Deserializer& deSer) override;
+    void deserialize(main::ClientContext* context, StorageManager* storageManager,
+        common::Deserializer& deSer) override;
 
 private:
     void validatePkNotExists(const transaction::Transaction* transaction,

--- a/src/include/storage/table/node_table.h
+++ b/src/include/storage/table/node_table.h
@@ -142,18 +142,30 @@ public:
     }
 
     void addIndex(std::unique_ptr<Index> index);
-    void addOrReplaceIndex(std::unique_ptr<Index> index);
 
     common::column_id_t getPKColumnID() const { return pkColumnID; }
     PrimaryKeyIndex* getPKIndex() const {
-        const auto index = getIndex(PrimaryKeyIndex::name);
+        const auto index = getIndex(PrimaryKeyIndex::DEFAULT_NAME);
         KU_ASSERT(index.has_value());
         return &index.value()->cast<PrimaryKeyIndex>();
     }
+    std::optional<std::reference_wrapper<IndexHolder>> getIndexHolder(const std::string& name) {
+        for (auto& index : indexes) {
+            if (common::StringUtils::caseInsensitiveEquals(index.getName(), name)) {
+                return index;
+            }
+        }
+        return std::nullopt;
+    }
     std::optional<Index*> getIndex(const std::string& name) const {
         for (auto& index : indexes) {
-            if (common::StringUtils::caseInsensitiveEquals(index->getName(), name)) {
-                return index.get();
+            if (common::StringUtils::caseInsensitiveEquals(index.getName(), name)) {
+                if (index.isLoaded()) {
+                    return index.getIndex();
+                }
+                throw common::RuntimeException(common::stringFormat(
+                    "Index {} is not loaded yet. Please load the index before accessing it.",
+                    name));
             }
         }
         return std::nullopt;
@@ -205,7 +217,7 @@ public:
     }
 
     void serialize(common::Serializer& serializer) const override;
-    void deserialize(common::Deserializer& deSer) override;
+    void deserialize(main::ClientContext* context, common::Deserializer& deSer) override;
 
 private:
     void validatePkNotExists(const transaction::Transaction* transaction,
@@ -220,7 +232,7 @@ private:
     std::vector<std::unique_ptr<Column>> columns;
     std::unique_ptr<NodeGroupCollection> nodeGroups;
     common::column_id_t pkColumnID;
-    std::vector<std::unique_ptr<Index>> indexes;
+    std::vector<IndexHolder> indexes;
     NodeTableVersionRecordHandler versionRecordHandler;
 };
 

--- a/src/include/storage/table/rel_table.h
+++ b/src/include/storage/table/rel_table.h
@@ -178,7 +178,8 @@ public:
     }
     common::column_id_t getNumColumns() const {
         KU_ASSERT(directedRelData.size() >= 1);
-        RUNTIME_CHECK(for (const auto& relData : directedRelData) {
+        RUNTIME_CHECK(for (const auto& relData
+                           : directedRelData) {
             KU_ASSERT(relData->getNumColumns() == directedRelData[0]->getNumColumns());
         });
         return directedRelData[0]->getNumColumns();

--- a/src/include/storage/table/rel_table.h
+++ b/src/include/storage/table/rel_table.h
@@ -178,8 +178,7 @@ public:
     }
     common::column_id_t getNumColumns() const {
         KU_ASSERT(directedRelData.size() >= 1);
-        RUNTIME_CHECK(for (const auto& relData
-                           : directedRelData) {
+        RUNTIME_CHECK(for (const auto& relData : directedRelData) {
             KU_ASSERT(relData->getNumColumns() == directedRelData[0]->getNumColumns());
         });
         return directedRelData[0]->getNumColumns();
@@ -216,7 +215,7 @@ public:
     common::table_id_t getRelGroupID() const { return relGroupID; }
 
     void serialize(common::Serializer& ser) const override;
-    void deserialize(catalog::TableCatalogEntry* tableEntry, common::Deserializer& deSer) override;
+    void deserialize(common::Deserializer& deSer) override;
 
 private:
     static void prepareCommitForNodeGroup(const transaction::Transaction* transaction,

--- a/src/include/storage/table/rel_table.h
+++ b/src/include/storage/table/rel_table.h
@@ -215,7 +215,8 @@ public:
     common::table_id_t getRelGroupID() const { return relGroupID; }
 
     void serialize(common::Serializer& ser) const override;
-    void deserialize(main::ClientContext* context, common::Deserializer& deSer) override;
+    void deserialize(main::ClientContext* context, StorageManager* storageManager,
+        common::Deserializer& deSer) override;
 
 private:
     static void prepareCommitForNodeGroup(const transaction::Transaction* transaction,

--- a/src/include/storage/table/rel_table.h
+++ b/src/include/storage/table/rel_table.h
@@ -215,7 +215,7 @@ public:
     common::table_id_t getRelGroupID() const { return relGroupID; }
 
     void serialize(common::Serializer& ser) const override;
-    void deserialize(common::Deserializer& deSer) override;
+    void deserialize(main::ClientContext* context, common::Deserializer& deSer) override;
 
 private:
     static void prepareCommitForNodeGroup(const transaction::Transaction* transaction,

--- a/src/include/storage/table/table.h
+++ b/src/include/storage/table/table.h
@@ -194,7 +194,7 @@ public:
         std::vector<common::LogicalType> types);
 
     virtual void serialize(common::Serializer& serializer) const = 0;
-    virtual void deserialize(catalog::TableCatalogEntry* entry, common::Deserializer& deSer) = 0;
+    virtual void deserialize(common::Deserializer& deSer) = 0;
 
 protected:
     virtual bool scanInternal(transaction::Transaction* transaction, TableScanState& scanState) = 0;

--- a/src/include/storage/table/table.h
+++ b/src/include/storage/table/table.h
@@ -194,7 +194,8 @@ public:
         std::vector<common::LogicalType> types);
 
     virtual void serialize(common::Serializer& serializer) const = 0;
-    virtual void deserialize(main::ClientContext* context, common::Deserializer& deSer) = 0;
+    virtual void deserialize(main::ClientContext* context, StorageManager* storageManager,
+        common::Deserializer& deSer) = 0;
 
 protected:
     virtual bool scanInternal(transaction::Transaction* transaction, TableScanState& scanState) = 0;

--- a/src/include/storage/table/table.h
+++ b/src/include/storage/table/table.h
@@ -194,7 +194,7 @@ public:
         std::vector<common::LogicalType> types);
 
     virtual void serialize(common::Serializer& serializer) const = 0;
-    virtual void deserialize(common::Deserializer& deSer) = 0;
+    virtual void deserialize(main::ClientContext* context, common::Deserializer& deSer) = 0;
 
 protected:
     virtual bool scanInternal(transaction::Transaction* transaction, TableScanState& scanState) = 0;

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -5,6 +5,7 @@
 #include "main/db_config.h"
 #include "storage/checkpointer.h"
 #include "storage/storage_manager.h"
+#include "storage/storage_utils.h"
 #include "transaction/transaction_manager.h"
 
 namespace kuzu {

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -4,6 +4,7 @@
 #include "common/exception/checkpoint.h"
 #include "common/exception/connection.h"
 #include "common/exception/runtime.h"
+#include "common/file_system/virtual_file_system.h"
 #include "common/random_engine.h"
 #include "common/string_utils.h"
 #include "common/task_system/progress_bar.h"

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -18,6 +18,7 @@
 #include "storage/checkpointer.h"
 #include "storage/storage_extension.h"
 #include "storage/storage_manager.h"
+#include "storage/storage_utils.h"
 #include "transaction/transaction_manager.h"
 
 using namespace kuzu::catalog;

--- a/src/processor/operator/ddl/alter.cpp
+++ b/src/processor/operator/ddl/alter.cpp
@@ -5,6 +5,7 @@
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
 #include "common/enums/alter_type.h"
 #include "common/exception/binder.h"
+#include "common/exception/runtime.h"
 #include "processor/execution_context.h"
 #include "storage/storage_manager.h"
 #include "storage/table/table.h"

--- a/src/storage/checkpointer.cpp
+++ b/src/storage/checkpointer.cpp
@@ -230,6 +230,7 @@ void Checkpointer::readCheckpoint() {
         storageManager);
 }
 
+// TODO(Guodong): Double check here to reduce passed params.
 void Checkpointer::readCheckpoint(const std::string& dbPath, main::ClientContext* context,
     common::VirtualFileSystem* vfs, catalog::Catalog* catalog, StorageManager* storageManager) {
     auto fileInfo = vfs->openFile(StorageUtils::getDataFName(vfs, dbPath),
@@ -242,7 +243,7 @@ void Checkpointer::readCheckpoint(const std::string& dbPath, main::ClientContext
     catalog->deserialize(deSer);
     deSer.getReader()->cast<common::BufferedFileReader>()->resetReadOffset(
         currentHeader.metadataPageRange.startPageIdx * common::KUZU_PAGE_SIZE);
-    storageManager->deserialize(*catalog, deSer);
+    storageManager->deserialize(context, deSer);
 }
 
 } // namespace storage

--- a/src/storage/checkpointer.cpp
+++ b/src/storage/checkpointer.cpp
@@ -1,10 +1,12 @@
 #include "storage/checkpointer.h"
 
 #include "catalog/catalog.h"
+#include "common/exception/runtime.h"
 #include "common/serializer/deserializer.h"
 #include "common/serializer/metadata_writer.h"
 #include "main/db_config.h"
 #include "storage/buffer_manager/buffer_manager.h"
+#include "storage/shadow_utils.h"
 #include "storage/storage_manager.h"
 #include "storage/storage_utils.h"
 #include "storage/storage_version_info.h"

--- a/src/storage/checkpointer.cpp
+++ b/src/storage/checkpointer.cpp
@@ -230,7 +230,6 @@ void Checkpointer::readCheckpoint() {
         storageManager);
 }
 
-// TODO(Guodong): Double check here to reduce passed params.
 void Checkpointer::readCheckpoint(const std::string& dbPath, main::ClientContext* context,
     common::VirtualFileSystem* vfs, catalog::Catalog* catalog, StorageManager* storageManager) {
     auto fileInfo = vfs->openFile(StorageUtils::getDataFName(vfs, dbPath),
@@ -243,7 +242,7 @@ void Checkpointer::readCheckpoint(const std::string& dbPath, main::ClientContext
     catalog->deserialize(deSer);
     deSer.getReader()->cast<common::BufferedFileReader>()->resetReadOffset(
         currentHeader.metadataPageRange.startPageIdx * common::KUZU_PAGE_SIZE);
-    storageManager->deserialize(context, deSer);
+    storageManager->deserialize(context, catalog, deSer);
 }
 
 } // namespace storage

--- a/src/storage/index/CMakeLists.txt
+++ b/src/storage/index/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_library(kuzu_storage_index
         OBJECT
         hash_index.cpp
-        in_mem_hash_index.cpp)
+        in_mem_hash_index.cpp
+        index.cpp)
 
 set(ALL_OBJECT_FILES
         ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_storage_index>

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -149,7 +149,7 @@ void HashIndex<T>::splitSlots(const Transaction* transaction, HashIndexHeader& h
         Slot<T>* originalSlot = &*originalSlotIterator.seek(header.nextSplitSlotId);
         do {
             for (entry_pos_t originalEntryPos = 0; originalEntryPos < getSlotCapacity<T>();
-                originalEntryPos++) {
+                 originalEntryPos++) {
                 if (!originalSlot->header.isEntryValid(originalEntryPos)) {
                     continue; // Skip invalid entries.
                 }
@@ -295,9 +295,10 @@ void HashIndex<T>::mergeBulkInserts(const Transaction* transaction,
     // may not be consecutive, but we reduce the memory overhead for storing the information about
     // the sorted data and still just process each page once.
     for (uint64_t localSlotId = 0; localSlotId < insertLocalStorage.numPrimarySlots();
-        localSlotId += NUM_SLOTS_PER_PAGE) {
+         localSlotId += NUM_SLOTS_PER_PAGE) {
         for (size_t i = 0;
-            i < NUM_SLOTS_PER_PAGE && localSlotId + i < insertLocalStorage.numPrimarySlots(); i++) {
+             i < NUM_SLOTS_PER_PAGE && localSlotId + i < insertLocalStorage.numPrimarySlots();
+             i++) {
             auto localSlot =
                 typename InMemHashIndex<T>::SlotIterator(localSlotId + i, &insertLocalStorage);
             partitionedEntries[i].clear();
@@ -458,7 +459,7 @@ PrimaryKeyIndex::PrimaryKeyIndex(IndexInfo indexInfo, std::unique_ptr<IndexStora
                 [&](auto* frame) {
                     const auto onDiskHeaders = reinterpret_cast<HashIndexHeaderOnDisk*>(frame);
                     for (size_t i = 0; i < INDEX_HEADERS_PER_PAGE && headerIdx < NUM_HASH_INDEXES;
-                        i++) {
+                         i++) {
                         hashIndexHeadersForReadTrx.emplace_back(onDiskHeaders[i]);
                         headerIdx++;
                     }
@@ -582,7 +583,7 @@ void PrimaryKeyIndex::writeHeaders() {
             [&](auto* frame) {
                 auto onDiskFrame = reinterpret_cast<HashIndexHeaderOnDisk*>(frame);
                 for (size_t i = 0; i < INDEX_HEADERS_PER_PAGE && headerIdx < NUM_HASH_INDEXES;
-                    i++) {
+                     i++) {
                     hashIndexHeadersForWriteTrx[headerIdx++].write(onDiskFrame[i]);
                 }
             });

--- a/src/storage/index/index.cpp
+++ b/src/storage/index/index.cpp
@@ -1,8 +1,9 @@
 #include "storage/index/index.h"
 
+#include "common/exception/runtime.h"
 #include "common/serializer/deserializer.h"
 #include "common/serializer/serializer.h"
-#include "storage/index/hash_index.h"
+#include "main/client_context.h"
 #include "storage/storage_manager.h"
 
 namespace kuzu {

--- a/src/storage/index/index.cpp
+++ b/src/storage/index/index.cpp
@@ -15,8 +15,8 @@ void IndexType::serialize(common::Serializer& ser) const {
 
 IndexType IndexType::deserialize(common::Deserializer& deSer) {
     std::string typeName;
-    IndexConstraintType constraintType;
-    IndexDefinitionType definitionType;
+    auto constraintType = IndexConstraintType::PRIMARY;
+    auto definitionType = IndexDefinitionType::BUILTIN;
     deSer.deserializeValue(typeName);
     deSer.deserializeValue<IndexConstraintType>(constraintType);
     deSer.deserializeValue<IndexDefinitionType>(definitionType);
@@ -32,8 +32,8 @@ void IndexInfo::serialize(common::Serializer& ser) const {
 
 IndexInfo IndexInfo::deserialize(common::Deserializer& deSer) {
     std::string name;
-    common::column_id_t columnID;
-    common::PhysicalTypeID keyDataType;
+    common::column_id_t columnID = common::INVALID_COLUMN_ID;
+    auto keyDataType = common::PhysicalTypeID::ANY;
     deSer.deserializeValue(name);
     IndexType indexType = IndexType::deserialize(deSer);
     deSer.deserializeValue<common::column_id_t>(columnID);

--- a/src/storage/index/index.cpp
+++ b/src/storage/index/index.cpp
@@ -1,0 +1,56 @@
+#include "storage/index/index.h"
+
+#include "common/serializer/deserializer.h"
+#include "common/serializer/serializer.h"
+#include "storage/index/hash_index.h"
+
+namespace kuzu {
+namespace storage {
+
+void IndexType::serialize(common::Serializer& ser) const {
+    ser.write<std::string>(typeName);
+    ser.write<IndexConstraintType>(constraintType);
+    ser.write<IndexDefinitionType>(definitionType);
+}
+
+IndexType IndexType::deserialize(common::Deserializer& deSer) {
+    std::string typeName;
+    IndexConstraintType constraintType;
+    IndexDefinitionType definitionType;
+    deSer.deserializeValue(typeName);
+    deSer.deserializeValue<IndexConstraintType>(constraintType);
+    deSer.deserializeValue<IndexDefinitionType>(definitionType);
+    return IndexType{std::move(typeName), constraintType, definitionType};
+}
+
+void IndexInfo::serialize(common::Serializer& ser) const {
+    ser.write<std::string>(name);
+    indexType.serialize(ser);
+    ser.write<common::column_id_t>(columnID);
+    ser.write<common::PhysicalTypeID>(keyDataType);
+}
+
+IndexInfo IndexInfo::deserialize(common::Deserializer& deSer) {
+    std::string name;
+    common::column_id_t columnID;
+    common::PhysicalTypeID keyDataType;
+    deSer.deserializeValue(name);
+    IndexType indexType = IndexType::deserialize(deSer);
+    deSer.deserializeValue<common::column_id_t>(columnID);
+    deSer.deserializeValue<common::PhysicalTypeID>(keyDataType);
+    return IndexInfo{std::move(name), std::move(indexType), columnID, keyDataType};
+}
+
+std::shared_ptr<common::BufferedSerializer> IndexStorageInfo::serialize() const {
+    return std::make_shared<common::BufferedSerializer>(0 /*maximumSize*/);
+}
+
+void Index::serialize(common::Serializer& ser) const {
+    indexInfo.serialize(ser);
+    auto bufferedWriter = storageInfo->serialize();
+    ser.write<uint64_t>(bufferedWriter->getSize());
+    ser.write(bufferedWriter->getData().data.get(), bufferedWriter->getSize());
+}
+
+} // namespace storage
+} // namespace kuzu

--- a/src/storage/shadow_file.cpp
+++ b/src/storage/shadow_file.cpp
@@ -10,7 +10,6 @@
 #include "storage/buffer_manager/memory_manager.h"
 #include "storage/file_handle.h"
 #include "storage/storage_manager.h"
-#include "storage/storage_utils.h"
 
 using namespace kuzu::common;
 using namespace kuzu::main;

--- a/src/storage/shadow_file.cpp
+++ b/src/storage/shadow_file.cpp
@@ -9,6 +9,7 @@
 #include "storage/buffer_manager/buffer_manager.h"
 #include "storage/buffer_manager/memory_manager.h"
 #include "storage/file_handle.h"
+#include "storage/storage_manager.h"
 #include "storage/storage_utils.h"
 
 using namespace kuzu::common;
@@ -73,7 +74,7 @@ page_idx_t ShadowFile::getShadowPage(file_idx_t originalFile, page_idx_t origina
 void ShadowFile::replayShadowPageRecords(ClientContext& context) const {
     const auto pageBuffer = std::make_unique<uint8_t[]>(KUZU_PAGE_SIZE);
     page_idx_t shadowPageIdx = 1; // Skip header page.
-    auto dataFileInfo = getDataFileInfo(context);
+    auto dataFileInfo = context.getStorageManager()->getDataFH()->getFileInfo();
     for (const auto& record : shadowPageRecords) {
         shadowingFH->readPageFromDisk(pageBuffer.get(), shadowPageIdx++);
         dataFileInfo->writeFile(pageBuffer.get(), KUZU_PAGE_SIZE,
@@ -112,13 +113,6 @@ void ShadowFile::clearAll(ClientContext& context) {
     shadowPageRecords.clear();
     // Reserve header page.
     shadowingFH->addNewPage();
-}
-
-std::unique_ptr<FileInfo> ShadowFile::getDataFileInfo(const ClientContext& context) {
-    const auto fileName =
-        StorageUtils::getDataFName(context.getVFSUnsafe(), context.getDatabasePath());
-    return context.getVFSUnsafe()->openFile(fileName,
-        FileOpenFlags(FileFlags::READ_ONLY | FileFlags::WRITE));
 }
 
 } // namespace storage

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -30,7 +30,7 @@ StorageManager::StorageManager(const std::string& databasePath, bool readOnly,
         *memoryManager.getBufferManager(), vfs, context);
     inMemory = main::DBConfig::isDBPathInMemory(databasePath);
     initDataFileHandle(vfs, context);
-    registeredIndexTypes.push_back(HASH_INDEX_TYPE);
+    registerIndexType(HASH_INDEX_TYPE);
 }
 
 StorageManager::~StorageManager() = default;
@@ -191,6 +191,16 @@ void StorageManager::rollbackCheckpoint(const Catalog& catalog) {
     dataFH->getPageManager()->rollbackCheckpoint();
 }
 
+std::optional<std::reference_wrapper<const IndexType>> StorageManager::getIndexType(
+    const std::string& typeName) const {
+    for (auto& indexType : registeredIndexTypes) {
+        if (StringUtils::caseInsensitiveEquals(indexType.typeName, typeName)) {
+            return indexType;
+        }
+    }
+    return std::nullopt;
+}
+
 void StorageManager::serialize(const Catalog& catalog, Serializer& ser) {
     std::lock_guard lck{mtx};
     auto nodeTableEntries = catalog.getNodeTableEntries(&DUMMY_CHECKPOINT_TRANSACTION);
@@ -225,24 +235,25 @@ void StorageManager::serialize(const Catalog& catalog, Serializer& ser) {
     dataFH->getPageManager()->serialize(ser);
 }
 
-void StorageManager::deserialize(const Catalog& catalog, Deserializer& deSer) {
+void StorageManager::deserialize(main::ClientContext* context, Deserializer& deSer) {
     std::string key;
     deSer.validateDebuggingInfo(key, "num_node_tables");
     uint64_t numNodeTables = 0;
     deSer.deserializeValue<uint64_t>(numNodeTables);
+    auto catalog = context->getCatalog();
     for (auto i = 0u; i < numNodeTables; i++) {
         deSer.validateDebuggingInfo(key, "table_id");
         table_id_t tableID = INVALID_TABLE_ID;
         deSer.deserializeValue<table_id_t>(tableID);
-        if (!catalog.containsTable(&DUMMY_TRANSACTION, tableID)) {
+        if (!catalog->containsTable(&DUMMY_TRANSACTION, tableID)) {
             throw RuntimeException(
                 stringFormat("Load table failed: table {} doesn't exist in catalog.", tableID));
         }
         KU_ASSERT(!tables.contains(tableID));
-        auto tableEntry = catalog.getTableCatalogEntry(&DUMMY_TRANSACTION, tableID)
+        auto tableEntry = catalog->getTableCatalogEntry(&DUMMY_TRANSACTION, tableID)
                               ->ptrCast<NodeTableCatalogEntry>();
         tables[tableID] = std::make_unique<NodeTable>(this, tableEntry, &memoryManager);
-        tables[tableID]->deserialize(deSer);
+        tables[tableID]->deserialize(context, deSer);
     }
     deSer.validateDebuggingInfo(key, "num_rel_groups");
     uint64_t numRelGroups = 0;
@@ -251,21 +262,21 @@ void StorageManager::deserialize(const Catalog& catalog, Deserializer& deSer) {
         deSer.validateDebuggingInfo(key, "rel_group_id");
         table_id_t relGroupID = INVALID_TABLE_ID;
         deSer.deserializeValue<table_id_t>(relGroupID);
-        if (!catalog.containsTable(&DUMMY_TRANSACTION, relGroupID)) {
+        if (!catalog->containsTable(&DUMMY_TRANSACTION, relGroupID)) {
             throw RuntimeException(
                 stringFormat("Load table failed: table {} doesn't exist in catalog.", relGroupID));
         }
         deSer.validateDebuggingInfo(key, "num_inner_rel_tables");
         uint64_t numInnerRelTables = 0;
         deSer.deserializeValue<uint64_t>(numInnerRelTables);
-        auto relGroupEntry = catalog.getTableCatalogEntry(&DUMMY_TRANSACTION, relGroupID)
+        auto relGroupEntry = catalog->getTableCatalogEntry(&DUMMY_TRANSACTION, relGroupID)
                                  ->ptrCast<RelGroupCatalogEntry>();
         for (auto k = 0u; k < numInnerRelTables; k++) {
             RelTableCatalogInfo info = RelTableCatalogInfo::deserialize(deSer);
             KU_ASSERT(!tables.contains(info.oid));
             tables[info.oid] = std::make_unique<RelTable>(relGroupEntry, info.nodePair.srcTableID,
                 info.nodePair.dstTableID, this, &memoryManager);
-            tables.at(info.oid)->deserialize(deSer);
+            tables.at(info.oid)->deserialize(context, deSer);
         }
     }
     deSer.validateDebuggingInfo(key, "page_manager");

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -30,6 +30,7 @@ StorageManager::StorageManager(const std::string& databasePath, bool readOnly,
         *memoryManager.getBufferManager(), vfs, context);
     inMemory = main::DBConfig::isDBPathInMemory(databasePath);
     initDataFileHandle(vfs, context);
+    registeredIndexTypes.push_back(HASH_INDEX_TYPE);
 }
 
 StorageManager::~StorageManager() = default;
@@ -241,7 +242,7 @@ void StorageManager::deserialize(const Catalog& catalog, Deserializer& deSer) {
         auto tableEntry = catalog.getTableCatalogEntry(&DUMMY_TRANSACTION, tableID)
                               ->ptrCast<NodeTableCatalogEntry>();
         tables[tableID] = std::make_unique<NodeTable>(this, tableEntry, &memoryManager);
-        tables[tableID]->deserialize(tableEntry, deSer);
+        tables[tableID]->deserialize(deSer);
     }
     deSer.validateDebuggingInfo(key, "num_rel_groups");
     uint64_t numRelGroups = 0;
@@ -264,7 +265,7 @@ void StorageManager::deserialize(const Catalog& catalog, Deserializer& deSer) {
             KU_ASSERT(!tables.contains(info.oid));
             tables[info.oid] = std::make_unique<RelTable>(relGroupEntry, info.nodePair.srcTableID,
                 info.nodePair.dstTableID, this, &memoryManager);
-            tables.at(info.oid)->deserialize(relGroupEntry, deSer);
+            tables.at(info.oid)->deserialize(deSer);
         }
     }
     deSer.validateDebuggingInfo(key, "page_manager");

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -30,7 +30,7 @@ StorageManager::StorageManager(const std::string& databasePath, bool readOnly,
         *memoryManager.getBufferManager(), vfs, context);
     inMemory = main::DBConfig::isDBPathInMemory(databasePath);
     initDataFileHandle(vfs, context);
-    registerIndexType(HASH_INDEX_TYPE);
+    registerIndexType(PrimaryKeyIndex::getIndexType());
 }
 
 StorageManager::~StorageManager() = default;

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -4,7 +4,6 @@
 #include "common/cast.h"
 #include "common/exception/message.h"
 #include "common/exception/runtime.h"
-#include "common/serializer/buffered_reader.h"
 #include "common/types/types.h"
 #include "main/client_context.h"
 #include "main/db_config.h"

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -232,8 +232,8 @@ NodeTable::NodeTable(const StorageManager* storageManager,
     auto pkColumnID = nodeTableEntry->getColumnID(pkDefinition.getName());
     KU_ASSERT(pkColumnID != INVALID_COLUMN_ID);
     auto hashIndexType = PrimaryKeyIndex::getIndexType();
-    IndexInfo indexInfo{PrimaryKeyIndex::DEFAULT_NAME, hashIndexType.typeName, tableID, pkColumnID,
-        pkDefinition.getType().getPhysicalType(),
+    IndexInfo indexInfo{PrimaryKeyIndex::DEFAULT_NAME, hashIndexType.typeName, tableID,
+        {pkColumnID}, {pkDefinition.getType().getPhysicalType()},
         hashIndexType.constraintType == IndexConstraintType::PRIMARY,
         hashIndexType.definitionType == IndexDefinitionType::BUILTIN};
     indexes.push_back(IndexHolder{
@@ -658,7 +658,8 @@ void NodeTable::serialize(Serializer& serializer) const {
     }
 }
 
-void NodeTable::deserialize(main::ClientContext* context, Deserializer& deSer) {
+void NodeTable::deserialize(main::ClientContext* context, StorageManager* storageManager,
+    Deserializer& deSer) {
     nodeGroups->deserialize(deSer, *memoryManager);
     std::vector<IndexInfo> indexInfos;
     std::vector<length_t> storageInfoBufferSizes;
@@ -684,7 +685,7 @@ void NodeTable::deserialize(main::ClientContext* context, Deserializer& deSer) {
         indexes.push_back(IndexHolder(indexInfos[i], std::move(storageInfoBuffers[i]),
             storageInfoBufferSizes[i]));
         if (indexInfos[i].isBuiltin) {
-            indexes[i].load(context);
+            indexes[i].load(context, storageManager);
         }
     }
 }

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -486,7 +486,7 @@ void NodeTable::commit(Transaction* transaction, TableCatalogEntry* tableEntry,
     // 2. Set deleted flag for tuples that are deleted in local storage.
     row_idx_t numLocalRows = 0u;
     for (auto localNodeGroupIdx = 0u; localNodeGroupIdx < localNodeTable.getNumNodeGroups();
-        localNodeGroupIdx++) {
+         localNodeGroupIdx++) {
         const auto localNodeGroup = localNodeTable.getNodeGroup(localNodeGroupIdx);
         if (localNodeGroup->hasDeletions(transaction)) {
             // TODO(Guodong): Assume local storage is small here. Should optimize the loop away by
@@ -623,7 +623,7 @@ void NodeTable::scanPKColumn(const Transaction* transaction, PKColumnScanHelper&
 
     const auto numNodeGroups = nodeGroups_.getNumNodeGroups();
     for (node_group_idx_t nodeGroupToScan = 0u; nodeGroupToScan < numNodeGroups;
-        ++nodeGroupToScan) {
+         ++nodeGroupToScan) {
         scanState->nodeGroup = nodeGroups_.getNodeGroupNoLock(nodeGroupToScan);
 
         // It is possible for the node group to have no chunked groups if we are rolling back due to

--- a/src/storage/table/rel_table.cpp
+++ b/src/storage/table/rel_table.cpp
@@ -523,7 +523,7 @@ void RelTable::serialize(Serializer& ser) const {
     }
 }
 
-void RelTable::deserialize(main::ClientContext*, Deserializer& deSer) {
+void RelTable::deserialize(main::ClientContext*, StorageManager*, Deserializer& deSer) {
     std::string key;
     deSer.validateDebuggingInfo(key, "next_rel_offset");
     deSer.deserializeValue<offset_t>(nextRelOffset);

--- a/src/storage/table/rel_table.cpp
+++ b/src/storage/table/rel_table.cpp
@@ -522,7 +522,7 @@ void RelTable::serialize(Serializer& ser) const {
     }
 }
 
-void RelTable::deserialize(TableCatalogEntry*, Deserializer& deSer) {
+void RelTable::deserialize(Deserializer& deSer) {
     std::string key;
     deSer.validateDebuggingInfo(key, "next_rel_offset");
     deSer.deserializeValue<offset_t>(nextRelOffset);

--- a/src/storage/table/rel_table.cpp
+++ b/src/storage/table/rel_table.cpp
@@ -10,6 +10,7 @@
 #include "storage/local_storage/local_storage.h"
 #include "storage/local_storage/local_table.h"
 #include "storage/storage_manager.h"
+#include "storage/storage_utils.h"
 #include "storage/table/rel_table_data.h"
 #include "transaction/transaction.h"
 #include <ranges>

--- a/src/storage/table/rel_table.cpp
+++ b/src/storage/table/rel_table.cpp
@@ -522,7 +522,7 @@ void RelTable::serialize(Serializer& ser) const {
     }
 }
 
-void RelTable::deserialize(Deserializer& deSer) {
+void RelTable::deserialize(main::ClientContext*, Deserializer& deSer) {
     std::string key;
     deSer.validateDebuggingInfo(key, "next_rel_offset");
     deSer.deserializeValue<offset_t>(nextRelOffset);


### PR DESCRIPTION
# Description

Add abstract `Index`. For index implemented as extension, e.g., HNSW, the index needs first to be registered in StorageManager and will only be loaded when the extension is loaded.