### PR TITLE
Fix pk rollback rolling back keys which failed to insert

### DIFF
--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -106,6 +106,8 @@ public:
     // For deletions, we don't check if the deleted keys exist or not. Thus, we don't need to check
     // in the persistent storage and directly delete keys in the local storage.
     void deleteInternal(Key key) const { localStorage->deleteKey(key); }
+    // Discards from local storage, but will not insert a deletion (used for rollbacks)
+    bool discardLocal(Key key) const { return localStorage->discard(key); }
 
     // For insertions, we first check in the local storage. There are three cases:
     // - the key is found in the local storage, return false;
@@ -437,6 +439,13 @@ public:
     inline void delete_(T key) {
         KU_ASSERT(indexInfo.keyDataTypes[0] == common::TypeUtils::getPhysicalTypeIDForType<T>());
         return getTypedHashIndex(key)->deleteInternal(key);
+    }
+
+    bool discardLocal(common::ku_string_t key) { return discardLocal(key.getAsStringView()); }
+    template<common::IndexHashable T>
+    inline bool discardLocal(T key) {
+        KU_ASSERT(indexInfo.keyDataTypes[0] == common::TypeUtils::getPhysicalTypeIDForType<T>());
+        return getTypedHashIndex(key)->discardLocal(key);
     }
 
     void delete_(common::ValueVector* keyVector);

--- a/src/include/storage/local_storage/local_hash_index.h
+++ b/src/include/storage/local_storage/local_hash_index.h
@@ -45,6 +45,8 @@ public:
         }
     }
 
+    bool discard(Key key) { return localInsertions.deleteKey(key); }
+
     bool insert(Key key, common::offset_t value, visible_func isVisible) {
         auto iter = localDeletions.find(key);
         if (iter != localDeletions.end()) {

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -167,7 +167,9 @@ bool RollbackPKDeleter::processScanOutput(Transaction* transaction, MemoryManage
             static constexpr auto isVisible = [](offset_t) { return true; };
             if (offset_t lookupOffset = 0;
                 pkIndex.lookup(transaction, key, lookupOffset, isVisible)) {
-                pkIndex.delete_(key);
+                // If we delete the key then it will not be visible to future transactions within
+                // this process
+                pkIndex.discardLocal(key);
             }
         }
     };

--- a/test/test_files/copy/copy_pk_duplicate.test
+++ b/test/test_files/copy/copy_pk_duplicate.test
@@ -1,0 +1,29 @@
+-DATASET CSV empty
+
+--
+
+-CASE CopyInt64PK
+-STATEMENT create node table person (ID INT64, fName STRING, age INT64, PRIMARY KEY (ID));
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/primary-key-tests/vPerson.csv";
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/primary-key-tests/vPerson.csv";
+---- error(regex)
+Copy exception: Found duplicated primary key value [0-9]+, which violates the uniqueness constraint of the primary key column.
+-STATEMENT MATCH (p:person) return p.*;
+---- 2
+100|Foo|10
+101|Bar|11
+
+-CASE CopyStringPK
+-STATEMENT create node table person (ID STRING, fName STRING, age INT64, PRIMARY KEY (ID));
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/primary-key-tests/vPerson.csv";
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/primary-key-tests/vPerson.csv";
+---- error(regex)
+Copy exception: Found duplicated primary key value [0-9]+, which violates the uniqueness constraint of the primary key column.
+-STATEMENT MATCH (p:person) return p.*;
+---- 2
+100|Foo|10
+101|Bar|11


### PR DESCRIPTION
Since 0.7.1, when inserting nodes fails, we attempt to delete the inserted values from the PKIndex (so that re-inserting those values in a later commit doesn't fail). This had the unfortunate side effect of temporarily removing keys which failed to insert due to them already existing (since we aren't persisting deletions, the issue can be worked around by re-loading the database).

This fixes the issue by discarding the keys from the primary key index's uncommitted local storage, instead of also adding a deletion to the local storage which would hide any value in the persistent hash index.