### PR TITLE
Clean up transaction in Column

### DIFF
--- a/src/include/storage/table/column.h
+++ b/src/include/storage/table/column.h
@@ -30,8 +30,6 @@ class Column {
     friend class RelTableData;
 
 public:
-    // TODO(Guodong): Remove transaction from interface of Column. There is no need to be aware
-    // of transaction when reading/writing from/to disk pages.
     Column(std::string name, common::LogicalType dataType, FileHandle* dataFH, MemoryManager* mm,
         ShadowFile* shadowFile, bool enableCompression, bool requireNullColumn = true);
     Column(std::string name, common::PhysicalTypeID physicalType, FileHandle* dataFH,
@@ -48,19 +46,18 @@ public:
         const ColumnChunkData& chunkData, FileHandle& dataFH);
     static ColumnChunkMetadata flushData(const ColumnChunkData& chunkData, FileHandle& dataFH);
 
-    virtual void scan(transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t startOffsetInChunk, common::row_idx_t numValuesToScan,
-        common::ValueVector* resultVector) const;
-    virtual void lookupValue(const transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t nodeOffset, common::ValueVector* resultVector, uint32_t posInVector) const;
+    virtual void scan(const ChunkState& state, common::offset_t startOffsetInChunk,
+        common::row_idx_t numValuesToScan, common::ValueVector* resultVector) const;
+    virtual void lookupValue(const ChunkState& state, common::offset_t nodeOffset,
+        common::ValueVector* resultVector, uint32_t posInVector) const;
 
     // Scan from [startOffsetInGroup, endOffsetInGroup).
-    virtual void scan(const transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
-        common::ValueVector* resultVector, uint64_t offsetInVector) const;
+    virtual void scan(const ChunkState& state, common::offset_t startOffsetInGroup,
+        common::offset_t endOffsetInGroup, common::ValueVector* resultVector,
+        uint64_t offsetInVector) const;
     // Scan from [startOffsetInGroup, endOffsetInGroup).
-    virtual void scan(const transaction::Transaction* transaction, const ChunkState& state,
-        ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
+    virtual void scan(const ChunkState& state, ColumnChunkData* columnChunk,
+        common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET) const;
 
     common::LogicalType& getDataType() { return dataType; }
@@ -70,8 +67,8 @@ public:
 
     std::string getName() const { return name; }
 
-    virtual void scan(const transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup, uint8_t* result);
+    virtual void scan(const ChunkState& state, common::offset_t startOffsetInGroup,
+        common::offset_t endOffsetInGroup, uint8_t* result);
 
     // Batch write to a set of sequential pages.
     virtual void write(ColumnChunkData& persistentChunk, ChunkState& state,
@@ -94,30 +91,22 @@ public:
     }
 
 protected:
-    virtual void scanInternal(transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t startOffsetInChunk, common::row_idx_t numValuesToScan,
-        common::ValueVector* resultVector) const;
+    virtual void scanInternal(const ChunkState& state, common::offset_t startOffsetInChunk,
+        common::row_idx_t numValuesToScan, common::ValueVector* resultVector) const;
 
-    virtual void lookupInternal(const transaction::Transaction* transaction,
-        const ChunkState& state, common::offset_t nodeOffset, common::ValueVector* resultVector,
-        uint32_t posInVector) const;
+    virtual void lookupInternal(const ChunkState& state, common::offset_t nodeOffset,
+        common::ValueVector* resultVector, uint32_t posInVector) const;
 
     void writeValues(ChunkState& state, common::offset_t dstOffset, const uint8_t* data,
         const common::NullMask* nullChunkData, common::offset_t srcOffset = 0,
         common::offset_t numValues = 1) const;
-
-    // Produces a page cursor for the offset relative to the given node group
-    static PageCursor getPageCursorForOffsetInGroup(common::offset_t offsetInChunk,
-        const ChunkState& state);
-    void updatePageWithCursor(PageCursor cursor,
-        const std::function<void(uint8_t*, common::offset_t)>& writeOp) const;
 
     void updateStatistics(ColumnChunkMetadata& metadata, common::offset_t maxIndex,
         const std::optional<StorageValue>& min, const std::optional<StorageValue>& max) const;
 
 protected:
     bool isEndOffsetOutOfPagesCapacity(const ColumnChunkMetadata& metadata,
-        common::offset_t maxOffset) const;
+        common::offset_t endOffset) const;
 
     virtual bool canCheckpointInPlace(const ChunkState& state,
         const ColumnCheckpointState& checkpointState);
@@ -154,30 +143,27 @@ public:
     InternalIDColumn(std::string name, FileHandle* dataFH, MemoryManager* mm,
         ShadowFile* shadowFile, bool enableCompression);
 
-    void scan(transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t startOffsetInChunk, common::row_idx_t numValuesToScan,
-        common::ValueVector* resultVector) const override {
-        Column::scan(transaction, state, startOffsetInChunk, numValuesToScan, resultVector);
+    void scan(const ChunkState& state, common::offset_t startOffsetInChunk,
+        common::row_idx_t numValuesToScan, common::ValueVector* resultVector) const override {
+        Column::scan(state, startOffsetInChunk, numValuesToScan, resultVector);
         populateCommonTableID(resultVector);
     }
 
-    void scan(const transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
-        common::ValueVector* resultVector, uint64_t offsetInVector) const override {
-        Column::scan(transaction, state, startOffsetInGroup, endOffsetInGroup, resultVector,
-            offsetInVector);
+    void scan(const ChunkState& state, common::offset_t startOffsetInGroup,
+        common::offset_t endOffsetInGroup, common::ValueVector* resultVector,
+        uint64_t offsetInVector) const override {
+        Column::scan(state, startOffsetInGroup, endOffsetInGroup, resultVector, offsetInVector);
         populateCommonTableID(resultVector);
     }
 
-    void lookupInternal(const transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t nodeOffset, common::ValueVector* resultVector,
-        uint32_t posInVector) const override {
-        Column::lookupInternal(transaction, state, nodeOffset, resultVector, posInVector);
+    void lookupInternal(const ChunkState& state, common::offset_t nodeOffset,
+        common::ValueVector* resultVector, uint32_t posInVector) const override {
+        Column::lookupInternal(state, nodeOffset, resultVector, posInVector);
         populateCommonTableID(resultVector);
     }
 
     common::table_id_t getCommonTableID() const { return commonTableID; }
-    // TODO(Guodong): This function should be removed through rewritting INTERNAL_ID as STRUCT.
+    // TODO(Guodong): This function should be removed through rewriting INTERNAL_ID as STRUCT.
     void setCommonTableID(common::table_id_t tableID) { commonTableID = tableID; }
 
 private:

--- a/src/include/storage/table/column_reader_writer.h
+++ b/src/include/storage/table/column_reader_writer.h
@@ -46,25 +46,22 @@ public:
 
     virtual ~ColumnReadWriter() = default;
 
-    virtual void readCompressedValueToPage(const transaction::Transaction* transaction,
-        const ChunkState& state, common::offset_t nodeOffset, uint8_t* result,
-        uint32_t offsetInResult, const read_value_from_page_func_t<uint8_t*>& readFunc) = 0;
+    virtual void readCompressedValueToPage(const ChunkState& state, common::offset_t nodeOffset,
+        uint8_t* result, uint32_t offsetInResult,
+        const read_value_from_page_func_t<uint8_t*>& readFunc) = 0;
 
-    virtual void readCompressedValueToVector(const transaction::Transaction* transaction,
-        const ChunkState& state, common::offset_t nodeOffset, common::ValueVector* result,
-        uint32_t offsetInResult,
+    virtual void readCompressedValueToVector(const ChunkState& state, common::offset_t nodeOffset,
+        common::ValueVector* result, uint32_t offsetInResult,
         const read_value_from_page_func_t<common::ValueVector*>& readFunc) = 0;
 
-    virtual uint64_t readCompressedValuesToPage(const transaction::Transaction* transaction,
-        const ChunkState& state, uint8_t* result, uint32_t startOffsetInResult,
-        uint64_t startNodeOffset, uint64_t endNodeOffset,
+    virtual uint64_t readCompressedValuesToPage(const ChunkState& state, uint8_t* result,
+        uint32_t startOffsetInResult, uint64_t startNodeOffset, uint64_t endNodeOffset,
         const read_values_from_page_func_t<uint8_t*>& readFunc,
         const std::optional<filter_func_t>& filterFunc = {}) = 0;
 
-    virtual uint64_t readCompressedValuesToVector(const transaction::Transaction* transaction,
-        const ChunkState& state, common::ValueVector* result, uint32_t startOffsetInResult,
-        uint64_t startNodeOffset, uint64_t endNodeOffset,
-        const read_values_from_page_func_t<common::ValueVector*>& readFunc,
+    virtual uint64_t readCompressedValuesToVector(const ChunkState& state,
+        common::ValueVector* result, uint32_t startOffsetInResult, uint64_t startNodeOffset,
+        uint64_t endNodeOffset, const read_values_from_page_func_t<common::ValueVector*>& readFunc,
         const std::optional<filter_func_t>& filterFunc = {}) = 0;
 
     virtual void writeValueToPageFromVector(ChunkState& state, common::offset_t offsetInChunk,
@@ -75,7 +72,7 @@ public:
         const uint8_t* data, const common::NullMask* nullChunkData, common::offset_t srcOffset,
         common::offset_t numValues, const write_values_func_t& writeFunc) = 0;
 
-    void readFromPage(const transaction::Transaction* transaction, common::page_idx_t pageIdx,
+    void readFromPage(common::page_idx_t pageIdx,
         const std::function<void(uint8_t*)>& readFunc) const;
 
     void updatePageWithCursor(PageCursor cursor,

--- a/src/include/storage/table/dictionary_column.h
+++ b/src/include/storage/table/dictionary_column.h
@@ -11,13 +11,11 @@ public:
     DictionaryColumn(const std::string& name, FileHandle* dataFH, MemoryManager* mm,
         ShadowFile* shadowFile, bool enableCompression);
 
-    void scan(const transaction::Transaction* transaction, const ChunkState& state,
-        DictionaryChunk& dictChunk) const;
+    void scan(const ChunkState& state, DictionaryChunk& dictChunk) const;
     // Offsets to scan should be a sorted list of pairs mapping the index of the entry in the string
     // dictionary (as read from the index column) to the output index in the result vector to store
     // the string.
-    void scan(const transaction::Transaction* transaction, const ChunkState& offsetState,
-        const ChunkState& dataState,
+    void scan(const ChunkState& offsetState, const ChunkState& dataState,
         std::vector<std::pair<DictionaryChunk::string_index_t, uint64_t>>& offsetsToScan,
         common::ValueVector* resultVector, const ColumnChunkMetadata& indexMeta) const;
 
@@ -25,22 +23,20 @@ public:
         std::string_view val);
 
     bool canCommitInPlace(const ChunkState& state, uint64_t numNewStrings,
-        uint64_t totalStringLengthToAdd);
+        uint64_t totalStringLengthToAdd) const;
 
     Column* getDataColumn() const { return dataColumn.get(); }
     Column* getOffsetColumn() const { return offsetColumn.get(); }
 
 private:
-    void scanOffsets(const transaction::Transaction* transaction, const ChunkState& state,
-        DictionaryChunk::string_offset_t* offsets, uint64_t index, uint64_t numValues,
-        uint64_t dataSize) const;
-    void scanValueToVector(const transaction::Transaction* transaction, const ChunkState& dataState,
-        uint64_t startOffset, uint64_t endOffset, common::ValueVector* resultVector,
-        uint64_t offsetInVector) const;
+    void scanOffsets(const ChunkState& state, DictionaryChunk::string_offset_t* offsets,
+        uint64_t index, uint64_t numValues, uint64_t dataSize) const;
+    void scanValueToVector(const ChunkState& dataState, uint64_t startOffset, uint64_t endOffset,
+        common::ValueVector* resultVector, uint64_t offsetInVector) const;
 
-    bool canDataCommitInPlace(const ChunkState& dataState, uint64_t totalStringLengthToAdd);
+    static bool canDataCommitInPlace(const ChunkState& dataState, uint64_t totalStringLengthToAdd);
     bool canOffsetCommitInPlace(const ChunkState& offsetState, const ChunkState& dataState,
-        uint64_t numNewStrings, uint64_t totalStringLengthToAdd);
+        uint64_t numNewStrings, uint64_t totalStringLengthToAdd) const;
 
 private:
     // The offset column stores the offsets for each index, and the data column stores the data in

--- a/src/include/storage/table/in_memory_exception_chunk.h
+++ b/src/include/storage/table/in_memory_exception_chunk.h
@@ -22,8 +22,8 @@ struct ChunkState;
 template<std::floating_point T>
 class KUZU_API InMemoryExceptionChunk {
 public:
-    InMemoryExceptionChunk(transaction::Transaction* transaction, const ChunkState& state,
-        FileHandle* dataFH, MemoryManager* memoryManager, ShadowFile* shadowFile);
+    InMemoryExceptionChunk(const ChunkState& state, FileHandle* dataFH,
+        MemoryManager* memoryManager, ShadowFile* shadowFile);
     ~InMemoryExceptionChunk();
 
     void finalizeAndFlushToDisk(ChunkState& state);

--- a/src/include/storage/table/list_column.h
+++ b/src/include/storage/table/list_column.h
@@ -57,11 +57,11 @@ public:
     static std::unique_ptr<ColumnChunkData> flushChunkData(const ColumnChunkData& chunk,
         FileHandle& dataFH);
 
-    void scan(const transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
-        common::ValueVector* resultVector, uint64_t offsetInVector = 0) const override;
-    void scan(const transaction::Transaction* transaction, const ChunkState& state,
-        ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
+    void scan(const ChunkState& state, common::offset_t startOffsetInGroup,
+        common::offset_t endOffsetInGroup, common::ValueVector* resultVector,
+        uint64_t offsetInVector = 0) const override;
+    void scan(const ChunkState& state, ColumnChunkData* columnChunk,
+        common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET) const override;
 
     Column* getOffsetColumn() const { return offsetColumn.get(); }
@@ -71,29 +71,23 @@ public:
     void checkpointColumnChunk(ColumnCheckpointState& checkpointState) override;
 
 protected:
-    void scanInternal(transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t startOffsetInChunk, common::row_idx_t numValuesToScan,
-        common::ValueVector* resultVector) const override;
+    void scanInternal(const ChunkState& state, common::offset_t startOffsetInChunk,
+        common::row_idx_t numValuesToScan, common::ValueVector* resultVector) const override;
 
-    void lookupInternal(const transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t nodeOffset, common::ValueVector* resultVector,
-        uint32_t posInVector) const override;
+    void lookupInternal(const ChunkState& state, common::offset_t nodeOffset,
+        common::ValueVector* resultVector, uint32_t posInVector) const override;
 
 private:
-    void scanUnfiltered(transaction::Transaction* transaction, const ChunkState& state,
-        common::ValueVector* resultVector, uint64_t numValuesToScan,
-        const ListOffsetSizeInfo& listOffsetInfoInStorage) const;
-    void scanFiltered(transaction::Transaction* transaction, const ChunkState& state,
-        common::ValueVector* offsetVector, const ListOffsetSizeInfo& listOffsetInfoInStorage) const;
+    void scanUnfiltered(const ChunkState& state, common::ValueVector* resultVector,
+        uint64_t numValuesToScan, const ListOffsetSizeInfo& listOffsetInfoInStorage) const;
+    void scanFiltered(const ChunkState& state, common::ValueVector* offsetVector,
+        const ListOffsetSizeInfo& listOffsetSizeInfo) const;
 
-    common::offset_t readOffset(const transaction::Transaction* transaction,
-        const ChunkState& state, common::offset_t offsetInNodeGroup) const;
-    common::list_size_t readSize(const transaction::Transaction* transaction,
-        const ChunkState& state, common::offset_t offsetInNodeGroup) const;
+    common::offset_t readOffset(const ChunkState& state, common::offset_t offsetInNodeGroup) const;
+    common::list_size_t readSize(const ChunkState& state, common::offset_t offsetInNodeGroup) const;
 
-    ListOffsetSizeInfo getListOffsetSizeInfo(const transaction::Transaction* transaction,
-        const ChunkState& state, common::offset_t startOffsetInNodeGroup,
-        common::offset_t endOffsetInNodeGroup) const;
+    ListOffsetSizeInfo getListOffsetSizeInfo(const ChunkState& state,
+        common::offset_t startOffsetInNodeGroup, common::offset_t endOffsetInNodeGroup) const;
 
 private:
     std::unique_ptr<Column> offsetColumn;

--- a/src/include/storage/table/string_column.h
+++ b/src/include/storage/table/string_column.h
@@ -17,11 +17,11 @@ public:
     static std::unique_ptr<ColumnChunkData> flushChunkData(const ColumnChunkData& chunkData,
         FileHandle& dataFH);
 
-    void scan(const transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
-        common::ValueVector* resultVector, uint64_t offsetInVector = 0) const override;
-    void scan(const transaction::Transaction* transaction, const ChunkState& state,
-        ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
+    void scan(const ChunkState& state, common::offset_t startOffsetInGroup,
+        common::offset_t endOffsetInGroup, common::ValueVector* resultVector,
+        uint64_t offsetInVector = 0) const override;
+    void scan(const ChunkState& state, ColumnChunkData* columnChunk,
+        common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET) const override;
 
     void write(ColumnChunkData& persistentChunk, ChunkState& state, common::offset_t dstOffset,
@@ -36,18 +36,16 @@ public:
     static const ChunkState& getChildState(const ChunkState& state, ChildStateIndex child);
 
 protected:
-    void scanInternal(transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t startOffsetInChunk, common::row_idx_t numValuesToScan,
-        common::ValueVector* resultVector) const override;
-    void scanUnfiltered(const transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t startOffsetInChunk, common::offset_t numValuesToRead,
-        common::ValueVector* resultVector, common::sel_t startPosInVector = 0) const;
-    void scanFiltered(transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t startOffsetInChunk, common::ValueVector* resultVector) const;
+    void scanInternal(const ChunkState& state, common::offset_t startOffsetInChunk,
+        common::row_idx_t numValuesToScan, common::ValueVector* resultVector) const override;
+    void scanUnfiltered(const ChunkState& state, common::offset_t startOffsetInChunk,
+        common::offset_t numValuesToRead, common::ValueVector* resultVector,
+        common::sel_t startPosInVector = 0) const;
+    void scanFiltered(const ChunkState& state, common::offset_t startOffsetInChunk,
+        common::ValueVector* resultVector) const;
 
-    void lookupInternal(const transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t nodeOffset, common::ValueVector* resultVector,
-        uint32_t posInVector) const override;
+    void lookupInternal(const ChunkState& state, common::offset_t nodeOffset,
+        common::ValueVector* resultVector, uint32_t posInVector) const override;
 
 private:
     bool canCheckpointInPlace(const ChunkState& state,

--- a/src/include/storage/table/struct_column.h
+++ b/src/include/storage/table/struct_column.h
@@ -14,12 +14,12 @@ public:
     static std::unique_ptr<ColumnChunkData> flushChunkData(const ColumnChunkData& chunk,
         FileHandle& dataFH);
 
-    void scan(const transaction::Transaction* transaction, const ChunkState& state,
-        ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
+    void scan(const ChunkState& state, ColumnChunkData* columnChunk,
+        common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET) const override;
-    void scan(const transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
-        common::ValueVector* resultVector, uint64_t offsetInVector) const override;
+    void scan(const ChunkState& state, common::offset_t startOffsetInGroup,
+        common::offset_t endOffsetInGroup, common::ValueVector* resultVector,
+        uint64_t offsetInVector) const override;
 
     Column* getChild(common::idx_t childIdx) const {
         KU_ASSERT(childIdx < childColumns.size());
@@ -31,13 +31,11 @@ public:
     void checkpointColumnChunk(ColumnCheckpointState& checkpointState) override;
 
 protected:
-    void scanInternal(transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t startOffsetInChunk, common::row_idx_t numValuesToScan,
-        common::ValueVector* resultVector) const override;
+    void scanInternal(const ChunkState& state, common::offset_t startOffsetInChunk,
+        common::row_idx_t numValuesToScan, common::ValueVector* resultVector) const override;
 
-    void lookupInternal(const transaction::Transaction* transaction, const ChunkState& state,
-        common::offset_t nodeOffset, common::ValueVector* resultVector,
-        uint32_t posInVector) const override;
+    void lookupInternal(const ChunkState& state, common::offset_t nodeOffset,
+        common::ValueVector* resultVector, uint32_t posInVector) const override;
 
 private:
     std::vector<std::unique_ptr<Column>> childColumns;

--- a/src/storage/table/column_chunk.cpp
+++ b/src/storage/table/column_chunk.cpp
@@ -45,7 +45,7 @@ void ColumnChunk::scan(const Transaction* transaction, const ChunkState& state, 
         data->scan(output, offsetInChunk, length);
     } break;
     case ResidencyState::ON_DISK: {
-        state.column->scan(&DUMMY_TRANSACTION, state, offsetInChunk, length, &output);
+        state.column->scan(state, offsetInChunk, length, &output);
     } break;
     default: {
         KU_UNREACHABLE;
@@ -91,8 +91,7 @@ void ColumnChunk::scanCommitted(const Transaction* transaction, ChunkState& chun
     switch (const auto residencyState = getResidencyState()) {
     case ResidencyState::ON_DISK: {
         if (SCAN_RESIDENCY_STATE == residencyState) {
-            chunkState.column->scan(transaction, chunkState, &output.getData(), startRow,
-                startRow + numRows);
+            chunkState.column->scan(chunkState, &output.getData(), startRow, startRow + numRows);
             scanCommittedUpdates(transaction, output.getData(), numValuesBeforeScan, startRow,
                 numRows);
         }
@@ -166,7 +165,7 @@ void ColumnChunk::lookup(const Transaction* transaction, const ChunkState& state
         data->lookup(rowInChunk, output, posInOutputVector);
     } break;
     case ResidencyState::ON_DISK: {
-        state.column->lookupValue(transaction, state, rowInChunk, &output, posInOutputVector);
+        state.column->lookupValue(state, rowInChunk, &output, posInOutputVector);
     } break;
     }
     if (updateInfo) {
@@ -201,7 +200,7 @@ void ColumnChunk::update(const Transaction* transaction, offset_t offsetInChunk,
 }
 
 MergedColumnChunkStats ColumnChunk::getMergedColumnChunkStats(
-    const transaction::Transaction* transaction) const {
+    const Transaction* transaction) const {
     auto baseStats = data->getMergedColumnChunkStats();
     if (updateInfo) {
         for (idx_t i = 0; i < updateInfo->getNumVectors(); ++i) {

--- a/src/storage/table/csr_chunked_node_group.cpp
+++ b/src/storage/table/csr_chunked_node_group.cpp
@@ -41,13 +41,13 @@ CSRRegion CSRRegion::upgradeLevel(const std::vector<CSRRegion>& leafRegions,
     const idx_t leftLeafRegionIdx = newRegion.getLeftLeafRegionIdx();
     const idx_t rightLeafRegionIdx = newRegion.getRightLeafRegionIdx();
     for (auto leafRegionIdx = leftLeafRegionIdx; leafRegionIdx <= rightLeafRegionIdx;
-         leafRegionIdx++) {
+        leafRegionIdx++) {
         KU_ASSERT(leafRegionIdx < leafRegions.size());
         newRegion.sizeChange += leafRegions[leafRegionIdx].sizeChange;
         newRegion.hasPersistentDeletions |= leafRegions[leafRegionIdx].hasPersistentDeletions;
         newRegion.hasInsertions |= leafRegions[leafRegionIdx].hasInsertions;
         for (auto columnID = 0u; columnID < leafRegions[leafRegionIdx].hasUpdates.size();
-             columnID++) {
+            columnID++) {
             newRegion.hasUpdates[columnID] =
                 static_cast<bool>(newRegion.hasUpdates[columnID]) ||
                 static_cast<bool>(leafRegions[leafRegionIdx].hasUpdates[columnID]);
@@ -281,11 +281,9 @@ void ChunkedCSRNodeGroup::scanCSRHeader(MemoryManager& memoryManager,
     KU_ASSERT(csrHeader.length->getResidencyState() == ResidencyState::ON_DISK);
     csrHeader.offset->initializeScanState(headerChunkState, csrState.csrOffsetColumn);
     KU_ASSERT(csrState.csrOffsetColumn && csrState.csrLengthColumn);
-    csrState.csrOffsetColumn->scan(&transaction::DUMMY_CHECKPOINT_TRANSACTION, headerChunkState,
-        &csrState.oldHeader->offset->getData());
+    csrState.csrOffsetColumn->scan(headerChunkState, &csrState.oldHeader->offset->getData());
     csrHeader.length->initializeScanState(headerChunkState, csrState.csrLengthColumn);
-    csrState.csrLengthColumn->scan(&transaction::DUMMY_CHECKPOINT_TRANSACTION, headerChunkState,
-        &csrState.oldHeader->length->getData());
+    csrState.csrLengthColumn->scan(headerChunkState, &csrState.oldHeader->length->getData());
 }
 
 void ChunkedCSRNodeGroup::serialize(Serializer& serializer) const {

--- a/src/storage/table/in_memory_exception_chunk.cpp
+++ b/src/storage/table/in_memory_exception_chunk.cpp
@@ -8,7 +8,6 @@
 #include "storage/storage_utils.h"
 #include "storage/table/column.h"
 #include "storage/table/column_chunk_data.h"
-#include "transaction/transaction.h"
 #include <concepts>
 
 namespace kuzu::storage {
@@ -20,8 +19,8 @@ template<std::floating_point T>
 using ExceptionInBuffer = std::array<std::byte, EncodeException<T>::sizeInBytes()>;
 
 template<std::floating_point T>
-InMemoryExceptionChunk<T>::InMemoryExceptionChunk(Transaction* transaction, const ChunkState& state,
-    FileHandle* dataFH, MemoryManager* memoryManager, ShadowFile* shadowFile)
+InMemoryExceptionChunk<T>::InMemoryExceptionChunk(const ChunkState& state, FileHandle* dataFH,
+    MemoryManager* memoryManager, ShadowFile* shadowFile)
     : exceptionCount(state.metadata.compMeta.floatMetadata()->exceptionCount),
       finalizedExceptionCount(exceptionCount),
       exceptionCapacity(state.metadata.compMeta.floatMetadata()->exceptionCapacity),
@@ -43,7 +42,7 @@ InMemoryExceptionChunk<T>::InMemoryExceptionChunk(Transaction* transaction, cons
     chunkData = std::make_unique<ColumnChunkData>(*memoryManager, physicalType, false,
         exceptionChunkMeta, true);
     chunkData->setToInMemory();
-    column->scan(transaction, *chunkState, chunkData.get());
+    column->scan(*chunkState, chunkData.get());
 }
 
 template<std::floating_point T>

--- a/src/storage/table/string_column.cpp
+++ b/src/storage/table/string_column.cpp
@@ -11,7 +11,6 @@
 #include "storage/table/column_chunk.h"
 #include "storage/table/null_column.h"
 #include "storage/table/string_chunk_data.h"
-#include "transaction/transaction.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;
@@ -23,7 +22,7 @@ namespace storage {
 using string_index_t = DictionaryChunk::string_index_t;
 using string_offset_t = DictionaryChunk::string_offset_t;
 
-StringColumn::StringColumn(std::string name, common::LogicalType dataType, FileHandle* dataFH,
+StringColumn::StringColumn(std::string name, LogicalType dataType, FileHandle* dataFH,
     MemoryManager* mm, ShadowFile* shadowFile, bool enableCompression)
     : Column{std::move(name), std::move(dataType), dataFH, mm, shadowFile, enableCompression,
           true /* requireNullColumn */},
@@ -60,38 +59,37 @@ std::unique_ptr<ColumnChunkData> StringColumn::flushChunkData(const ColumnChunkD
     return flushedChunkData;
 }
 
-void StringColumn::scan(const Transaction* transaction, const ChunkState& state,
-    offset_t startOffsetInGroup, offset_t endOffsetInGroup, ValueVector* resultVector,
-    uint64_t offsetInVector) const {
-    nullColumn->scan(transaction, *state.nullState, startOffsetInGroup, endOffsetInGroup,
-        resultVector, offsetInVector);
-    scanUnfiltered(transaction, state, startOffsetInGroup, endOffsetInGroup - startOffsetInGroup,
-        resultVector, offsetInVector);
+void StringColumn::scan(const ChunkState& state, offset_t startOffsetInGroup,
+    offset_t endOffsetInGroup, ValueVector* resultVector, uint64_t offsetInVector) const {
+    nullColumn->scan(*state.nullState, startOffsetInGroup, endOffsetInGroup, resultVector,
+        offsetInVector);
+    scanUnfiltered(state, startOffsetInGroup, endOffsetInGroup - startOffsetInGroup, resultVector,
+        offsetInVector);
 }
 
-void StringColumn::scan(const Transaction* transaction, const ChunkState& state,
-    ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) const {
+void StringColumn::scan(const ChunkState& state, ColumnChunkData* columnChunk, offset_t startOffset,
+    offset_t endOffset) const {
     KU_ASSERT(state.nullState);
-    Column::scan(transaction, state, columnChunk, startOffset, endOffset);
+    Column::scan(state, columnChunk, startOffset, endOffset);
     if (columnChunk->getNumValues() == 0) {
         return;
     }
 
     auto& stringColumnChunk = columnChunk->cast<StringChunkData>();
-    indexColumn->scan(transaction, getChildState(state, ChildStateIndex::INDEX),
+    indexColumn->scan(getChildState(state, ChildStateIndex::INDEX),
         stringColumnChunk.getIndexColumnChunk(), startOffset, endOffset);
-    dictionary.scan(transaction, state, stringColumnChunk.getDictionaryChunk());
+    dictionary.scan(state, stringColumnChunk.getDictionaryChunk());
 }
 
-void StringColumn::lookupInternal(const Transaction* transaction, const ChunkState& state,
-    offset_t nodeOffset, ValueVector* resultVector, uint32_t posInVector) const {
+void StringColumn::lookupInternal(const ChunkState& state, offset_t nodeOffset,
+    ValueVector* resultVector, uint32_t posInVector) const {
     auto [nodeGroupIdx, offsetInChunk] = StorageUtils::getNodeGroupIdxAndOffsetInChunk(nodeOffset);
     string_index_t index = 0;
-    indexColumn->scan(transaction, getChildState(state, ChildStateIndex::INDEX), offsetInChunk,
+    indexColumn->scan(getChildState(state, ChildStateIndex::INDEX), offsetInChunk,
         offsetInChunk + 1, reinterpret_cast<uint8_t*>(&index));
     std::vector<std::pair<string_index_t, uint64_t>> offsetsToScan(1);
     offsetsToScan.emplace_back(index, posInVector);
-    dictionary.scan(transaction, getChildState(state, ChildStateIndex::OFFSET),
+    dictionary.scan(getChildState(state, ChildStateIndex::OFFSET),
         getChildState(state, ChildStateIndex::DATA), offsetsToScan, resultVector,
         getChildState(state, ChildStateIndex::INDEX).metadata);
 }
@@ -132,23 +130,22 @@ void StringColumn::checkpointColumnChunk(ColumnCheckpointState& checkpointState)
     checkpointState.persistentData.syncNumValues();
 }
 
-void StringColumn::scanInternal(Transaction* transaction, const ChunkState& state,
+void StringColumn::scanInternal(const ChunkState& state,
     offset_t startOffsetInChunk, row_idx_t numValuesToScan, ValueVector* resultVector) const {
     KU_ASSERT(resultVector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
     if (resultVector->state->getSelVector().isUnfiltered()) {
-        scanUnfiltered(transaction, state, startOffsetInChunk, numValuesToScan, resultVector);
+        scanUnfiltered(state, startOffsetInChunk, numValuesToScan, resultVector);
     } else {
-        scanFiltered(transaction, state, startOffsetInChunk, resultVector);
+        scanFiltered(state, startOffsetInChunk, resultVector);
     }
 }
 
-void StringColumn::scanUnfiltered(const Transaction* transaction, const ChunkState& state,
-    offset_t startOffsetInChunk, offset_t numValuesToRead, ValueVector* resultVector,
-    sel_t startPosInVector) const {
+void StringColumn::scanUnfiltered(const ChunkState& state, offset_t startOffsetInChunk,
+    offset_t numValuesToRead, ValueVector* resultVector, sel_t startPosInVector) const {
     // TODO: Replace indices with ValueVector to avoid maintaining `scan` interface from
     // uint8_t*.
     auto indices = std::make_unique<string_index_t[]>(numValuesToRead);
-    indexColumn->scan(transaction, getChildState(state, ChildStateIndex::INDEX), startOffsetInChunk,
+    indexColumn->scan(getChildState(state, ChildStateIndex::INDEX), startOffsetInChunk,
         startOffsetInChunk + numValuesToRead, reinterpret_cast<uint8_t*>(indices.get()));
 
     std::vector<std::pair<string_index_t, uint64_t>> offsetsToScan;
@@ -162,12 +159,12 @@ void StringColumn::scanUnfiltered(const Transaction* transaction, const ChunkSta
         // All scanned values are null
         return;
     }
-    dictionary.scan(transaction, getChildState(state, ChildStateIndex::OFFSET),
+    dictionary.scan(getChildState(state, ChildStateIndex::OFFSET),
         getChildState(state, ChildStateIndex::DATA), offsetsToScan, resultVector,
         getChildState(state, ChildStateIndex::INDEX).metadata);
 }
 
-void StringColumn::scanFiltered(Transaction* transaction, const ChunkState& state,
+void StringColumn::scanFiltered(const ChunkState& state,
     offset_t startOffsetInChunk, ValueVector* resultVector) const {
     std::vector<std::pair<string_index_t, uint64_t>> offsetsToScan;
     for (auto i = 0u; i < resultVector->state->getSelVector().getSelSize(); i++) {
@@ -176,7 +173,7 @@ void StringColumn::scanFiltered(Transaction* transaction, const ChunkState& stat
             // TODO(bmwinger): optimize index scans by grouping them when adjacent
             const auto offsetInGroup = startOffsetInChunk + pos;
             string_index_t index = 0;
-            indexColumn->scan(transaction, getChildState(state, ChildStateIndex::INDEX),
+            indexColumn->scan(getChildState(state, ChildStateIndex::INDEX),
                 offsetInGroup, offsetInGroup + 1, reinterpret_cast<uint8_t*>(&index));
             offsetsToScan.emplace_back(index, pos);
         }
@@ -186,7 +183,7 @@ void StringColumn::scanFiltered(Transaction* transaction, const ChunkState& stat
         // All scanned values are null
         return;
     }
-    dictionary.scan(transaction, getChildState(state, ChildStateIndex::OFFSET),
+    dictionary.scan(getChildState(state, ChildStateIndex::OFFSET),
         getChildState(state, ChildStateIndex::DATA), offsetsToScan, resultVector,
         getChildState(state, ChildStateIndex::INDEX).metadata);
 }

--- a/src/storage/table/struct_column.cpp
+++ b/src/storage/table/struct_column.cpp
@@ -40,44 +40,42 @@ std::unique_ptr<ColumnChunkData> StructColumn::flushChunkData(const ColumnChunkD
     return flushedChunk;
 }
 
-void StructColumn::scan(const Transaction* transaction, const ChunkState& state,
-    ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) const {
+void StructColumn::scan(const ChunkState& state, ColumnChunkData* columnChunk, offset_t startOffset,
+    offset_t endOffset) const {
     KU_ASSERT(columnChunk->getDataType().getPhysicalType() == PhysicalTypeID::STRUCT);
-    Column::scan(transaction, state, columnChunk, startOffset, endOffset);
+    Column::scan(state, columnChunk, startOffset, endOffset);
     auto& structColumnChunk = columnChunk->cast<StructChunkData>();
     for (auto i = 0u; i < childColumns.size(); i++) {
-        childColumns[i]->scan(transaction, state.childrenStates[i], structColumnChunk.getChild(i),
-            startOffset, endOffset);
+        childColumns[i]->scan(state.childrenStates[i], structColumnChunk.getChild(i), startOffset,
+            endOffset);
     }
 }
 
-void StructColumn::scan(const Transaction* transaction, const ChunkState& state,
-    offset_t startOffsetInGroup, offset_t endOffsetInGroup, ValueVector* resultVector,
-    uint64_t offsetInVector) const {
-    nullColumn->scan(transaction, *state.nullState, startOffsetInGroup, endOffsetInGroup,
-        resultVector, offsetInVector);
+void StructColumn::scan(const ChunkState& state, offset_t startOffsetInGroup,
+    offset_t endOffsetInGroup, ValueVector* resultVector, uint64_t offsetInVector) const {
+    nullColumn->scan(*state.nullState, startOffsetInGroup, endOffsetInGroup, resultVector,
+        offsetInVector);
     for (auto i = 0u; i < childColumns.size(); i++) {
         const auto fieldVector = StructVector::getFieldVector(resultVector, i).get();
-        childColumns[i]->scan(transaction, state.childrenStates[i], startOffsetInGroup,
-            endOffsetInGroup, fieldVector, offsetInVector);
+        childColumns[i]->scan(state.childrenStates[i], startOffsetInGroup, endOffsetInGroup,
+            fieldVector, offsetInVector);
     }
 }
 
-void StructColumn::scanInternal(Transaction* transaction, const ChunkState& state,
-    offset_t startOffsetInChunk, row_idx_t numValuesToScan, ValueVector* resultVector) const {
+void StructColumn::scanInternal(const ChunkState& state, offset_t startOffsetInChunk,
+    row_idx_t numValuesToScan, ValueVector* resultVector) const {
     for (auto i = 0u; i < childColumns.size(); i++) {
         const auto fieldVector = StructVector::getFieldVector(resultVector, i).get();
-        childColumns[i]->scan(transaction, state.childrenStates[i], startOffsetInChunk,
-            numValuesToScan, fieldVector);
+        childColumns[i]->scan(state.childrenStates[i], startOffsetInChunk, numValuesToScan,
+            fieldVector);
     }
 }
 
-void StructColumn::lookupInternal(const Transaction* transaction, const ChunkState& state,
-    offset_t nodeOffset, ValueVector* resultVector, uint32_t posInVector) const {
+void StructColumn::lookupInternal(const ChunkState& state, offset_t nodeOffset,
+    ValueVector* resultVector, uint32_t posInVector) const {
     for (auto i = 0u; i < childColumns.size(); i++) {
         const auto fieldVector = StructVector::getFieldVector(resultVector, i).get();
-        childColumns[i]->lookupValue(transaction, state.childrenStates[i], nodeOffset, fieldVector,
-            posInVector);
+        childColumns[i]->lookupValue(state.childrenStates[i], nodeOffset, fieldVector, posInVector);
     }
 }
 


### PR DESCRIPTION
# Description

Column shouldn't take in Transaction for reads and writes. Whenever we read through Column, we're reading checkpointed data (note that we should guarantee that we never need to read from shadow pages), and whenever we write through Column, we're in the middle of checkpointing. So there is no need for passing Transaction around in Column's interfaces.