### PR TITLE
Fix hashing of struct vectors which are children of a list vector

### DIFF
--- a/src/include/function/hash/vector_hash_functions.h
+++ b/src/include/function/hash/vector_hash_functions.h
@@ -9,26 +9,26 @@ namespace function {
 struct UnaryHashFunctionExecutor {
     template<typename OPERAND_TYPE, typename RESULT_TYPE>
     static void execute(const common::ValueVector& operand,
-        const common::SelectionVector& operandSelectVec, common::ValueVector& result,
-        const common::SelectionVector& resultSelectVec);
+        const common::SelectionView& operandSelectVec, common::ValueVector& result,
+        const common::SelectionView& resultSelectVec);
 };
 
 struct BinaryHashFunctionExecutor {
     template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC>
-    static void execute(const common::ValueVector& left, const common::SelectionVector& leftSelVec,
-        const common::ValueVector& right, const common::SelectionVector& rightSelVec,
-        common::ValueVector& result, const common::SelectionVector& resultSelVec);
+    static void execute(const common::ValueVector& left, const common::SelectionView& leftSelVec,
+        const common::ValueVector& right, const common::SelectionView& rightSelVec,
+        common::ValueVector& result, const common::SelectionView& resultSelVec);
 };
 
 struct VectorHashFunction {
     static void computeHash(const common::ValueVector& operand,
-        const common::SelectionVector& operandSelectVec, common::ValueVector& result,
-        const common::SelectionVector& resultSelectVec);
+        const common::SelectionView& operandSelectVec, common::ValueVector& result,
+        const common::SelectionView& resultSelectVec);
 
     static void combineHash(const common::ValueVector& left,
-        const common::SelectionVector& leftSelVec, const common::ValueVector& right,
-        const common::SelectionVector& rightSelVec, common::ValueVector& result,
-        const common::SelectionVector& resultSelVec);
+        const common::SelectionView& leftSelVec, const common::ValueVector& right,
+        const common::SelectionView& rightSelVec, common::ValueVector& result,
+        const common::SelectionView& resultSelVec);
 };
 
 struct MD5Function {


### PR DESCRIPTION
The result vector might have larger than the default capacity in this case, meaning that the result selection vector may point to indices larger than what is allocated for the temp vector

I've also changed the `const SelectionVector&` parameters in these files to be `const SelectionView&` so that we can pass a SelectionView (did all of them at once for convenience).