### PR TITLE
Reenable some BM exception handling tests

### DIFF
--- a/src/include/common/finally_wrapper.h
+++ b/src/include/common/finally_wrapper.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <concepts>
+
+namespace kuzu::common {
+// RAII wrapper that calls an enclosed function when this class goes out of scope
+// Should be used for any cleanup code that must be executed even if exceptions occur
+template<std::invocable Func>
+struct FinallyWrapper {
+    explicit FinallyWrapper(Func&& func) : func(func) {}
+    ~FinallyWrapper() { func(); }
+    Func func;
+};
+} // namespace kuzu::common

--- a/src/storage/file_handle.cpp
+++ b/src/storage/file_handle.cpp
@@ -58,12 +58,12 @@ page_idx_t FileHandle::addNewPage() {
 }
 
 page_idx_t FileHandle::addNewPages(page_idx_t numNewPages) {
-    while (!fhSharedMutex.try_lock()) {}
+    std::unique_lock lck{fhSharedMutex, std::defer_lock_t{}};
+    while (!lck.try_lock()) {}
     const auto numPagesBeforeChange = numPages;
     for (auto i = 0u; i < numNewPages; i++) {
         addNewPageWithoutLock();
     }
-    fhSharedMutex.unlock();
     return numPagesBeforeChange;
 }
 

--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -344,11 +344,6 @@ TEST_F(CopyTest, GracefulBMExceptionHandlingManyThreads) {
     GTEST_SKIP();
 #endif
 #endif
-
-    // TODO(Royi) Figure why this test sometimes fails for in mem mode
-    if (inMemMode) {
-        GTEST_SKIP();
-    }
     systemConfig->maxNumThreads = 32;
     resetDB(TestHelper::DEFAULT_BUFFER_POOL_SIZE_FOR_TESTING);
 
@@ -384,9 +379,9 @@ TEST_F(CopyTest, OutOfMemoryRecovery) {
             "COPY follows FROM '{}/dataset/snap/twitter/csv/twitter-edges.csv' (DELIM=' ')",
             KUZU_ROOT_DIRECTORY));
         ASSERT_FALSE(result->isSuccess());
-        ASSERT_EQ(result->getErrorMessage(),
-            "Buffer manager exception: Unable to allocate memory! The buffer pool is full and no "
-            "memory could be freed!");
+        ASSERT_EQ(result->getErrorMessage(), "Buffer manager exception: Unable to allocate "
+                                             "memory! The buffer pool is full and no "
+                                             "memory could be freed!");
     }
     // Try opening then closing the database
     resetDB(256 * 1024 * 1024 + TestHelper::HASH_INDEX_MEM);
@@ -423,9 +418,9 @@ TEST_F(CopyTest, OutOfMemoryRecoveryDropTable) {
             "COPY follows FROM '{}/dataset/snap/twitter/csv/twitter-edges.csv' (DELIM=' ')",
             KUZU_ROOT_DIRECTORY));
         ASSERT_FALSE(result->isSuccess());
-        ASSERT_EQ(result->getErrorMessage(),
-            "Buffer manager exception: Unable to allocate memory! The buffer pool is full and no "
-            "memory could be freed!");
+        ASSERT_EQ(result->getErrorMessage(), "Buffer manager exception: Unable to allocate "
+                                             "memory! The buffer pool is full and no "
+                                             "memory could be freed!");
     }
     // Try dropping the table before trying again with a larger buffer pool size
     resetDB(256 * 1024 * 1024 + TestHelper::HASH_INDEX_MEM);


### PR DESCRIPTION
# Description

Fixes the reason why `GracefulBMExceptionHandlingManyThreads` was sometimes failing in in-memory mode. There were a few issues:

1. In `FileHandle::addNewPages` it is possible for `addNewPageWithoutLock` to throw a BM exception if we are in in-mem mode (since we pin a page). In that case previously we would never unlock the lock.
2. We slice out the columns containing data for populating errors in node batch insert. However the slice wasn't restored to the original chunked group if a BM exception was thrown which could cause other threads to read invalid data before they detect that an exception is thrown.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).