### PR TITLE
Support CREATE TABLE IF NOT EXISTS AS

### DIFF
--- a/src/common/task_system/task.cpp
+++ b/src/common/task_system/task.cpp
@@ -3,10 +3,6 @@
 namespace kuzu {
 namespace common {
 
-Task::Task(uint64_t maxNumThreads)
-    : parent{nullptr}, maxNumThreads{maxNumThreads}, numThreadsFinished{0}, numThreadsRegistered{0},
-      exceptionsPtr{nullptr}, ID{UINT64_MAX} {}
-
 bool Task::registerThread() {
     lock_t lck{taskMtx};
     if (!hasExceptionNoLock() && canRegisterNoLock()) {
@@ -21,7 +17,7 @@ void Task::deRegisterThreadAndFinalizeTask() {
     ++numThreadsFinished;
     if (!hasExceptionNoLock() && isCompletedNoLock()) {
         try {
-            finalizeIfNecessary();
+            finalize();
         } catch (std::exception& e) {
             setExceptionNoLock(std::current_exception());
         }

--- a/src/common/task_system/task_scheduler.cpp
+++ b/src/common/task_system/task_scheduler.cpp
@@ -26,6 +26,9 @@ void TaskScheduler::scheduleTaskAndWaitOrError(const std::shared_ptr<Task>& task
     processor::ExecutionContext* context, bool launchNewWorkerThread) {
     for (auto& dependency : task->children) {
         scheduleTaskAndWaitOrError(dependency, context);
+        if (dependency->terminate()) {
+            return;
+        }
     }
     std::thread newWorkerThread;
     if (launchNewWorkerThread) {
@@ -128,6 +131,9 @@ void TaskScheduler::scheduleTaskAndWaitOrError(const std::shared_ptr<Task>& task
     processor::ExecutionContext* context, bool) {
     for (auto& dependency : task->children) {
         scheduleTaskAndWaitOrError(dependency, context);
+        if (dependency->terminate()) {
+            return;
+        }
     }
     task->registerThread();
     // runTask deregisters, so we don't need to deregister explicitly here

--- a/src/include/parser/ddl/create_table.h
+++ b/src/include/parser/ddl/create_table.h
@@ -8,15 +8,15 @@ namespace kuzu {
 namespace parser {
 
 class CreateTable final : public Statement {
+    static constexpr common::StatementType type_ = common::StatementType::CREATE_TABLE;
+
 public:
-    explicit CreateTable(CreateTableInfo info)
-        : Statement{common::StatementType::CREATE_TABLE}, info{std::move(info)} {}
+    explicit CreateTable(CreateTableInfo info) : Statement{type_}, info{std::move(info)} {}
 
     CreateTable(CreateTableInfo info, std::unique_ptr<QueryScanSource>&& source)
-        : Statement{common::StatementType::CREATE_TABLE}, info{std::move(info)},
-          source{std::move(source)} {}
+        : Statement{type_}, info{std::move(info)}, source{std::move(source)} {}
 
-    inline const CreateTableInfo* getInfo() const { return &info; }
+    const CreateTableInfo* getInfo() const { return &info; }
     const QueryScanSource* getSource() const { return source.get(); }
 
 private:

--- a/src/include/processor/operator/ddl/create_table.h
+++ b/src/include/processor/operator/ddl/create_table.h
@@ -1,31 +1,41 @@
 #pragma once
 
 #include "binder/ddl/bound_create_table_info.h"
-#include "processor/operator/simple/simple.h"
+#include "processor/operator/sink.h"
 
 namespace kuzu {
 namespace processor {
 
-class CreateTable final : public Simple {
+struct CreateTableSharedState {
+    bool tableCreated = false;
+};
+
+class CreateTable final : public SimpleSink {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::CREATE_TABLE;
 
 public:
-    CreateTable(binder::BoundCreateTableInfo info, const DataPos& outputPos, uint32_t id,
+    CreateTable(binder::BoundCreateTableInfo info, std::shared_ptr<FactorizedTable> messageTable,
+        std::shared_ptr<CreateTableSharedState> sharedState, physical_op_id id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : Simple{type_, outputPos, id, std::move(printInfo)}, info{std::move(info)},
-          tableCreated{false} {}
+        : SimpleSink{type_, std::move(messageTable), id, std::move(printInfo)},
+          info{std::move(info)}, sharedState{std::move(sharedState)} {}
 
     void executeInternal(ExecutionContext* context) override;
 
-    std::string getOutputMsg() override;
+    bool terminate() const override {
+        // If table is not created, meaning table already exists. Then subsequent copy tasks should
+        // not be executed.
+        return !sharedState->tableCreated;
+    }
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<CreateTable>(info.copy(), outputPos, id, printInfo->copy());
+        return std::make_unique<CreateTable>(info.copy(), messageTable, sharedState, id,
+            printInfo->copy());
     }
 
 private:
     binder::BoundCreateTableInfo info;
-    bool tableCreated;
+    std::shared_ptr<CreateTableSharedState> sharedState;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/intersect/intersect.h
+++ b/src/include/processor/operator/intersect/intersect.h
@@ -62,7 +62,7 @@ private:
         const std::vector<uint32_t>& listIdxes);
     bool hasNextTuplesToIntersect();
 
-    inline uint32_t getNumBuilds() { return sharedHTs.size(); }
+    uint32_t getNumBuilds() { return sharedHTs.size(); }
 
 private:
     DataPos outputDataPos;

--- a/src/include/processor/operator/intersect/intersect_build.h
+++ b/src/include/processor/operator/intersect/intersect_build.h
@@ -36,9 +36,9 @@ class IntersectBuild final : public HashJoinBuild {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::INTERSECT_BUILD;
 
 public:
-    IntersectBuild(std::shared_ptr<HashJoinSharedState> sharedState,
-        std::unique_ptr<HashJoinBuildInfo> info, std::unique_ptr<PhysicalOperator> child,
-        uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
+    IntersectBuild(std::shared_ptr<HashJoinSharedState> sharedState, HashJoinBuildInfo info,
+        std::unique_ptr<PhysicalOperator> child, uint32_t id,
+        std::unique_ptr<OPPrintInfo> printInfo)
         : HashJoinBuild{type_, std::move(sharedState), std::move(info), std::move(child), id,
               std::move(printInfo)} {}
 
@@ -48,7 +48,7 @@ public:
     }
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return make_unique<IntersectBuild>(sharedState, info->copy(), children[0]->copy(), id,
+        return make_unique<IntersectBuild>(sharedState, info.copy(), children[0]->copy(), id,
             printInfo->copy());
     }
 };

--- a/src/include/processor/operator/physical_operator.h
+++ b/src/include/processor/operator/physical_operator.h
@@ -74,12 +74,9 @@ enum class PhysicalOperatorType : uint8_t {
 };
 
 class PhysicalOperator;
-class PhysicalOperatorUtils {
-public:
+struct PhysicalOperatorUtils {
     static std::string operatorToString(const PhysicalOperator* physicalOp);
-
-private:
-    static std::string operatorTypeToString(PhysicalOperatorType operatorType);
+    KUZU_API static std::string operatorTypeToString(PhysicalOperatorType operatorType);
 };
 
 struct OperatorMetrics {

--- a/src/include/processor/operator/result_collector.h
+++ b/src/include/processor/operator/result_collector.h
@@ -77,7 +77,9 @@ public:
 
     void finalizeInternal(ExecutionContext* context) override;
 
-    std::shared_ptr<FactorizedTable> getResultFactorizedTable() { return sharedState->getTable(); }
+    std::shared_ptr<FactorizedTable> getResultFTable() const override {
+        return sharedState->getTable();
+    }
 
     std::unique_ptr<PhysicalOperator> copy() override {
         return std::make_unique<ResultCollector>(info.copy(), sharedState, children[0]->copy(), id,

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -35,7 +35,7 @@ class LogicalCopyFrom;
 
 namespace processor {
 
-class HashJoinBuildInfo;
+struct HashJoinBuildInfo;
 struct AggregateInfo;
 class NodeInsertExecutor;
 class RelInsertExecutor;
@@ -198,9 +198,8 @@ public:
         const binder::expression_vector& exprs, const planner::Schema* schema,
         std::shared_ptr<FactorizedTable> table, uint64_t maxMorselSize);
 
-    static std::unique_ptr<HashJoinBuildInfo> createHashBuildInfo(
-        const planner::Schema& buildSideSchema, const binder::expression_vector& keys,
-        const binder::expression_vector& payloads);
+    static HashJoinBuildInfo createHashBuildInfo(const planner::Schema& buildSideSchema,
+        const binder::expression_vector& keys, const binder::expression_vector& payloads);
 
     std::unique_ptr<PhysicalOperator> createDistinctHashAggregate(
         const binder::expression_vector& keys, const binder::expression_vector& payloads,

--- a/src/include/processor/processor_task.h
+++ b/src/include/processor/processor_task.h
@@ -13,7 +13,10 @@ public:
     ProcessorTask(Sink* sink, ExecutionContext* executionContext);
 
     void run() override;
-    void finalizeIfNecessary() override;
+
+    void finalize() override;
+
+    bool terminate() override;
 
 private:
     bool sharedStateInitialized;

--- a/src/include/processor/result/factorized_table_util.h
+++ b/src/include/processor/result/factorized_table_util.h
@@ -17,10 +17,10 @@ public:
     // because the current QueryProcessor::execute requires the last operator in the physical plan
     // must be ResultCollector. We should remove this class after we remove the assumption that the
     // last operator in the pipeline must be resultCollector.
-    static void appendStringToTable(FactorizedTable* factorizedTable, std::string& outputMsg,
+    static void appendStringToTable(FactorizedTable* factorizedTable, const std::string& outputMsg,
         storage::MemoryManager* memoryManager);
-    static std::shared_ptr<FactorizedTable> getFactorizedTableForOutputMsg(std::string& outputMsg,
-        storage::MemoryManager* memoryManager);
+    static std::shared_ptr<FactorizedTable> getFactorizedTableForOutputMsg(
+        const std::string& outputMsg, storage::MemoryManager* memoryManager);
     static KUZU_API std::shared_ptr<FactorizedTable> getSingleStringColumnFTable(
         storage::MemoryManager* mm);
 };

--- a/src/planner/plan/append_simple.cpp
+++ b/src/planner/plan/append_simple.cpp
@@ -19,7 +19,6 @@
 #include "planner/operator/ddl/logical_create_type.h"
 #include "planner/operator/ddl/logical_drop.h"
 #include "planner/operator/logical_create_macro.h"
-#include "planner/operator/logical_dummy_sink.h"
 #include "planner/operator/logical_explain.h"
 #include "planner/operator/logical_noop.h"
 #include "planner/operator/logical_standalone_call.h"
@@ -69,8 +68,7 @@ LogicalPlan Planner::planCreateTable(const BoundStatement& statement) {
         }
         }
         auto create = std::make_shared<LogicalCreateTable>(info.copy(), dummyStr);
-        auto dummySink = std::make_shared<LogicalDummySink>(std::move(create));
-        children.push_back(std::move(dummySink));
+        children.push_back(std::move(create));
         auto noop = std::make_shared<LogicalNoop>(children);
         return getSimplePlan(std::move(noop));
     }

--- a/src/processor/map/map_accumulate.cpp
+++ b/src/processor/map/map_accumulate.cpp
@@ -18,7 +18,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapAccumulate(
     auto expressions = acc.getPayloads();
     auto resultCollector = createResultCollector(acc.getAccumulateType(), expressions, inSchema,
         std::move(prevOperator));
-    auto table = resultCollector->getResultFactorizedTable();
+    auto table = resultCollector->getResultFTable();
     auto maxMorselSize = table->hasUnflatCol() ? 1 : DEFAULT_VECTOR_CAPACITY;
     if (acc.hasMark()) {
         expressions.push_back(acc.getMark());

--- a/src/processor/map/map_cross_product.cpp
+++ b/src/processor/map/map_cross_product.cpp
@@ -33,7 +33,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCrossProduct(
         colIndicesToScan.push_back(i);
     }
     auto info = CrossProductInfo(std::move(outVecPos), std::move(colIndicesToScan));
-    auto table = resultCollector->getResultFactorizedTable();
+    auto table = resultCollector->getResultFTable();
     auto maxMorselSize = table->hasUnflatCol() ? 1 : DEFAULT_VECTOR_CAPACITY;
     auto localState = CrossProductLocalState(table, maxMorselSize);
     auto printInfo = std::make_unique<OPPrintInfo>();

--- a/src/processor/map/map_ddl.cpp
+++ b/src/processor/map/map_ddl.cpp
@@ -10,6 +10,7 @@
 #include "processor/operator/ddl/create_type.h"
 #include "processor/operator/ddl/drop.h"
 #include "processor/plan_mapper.h"
+#include "processor/result/factorized_table_util.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -28,7 +29,10 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCreateTable(
     const LogicalOperator* logicalOperator) {
     auto& createTable = logicalOperator->constCast<LogicalCreateTable>();
     auto printInfo = std::make_unique<LogicalCreateTablePrintInfo>(createTable.getInfo()->copy());
-    return std::make_unique<CreateTable>(createTable.getInfo()->copy(), getOutputPos(createTable),
+    auto messageTable =
+        FactorizedTableUtils::getSingleStringColumnFTable(clientContext->getMemoryManager());
+    auto sharedState = std::make_shared<CreateTableSharedState>();
+    return std::make_unique<CreateTable>(createTable.getInfo()->copy(), messageTable, sharedState,
         getOperatorID(), std::move(printInfo));
 }
 

--- a/src/processor/map/map_explain.cpp
+++ b/src/processor/map/map_explain.cpp
@@ -19,8 +19,11 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapExplain(const LogicalOperator* 
     auto outSchema = logicalExplain.getSchema();
     auto inSchema = logicalExplain.getChild(0)->getSchema();
     auto root = mapOperator(logicalExplain.getChild(0).get());
-    root = createResultCollector(AccumulateType::REGULAR,
-        logicalExplain.getOutputExpressionsToExplain(), inSchema, std::move(root));
+    if (!root->isSink()) {
+        root = createResultCollector(AccumulateType::REGULAR,
+            logicalExplain.getOutputExpressionsToExplain(), inSchema, std::move(root));
+    }
+
     auto outputExpression = logicalExplain.getOutputExpression();
     if (logicalExplain.getExplainType() == ExplainType::PROFILE) {
         auto outputPosition = getDataPos(*outputExpression, *outSchema);

--- a/src/processor/map/map_expressions_scan.cpp
+++ b/src/processor/map/map_expressions_scan.cpp
@@ -32,7 +32,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapExpressionsScan(
     KU_ASSERT(physicalOp->getOperatorType() == PhysicalOperatorType::TABLE_FUNCTION_CALL);
     KU_ASSERT(physicalOp->getChild(0)->getOperatorType() == PhysicalOperatorType::RESULT_COLLECTOR);
     auto resultCollector = physicalOp->getChild(0)->ptrCast<ResultCollector>();
-    auto table = resultCollector->getResultFactorizedTable();
+    auto table = resultCollector->getResultFTable();
     return createFTableScan(expressionsToScan, colIndicesToScan, schema, table,
         DEFAULT_VECTOR_CAPACITY /* maxMorselSize */);
 }

--- a/src/processor/map/map_intersect.cpp
+++ b/src/processor/map/map_intersect.cpp
@@ -29,7 +29,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapIntersect(const LogicalOperator
             ExpressionUtil::excludeExpressions(buildSchema->getExpressionsInScope(), keys);
         auto buildInfo = createHashBuildInfo(*buildSchema, keys, payloadExpressions);
         auto globalHashTable = std::make_unique<JoinHashTable>(*clientContext->getMemoryManager(),
-            ExpressionUtil::getDataTypes(keys), buildInfo->getTableSchema()->copy());
+            ExpressionUtil::getDataTypes(keys), buildInfo.tableSchema.copy());
         auto sharedState = std::make_shared<HashJoinSharedState>(std::move(globalHashTable));
         sharedStates.push_back(sharedState);
         auto printInfo = std::make_unique<IntersectBuildPrintInfo>(keys, payloadExpressions);

--- a/src/processor/map/map_path_property_probe.cpp
+++ b/src/processor/map/map_path_property_probe.cpp
@@ -63,7 +63,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPathPropertyProbe(
             ExpressionUtil::excludeExpressions(nodeBuildSchema->getExpressionsInScope(), nodeKeys);
         auto nodeBuildInfo = createHashBuildInfo(*nodeBuildSchema, nodeKeys, nodePayloads);
         auto nodeHashTable = std::make_unique<JoinHashTable>(*clientContext->getMemoryManager(),
-            std::move(nodeKeyTypes), nodeBuildInfo->getTableSchema()->copy());
+            std::move(nodeKeyTypes), nodeBuildInfo.tableSchema.copy());
         nodeBuildSharedState = std::make_shared<HashJoinSharedState>(std::move(nodeHashTable));
         nodeBuild = make_unique<HashJoinBuild>(PhysicalOperatorType::HASH_JOIN_BUILD,
             nodeBuildSharedState, std::move(nodeBuildInfo), std::move(nodeBuildPrevOperator),
@@ -89,7 +89,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPathPropertyProbe(
             ExpressionUtil::excludeExpressions(relBuildSchema->getExpressionsInScope(), relKeys);
         auto relBuildInfo = createHashBuildInfo(*relBuildSchema, relKeys, relPayloads);
         auto relHashTable = std::make_unique<JoinHashTable>(*clientContext->getMemoryManager(),
-            std::move(relKeyTypes), relBuildInfo->getTableSchema()->copy());
+            std::move(relKeyTypes), relBuildInfo.tableSchema.copy());
         relBuildSharedState = std::make_shared<HashJoinSharedState>(std::move(relHashTable));
         relBuild = std::make_unique<HashJoinBuild>(PhysicalOperatorType::HASH_JOIN_BUILD,
             relBuildSharedState, std::move(relBuildInfo), std::move(relBuildPrvOperator),

--- a/src/processor/map/map_simple.cpp
+++ b/src/processor/map/map_simple.cpp
@@ -76,7 +76,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapExportDatabase(
     auto outputExpr = {exportDatabase->getOutputExpression()};
     auto resultCollector = createResultCollector(AccumulateType::REGULAR, outputExpr,
         exportDatabase->getSchema(), std::move(exportDB));
-    auto resultFT = resultCollector->getResultFactorizedTable();
+    auto resultFT = resultCollector->getResultFTable();
     children.push_back(std::move(resultCollector));
     return createFTableScan(outputExpr, {0} /* colIdxes */, exportDatabase->getSchema(), resultFT,
         1 /* maxMorselSize */, std::move(children));

--- a/src/processor/map/map_union.cpp
+++ b/src/processor/map/map_union.cpp
@@ -21,7 +21,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapUnionAll(const LogicalOperator*
         auto prevOperator = mapOperator(child.get());
         auto resultCollector = createResultCollector(AccumulateType::REGULAR,
             childSchema->getExpressionsInScope(), childSchema, std::move(prevOperator));
-        tables.push_back(resultCollector->getResultFactorizedTable());
+        tables.push_back(resultCollector->getResultFTable());
         prevOperators.push_back(std::move(resultCollector));
     }
     // append union all

--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -22,8 +22,10 @@ static void setPhysicalPlanIfProfile(const LogicalPlan* logicalPlan, PhysicalPla
 std::unique_ptr<PhysicalPlan> PlanMapper::mapLogicalPlanToPhysical(const LogicalPlan* logicalPlan,
     const expression_vector& expressionsToCollect) {
     auto lastOperator = mapOperator(logicalPlan->getLastOperator().get());
-    lastOperator = createResultCollector(AccumulateType::REGULAR, expressionsToCollect,
-        logicalPlan->getSchema(), std::move(lastOperator));
+    if (!lastOperator->isSink()) {
+        lastOperator = createResultCollector(AccumulateType::REGULAR, expressionsToCollect,
+            logicalPlan->getSchema(), std::move(lastOperator));
+    }
     auto physicalPlan = make_unique<PhysicalPlan>(std::move(lastOperator));
     setPhysicalPlanIfProfile(logicalPlan, physicalPlan.get());
     return physicalPlan;

--- a/src/processor/operator/hash_join/hash_join_build.cpp
+++ b/src/processor/operator/hash_join/hash_join_build.cpp
@@ -26,10 +26,10 @@ void HashJoinSharedState::mergeLocalHashTable(JoinHashTable& localHashTable) {
 
 void HashJoinBuild::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     std::vector<LogicalType> keyTypes;
-    for (auto i = 0u; i < info->keysPos.size(); ++i) {
-        auto vector = resultSet->getValueVector(info->keysPos[i]).get();
+    for (auto i = 0u; i < info.keysPos.size(); ++i) {
+        auto vector = resultSet->getValueVector(info.keysPos[i]).get();
         keyTypes.push_back(vector->dataType.copy());
-        if (info->fStateTypes[i] == common::FStateType::UNFLAT) {
+        if (info.fStateTypes[i] == common::FStateType::UNFLAT) {
             setKeyState(vector->state.get());
         }
         keyVectors.push_back(vector);
@@ -37,11 +37,11 @@ void HashJoinBuild::initLocalStateInternal(ResultSet* resultSet, ExecutionContex
     if (keyState == nullptr) {
         setKeyState(keyVectors[0]->state.get());
     }
-    for (auto& pos : info->payloadsPos) {
+    for (auto& pos : info.payloadsPos) {
         payloadVectors.push_back(resultSet->getValueVector(pos).get());
     }
     hashTable = std::make_unique<JoinHashTable>(*context->clientContext->getMemoryManager(),
-        std::move(keyTypes), info->tableSchema.copy());
+        std::move(keyTypes), info.tableSchema.copy());
 }
 
 void HashJoinBuild::setKeyState(common::DataChunkState* state) {

--- a/src/processor/operator/physical_operator.cpp
+++ b/src/processor/operator/physical_operator.cpp
@@ -130,7 +130,7 @@ std::string PhysicalOperatorUtils::operatorTypeToString(PhysicalOperatorType ope
 }
 
 std::string PhysicalOperatorUtils::operatorToString(const PhysicalOperator* physicalOp) {
-    return PhysicalOperatorUtils::operatorTypeToString(physicalOp->getOperatorType()) + "[" +
+    return operatorTypeToString(physicalOp->getOperatorType()) + "[" +
            std::to_string(physicalOp->getOperatorID()) + "]";
 }
 // LCOV_EXCL_STOP

--- a/src/processor/operator/sink.cpp
+++ b/src/processor/operator/sink.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/sink.h"
 
+#include "processor/result/factorized_table_util.h"
+
 namespace kuzu {
 namespace processor {
 
@@ -9,6 +11,10 @@ std::unique_ptr<ResultSet> Sink::getResultSet(storage::MemoryManager* memoryMana
         return std::unique_ptr<ResultSet>();
     }
     return std::make_unique<ResultSet>(resultSetDescriptor.get(), memoryManager);
+}
+
+void SimpleSink::appendMessage(const std::string& msg, storage::MemoryManager* memoryManager) {
+    FactorizedTableUtils::appendStringToTable(messageTable.get(), msg, memoryManager);
 }
 
 } // namespace processor

--- a/src/processor/processor_task.cpp
+++ b/src/processor/processor_task.cpp
@@ -27,9 +27,13 @@ void ProcessorTask::run() {
     taskRoot->ptrCast<Sink>()->execute(resultSet.get(), executionContext);
 }
 
-void ProcessorTask::finalizeIfNecessary() {
+void ProcessorTask::finalize() {
     executionContext->clientContext->getProgressBar()->finishPipeline(executionContext->queryID);
     sink->finalize(executionContext);
+}
+
+bool ProcessorTask::terminate() {
+    return sink->terminate();
 }
 
 } // namespace processor

--- a/src/processor/result/factorized_table_util.cpp
+++ b/src/processor/result/factorized_table_util.cpp
@@ -39,7 +39,7 @@ FactorizedTableSchema FactorizedTableUtils::createFlatTableSchema(
 }
 
 void FactorizedTableUtils::appendStringToTable(FactorizedTable* factorizedTable,
-    std::string& outputMsg, MemoryManager* memoryManager) {
+    const std::string& outputMsg, MemoryManager* memoryManager) {
     auto outputMsgVector = std::make_shared<ValueVector>(LogicalTypeID::STRING, memoryManager);
     outputMsgVector->state = DataChunkState::getSingleValueDataChunkState();
     auto outputKUStr = ku_string_t();
@@ -52,7 +52,7 @@ void FactorizedTableUtils::appendStringToTable(FactorizedTable* factorizedTable,
 }
 
 std::shared_ptr<FactorizedTable> FactorizedTableUtils::getFactorizedTableForOutputMsg(
-    std::string& outputMsg, MemoryManager* memoryManager) {
+    const std::string& outputMsg, MemoryManager* memoryManager) {
     auto table = getSingleStringColumnFTable(memoryManager);
     appendStringToTable(table.get(), outputMsg, memoryManager);
     return table;

--- a/test/test_files/ddl/ddl.test
+++ b/test/test_files/ddl/ddl.test
@@ -567,7 +567,9 @@ Binder exception: Expression ABC has data type STRING but expected INT64[3]. Imp
 ---- 2
 0|1|Alice
 2|2|Bob
--STATEMENT CREATE NODE TABLE Test2 AS MATCH (a:TEST) RETURN a.id, a.fname;
+-STATEMENT CREATE NODE TABLE IF NOT EXISTS Test AS LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv" WHERE ISStudent = True RETURN id, Gender, fname;
+---- ok
+-STATEMENT CREATE NODE TABLE IF NOT EXISTS Test2 AS MATCH (a:TEST) RETURN a.id, a.fname;
 ---- ok
 -STATEMENT MATCH (a:Test2) RETURN a.*;
 ---- 2
@@ -594,6 +596,8 @@ Binder exception: RETURN or WITH * is not allowed when there are no variables in
 ---- ok
 -STATEMENT CREATE REL TABLE Knows2 (FROM Person2 TO Person2) AS LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv" RETURN *;
 ---- ok
+-STATEMENT CREATE REL TABLE IF NOT EXISTS Knows2 (FROM Person2 TO Person2) AS LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv" RETURN *;
+---- ok
 -STATEMENT MATCH (a:Person2)-[k:Knows2]->(b:Person2) RETURN a.fname, b.fname;
 ---- 6
 Alice|Dan
@@ -608,7 +612,7 @@ Binder exception: Knows2 already exists in catalog.
 -STATEMENT CREATE REL TABLE Failure (FROM Person2 TO Person2, FROM Person TO Test2) AS MATCH (:Person2)-[e:Knows2]->(:Person2) RETURN *;
 ---- error
 Binder exception: Multiple FROM/TO pairs are not supported for CREATE REL TABLE AS.
--STATEMENT CREATE REL TABLE Knows3 (FROM Person2 TO Person2) AS MATCH (a:Person2)-[e:Knows2]->(b:Person2) WHERE a.Gender = b.Gender RETURN a.id, b.id;
+-STATEMENT CREATE REL TABLE IF NOT EXISTS Knows3 (FROM Person2 TO Person2) AS MATCH (a:Person2)-[e:Knows2]->(b:Person2) WHERE a.Gender = b.Gender RETURN a.id, b.id;
 ---- ok
 -STATEMENT MATCH (a:Person2)-[e:Knows3]->(b:Person2) RETURN a.fname, b.fname;
 ---- 2


### PR DESCRIPTION
# Description

This PR supports `CREATE TABLE IF NOT EXISTS AS`. The primary challenge is to have one pipeline terminates the execution for subsequent pipelines. So we make the following change

- Make CreateTable a Sink operator (we will propagate this change to other simple operators)
- Add a `terminate()` interface to Sink operator
- Let task check termination state from its Sink operator after scheduling.


