### PR TITLE
Remove compression disabled step from TSAN test

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -426,17 +426,6 @@ jobs:
           TSAN: 1
           RUNTIME_CHECKS: 0
 
-      - name: Test compression disabled with TSAN
-        env:
-          ENABLE_COMPRESSION: false
-          TSAN_OPTIONS: "halt_on_error=1"
-          # 32GB
-          MAX_DB_SIZE: 34359738368
-          TSAN: 1
-          RUNTIME_CHECKS: 0
-        run: |
-          make test
-
   gcc-build-test-with-asan:
     name: gcc build & test with asan
     needs: [ gcc-build-test, generate-binary-datasets ]


### PR DESCRIPTION
# Description

I don't think disabling compression changes the concurrency that tests run at so I don't think having this step is meaningful and removing it will halve the amount of time it takes to run the TSAN test (which can be quite slow). Maybe in the future it may make more sense to add a different test that stresses the concurrency more (e.g with `VECTOR_CAPACITY_LOG2=2`) but I'll leave that out of this PR.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).