### PR TITLE
AggregateHashTable memory tuning

### DIFF
--- a/src/include/processor/result/base_hash_table.h
+++ b/src/include/processor/result/base_hash_table.h
@@ -38,7 +38,7 @@ public:
 protected:
     static constexpr uint64_t HASH_BLOCK_SIZE = common::TEMP_PAGE_SIZE;
 
-    uint64_t getSlotIdxForHash(common::hash_t hash) const { return hash & bitmask; }
+    uint64_t getSlotIdxForHash(common::hash_t hash) const { return hash % maxNumHashSlots; }
     void setMaxNumHashSlots(uint64_t newSize);
 
     void computeVectorHashes(const std::vector<common::ValueVector*>& flatKeyVectors) {
@@ -60,7 +60,6 @@ private:
 
 protected:
     uint64_t maxNumHashSlots;
-    uint64_t bitmask;
     uint64_t numSlotsPerBlockLog2;
     uint64_t slotIdxInBlockMask;
     std::vector<std::unique_ptr<DataBlock>> hashSlotsBlocks;

--- a/src/processor/operator/aggregate/aggregate_hash_table.cpp
+++ b/src/processor/operator/aggregate/aggregate_hash_table.cpp
@@ -460,7 +460,7 @@ uint8_t* AggregateHashTable::createEntryInDistinctHT(
 }
 
 void AggregateHashTable::increaseSlotIdx(uint64_t& slotIdx) const {
-    slotIdx = (slotIdx + 1) & bitmask;
+    slotIdx = (slotIdx + 1) % maxNumHashSlots;
 }
 
 void AggregateHashTable::initTmpHashSlotsAndIdxes(const FactorizedTable& sourceTable,
@@ -658,8 +658,8 @@ void AggregateHashTable::resizeHashTableIfNecessary(uint32_t maxNumDistinctHashK
     if (factorizedTable->getNumTuples() + maxNumDistinctHashKeys > maxNumHashSlots ||
         static_cast<double>(factorizedTable->getNumTuples()) + maxNumDistinctHashKeys >
             static_cast<double>(maxNumHashSlots) / DEFAULT_HT_LOAD_FACTOR) {
-        resize(std::bit_ceil(static_cast<uint64_t>(
-            (factorizedTable->getNumTuples() + maxNumDistinctHashKeys) * DEFAULT_HT_LOAD_FACTOR)));
+        resize(std::max(factorizedTable->getNumTuples() + maxNumDistinctHashKeys, maxNumHashSlots) *
+               DEFAULT_HT_LOAD_FACTOR);
     }
 }
 

--- a/src/processor/result/base_hash_table.cpp
+++ b/src/processor/result/base_hash_table.cpp
@@ -18,7 +18,7 @@ namespace kuzu {
 namespace processor {
 
 BaseHashTable::BaseHashTable(storage::MemoryManager& memoryManager, logical_type_vec_t keyTypes)
-    : maxNumHashSlots{0}, bitmask{0}, numSlotsPerBlockLog2{0}, slotIdxInBlockMask{0},
+    : maxNumHashSlots{0}, numSlotsPerBlockLog2{0}, slotIdxInBlockMask{0},
       memoryManager{&memoryManager}, keyTypes{std::move(keyTypes)} {
     initCompareFuncs();
     initTmpHashVector();
@@ -26,7 +26,6 @@ BaseHashTable::BaseHashTable(storage::MemoryManager& memoryManager, logical_type
 
 void BaseHashTable::setMaxNumHashSlots(uint64_t newSize) {
     maxNumHashSlots = newSize;
-    bitmask = maxNumHashSlots - 1;
 }
 
 void BaseHashTable::computeVectorHashes(std::span<const ValueVector*> keyVectors) {


### PR DESCRIPTION
1. Remove the space reservation during finalization so that the size of the hash table just grows as data is moved from the queue and destroyed (should reduce peak memory at this point by a little).
2. Resize the AggregateHashTable by a factor of 1.5 instead of a factor of 2 (we can end up with a large amount of free slots wasting space. This changes the load (after the first resize) from 33-66% to 44-66%).

This doesn't have a particularly large impact on memory usage, but also doesn't hurt performance much.

Creating an fts index for the first segment of the msmarco 2.1 segmented dataset (from [here](https://trec-rag.github.io/annoucements/2024-corpus-finalization/)) required at least 18GB buffer pool before and succeeded with a 17GB buffer pool with these changes (the results were a little inconsistent; a few times I was able to get it to succeed with a 15-16GB buffer pool even without these changes).