### PR TITLE
Move OnDiskGraph and TableEntry out of HNSWIndex

### DIFF
--- a/extension/vector/src/function/create_hnsw_index.cpp
+++ b/extension/vector/src/function/create_hnsw_index.cpp
@@ -27,8 +27,8 @@ namespace vector_extension {
 CreateInMemHNSWSharedState::CreateInMemHNSWSharedState(const CreateHNSWIndexBindData& bindData)
     : SimpleTableFuncSharedState{bindData.numRows}, name{bindData.indexName},
       nodeTable{bindData.context->getStorageManager()
-              ->getTable(bindData.tableEntry->getTableID())
-              ->cast<storage::NodeTable>()},
+                    ->getTable(bindData.tableEntry->getTableID())
+                    ->cast<storage::NodeTable>()},
       numNodes{bindData.numRows}, bindData{&bindData} {
     storage::IndexInfo dummyIndexInfo{"", "", bindData.tableEntry->getTableID(),
         {bindData.tableEntry->getColumnID(bindData.propertyID)}, {PhysicalTypeID::ARRAY}, false,

--- a/extension/vector/src/function/create_hnsw_index.cpp
+++ b/extension/vector/src/function/create_hnsw_index.cpp
@@ -27,8 +27,8 @@ namespace vector_extension {
 CreateInMemHNSWSharedState::CreateInMemHNSWSharedState(const CreateHNSWIndexBindData& bindData)
     : SimpleTableFuncSharedState{bindData.numRows}, name{bindData.indexName},
       nodeTable{bindData.context->getStorageManager()
-                    ->getTable(bindData.tableEntry->getTableID())
-                    ->cast<storage::NodeTable>()},
+              ->getTable(bindData.tableEntry->getTableID())
+              ->cast<storage::NodeTable>()},
       numNodes{bindData.numRows}, bindData{&bindData} {
     storage::IndexInfo dummyIndexInfo{"", "", bindData.tableEntry->getTableID(),
         {bindData.tableEntry->getColumnID(bindData.propertyID)}, {PhysicalTypeID::ARRAY}, false,
@@ -266,20 +266,20 @@ static void finalizeHNSWTableFinalizeFunc(const ExecutionContext* context,
         bindData->tableEntry->getTableID(), bindData->indexName, std::vector{bindData->propertyID},
         std::move(auxInfo));
     catalog->createIndex(transaction, std::move(indexEntry));
-    auto nodeTable =
-        clientContext->getStorageManager()->getTable(nodeTableID)->ptrCast<storage::NodeTable>();
     auto columnID = bindData->tableEntry->getColumnID(bindData->propertyID);
-    auto hnswIndexType = OnDiskHNSWIndex::getIndexType();
+    const auto hnswIndexType = OnDiskHNSWIndex::getIndexType();
     storage::IndexInfo indexInfo{bindData->indexName, hnswIndexType.typeName, nodeTableID,
         {columnID}, {PhysicalTypeID::ARRAY},
         hnswIndexType.constraintType == storage::IndexConstraintType::PRIMARY,
         hnswIndexType.definitionType == storage::IndexDefinitionType::BUILTIN};
-    auto storageInfo = std::make_unique<HNSWStorageInfo>(upperTable->getTableID(),
-        lowerTable->getTableID(), index->getUpperEntryPoint(), index->getLowerEntryPoint());
+    auto storageInfo = std::make_unique<HNSWStorageInfo>(
+        upperTable->cast<catalog::RelGroupCatalogEntry>().getSingleRelEntryInfo().oid,
+        lowerTable->cast<catalog::RelGroupCatalogEntry>().getSingleRelEntryInfo().oid,
+        index->getUpperEntryPoint(), index->getLowerEntryPoint());
     auto onDiskIndex = std::make_unique<OnDiskHNSWIndex>(context->clientContext, indexInfo,
-        std::move(storageInfo), bindData->tableEntry->ptrCast<catalog::NodeTableCatalogEntry>(),
-        upperTable->ptrCast<catalog::RelGroupCatalogEntry>(),
-        lowerTable->ptrCast<catalog::RelGroupCatalogEntry>(), bindData->config.copy());
+        std::move(storageInfo), bindData->config.copy());
+    auto nodeTable =
+        clientContext->getStorageManager()->getTable(nodeTableID)->ptrCast<storage::NodeTable>();
     nodeTable->addIndex(std::move(onDiskIndex));
 }
 

--- a/extension/vector/src/include/index/hnsw_index.h
+++ b/extension/vector/src/include/index/hnsw_index.h
@@ -218,6 +218,8 @@ struct HNSWSearchState {
     QueryHNSWConfig config;
     uint64_t ef;
     common::SemiMask* semiMask;
+    catalog::TableCatalogEntry* upperRelTableEntry;
+    catalog::TableCatalogEntry* lowerRelTableEntry;
     std::unique_ptr<graph::OnDiskGraph> upperGraph;
     std::unique_ptr<graph::OnDiskGraph> lowerGraph;
 
@@ -240,10 +242,7 @@ struct HNSWSearchState {
 class OnDiskHNSWIndex final : public HNSWIndex {
 public:
     OnDiskHNSWIndex(main::ClientContext* context, storage::IndexInfo indexInfo,
-        std::unique_ptr<storage::IndexStorageInfo> storageInfo,
-        catalog::NodeTableCatalogEntry* nodeTableEntry,
-        catalog::RelGroupCatalogEntry* upperRelTableEntry,
-        catalog::RelGroupCatalogEntry* lowerRelTableEntry, HNSWIndexConfig config);
+        std::unique_ptr<storage::IndexStorageInfo> storageInfo, HNSWIndexConfig config);
 
     std::vector<NodeWithDistance> search(transaction::Transaction* transaction,
         const void* queryVector, HNSWSearchState& searchState) const;
@@ -318,11 +317,6 @@ private:
     static constexpr uint64_t FILTERED_SEARCH_INITIAL_CANDIDATES = 10;
 
     storage::NodeTable& nodeTable;
-    catalog::RelGroupCatalogEntry* upperRelTableEntry;
-    catalog::RelGroupCatalogEntry* lowerRelTableEntry;
-
-    // std::unique_ptr<graph::OnDiskGraph> upperGraph;
-    // std::unique_ptr<graph::OnDiskGraph> lowerGraph;
     storage::RelTable* upperRelTable;
     storage::RelTable* lowerRelTable;
     std::unique_ptr<OnDiskEmbeddings> embeddings;


### PR DESCRIPTION
# Description

`OnDiskGraph` and `TableEntry` should not be part of the `HNSWIndex`, as the index now should be oblivious to transactions.