### PR TITLE
Optimize stem function with static stemmer

### DIFF
--- a/extension/extension_config.cmake
+++ b/extension/extension_config.cmake
@@ -1,7 +1,7 @@
 #add_static_link_extension(azure)
 #add_static_link_extension(delta)
 #add_static_link_extension(duckdb)
-add_static_link_extension(fts)
+#add_static_link_extension(fts)
 #add_static_link_extension(httpfs)
 #add_static_link_extension(iceberg)
 #add_static_link_extension(json)

--- a/extension/extension_config.cmake
+++ b/extension/extension_config.cmake
@@ -1,7 +1,7 @@
 #add_static_link_extension(azure)
 #add_static_link_extension(delta)
 #add_static_link_extension(duckdb)
-#add_static_link_extension(fts)
+add_static_link_extension(fts)
 #add_static_link_extension(httpfs)
 #add_static_link_extension(iceberg)
 #add_static_link_extension(json)

--- a/extension/fts/src/function/stem.cpp
+++ b/extension/fts/src/function/stem.cpp
@@ -91,13 +91,12 @@ void StemStaticStemmer::operation(common::ku_string_t& word, common::ku_string_t
     common::ku_string_t& result, common::ValueVector& /*leftValueVector*/,
     common::ValueVector& /*rightValueVector*/, common::ValueVector& resultVector, void* dataPtr) {
     auto stemBindData = reinterpret_cast<StemBindData*>(dataPtr);
-    auto stemData = sb_stemmer_stem(stemBindData->sbStemmer,
-        reinterpret_cast<const sb_symbol*>(word.getData()), word.len);
     if (stemBindData->sbStemmer == nullptr) {
         common::StringVector::addString(&resultVector, result,
-            reinterpret_cast<const char*>(word.getData()),
-            sb_stemmer_length(stemBindData->sbStemmer));
+            reinterpret_cast<const char*>(word.getData()), word.len);
     } else {
+        auto stemData = sb_stemmer_stem(stemBindData->sbStemmer,
+            reinterpret_cast<const sb_symbol*>(word.getData()), word.len);
         common::StringVector::addString(&resultVector, result,
             reinterpret_cast<const char*>(stemData), sb_stemmer_length(stemBindData->sbStemmer));
     }

--- a/extension/fts/test/test_files/stem.test
+++ b/extension/fts/test/test_files/stem.test
@@ -26,3 +26,8 @@ Runtime exception: Unrecognized stemmer 'wrong'. Supported stemmers are: ['arabi
 -STATEMENT RETURN STEM('kitaplar', 'turkish')
 ---- 1
 kitap
+-STATEMENT UNWIND ['alice', 'bob', 'carol'] as t RETURN STEM(t, 'porter')
+---- 3
+alic
+bob
+carol


### PR DESCRIPTION
This PR improves the performance of the `stem` function by introducing a special code path for static stemmers.
In the specialized code path, we don't have to compile the stemmer in each function call.
Performance improvement is around 15% on ms_passage dataset:
Query:
```
match (d:doc) return stem(d.content, 'english');
```
With 10threads, the improvement is:
master: 5.361s
this branch: 4.631s
