### PR TITLE
Correctly calculate the number of tuples in a CSR node group after checkpoint

### DIFF
--- a/src/include/storage/table/node_group_collection.h
+++ b/src/include/storage/table/node_group_collection.h
@@ -110,7 +110,7 @@ private:
 
     bool enableCompression;
     // Num rows in the collection regardless of deletions.
-    common::row_idx_t numTotalRows;
+    std::atomic<common::row_idx_t> numTotalRows;
     std::vector<common::LogicalType> types;
     GroupCollection<NodeGroup> nodeGroups;
     FileHandle* dataFH;

--- a/src/storage/table/csr_node_group.cpp
+++ b/src/storage/table/csr_node_group.cpp
@@ -529,7 +529,7 @@ void CSRNodeGroup::checkpointInMemAndOnDisk(const UniqLock& lock, NodeGroupCheck
 
     uint64_t numTuplesAfterCheckpoint = 0;
     for (const auto& region : regionsToCheckpoint) {
-        for (auto i = region.leftNodeOffset; i < region.rightNodeOffset; ++i) {
+        for (auto i = region.leftNodeOffset; i <= region.rightNodeOffset; ++i) {
             numTuplesAfterCheckpoint += csrState.newHeader->getCSRLength(i);
         }
     }

--- a/test/test_files/dml_rel/delete/delete_ldbc_sf01.test
+++ b/test/test_files/dml_rel/delete/delete_ldbc_sf01.test
@@ -6,6 +6,11 @@
 -STATEMENT MATCH (n:Person)-[e:likes_Comment]->(m:Comment) WHERE n.id=6597069767457 RETURN COUNT(*);
 ---- 1
 66
+# Sanity check to see if the rel batch insert succeeded
+-STATEMENT MATCH (n:Person)-[e:likes_Comment]->(m:Comment)
+            WHERE n.id=6597069767457 AND NOT EXISTS {MATCH (n1:Person)-[e1:likes_Comment]->(m1:Comment) WHERE n.id=6597069767457 and m1.id = m.id}
+            RETURN n.id, m.id
+---- 0
 -STATEMENT MATCH (n:Person)-[e:likes_Comment]->(m:Comment) WHERE n.id=6597069767457 AND m.id=412317167195 DELETE e;
 ---- ok
 -STATEMENT MATCH (n:Person)-[e:likes_Comment]->(m:Comment) WHERE n.id=6597069767457 RETURN COUNT(*);


### PR DESCRIPTION
# Description

Fixes https://github.com/kuzudb/kuzu/issues/5513

The loop used to calculate the number of tuples to checkpoint wasn't including the upper bound of a region's CSR offset. This was sometimes causing node groups to be incorrectly detected as all deleted and reclaimed.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).