### PR TITLE
Fix serializing FSM

### DIFF
--- a/src/common/serializer/metadata_writer.cpp
+++ b/src/common/serializer/metadata_writer.cpp
@@ -42,7 +42,7 @@ void MetaWriter::flush(storage::PageRange allocatedPageRange, storage::FileHandl
     storage::ShadowFile& shadowFile) const {
     KU_ASSERT(allocatedPageRange.numPages >= getNumPagesToFlush());
     auto numPagesBeforeAllocate = allocatedPageRange.startPageIdx;
-    for (auto i = 0u; i < allocatedPageRange.numPages; i++) {
+    for (auto i = 0u; i < getNumPagesToFlush(); i++) {
         auto pageIdx = allocatedPageRange.startPageIdx + i;
         auto insertingNewPage = pageIdx >= numPagesBeforeAllocate;
         auto shadowPageAndFrame = storage::ShadowUtils::createShadowVersionIfNecessaryAndPinPage(

--- a/src/include/common/serializer/metadata_writer.h
+++ b/src/include/common/serializer/metadata_writer.h
@@ -26,6 +26,12 @@ public:
 
     storage::PageRange flush(storage::FileHandle* fileHandle,
         storage::ShadowFile& shadowFile) const;
+    void flush(storage::PageRange allocatedPages, storage::FileHandle* fileHandle,
+        storage::ShadowFile& shadowFile) const;
+
+    page_idx_t getNumPagesToFlush() const { return pages.size(); }
+
+    static uint64_t getPageSize();
 
 private:
     bool needNewBuffer(uint64_t size) const;

--- a/src/include/storage/free_space_manager.h
+++ b/src/include/storage/free_space_manager.h
@@ -31,6 +31,7 @@ public:
     void addUncheckpointedFreePages(PageRange entry);
     void rollbackCheckpoint();
 
+    common::page_idx_t estimateNumPagesNeededForSerialize() const;
     void serialize(common::Serializer& serializer) const;
     void deserialize(common::Deserializer& deSer);
     void finalizeCheckpoint(FileHandle* fileHandle);
@@ -45,6 +46,10 @@ private:
     void handleLastPageRange(PageRange pageRange, FileHandle* fileHandle);
     void resetFreeLists();
     static common::idx_t getLevel(common::page_idx_t numPages);
+
+    template<typename ValueProcessor>
+    void serializeInternal(ValueProcessor& serializer) const;
+    common::page_idx_t estimateNumPagesForSerialization();
 
     std::vector<sorted_free_list_t> freeLists;
     free_list_t uncheckpointedFreePageRanges;

--- a/src/include/storage/free_space_manager.h
+++ b/src/include/storage/free_space_manager.h
@@ -31,7 +31,7 @@ public:
     void addUncheckpointedFreePages(PageRange entry);
     void rollbackCheckpoint();
 
-    common::page_idx_t estimateNumPagesNeededForSerialize() const;
+    common::page_idx_t getMaxNumPagesForSerialization() const;
     void serialize(common::Serializer& serializer) const;
     void deserialize(common::Deserializer& deSer);
     void finalizeCheckpoint(FileHandle* fileHandle);

--- a/src/include/storage/page_manager.h
+++ b/src/include/storage/page_manager.h
@@ -31,6 +31,10 @@ public:
     void freePageRange(PageRange block);
     void freePage(common::page_idx_t pageIdx) { freePageRange(PageRange(pageIdx, 1)); }
 
+    // The page manager must first allocate space for itself so that its serialized version also
+    // tracks the pages allocated itself
+    // Thus this function also allocates and returns the space for the serialized storage maanger
+    common::page_idx_t estimatePagesNeededForSerialize();
     void serialize(common::Serializer& serializer);
     void deserialize(common::Deserializer& deSer);
     void finalizeCheckpoint();

--- a/src/storage/checkpointer.cpp
+++ b/src/storage/checkpointer.cpp
@@ -71,6 +71,10 @@ PageRange Checkpointer::serializeMetadata(const catalog::Catalog& catalog,
     // The number of pages needed for the page manager should only decrease after making an
     // additional allocation so we just calculate the number of pages needed to serialize the
     // current state of the page manager
+    // Thus it is possible that we allocate an extra page that we won't end up writing to when we
+    // flush the metadata writer. This may cause a discrepancy between the number of tracked pages
+    // and the number of physical pages in the file but shouldn't cause any actual incorrect
+    // behaviour in the database
     auto& pageManager = *storageManager.getDataFH()->getPageManager();
     const auto pagesForPageManager = pageManager.estimatePagesNeededForSerialize();
     const auto allocatedPages =

--- a/src/storage/free_space_manager.cpp
+++ b/src/storage/free_space_manager.cpp
@@ -17,7 +17,7 @@ static FreeSpaceManager::sorted_free_list_t& getFreeList(
     return freeLists[level];
 }
 
-FreeSpaceManager::FreeSpaceManager() : freeLists{}, numEntries(0) {};
+FreeSpaceManager::FreeSpaceManager() : freeLists{}, numEntries(0){};
 
 common::idx_t FreeSpaceManager::getLevel(common::page_idx_t numPages) {
     // level is exponent of largest power of 2 that is <= numPages

--- a/src/storage/free_space_manager.cpp
+++ b/src/storage/free_space_manager.cpp
@@ -149,7 +149,7 @@ void FreeSpaceManager::serializeInternal(ValueProcessor& ser) const {
     KU_ASSERT(numCheckpointedEntries + numUncheckpointedEntries == numEntries);
 }
 
-common::page_idx_t FreeSpaceManager::estimateNumPagesNeededForSerialize() const {
+common::page_idx_t FreeSpaceManager::getMaxNumPagesForSerialization() const {
     SerializePagesUsedTracker ser{};
     serializeInternal(ser);
     return ser.numPagesUsed + (ser.numBytesUsedInPage > 0);

--- a/src/storage/page_manager.cpp
+++ b/src/storage/page_manager.cpp
@@ -31,7 +31,7 @@ void PageManager::freePageRange(PageRange entry) {
 }
 
 common::page_idx_t PageManager::estimatePagesNeededForSerialize() {
-    return freeSpaceManager->estimateNumPagesNeededForSerialize();
+    return freeSpaceManager->getMaxNumPagesForSerialization();
 }
 
 void PageManager::serialize(common::Serializer& serializer) {

--- a/src/storage/page_manager.cpp
+++ b/src/storage/page_manager.cpp
@@ -30,6 +30,10 @@ void PageManager::freePageRange(PageRange entry) {
     }
 }
 
+common::page_idx_t PageManager::estimatePagesNeededForSerialize() {
+    return freeSpaceManager->estimateNumPagesNeededForSerialize();
+}
+
 void PageManager::serialize(common::Serializer& serializer) {
     freeSpaceManager->serialize(serializer);
 }

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -8,7 +8,6 @@
 #include "storage/buffer_manager/buffer_manager.h"
 #include "storage/buffer_manager/memory_manager.h"
 #include "storage/checkpointer.h"
-#include "storage/page_manager.h"
 #include "storage/table/node_table.h"
 #include "storage/table/rel_table.h"
 #include "storage/wal/wal_replayer.h"
@@ -247,8 +246,6 @@ void StorageManager::serialize(const Catalog& catalog, Serializer& ser) {
             tables.at(info.oid)->serialize(ser);
         }
     }
-    ser.writeDebuggingInfo("page_manager");
-    dataFH->getPageManager()->serialize(ser);
 }
 
 void StorageManager::deserialize(main::ClientContext* context, const Catalog* catalog,
@@ -295,8 +292,6 @@ void StorageManager::deserialize(main::ClientContext* context, const Catalog* ca
             tables.at(info.oid)->deserialize(context, this, deSer);
         }
     }
-    deSer.validateDebuggingInfo(key, "page_manager");
-    dataFH->getPageManager()->deserialize(deSer);
 }
 
 } // namespace storage

--- a/test/test_files/ddl/ddl.test
+++ b/test/test_files/ddl/ddl.test
@@ -614,3 +614,14 @@ Binder exception: Multiple FROM/TO pairs are not supported for CREATE REL TABLE 
 ---- 2
 Alice|Carol
 Bob|Dan
+
+-CASE DropTablesReloadWithoutForceCheckpoint
+-STATEMENT CALL force_checkpoint_on_close=false;
+---- ok
+-STATEMENT DROP TABLE studyAt
+---- ok
+-STATEMENT DROP TABLE workAt
+---- ok
+-RELOADDB
+-STATEMENT DROP TABLE knows
+---- ok

--- a/test/test_files/function/call/fsm_info.test
+++ b/test/test_files/function/call/fsm_info.test
@@ -53,10 +53,10 @@ True
 # copy for new table should reuse most of the old pages
 -STATEMENT COPY person1 FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv";
 ---- ok
-# allow margin equal to the largest page range for a column chunk in the table
--STATEMENT CALL fsm_info() with sum(num_pages) as num_free_pages
-           call storage_info('person1') with num_free_pages, max(num_pages) as largest_range
-           return num_free_pages is null or largest_range >= num_free_pages
+# since the copy should reuse pages use start_page_idx to see if person1 has older pages than some pages in person
+-STATEMENT call storage_info('person1') with min(start_page_idx) as oldest_newly_allocated_page
+            call storage_info('person') where start_page_idx < 4294967295 with oldest_newly_allocated_page, max(start_page_idx) as newest_old_allocated_page
+           return oldest_newly_allocated_page < newest_old_allocated_page
 ---- 1
 True
 


### PR DESCRIPTION
# Description

We serialized slightly out-of-date data for the FSM because the order of the serializing is:
1. We serialize the FSM
2. We allocate the pages for the serialized FSM (which may alter the FSM)
3. Checkpoint ends (the state of the FSM may be slightly different from the serialized version)

This PR fixes this by allocating the pages for the serialized FSM before the serializing actually happens (the estimate the number of pages for serializing the FSM beforehand).

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).