### PR TITLE
Properly finalize physical operator

### DIFF
--- a/src/include/processor/operator/physical_operator.h
+++ b/src/include/processor/operator/physical_operator.h
@@ -175,8 +175,6 @@ protected:
     physical_op_vector_t children;
     ResultSet* resultSet;
     std::unique_ptr<OPPrintInfo> printInfo;
-
-    bool hasBeenFinalized = false;
 };
 
 } // namespace processor

--- a/src/processor/operator/physical_operator.cpp
+++ b/src/processor/operator/physical_operator.cpp
@@ -205,14 +205,8 @@ bool PhysicalOperator::getNextTuple(ExecutionContext* context) {
 }
 
 void PhysicalOperator::finalize(ExecutionContext* context) {
-    if (hasBeenFinalized) {
-        return;
-    }
-    hasBeenFinalized = true;
     if (!isSource()) {
-        for (auto& child : children) {
-            child->finalize(context);
-        }
+        children[0]->finalize(context);
     }
     finalizeInternal(context);
 }


### PR DESCRIPTION
# Description

We should provide the guarantee that each physical operator is only finalized once, i.e. only finalize on its pipeline.

Fixes #4121