### PR TITLE
Implement `projected_graph_info` function

### DIFF
--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -36,23 +36,22 @@ namespace kuzu {
 namespace function {
 
 #define SCALAR_FUNCTION_BASE(_PARAM, _NAME)                                                        \
-    { _PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
 #define SCALAR_FUNCTION(_PARAM) SCALAR_FUNCTION_BASE(_PARAM, _PARAM::name)
 #define SCALAR_FUNCTION_ALIAS(_PARAM) SCALAR_FUNCTION_BASE(_PARAM::alias, _PARAM::name)
 #define REWRITE_FUNCTION_BASE(_PARAM, _NAME)                                                       \
-    { _PARAM::getFunctionSet, _NAME, CatalogEntryType::REWRITE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _NAME, CatalogEntryType::REWRITE_FUNCTION_ENTRY}
 #define REWRITE_FUNCTION(_PARAM) REWRITE_FUNCTION_BASE(_PARAM, _PARAM::name)
 #define REWRITE_FUNCTION_ALIAS(_PARAM) REWRITE_FUNCTION_BASE(_PARAM::alias, _PARAM::name)
 #define AGGREGATE_FUNCTION(_PARAM)                                                                 \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY}
 #define EXPORT_FUNCTION(_PARAM)                                                                    \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY}
 #define TABLE_FUNCTION(_PARAM)                                                                     \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY}
 #define STANDALONE_TABLE_FUNCTION(_PARAM)                                                          \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY }
-#define FINAL_FUNCTION                                                                             \
-    { nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY}
+#define FINAL_FUNCTION {nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
 
 FunctionCollection* FunctionCollection::getFunctions() {
     static FunctionCollection functions[] = {
@@ -228,7 +227,7 @@ FunctionCollection* FunctionCollection::getFunctions() {
         TABLE_FUNCTION(ShowFunctionsFunction), TABLE_FUNCTION(BMInfoFunction),
         TABLE_FUNCTION(FileInfoFunction), TABLE_FUNCTION(ShowLoadedExtensionsFunction),
         TABLE_FUNCTION(ShowOfficialExtensionsFunction), TABLE_FUNCTION(ShowIndexesFunction),
-        TABLE_FUNCTION(ShowProjectedGraphsFunction),
+        TABLE_FUNCTION(ShowProjectedGraphsFunction), TABLE_FUNCTION(ProjectedGraphInfoFunction),
 
         // Standalone Table functions
         STANDALONE_TABLE_FUNCTION(LocalCacheArrayColumnFunction),

--- a/src/function/table/CMakeLists.txt
+++ b/src/function/table/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(kuzu_table_function
         simple_table_function.cpp
         table_function.cpp
         table_info.cpp
+        projected_graph_info.cpp
         )
 
 set(ALL_OBJECT_FILES

--- a/src/function/table/projected_graph_info.cpp
+++ b/src/function/table/projected_graph_info.cpp
@@ -1,0 +1,159 @@
+#include "binder/binder.h"
+#include "function/table/bind_data.h"
+#include "function/table/bind_input.h"
+#include "function/table/simple_table_function.h"
+#include "graph/graph_entry_set.h"
+#include "main/client_context.h"
+
+using namespace kuzu::common;
+using namespace kuzu::main;
+
+namespace kuzu {
+namespace function {
+
+struct ProjectedGraphInfo {
+    virtual ~ProjectedGraphInfo() = default;
+
+    template<class TARGET>
+    const TARGET& constCast() const {
+        return common::ku_dynamic_cast<const TARGET&>(*this);
+    }
+
+    virtual std::unique_ptr<ProjectedGraphInfo> copy() const = 0;
+};
+
+struct NativeProjectedGraphInfo : public ProjectedGraphInfo {
+    std::string nodeInfo;
+    std::string relInfo;
+
+    NativeProjectedGraphInfo(std::string nodeInfo, std::string relInfo)
+        : nodeInfo{std::move(nodeInfo)}, relInfo{std::move(relInfo)} {}
+
+    std::unique_ptr<ProjectedGraphInfo> copy() const override {
+        return std::make_unique<NativeProjectedGraphInfo>(nodeInfo, relInfo);
+    }
+};
+
+struct CypherProjectedGraphInfo : public ProjectedGraphInfo {
+    std::string cypherQuery;
+
+    explicit CypherProjectedGraphInfo(std::string cypherQuery)
+        : cypherQuery{std::move(cypherQuery)} {}
+
+    std::unique_ptr<ProjectedGraphInfo> copy() const override {
+        return std::make_unique<CypherProjectedGraphInfo>(cypherQuery);
+    }
+};
+
+struct ProjectedGraphInfoBindData : public TableFuncBindData {
+    graph::GraphEntryType type;
+    std::unique_ptr<ProjectedGraphInfo> info;
+
+    ProjectedGraphInfoBindData(binder::expression_vector columns, graph::GraphEntryType type,
+        std::unique_ptr<ProjectedGraphInfo> info)
+        : TableFuncBindData{std::move(columns), 1 /* oneRowResult */}, type{std::move(type)},
+          info{std::move(info)} {}
+
+    std::unique_ptr<TableFuncBindData> copy() const override {
+        return std::make_unique<ProjectedGraphInfoBindData>(columns, type, info->copy());
+    }
+};
+
+static offset_t internalTableFunc(const TableFuncMorsel& /*morsel*/, const TableFuncInput& input,
+    DataChunk& output) {
+    auto projectedGraphData = input.bindData->constPtrCast<ProjectedGraphInfoBindData>();
+    output.getValueVectorMutable(0).setValue(0,
+        graph::GraphEntryTypeUtils::toString(projectedGraphData->type));
+    switch (projectedGraphData->type) {
+    case graph::GraphEntryType::NATIVE: {
+        output.getValueVectorMutable(1).setValue(0,
+            projectedGraphData->info->constCast<NativeProjectedGraphInfo>().nodeInfo);
+        output.getValueVectorMutable(2).setValue(0,
+            projectedGraphData->info->constCast<NativeProjectedGraphInfo>().relInfo);
+    } break;
+    case graph::GraphEntryType::CYPHER: {
+        output.getValueVectorMutable(1).setValue(0,
+            projectedGraphData->info->constCast<CypherProjectedGraphInfo>().cypherQuery);
+    } break;
+    default:
+        KU_UNREACHABLE;
+    }
+    return 1;
+}
+
+static std::string getNodeOrRelInfo(
+    const std::vector<graph::ParsedNativeGraphTableInfo>& tableInfo) {
+    if (tableInfo.empty()) {
+        return "";
+    }
+    std::string info = "{";
+    for (auto i = 0u; i < tableInfo.size(); i++) {
+        info += tableInfo[i].toString();
+        if (i == tableInfo.size() - 1) {
+            info += "}";
+        } else {
+            info += ",";
+        }
+    }
+    return info;
+}
+
+static std::unique_ptr<TableFuncBindData> bindFunc(const ClientContext* context,
+    const TableFuncBindInput* input) {
+    std::vector<std::string> returnColumnNames;
+    std::vector<LogicalType> returnTypes;
+    returnColumnNames.emplace_back("type");
+    returnTypes.emplace_back(LogicalType::STRING());
+    auto graphEntry = context->getGraphEntrySet().getEntry(input->getValue(0).toString());
+    switch (graphEntry->type) {
+    case graph::GraphEntryType::CYPHER: {
+        returnColumnNames.emplace_back("cypher statement");
+        returnTypes.emplace_back(LogicalType::STRING());
+    } break;
+    case graph::GraphEntryType::NATIVE: {
+        returnColumnNames.emplace_back("nodes");
+        returnTypes.emplace_back(LogicalType::STRING());
+        returnColumnNames.emplace_back("rels");
+        returnTypes.emplace_back(LogicalType::STRING());
+    } break;
+    default: {
+        KU_UNREACHABLE;
+    }
+    }
+    returnColumnNames =
+        TableFunction::extractYieldVariables(returnColumnNames, input->yieldVariables);
+    auto columns = input->binder->createVariables(returnColumnNames, returnTypes);
+    std::unique_ptr<ProjectedGraphInfo> projectedGraphInfo;
+    switch (graphEntry->type) {
+    case graph::GraphEntryType::CYPHER: {
+        auto& cypherGraphEntry = graphEntry->cast<graph::ParsedCypherGraphEntry>();
+        projectedGraphInfo =
+            std::make_unique<CypherProjectedGraphInfo>(cypherGraphEntry.cypherQuery);
+    } break;
+    case graph::GraphEntryType::NATIVE: {
+        auto& nativeGraphEntry = graphEntry->cast<graph::ParsedNativeGraphEntry>();
+        projectedGraphInfo =
+            std::make_unique<NativeProjectedGraphInfo>(getNodeOrRelInfo(nativeGraphEntry.nodeInfos),
+                getNodeOrRelInfo(nativeGraphEntry.relInfos));
+    } break;
+    default:
+        KU_UNREACHABLE;
+    }
+    return std::make_unique<ProjectedGraphInfoBindData>(std::move(columns), graphEntry->type,
+        std::move(projectedGraphInfo));
+}
+
+function_set ProjectedGraphInfoFunction::getFunctionSet() {
+    function_set functionSet;
+    auto function =
+        std::make_unique<TableFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING});
+    function->tableFunc = SimpleTableFunc::getTableFunc(internalTableFunc);
+    function->bindFunc = bindFunc;
+    function->initSharedStateFunc = SimpleTableFunc::initSharedState;
+    function->initLocalStateFunc = TableFunction::initEmptyLocalState;
+    functionSet.push_back(std::move(function));
+    return functionSet;
+}
+
+} // namespace function
+} // namespace kuzu

--- a/src/graph/parsed_graph_entry.cpp
+++ b/src/graph/parsed_graph_entry.cpp
@@ -16,5 +16,14 @@ std::string GraphEntryTypeUtils::toString(GraphEntryType type) {
     }
 }
 
+std::string ParsedNativeGraphTableInfo::toString() const {
+    auto result = common::stringFormat("{'table': '{}'", tableName);
+    if (predicate != "") {
+        result += common::stringFormat(",'predicate': '{}'", predicate);
+    }
+    result += "}";
+    return result;
+}
+
 } // namespace graph
 } // namespace kuzu

--- a/src/include/function/table/simple_table_function.h
+++ b/src/include/function/table/simple_table_function.h
@@ -164,6 +164,12 @@ struct ShowProjectedGraphsFunction final {
     static function_set getFunctionSet();
 };
 
+struct ProjectedGraphInfoFunction final {
+    static constexpr const char* name = "PROJECTED_GRAPH_INFO";
+
+    static function_set getFunctionSet();
+};
+
 // Cache a table column to the transaction local cache.
 // Note this is only used for internal purpose, and only supports node tables for now.
 struct LocalCacheArrayColumnFunction final {

--- a/src/include/graph/parsed_graph_entry.h
+++ b/src/include/graph/parsed_graph_entry.h
@@ -36,6 +36,8 @@ struct ParsedNativeGraphTableInfo {
 
     ParsedNativeGraphTableInfo(std::string tableName, std::string predicate)
         : tableName{std::move(tableName)}, predicate{std::move(predicate)} {}
+
+    std::string toString() const;
 };
 
 struct KUZU_API ParsedNativeGraphEntry : ParsedGraphEntry {

--- a/test/test_files/function/gds/basic.test
+++ b/test/test_files/function/gds/basic.test
@@ -51,6 +51,24 @@ PK|NATIVE
 multipleTableWithFilter|NATIVE
 withFilter|NATIVE
 emptygraph|NATIVE
+-STATEMENT CALL PROJECTED_GRAPH_INFO('emptygraph') RETURN *
+---- 1
+NATIVE||
+-STATEMENT CALL PROJECTED_GRAPH_INFO('G') RETURN *
+---- 1
+CYPHER|MATCH (n) WHERE n.age < 10 RETURN n
+-STATEMENT CALL PROJECTED_GRAPH_INFO('withFilter') RETURN *
+---- 1
+NATIVE|{{'table': 'person','predicate': 'n.age > 35'}}|{{'table': 'knows','predicate': 'size(r.comments) > 5'}}
+-STATEMENT CALL PROJECTED_GRAPH_INFO('multipleTableWithFilter') RETURN *
+---- 1
+NATIVE|{{'table': 'person','predicate': 'n.age > 35'},{'table': 'organisation','predicate': 'n.ID > 2'}}|{{'table': 'knows','predicate': 'size(r.comments) > 5'}}
+-STATEMENT CALL PROJECTED_GRAPH_INFO('PKWO') RETURN *
+---- 1
+NATIVE|{{'table': 'person'},{'table': 'organisation'}}|{{'table': 'knows'},{'table': 'workAt'}}
+-STATEMENT CALL PROJECTED_GRAPH_INFO('PK') RETURN *
+---- 1
+NATIVE|{{'table': 'person'}}|{{'table': 'knows'}}
 -STATEMENT CALL drop_projected_graph('dummy')
 ---- error
 Runtime exception: Projected graph dummy does not exists.


### PR DESCRIPTION
Closes #5556
Implemented `projected_graph_info` function which prints projected graph info.
If the projected graph is CYPHER:
Prints out the cypher statement.
If the projected graph is NATIVE:
Prints out the nodes and rels with filters