### PR TITLE
Refactor card estimator

### DIFF
--- a/extension/vector/src/function/query_hnsw_index.cpp
+++ b/extension/vector/src/function/query_hnsw_index.cpp
@@ -287,6 +287,7 @@ static void getLogicalPlan(Planner* planner, const BoundReadingClause& readingCl
     planner->planReadOp(op, predicates, plan);
     auto nodeOutput = bindData->outputNode->ptrCast<NodeExpression>();
     KU_ASSERT(nodeOutput != nullptr);
+    planner->getCardinliatyEstimatorUnsafe().init(*nodeOutput);
     auto scanPlan = planner->getNodePropertyScanPlan(*nodeOutput);
     if (scanPlan.isEmpty()) {
         return;

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -174,8 +174,8 @@ std::vector<std::shared_ptr<LogicalOperator>> getNodeMaskPlanRoots(const GDSBind
         }
         auto& node = nodeInfo.nodeOrRel->constCast<NodeExpression>();
         planner->getCardinliatyEstimatorUnsafe().init(node);
-        auto p = planner->getNodeSemiMaskPlan(SemiMaskTargetType::GDS_GRAPH_NODE,
-            node, nodeInfo.predicate);
+        auto p = planner->getNodeSemiMaskPlan(SemiMaskTargetType::GDS_GRAPH_NODE, node,
+            nodeInfo.predicate);
         nodeMaskPlanRoots.push_back(p.getLastOperator());
     }
     return nodeMaskPlanRoots;

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -172,8 +172,10 @@ std::vector<std::shared_ptr<LogicalOperator>> getNodeMaskPlanRoots(const GDSBind
         if (nodeInfo.predicate == nullptr) {
             continue;
         }
+        auto& node = nodeInfo.nodeOrRel->constCast<NodeExpression>();
+        planner->getCardinliatyEstimatorUnsafe().init(node);
         auto p = planner->getNodeSemiMaskPlan(SemiMaskTargetType::GDS_GRAPH_NODE,
-            nodeInfo.nodeOrRel->constCast<NodeExpression>(), nodeInfo.predicate);
+            node, nodeInfo.predicate);
         nodeMaskPlanRoots.push_back(p.getLastOperator());
     }
     return nodeMaskPlanRoots;
