### PR TITLE
Fix malloc-based BM bug causing reads after memory has been freed

### DIFF
--- a/src/include/storage/buffer_manager/buffer_manager.h
+++ b/src/include/storage/buffer_manager/buffer_manager.h
@@ -21,6 +21,7 @@ class VirtualFileSystem;
 };
 namespace testing {
 class FlakyBufferManager;
+class BufferManagerTest;
 class CopyTestHelper;
 }; // namespace testing
 namespace storage {
@@ -185,6 +186,7 @@ private:
  */
 class BufferManager {
     friend class testing::FlakyBufferManager;
+    friend class testing::BufferManagerTest;
     friend class testing::CopyTestHelper;
 
     friend class FileHandle;


### PR DESCRIPTION
It was previously possible for an optimistic read to still be reading when the page is evicted and freed.
It was already unlikely since new reads would clear the marked state and delay eviction, but was still possible if the page being read is marked and then evicted in the second pass before the read finishes. malloc also usually doesn't immediately return memory to the OS so the read after free would rarely be a fatal error. Now a counter tracks the number of ongoing optimistic reads for the page and we skip evicting if the counter is nonzero.
Once the page state is locked, new reads are blocked, so there is no data race when evicting.

Doesn't seem to have a noticeable performance impact (I tried benchmarking some scans and a multi copy and there was no noticeable difference in runtime).