@@ -192,6 +194,7 @@ void GDSFunction::getLogicalPlan(Planner* planner, const BoundReadingClause& rea
 
     auto nodeOutput = bindData->nodeOutput->ptrCast<NodeExpression>();
     KU_ASSERT(nodeOutput != nullptr);
+    planner->getCardinliatyEstimatorUnsafe().init(*nodeOutput);
     auto scanPlan = planner->getNodePropertyScanPlan(*nodeOutput);
     if (scanPlan.isEmpty()) {
         return;

--- a/src/include/function/table/bind_data.h
+++ b/src/include/function/table/bind_data.h
@@ -37,8 +37,6 @@ struct KUZU_API TableFuncBindData {
         return columnPredicates;
     }
 
-    virtual std::shared_ptr<binder::Expression> getNodeOutput() const { return nullptr; }
-
     virtual bool getIgnoreErrorsOption() const;
 
     virtual std::unique_ptr<TableFuncBindData> copy() const;

--- a/src/include/planner/join_order/cardinality_estimator.h
+++ b/src/include/planner/join_order/cardinality_estimator.h
@@ -19,17 +19,13 @@ class LogicalAggregate;
 
 class CardinalityEstimator {
 public:
-    CardinalityEstimator() : context{nullptr} {};
     explicit CardinalityEstimator(main::ClientContext* context) : context{context} {}
     DELETE_COPY_DEFAULT_MOVE(CardinalityEstimator);
 
-    // TODO(Xiyang): revisit this init at some point. Maybe we should init while enumerating.
-    void initNodeIDDom(const transaction::Transaction* transaction,
-        const binder::QueryGraph& queryGraph);
-    KUZU_API void addNodeIDDomAndStats(const transaction::Transaction* transaction,
-        const binder::Expression& nodeID, const std::vector<common::table_id_t>& tableIDs);
-    void addPerQueryGraphNodeIDDom(const binder::Expression& nodeID, cardinality_t numNodes);
-    void clearPerQueryGraphStats();
+    void init(const binder::QueryGraph& queryGraph);
+    KUZU_API void init(const binder::NodeExpression& node);
+
+    void rectifyCardinality(const binder::Expression& nodeID, cardinality_t card);
 
     cardinality_t estimateScanNode(const LogicalOperator& op) const;
     cardinality_t estimateHashJoin(const std::vector<binder::expression_pair>& joinConditions,
@@ -61,11 +57,6 @@ private:
     std::unordered_map<common::table_id_t, storage::TableStats> nodeTableStats;
     // The domain of nodeID is defined as the number of unique value of nodeID, i.e. num nodes.
     std::unordered_map<std::string, cardinality_t> nodeIDName2dom;
-    // additional per-query-graph statistics for nodeIDName2dom (e.g. from correlated expressions)
-    // when estimating the cardinality of a node we will use the minimum of the estimations from
-    // nodeIDName2dom and perQueryGraphNodeIDName2dom
-    // when we start enumerating a new query graph we will reset this map
-    std::unordered_map<std::string, cardinality_t> perQueryGraphNodeIDName2dom;
 };
 
 } // namespace planner

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -157,7 +157,7 @@ public:
     void planBaseTableScans(const QueryGraphPlanningInfo& info);
     void planCorrelatedExpressionsScan(const QueryGraphPlanningInfo& info);
     void planNodeScan(uint32_t nodePos);
-    void planNodeIDScan(uint32_t nodePos, const QueryGraphPlanningInfo& info);
+    void planNodeIDScan(uint32_t nodePos);
     void planRelScan(uint32_t relPos);
     void appendExtend(std::shared_ptr<binder::NodeExpression> boundNode,
         std::shared_ptr<binder::NodeExpression> nbrNode, std::shared_ptr<binder::RelExpression> rel,
@@ -309,7 +309,7 @@ public:
     void appendDistinct(const binder::expression_vector& keys, LogicalPlan& plan);
 
     const CardinalityEstimator& getCardinalityEstimator() const { return cardinalityEstimator; }
-    CardinalityEstimator& getCardinalityEstimator() { return cardinalityEstimator; }
+    CardinalityEstimator& getCardinliatyEstimatorUnsafe() { return cardinalityEstimator; }
 
     // Get operators
     static std::shared_ptr<LogicalOperator> getTableFunctionCall(

--- a/src/planner/join_order/cardinality_estimator.cpp
+++ b/src/planner/join_order/cardinality_estimator.cpp
@@ -51,8 +51,7 @@ void CardinalityEstimator::init(const NodeExpression& node) {
     }
 }
 
-void CardinalityEstimator::rectifyCardinality(const Expression& nodeID,
-    cardinality_t card) {
+void CardinalityEstimator::rectifyCardinality(const Expression& nodeID, cardinality_t card) {
     KU_ASSERT(nodeIDName2dom.contains(nodeID.getUniqueName()));
     auto newCard = std::min(nodeIDName2dom.at(nodeID.getUniqueName()), card);
     nodeIDName2dom[nodeID.getUniqueName()] = newCard;

--- a/src/planner/plan/plan_join_order.cpp
+++ b/src/planner/plan/plan_join_order.cpp
@@ -187,10 +187,11 @@ void Planner::planBaseTableScans(const QueryGraphPlanningInfo& info) {
         for (auto nodePos = 0u; nodePos < queryGraph->getNumQueryNodes(); ++nodePos) {
             auto queryNode = queryGraph->getQueryNode(nodePos);
             if (info.containsCorrExpr(*queryNode->getInternalID())) {
-                // NodeID will be a join condition with outer plan so very likely we will apply a semi mask
-                // later in the optimization stage. So we can assume the cardinality will not exceed outer
-                // plan cardinality.
-                cardinalityEstimator.rectifyCardinality(*queryNode->getInternalID(), info.corrExprsCard);
+                // NodeID will be a join condition with outer plan so very likely we will apply a
+                // semi mask later in the optimization stage. So we can assume the cardinality will
+                // not exceed outer plan cardinality.
+                cardinalityEstimator.rectifyCardinality(*queryNode->getInternalID(),
+                    info.corrExprsCard);
                 // In un-nested subquery, e.g. MATCH (a) OPTIONAL MATCH (a)-[e1]->(b), the inner
                 // query ("(a)-[e1]->(b)") needs to scan a, which is already scanned in the outer
                 // query (a). To avoid scanning storage twice, we keep track of node table "a" and

--- a/src/planner/plan/plan_join_order.cpp
+++ b/src/planner/plan/plan_join_order.cpp
@@ -4,7 +4,6 @@
 #include "common/enums/join_type.h"
 #include "common/enums/rel_direction.h"
 #include "common/utils.h"
-#include "main/client_context.h"
 #include "planner/join_order/cost_model.h"
 #include "planner/join_order/join_plan_solver.h"
 #include "planner/join_order/join_tree_constructor.h"
@@ -124,13 +123,12 @@ LogicalPlan Planner::planQueryGraphCollection(const QueryGraphCollection& queryG
 LogicalPlan Planner::planQueryGraph(const QueryGraph& queryGraph,
     const QueryGraphPlanningInfo& info) {
     context.init(&queryGraph, info.predicates);
-    cardinalityEstimator.initNodeIDDom(clientContext->getTransaction(), queryGraph);
+    cardinalityEstimator.init(queryGraph);
     if (info.hint != nullptr) {
         auto constructor =
             JoinTreeConstructor(queryGraph, propertyExprCollection, info.predicates, info);
         auto joinTree = constructor.construct(info.hint);
         auto plan = JoinPlanSolver(this).solve(joinTree);
-        cardinalityEstimator.clearPerQueryGraphStats();
         return plan.copy();
     }
     planBaseTableScans(info);
@@ -150,7 +148,6 @@ LogicalPlan Planner::planQueryGraph(const QueryGraph& queryGraph,
     if (queryGraph.isEmpty()) {
         appendEmptyResult(bestPlan);
     }
-    cardinalityEstimator.clearPerQueryGraphStats();
     return bestPlan;
 }
 
@@ -190,11 +187,15 @@ void Planner::planBaseTableScans(const QueryGraphPlanningInfo& info) {
         for (auto nodePos = 0u; nodePos < queryGraph->getNumQueryNodes(); ++nodePos) {
             auto queryNode = queryGraph->getQueryNode(nodePos);
             if (info.containsCorrExpr(*queryNode->getInternalID())) {
+                // NodeID will be a join condition with outer plan so very likely we will apply a semi mask
+                // later in the optimization stage. So we can assume the cardinality will not exceed outer
+                // plan cardinality.
+                cardinalityEstimator.rectifyCardinality(*queryNode->getInternalID(), info.corrExprsCard);
                 // In un-nested subquery, e.g. MATCH (a) OPTIONAL MATCH (a)-[e1]->(b), the inner
                 // query ("(a)-[e1]->(b)") needs to scan a, which is already scanned in the outer
                 // query (a). To avoid scanning storage twice, we keep track of node table "a" and
                 // make sure when planning inner query, we only scan internal ID of "a".
-                planNodeIDScan(nodePos, info);
+                planNodeIDScan(nodePos);
             } else {
                 planNodeScan(nodePos);
             }
@@ -251,17 +252,11 @@ void Planner::planNodeScan(uint32_t nodePos) {
     context.addPlan(newSubgraph, std::move(plan));
 }
 
-void Planner::planNodeIDScan(uint32_t nodePos, const QueryGraphPlanningInfo& info) {
+void Planner::planNodeIDScan(uint32_t nodePos) {
     auto node = context.queryGraph->getQueryNode(nodePos);
     auto newSubgraph = context.getEmptySubqueryGraph();
     newSubgraph.addQueryNode(nodePos);
     auto plan = LogicalPlan();
-
-    // NodeID will be a join condition with outer plan so very likely we will apply a semi mask
-    // later in the optimization stage. So we can assume the cardinality will not exceed outer
-    // plan cardinality.
-    cardinalityEstimator.addPerQueryGraphNodeIDDom(*node->getInternalID(), info.corrExprsCard);
-
     appendScanNodeTable(node->getInternalID(), node->getTableIDs(), {}, plan);
     context.addPlan(newSubgraph, std::move(plan));
 }

--- a/src/planner/plan/plan_node_scan.cpp
+++ b/src/planner/plan/plan_node_scan.cpp
@@ -1,4 +1,3 @@
-#include "main/client_context.h"
 #include "planner/planner.h"
 
 using namespace kuzu::binder;
@@ -12,9 +11,6 @@ LogicalPlan Planner::getNodePropertyScanPlan(const NodeExpression& node) {
     if (properties.empty()) {
         return scanPlan;
     }
-    // Because the node is not
-    cardinalityEstimator.addNodeIDDomAndStats(clientContext->getTransaction(),
-        *node.getInternalID(), node.getTableIDs());
     appendScanNodeTable(node.getInternalID(), node.getTableIDs(), properties, scanPlan);
     return scanPlan;
 }

--- a/src/planner/plan/plan_node_semi_mask.cpp
+++ b/src/planner/plan/plan_node_semi_mask.cpp
@@ -1,7 +1,6 @@
 #include "binder/expression/expression_util.h"
 #include "binder/expression/property_expression.h"
 #include "binder/expression_visitor.h"
-#include "main/client_context.h"
 #include "planner/operator/logical_dummy_sink.h"
 #include "planner/operator/sip/logical_semi_masker.h"
 #include "planner/planner.h"
@@ -37,8 +36,6 @@ LogicalPlan Planner::getNodeSemiMaskPlan(SemiMaskTargetType targetType, const No
         auto& propExpr = expr->constCast<PropertyExpression>();
         propertyExprCollection.addProperties(propExpr.getVariableName(), expr);
     }
-    cardinalityEstimator.addNodeIDDomAndStats(clientContext->getTransaction(),
-        *node.getInternalID(), node.getTableIDs());
     appendScanNodeTable(node.getInternalID(), node.getTableIDs(), getProperties(node), plan);
     appendFilter(nodePredicate, plan);
     exitPropertyExprCollection(std::move(prevCollection));

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -53,70 +53,67 @@ void PropertyExprCollection::clear() {
     patternNameToProperties.clear();
 }
 
-Planner::Planner(main::ClientContext* clientContext) : clientContext{clientContext} {
-    cardinalityEstimator = CardinalityEstimator(clientContext);
-    context = JoinOrderEnumeratorContext();
-}
+Planner::Planner(main::ClientContext* clientContext) : clientContext{clientContext}, cardinalityEstimator{clientContext}, context{} {}
 
 LogicalPlan Planner::planStatement(const BoundStatement& statement) {
     switch (statement.getStatementType()) {
     case StatementType::QUERY: {
         return planQuery(statement);
-    } break;
+    }
     case StatementType::CREATE_TABLE: {
         return planCreateTable(statement);
-    } break;
+    }
     case StatementType::CREATE_SEQUENCE: {
         return planCreateSequence(statement);
-    } break;
+    }
     case StatementType::CREATE_TYPE: {
         return planCreateType(statement);
-    } break;
+    }
     case StatementType::COPY_FROM: {
         return planCopyFrom(statement);
-    } break;
+    }
     case StatementType::COPY_TO: {
         return planCopyTo(statement);
-    } break;
+    }
     case StatementType::DROP: {
         return planDrop(statement);
-    } break;
+    }
     case StatementType::ALTER: {
         return planAlter(statement);
-    } break;
+    }
     case StatementType::STANDALONE_CALL: {
         return planStandaloneCall(statement);
-    } break;
+    }
     case StatementType::STANDALONE_CALL_FUNCTION: {
         return planStandaloneCallFunction(statement);
-    } break;
+    }
     case StatementType::EXPLAIN: {
         return planExplain(statement);
-    } break;
+    }
     case StatementType::CREATE_MACRO: {
         return planCreateMacro(statement);
-    } break;
+    }
     case StatementType::TRANSACTION: {
         return planTransaction(statement);
-    } break;
+    }
     case StatementType::EXTENSION: {
         return planExtension(statement);
-    } break;
+    }
     case StatementType::EXPORT_DATABASE: {
         return planExportDatabase(statement);
-    } break;
+    }
     case StatementType::IMPORT_DATABASE: {
         return planImportDatabase(statement);
-    } break;
+    }
     case StatementType::ATTACH_DATABASE: {
         return planAttachDatabase(statement);
-    } break;
+    }
     case StatementType::DETACH_DATABASE: {
         return planDetachDatabase(statement);
-    } break;
+    }
     case StatementType::USE_DATABASE: {
         return planUseDatabase(statement);
-    } break;
+    }
     default:
         KU_UNREACHABLE;
     }

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -53,7 +53,8 @@ void PropertyExprCollection::clear() {
     patternNameToProperties.clear();
 }
 
-Planner::Planner(main::ClientContext* clientContext) : clientContext{clientContext}, cardinalityEstimator{clientContext}, context{} {}
+Planner::Planner(main::ClientContext* clientContext)
+    : clientContext{clientContext}, cardinalityEstimator{clientContext}, context{} {}
 
 LogicalPlan Planner::planStatement(const BoundStatement& statement) {
     switch (statement.getStatementType()) {


### PR DESCRIPTION
# Description

This PR removes `addNodeIDDomAndStats` that is being called inside `appendXXOperator`. It's better the enforce the assumption that the cardinality of base should be ready before join order enumeration. Otherwise, we might end up repeatedly calculate cardinality if `appendXXOperator` is called multiple times. 

Also, we remove `perQueryGraphNodeIDName2dom`. For subquery, we can directly modify based table cardinality with outer cardinality.
