### PR TITLE
Replace `DUMMY_TRANSACTION` with the actual transaction when loading extensions

### DIFF
--- a/extension/algo/src/main/algo_extension.cpp
+++ b/extension/algo/src/main/algo_extension.cpp
@@ -10,17 +10,17 @@ using namespace extension;
 
 void AlgoExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    extension::ExtensionUtils::addTableFunc<SCCFunction>(db);
-    extension::ExtensionUtils::addTableFuncAlias<SCCAliasFunction>(db);
-    extension::ExtensionUtils::addTableFunc<SCCKosarajuFunction>(db);
-    extension::ExtensionUtils::addTableFuncAlias<SCCKosarajuAliasFunction>(db);
-    extension::ExtensionUtils::addTableFunc<WeaklyConnectedComponentsFunction>(db);
-    extension::ExtensionUtils::addTableFuncAlias<WeaklyConnectedComponentsAliasFunction>(db);
-    extension::ExtensionUtils::addTableFunc<PageRankFunction>(db);
-    extension::ExtensionUtils::addTableFuncAlias<PageRankAliasFunction>(db);
-    extension::ExtensionUtils::addTableFunc<KCoreDecompositionFunction>(db);
-    extension::ExtensionUtils::addTableFuncAlias<KCoreDecompositionAliasFunction>(db);
-    extension::ExtensionUtils::addTableFunc<LouvainFunction>(db);
+    ExtensionUtils::addTableFunc<SCCFunction>(db);
+    ExtensionUtils::addTableFuncAlias<SCCAliasFunction>(db);
+    ExtensionUtils::addTableFunc<SCCKosarajuFunction>(db);
+    ExtensionUtils::addTableFuncAlias<SCCKosarajuAliasFunction>(db);
+    ExtensionUtils::addTableFunc<WeaklyConnectedComponentsFunction>(db);
+    ExtensionUtils::addTableFuncAlias<WeaklyConnectedComponentsAliasFunction>(db);
+    ExtensionUtils::addTableFunc<PageRankFunction>(db);
+    ExtensionUtils::addTableFuncAlias<PageRankAliasFunction>(db);
+    ExtensionUtils::addTableFunc<KCoreDecompositionFunction>(db);
+    ExtensionUtils::addTableFuncAlias<KCoreDecompositionAliasFunction>(db);
+    ExtensionUtils::addTableFunc<LouvainFunction>(db);
 }
 
 } // namespace algo_extension

--- a/extension/algo/src/main/algo_extension.cpp
+++ b/extension/algo/src/main/algo_extension.cpp
@@ -10,17 +10,19 @@ using namespace extension;
 
 void AlgoExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    ExtensionUtils::addTableFunc<SCCFunction>(db);
-    ExtensionUtils::addTableFuncAlias<SCCAliasFunction>(db);
-    ExtensionUtils::addTableFunc<SCCKosarajuFunction>(db);
-    ExtensionUtils::addTableFuncAlias<SCCKosarajuAliasFunction>(db);
-    ExtensionUtils::addTableFunc<WeaklyConnectedComponentsFunction>(db);
-    ExtensionUtils::addTableFuncAlias<WeaklyConnectedComponentsAliasFunction>(db);
-    ExtensionUtils::addTableFunc<PageRankFunction>(db);
-    ExtensionUtils::addTableFuncAlias<PageRankAliasFunction>(db);
-    ExtensionUtils::addTableFunc<KCoreDecompositionFunction>(db);
-    ExtensionUtils::addTableFuncAlias<KCoreDecompositionAliasFunction>(db);
-    ExtensionUtils::addTableFunc<LouvainFunction>(db);
+    ExtensionUtils::addTableFunc<SCCFunction>(context->getTransaction(), db);
+    ExtensionUtils::addTableFuncAlias<SCCAliasFunction>(context->getTransaction(), db);
+    ExtensionUtils::addTableFunc<SCCKosarajuFunction>(context->getTransaction(), db);
+    ExtensionUtils::addTableFuncAlias<SCCKosarajuAliasFunction>(context->getTransaction(), db);
+    ExtensionUtils::addTableFunc<WeaklyConnectedComponentsFunction>(context->getTransaction(), db);
+    ExtensionUtils::addTableFuncAlias<WeaklyConnectedComponentsAliasFunction>(
+        context->getTransaction(), db);
+    ExtensionUtils::addTableFunc<PageRankFunction>(context->getTransaction(), db);
+    ExtensionUtils::addTableFuncAlias<PageRankAliasFunction>(context->getTransaction(), db);
+    ExtensionUtils::addTableFunc<KCoreDecompositionFunction>(context->getTransaction(), db);
+    ExtensionUtils::addTableFuncAlias<KCoreDecompositionAliasFunction>(context->getTransaction(),
+        db);
+    ExtensionUtils::addTableFunc<LouvainFunction>(context->getTransaction(), db);
 }
 
 } // namespace algo_extension

--- a/extension/azure/src/main/azure_extension.cpp
+++ b/extension/azure/src/main/azure_extension.cpp
@@ -12,7 +12,7 @@ namespace azure_extension {
 
 void AzureExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    extension::ExtensionUtils::addTableFunc<AzureScanFunction>(db);
+    extension::ExtensionUtils::addTableFunc<AzureScanFunction>(context->getTransaction(), db);
     db.registerFileSystem(std::make_unique<AzureFileSystem>());
     auto config = AzureConfig::getDefault();
     config.registerExtensionOptions(context->getDatabase());

--- a/extension/delta/src/main/delta_extension.cpp
+++ b/extension/delta/src/main/delta_extension.cpp
@@ -10,7 +10,7 @@ namespace delta_extension {
 
 void DeltaExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    extension::ExtensionUtils::addTableFunc<DeltaScanFunction>(db);
+    extension::ExtensionUtils::addTableFunc<DeltaScanFunction>(context->getTransaction(), db);
     duckdb_extension::DuckdbExtension::loadRemoteFSOptions(context);
 }
 

--- a/extension/duckdb/src/include/storage/duckdb_storage.h
+++ b/extension/duckdb/src/include/storage/duckdb_storage.h
@@ -18,9 +18,10 @@ public:
 
     static constexpr bool SKIP_UNSUPPORTED_TABLE_DEFAULT_VAL = false;
 
-    explicit DuckDBStorageExtension(main::Database* database);
+    explicit DuckDBStorageExtension(transaction::Transaction* transaction,
+        main::Database& db);
 
-    bool canHandleDB(std::string dbType) const override;
+    bool canHandleDB(std::string dbType_) const override;
 };
 
 } // namespace duckdb_extension

--- a/extension/duckdb/src/main/duckdb_extension.cpp
+++ b/extension/duckdb/src/main/duckdb_extension.cpp
@@ -1,7 +1,6 @@
 #include "main/duckdb_extension.h"
 
 #include "connector/duckdb_connector.h"
-#include "connector/duckdb_secret_manager.h"
 #include "main/client_context.h"
 #include "s3fs_config.h"
 #include "storage/duckdb_storage.h"
@@ -11,7 +10,8 @@ namespace duckdb_extension {
 
 void DuckdbExtension::load(main::ClientContext* context) {
     auto db = context->getDatabase();
-    db->registerStorageExtension(EXTENSION_NAME, std::make_unique<DuckDBStorageExtension>(db));
+    db->registerStorageExtension(EXTENSION_NAME,
+        std::make_unique<DuckDBStorageExtension>(context->getTransaction(), *db));
     loadRemoteFSOptions(context);
 }
 

--- a/extension/duckdb/src/storage/duckdb_storage.cpp
+++ b/extension/duckdb/src/storage/duckdb_storage.cpp
@@ -2,7 +2,6 @@
 
 #include <filesystem>
 
-#include "binder/bound_attach_info.h"
 #include "catalog/duckdb_catalog.h"
 #include "common/file_system/virtual_file_system.h"
 #include "common/string_utils.h"
@@ -37,9 +36,9 @@ std::unique_ptr<main::AttachedDatabase> attachDuckDB(std::string dbName, std::st
         std::move(duckdbCatalog), std::move(connector));
 }
 
-DuckDBStorageExtension::DuckDBStorageExtension(main::Database* db)
+DuckDBStorageExtension::DuckDBStorageExtension(transaction::Transaction* transaction, main::Database& db)
     : StorageExtension{attachDuckDB} {
-    extension::ExtensionUtils::addStandaloneTableFunc<ClearCacheFunction>(*db);
+    extension::ExtensionUtils::addStandaloneTableFunc<ClearCacheFunction>(transaction, db);
 }
 
 bool DuckDBStorageExtension::canHandleDB(std::string dbType_) const {

--- a/extension/fts/src/index/fts_index.cpp
+++ b/extension/fts/src/index/fts_index.cpp
@@ -18,13 +18,14 @@ FTSIndex::FTSIndex(IndexInfo indexInfo, std::unique_ptr<IndexStorageInfo> storag
       internalTableInfo{context, indexInfo.tableID, indexInfo.name, config.stopWordsTableName},
       config{std::move(config)} {}
 
-std::unique_ptr<Index> FTSIndex::load(main::ClientContext* context,
-    StorageManager* /*storageManager*/, IndexInfo indexInfo, std::span<uint8_t> storageInfoBuffer) {
+std::unique_ptr<Index> FTSIndex::load(main::ClientContext* context, StorageManager*,
+    IndexInfo indexInfo, std::span<uint8_t> storageInfoBuffer) {
     auto catalog = context->getCatalog();
     auto reader =
         std::make_unique<BufferReader>(storageInfoBuffer.data(), storageInfoBuffer.size());
     auto storageInfo = FTSStorageInfo::deserialize(std::move(reader));
-    auto indexEntry = catalog->getIndex(&DUMMY_TRANSACTION, indexInfo.tableID, indexInfo.name);
+    auto indexEntry =
+        catalog->getIndex(context->getTransaction(), indexInfo.tableID, indexInfo.name);
     auto ftsConfig = indexEntry->getAuxInfo().cast<FTSIndexAuxInfo>().config;
     return std::make_unique<FTSIndex>(std::move(indexInfo), std::move(storageInfo),
         std::move(ftsConfig), context);

--- a/extension/fts/src/main/fts_extension.cpp
+++ b/extension/fts/src/main/fts_extension.cpp
@@ -34,12 +34,14 @@ static void initFTSEntries(main::ClientContext* context, catalog::Catalog& catal
 
 void FtsExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    ExtensionUtils::addScalarFunc<StemFunction>(db);
-    ExtensionUtils::addTableFunc<QueryFTSFunction>(db);
-    ExtensionUtils::addStandaloneTableFunc<CreateFTSFunction>(db);
-    ExtensionUtils::addInternalStandaloneTableFunc<InternalCreateFTSFunction>(db);
-    ExtensionUtils::addStandaloneTableFunc<DropFTSFunction>(db);
-    ExtensionUtils::addInternalStandaloneTableFunc<InternalDropFTSFunction>(db);
+    ExtensionUtils::addScalarFunc<StemFunction>(context->getTransaction(), db);
+    ExtensionUtils::addTableFunc<QueryFTSFunction>(context->getTransaction(), db);
+    ExtensionUtils::addStandaloneTableFunc<CreateFTSFunction>(context->getTransaction(), db);
+    ExtensionUtils::addInternalStandaloneTableFunc<InternalCreateFTSFunction>(
+        context->getTransaction(), db);
+    ExtensionUtils::addStandaloneTableFunc<DropFTSFunction>(context->getTransaction(), db);
+    ExtensionUtils::addInternalStandaloneTableFunc<InternalDropFTSFunction>(
+        context->getTransaction(), db);
     ExtensionUtils::registerIndexType(db, FTSIndex::getIndexType());
     initFTSEntries(context, *db.getCatalog());
 }

--- a/extension/fts/src/main/fts_extension.cpp
+++ b/extension/fts/src/main/fts_extension.cpp
@@ -17,7 +17,7 @@ using namespace extension;
 
 static void initFTSEntries(main::ClientContext* context, catalog::Catalog& catalog) {
     auto storageManager = context->getStorageManager();
-    for (auto& indexEntry : catalog.getIndexEntries(&transaction::DUMMY_TRANSACTION)) {
+    for (auto& indexEntry : catalog.getIndexEntries(context->getTransaction())) {
         if (indexEntry->getIndexType() == FTSIndexCatalogEntry::TYPE_NAME &&
             !indexEntry->isLoaded()) {
             indexEntry->setAuxInfo(FTSIndexAuxInfo::deserialize(indexEntry->getAuxBufferReader()));

--- a/extension/httpfs/src/httpfs_extension.cpp
+++ b/extension/httpfs/src/httpfs_extension.cpp
@@ -11,22 +11,22 @@ namespace kuzu {
 namespace httpfs_extension {
 
 static void registerExtensionOptions(main::Database* db) {
-    for (auto& fsConfig : httpfs_extension::S3FileSystemConfig::getAvailableConfigs()) {
+    for (auto& fsConfig : S3FileSystemConfig::getAvailableConfigs()) {
         fsConfig.registerExtensionOptions(db);
     }
     db->addExtensionOption("s3_uploader_max_num_parts_per_file", common::LogicalTypeID::INT64,
-        common::Value{(int64_t)800000000000});
+        common::Value{static_cast<int64_t>(800000000000)});
     db->addExtensionOption("s3_uploader_max_filesize", common::LogicalTypeID::INT64,
-        common::Value{(int64_t)10000});
+        common::Value{static_cast<int64_t>(10000)});
     db->addExtensionOption("s3_uploader_threads_limit", common::LogicalTypeID::INT64,
-        common::Value{(int64_t)50});
+        common::Value{static_cast<int64_t>(50)});
     db->addExtensionOption(HTTPCacheFileConfig::HTTP_CACHE_FILE_OPTION, common::LogicalTypeID::BOOL,
         common::Value{HTTPCacheFileConfig::DEFAULT_CACHE_FILE});
 }
 
 static void registerFileSystem(main::Database* db) {
     db->registerFileSystem(std::make_unique<HTTPFileSystem>());
-    for (auto& fsConfig : httpfs_extension::S3FileSystemConfig::getAvailableConfigs()) {
+    for (auto& fsConfig : S3FileSystemConfig::getAvailableConfigs()) {
         db->registerFileSystem(std::make_unique<S3FileSystem>(fsConfig));
     }
 }
@@ -35,7 +35,7 @@ void HttpfsExtension::load(main::ClientContext* context) {
     auto db = context->getDatabase();
     registerFileSystem(db);
     registerExtensionOptions(db);
-    for (auto& fsConfig : httpfs_extension::S3FileSystemConfig::getAvailableConfigs()) {
+    for (auto& fsConfig : S3FileSystemConfig::getAvailableConfigs()) {
         fsConfig.setEnvValue(context);
     }
     HTTPConfigEnvProvider::setOptionValue(context);

--- a/extension/iceberg/src/main/iceberg_extension.cpp
+++ b/extension/iceberg/src/main/iceberg_extension.cpp
@@ -4,7 +4,6 @@
 #include "main/client_context.h"
 #include "main/database.h"
 #include "main/duckdb_extension.h"
-#include "s3fs_config.h"
 
 namespace kuzu {
 namespace iceberg_extension {
@@ -13,9 +12,9 @@ using namespace kuzu::extension;
 
 void IcebergExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    ExtensionUtils::addTableFunc<IcebergScanFunction>(db);
-    ExtensionUtils::addTableFunc<IcebergMetadataFunction>(db);
-    ExtensionUtils::addTableFunc<IcebergSnapshotsFunction>(db);
+    ExtensionUtils::addTableFunc<IcebergScanFunction>(context->getTransaction(), db);
+    ExtensionUtils::addTableFunc<IcebergMetadataFunction>(context->getTransaction(), db);
+    ExtensionUtils::addTableFunc<IcebergSnapshotsFunction>(context->getTransaction(), db);
     duckdb_extension::DuckdbExtension::loadRemoteFSOptions(context);
 }
 

--- a/extension/iceberg/src/main/iceberg_extension.cpp
+++ b/extension/iceberg/src/main/iceberg_extension.cpp
@@ -13,9 +13,9 @@ using namespace kuzu::extension;
 
 void IcebergExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    extension::ExtensionUtils::addTableFunc<IcebergScanFunction>(db);
-    extension::ExtensionUtils::addTableFunc<IcebergMetadataFunction>(db);
-    extension::ExtensionUtils::addTableFunc<IcebergSnapshotsFunction>(db);
+    ExtensionUtils::addTableFunc<IcebergScanFunction>(db);
+    ExtensionUtils::addTableFunc<IcebergMetadataFunction>(db);
+    ExtensionUtils::addTableFunc<IcebergSnapshotsFunction>(db);
     duckdb_extension::DuckdbExtension::loadRemoteFSOptions(context);
 }
 

--- a/extension/json/src/main/json_extension.cpp
+++ b/extension/json/src/main/json_extension.cpp
@@ -15,38 +15,38 @@ namespace json_extension {
 
 using namespace kuzu::extension;
 
-static void addJsonCreationFunction(main::Database& db) {
-    ExtensionUtils::addScalarFunc<ToJsonFunction>(db);
-    ExtensionUtils::addScalarFuncAlias<JsonQuoteFunction>(db);
-    ExtensionUtils::addScalarFuncAlias<ArrayToJsonFunction>(db);
-    ExtensionUtils::addScalarFuncAlias<RowToJsonFunction>(db);
-    ExtensionUtils::addScalarFunc<CastToJsonFunction>(db);
-    ExtensionUtils::addScalarFunc<JsonArrayFunction>(db);
-    ExtensionUtils::addScalarFunc<JsonObjectFunction>(db);
-    ExtensionUtils::addScalarFunc<JsonMergePatchFunction>(db);
+static void addJsonCreationFunction(transaction::Transaction* transaction, main::Database& db) {
+    ExtensionUtils::addScalarFunc<ToJsonFunction>(transaction, db);
+    ExtensionUtils::addScalarFuncAlias<JsonQuoteFunction>(transaction, db);
+    ExtensionUtils::addScalarFuncAlias<ArrayToJsonFunction>(transaction, db);
+    ExtensionUtils::addScalarFuncAlias<RowToJsonFunction>(transaction, db);
+    ExtensionUtils::addScalarFunc<CastToJsonFunction>(transaction, db);
+    ExtensionUtils::addScalarFunc<JsonArrayFunction>(transaction, db);
+    ExtensionUtils::addScalarFunc<JsonObjectFunction>(transaction, db);
+    ExtensionUtils::addScalarFunc<JsonMergePatchFunction>(transaction, db);
 }
 
-static void addJsonExtractFunction(main::Database& db) {
-    ExtensionUtils::addScalarFunc<JsonExtractFunction>(db);
+static void addJsonExtractFunction(transaction::Transaction* transaction, main::Database& db) {
+    ExtensionUtils::addScalarFunc<JsonExtractFunction>(transaction, db);
 }
 
-static void addJsonScalarFunction(main::Database& db) {
-    ExtensionUtils::addScalarFunc<JsonArrayLengthFunction>(db);
-    ExtensionUtils::addScalarFunc<JsonContainsFunction>(db);
-    ExtensionUtils::addScalarFunc<JsonKeysFunction>(db);
-    ExtensionUtils::addScalarFunc<JsonStructureFunction>(db);
-    ExtensionUtils::addScalarFunc<JsonValidFunction>(db);
-    ExtensionUtils::addScalarFunc<MinifyJsonFunction>(db);
+static void addJsonScalarFunction(transaction::Transaction* transaction, main::Database& db) {
+    ExtensionUtils::addScalarFunc<JsonArrayLengthFunction>(transaction, db);
+    ExtensionUtils::addScalarFunc<JsonContainsFunction>(transaction, db);
+    ExtensionUtils::addScalarFunc<JsonKeysFunction>(transaction, db);
+    ExtensionUtils::addScalarFunc<JsonStructureFunction>(transaction, db);
+    ExtensionUtils::addScalarFunc<JsonValidFunction>(transaction, db);
+    ExtensionUtils::addScalarFunc<MinifyJsonFunction>(transaction, db);
 }
 
 void JsonExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
     db.getCatalog()->createType(context->getTransaction(), JSON_TYPE_NAME, JsonType::getJsonType());
-    addJsonCreationFunction(db);
-    addJsonExtractFunction(db);
-    addJsonScalarFunction(db);
-    ExtensionUtils::addScalarFunc<JsonExportFunction>(db);
-    ExtensionUtils::addTableFunc<JsonScan>(db);
+    addJsonCreationFunction(context->getTransaction(), db);
+    addJsonExtractFunction(context->getTransaction(), db);
+    addJsonScalarFunction(context->getTransaction(), db);
+    ExtensionUtils::addScalarFunc<JsonExportFunction>(context->getTransaction(), db);
+    ExtensionUtils::addTableFunc<JsonScan>(context->getTransaction(), db);
 }
 
 } // namespace json_extension

--- a/extension/json/src/main/json_extension.cpp
+++ b/extension/json/src/main/json_extension.cpp
@@ -41,8 +41,7 @@ static void addJsonScalarFunction(main::Database& db) {
 
 void JsonExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    db.getCatalog()->createType(&transaction::DUMMY_TRANSACTION, JSON_TYPE_NAME,
-        JsonType::getJsonType());
+    db.getCatalog()->createType(context->getTransaction(), JSON_TYPE_NAME, JsonType::getJsonType());
     addJsonCreationFunction(db);
     addJsonExtractFunction(db);
     addJsonScalarFunction(db);

--- a/extension/llm/src/main/llm_extension.cpp
+++ b/extension/llm/src/main/llm_extension.cpp
@@ -17,7 +17,7 @@ namespace llm_extension {
 void LLMExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
 
-    extension::ExtensionUtils::addScalarFunc<CreateEmbedding>(db);
+    extension::ExtensionUtils::addScalarFunc<CreateEmbedding>(context->getTransaction(), db);
 }
 
 } // namespace llm_extension

--- a/extension/neo4j/src/main/neo4j_extension.cpp
+++ b/extension/neo4j/src/main/neo4j_extension.cpp
@@ -10,7 +10,7 @@ using namespace extension;
 
 void Neo4jExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    ExtensionUtils::addStandaloneTableFunc<Neo4jMigrateFunction>(db);
+    ExtensionUtils::addStandaloneTableFunc<Neo4jMigrateFunction>(context->getTransaction(), db);
 }
 
 } // namespace neo4j_extension

--- a/extension/postgres/src/include/storage/postgres_storage.h
+++ b/extension/postgres/src/include/storage/postgres_storage.h
@@ -15,9 +15,10 @@ public:
 
     static constexpr const char* DEFAULT_SCHEMA_NAME = "public";
 
-    explicit PostgresStorageExtension(main::Database* database);
+    explicit PostgresStorageExtension(transaction::Transaction* transaction,
+        main::Database& database);
 
-    bool canHandleDB(std::string dbType) const override;
+    bool canHandleDB(std::string dbType_) const override;
 };
 
 } // namespace postgres_extension

--- a/extension/postgres/src/main/postgres_extension.cpp
+++ b/extension/postgres/src/main/postgres_extension.cpp
@@ -10,8 +10,8 @@ namespace postgres_extension {
 
 void PostgresExtension::load(main::ClientContext* context) {
     auto db = context->getDatabase();
-    db->registerStorageExtension(EXTENSION_NAME, std::make_unique<PostgresStorageExtension>(db));
-    extension::ExtensionUtils::addTableFunc<SqlQueryFunction>(*db);
+    db->registerStorageExtension(EXTENSION_NAME, std::make_unique<PostgresStorageExtension>(context->getTransaction(), *db));
+    extension::ExtensionUtils::addTableFunc<SqlQueryFunction>(context->getTransaction(), *db);
 }
 
 } // namespace postgres_extension

--- a/extension/postgres/src/storage/postgres_storage.cpp
+++ b/extension/postgres/src/storage/postgres_storage.cpp
@@ -39,10 +39,11 @@ std::unique_ptr<main::AttachedDatabase> attachPostgres(std::string dbName, std::
         std::move(catalog), std::move(connector), catalogName);
 }
 
-PostgresStorageExtension::PostgresStorageExtension(main::Database* database)
+PostgresStorageExtension::PostgresStorageExtension(transaction::Transaction* transaction,
+    main::Database& database)
     : StorageExtension{attachPostgres} {
     extension::ExtensionUtils::addStandaloneTableFunc<duckdb_extension::ClearCacheFunction>(
-        *database);
+        transaction, database);
 }
 
 bool PostgresStorageExtension::canHandleDB(std::string dbType_) const {

--- a/extension/sqlite/src/include/storage/sqlite_storage.h
+++ b/extension/sqlite/src/include/storage/sqlite_storage.h
@@ -12,9 +12,9 @@ public:
 
     static constexpr const char* DEFAULT_SCHEMA_NAME = "main";
 
-    explicit SqliteStorageExtension(main::Database* database);
+    explicit SqliteStorageExtension(transaction::Transaction* transaction, main::Database& database);
 
-    bool canHandleDB(std::string dbType) const override;
+    bool canHandleDB(std::string dbType_) const override;
 };
 
 } // namespace sqlite_extension

--- a/extension/sqlite/src/main/sqlite_extension.cpp
+++ b/extension/sqlite/src/main/sqlite_extension.cpp
@@ -9,7 +9,8 @@ namespace sqlite_extension {
 
 void SqliteExtension::load(main::ClientContext* context) {
     auto db = context->getDatabase();
-    db->registerStorageExtension(EXTENSION_NAME, std::make_unique<SqliteStorageExtension>(db));
+    db->registerStorageExtension(EXTENSION_NAME,
+        std::make_unique<SqliteStorageExtension>(context->getTransaction(), *db));
     db->addExtensionOption("sqlite_all_varchar", common::LogicalTypeID::BOOL, common::Value{false});
 }
 

--- a/extension/sqlite/src/storage/sqlite_storage.cpp
+++ b/extension/sqlite/src/storage/sqlite_storage.cpp
@@ -3,7 +3,6 @@
 #include <filesystem>
 
 #include "catalog/duckdb_catalog.h"
-#include "common/exception/runtime.h"
 #include "common/string_utils.h"
 #include "connector/sqlite_connector.h"
 #include "extension/extension.h"
@@ -34,10 +33,11 @@ std::unique_ptr<main::AttachedDatabase> attachSqlite(std::string dbName, std::st
         SqliteStorageExtension::DB_TYPE, std::move(catalog), std::move(connector));
 }
 
-SqliteStorageExtension::SqliteStorageExtension(main::Database* database)
+SqliteStorageExtension::SqliteStorageExtension(transaction::Transaction* transaction,
+    main::Database& database)
     : StorageExtension{attachSqlite} {
     extension::ExtensionUtils::addStandaloneTableFunc<duckdb_extension::ClearCacheFunction>(
-        *database);
+        transaction, database);
 }
 
 bool SqliteStorageExtension::canHandleDB(std::string dbType_) const {

--- a/extension/unity_catalog/src/include/storage/unity_catalog_storage.h
+++ b/extension/unity_catalog/src/include/storage/unity_catalog_storage.h
@@ -15,7 +15,8 @@ public:
 
     static constexpr const char* DEFAULT_SCHEMA_NAME = "default";
 
-    explicit UnityCatalogStorageExtension(main::Database* database);
+    explicit UnityCatalogStorageExtension(transaction::Transaction* transaction,
+        main::Database& database);
 
     bool canHandleDB(std::string dbType) const override;
 };

--- a/extension/unity_catalog/src/main/unity_catalog_extension.cpp
+++ b/extension/unity_catalog/src/main/unity_catalog_extension.cpp
@@ -11,7 +11,7 @@ namespace unity_catalog_extension {
 void UnityCatalogExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
     db.registerStorageExtension(EXTENSION_NAME,
-        std::make_unique<UnityCatalogStorageExtension>(&db));
+        std::make_unique<UnityCatalogStorageExtension>(context->getTransaction(), db));
     UnityCatalogOptions::registerExtensionOptions(&db);
     UnityCatalogOptions::setEnvValue(context);
 }

--- a/extension/unity_catalog/src/storage/unity_catalog_storage.cpp
+++ b/extension/unity_catalog/src/storage/unity_catalog_storage.cpp
@@ -1,7 +1,6 @@
 #include "storage/unity_catalog_storage.h"
 
 #include "catalog/duckdb_catalog.h"
-#include "common/exception/runtime.h"
 #include "common/string_utils.h"
 #include "connector/unity_catalog_connector.h"
 #include "extension/extension.h"
@@ -26,10 +25,11 @@ std::unique_ptr<main::AttachedDatabase> attachUnityCatalog(std::string dbName, s
         UnityCatalogStorageExtension::DB_TYPE, std::move(catalog), std::move(connector));
 }
 
-UnityCatalogStorageExtension::UnityCatalogStorageExtension(main::Database* database)
+UnityCatalogStorageExtension::UnityCatalogStorageExtension(transaction::Transaction* transaction,
+    main::Database& database)
     : StorageExtension{attachUnityCatalog} {
     extension::ExtensionUtils::addStandaloneTableFunc<duckdb_extension::ClearCacheFunction>(
-        *database);
+        transaction, database);
 }
 
 bool UnityCatalogStorageExtension::canHandleDB(std::string dbType_) const {

--- a/extension/vector/src/index/hnsw_index.cpp
+++ b/extension/vector/src/index/hnsw_index.cpp
@@ -469,7 +469,7 @@ std::unique_ptr<Index> OnDiskHNSWIndex::load(main::ClientContext* context, Stora
     auto storageInfo = HNSWStorageInfo::deserialize(std::move(reader));
     const auto catalog = context->getCatalog();
     const auto indexEntry =
-        catalog->getIndex(&transaction::DUMMY_TRANSACTION, indexInfo.tableID, indexInfo.name);
+        catalog->getIndex(context->getTransaction(), indexInfo.tableID, indexInfo.name);
     const auto auxInfo = indexEntry->getAuxInfo().cast<HNSWIndexAuxInfo>();
     return std::make_unique<OnDiskHNSWIndex>(context, std::move(indexInfo), std::move(storageInfo),
         auxInfo.config.copy());

--- a/extension/vector/src/main/vector_extension.cpp
+++ b/extension/vector/src/main/vector_extension.cpp
@@ -12,7 +12,7 @@ namespace vector_extension {
 static void initHNSWEntries(main::ClientContext* context) {
     auto catalog = context->getCatalog();
     auto storageManager = context->getStorageManager();
-    for (auto& indexEntry : catalog->getIndexEntries(&transaction::DUMMY_TRANSACTION)) {
+    for (auto& indexEntry : catalog->getIndexEntries(context->getTransaction())) {
         if (indexEntry->getIndexType() == HNSWIndexCatalogEntry::TYPE_NAME &&
             !indexEntry->isLoaded()) {
             indexEntry->setAuxInfo(HNSWIndexAuxInfo::deserialize(indexEntry->getAuxBufferReader()));

--- a/extension/vector/src/main/vector_extension.cpp
+++ b/extension/vector/src/main/vector_extension.cpp
@@ -30,13 +30,18 @@ static void initHNSWEntries(main::ClientContext* context) {
 
 void VectorExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    extension::ExtensionUtils::addTableFunc<QueryVectorIndexFunction>(db);
-    extension::ExtensionUtils::addInternalStandaloneTableFunc<InternalCreateHNSWIndexFunction>(db);
-    extension::ExtensionUtils::addInternalStandaloneTableFunc<InternalFinalizeHNSWIndexFunction>(
+    extension::ExtensionUtils::addTableFunc<QueryVectorIndexFunction>(context->getTransaction(),
         db);
-    extension::ExtensionUtils::addStandaloneTableFunc<CreateVectorIndexFunction>(db);
-    extension::ExtensionUtils::addInternalStandaloneTableFunc<InternalDropHNSWIndexFunction>(db);
-    extension::ExtensionUtils::addStandaloneTableFunc<DropVectorIndexFunction>(db);
+    extension::ExtensionUtils::addInternalStandaloneTableFunc<InternalCreateHNSWIndexFunction>(
+        context->getTransaction(), db);
+    extension::ExtensionUtils::addInternalStandaloneTableFunc<InternalFinalizeHNSWIndexFunction>(
+        context->getTransaction(), db);
+    extension::ExtensionUtils::addStandaloneTableFunc<CreateVectorIndexFunction>(
+        context->getTransaction(), db);
+    extension::ExtensionUtils::addInternalStandaloneTableFunc<InternalDropHNSWIndexFunction>(
+        context->getTransaction(), db);
+    extension::ExtensionUtils::addStandaloneTableFunc<DropVectorIndexFunction>(
+        context->getTransaction(), db);
     extension::ExtensionUtils::registerIndexType(db, OnDiskHNSWIndex::getIndexType());
     initHNSWEntries(context);
 }

--- a/src/extension/extension_manager.cpp
+++ b/src/extension/extension_manager.cpp
@@ -19,7 +19,7 @@ static void executeExtensionLoader(main::ClientContext* context, const std::stri
 
 void ExtensionManager::loadExtension(const std::string& path, main::ClientContext* context) {
     auto fullPath = path;
-    bool isOfficial = extension::ExtensionUtils::isOfficialExtension(path);
+    bool isOfficial = ExtensionUtils::isOfficialExtension(path);
     if (isOfficial) {
         auto localPathForSharedLib = ExtensionUtils::getLocalPathForSharedLib(context);
         if (!context->getVFSUnsafe()->fileOrPathExists(localPathForSharedLib)) {

--- a/src/include/extension/extension.h
+++ b/src/include/extension/extension.h
@@ -53,14 +53,14 @@ struct ExtensionSourceUtils {
 };
 
 template<typename T>
-void addFunc(main::Database& database, std::string name, catalog::CatalogEntryType functionType,
-    bool isInternal = false) {
+void addFunc(transaction::Transaction* transaction, main::Database& database, std::string name,
+    catalog::CatalogEntryType functionType, bool isInternal = false) {
     auto catalog = database.getCatalog();
-    if (catalog->containsFunction(&transaction::DUMMY_TRANSACTION, name, isInternal)) {
+    if (catalog->containsFunction(transaction, name, isInternal)) {
         return;
     }
-    catalog->addFunction(&transaction::DUMMY_TRANSACTION, functionType, std::move(name),
-        T::getFunctionSet(), isInternal);
+    catalog->addFunction(transaction, functionType, std::move(name), T::getFunctionSet(),
+        isInternal);
 }
 
 struct KUZU_API ExtensionUtils {
@@ -116,35 +116,39 @@ struct KUZU_API ExtensionUtils {
     static bool isOfficialExtension(const std::string& extension);
 
     template<typename T>
-    static void addTableFunc(main::Database& database) {
-        addFunc<T>(database, T::name, catalog::CatalogEntryType::TABLE_FUNCTION_ENTRY);
+    static void addTableFunc(transaction::Transaction* transaction, main::Database& database) {
+        addFunc<T>(transaction, database, T::name, catalog::CatalogEntryType::TABLE_FUNCTION_ENTRY);
     }
 
     template<typename T>
-    static void addTableFuncAlias(main::Database& database) {
-        addFunc<typename T::alias>(database, T::name,
+    static void addTableFuncAlias(transaction::Transaction* transaction, main::Database& database) {
+        addFunc<typename T::alias>(transaction, database, T::name,
             catalog::CatalogEntryType::TABLE_FUNCTION_ENTRY);
     }
 
     template<typename T>
-    static void addStandaloneTableFunc(main::Database& database) {
-        addFunc<T>(database, T::name, catalog::CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY,
-            false /* isInternal */);
+    static void addStandaloneTableFunc(transaction::Transaction* transaction,
+        main::Database& database) {
+        addFunc<T>(transaction, database, T::name,
+            catalog::CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY, false /* isInternal */);
     }
     template<typename T>
-    static void addInternalStandaloneTableFunc(main::Database& database) {
-        addFunc<T>(database, T::name, catalog::CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY,
-            true /* isInternal */);
-    }
-
-    template<typename T>
-    static void addScalarFunc(main::Database& database) {
-        addFunc<T>(database, T::name, catalog::CatalogEntryType::SCALAR_FUNCTION_ENTRY);
+    static void addInternalStandaloneTableFunc(transaction::Transaction* transaction,
+        main::Database& database) {
+        addFunc<T>(transaction, database, T::name,
+            catalog::CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY, true /* isInternal */);
     }
 
     template<typename T>
-    static void addScalarFuncAlias(main::Database& database) {
-        addFunc<typename T::alias>(database, T::name,
+    static void addScalarFunc(transaction::Transaction* transaction, main::Database& database) {
+        addFunc<T>(transaction, database, T::name,
+            catalog::CatalogEntryType::SCALAR_FUNCTION_ENTRY);
+    }
+
+    template<typename T>
+    static void addScalarFuncAlias(transaction::Transaction* transaction,
+        main::Database& database) {
+        addFunc<typename T::alias>(transaction, database, T::name,
             catalog::CatalogEntryType::SCALAR_FUNCTION_ENTRY);
     }
 

--- a/src/include/parser/visitor/statement_read_write_analyzer.h
+++ b/src/include/parser/visitor/statement_read_write_analyzer.h
@@ -23,7 +23,7 @@ private:
     void visitStandaloneCall(const Statement& /*statement*/) override { readOnly = true; }
     void visitStandaloneCallFunction(const Statement& /*statement*/) override { readOnly = false; }
     void visitCreateMacro(const Statement& /*statement*/) override { readOnly = false; }
-    void visitExtension(const Statement& /*statement*/) override { readOnly = true; }
+    void visitExtension(const Statement& /*statement*/) override { readOnly = false; }
 
     void visitReadingClause(const ReadingClause* readingClause) override;
     void visitWithClause(const WithClause* withClause) override;

--- a/src/parser/visitor/standalone_call_rewriter.cpp
+++ b/src/parser/visitor/standalone_call_rewriter.cpp
@@ -22,7 +22,7 @@ void StandaloneCallRewriter::visitStandaloneCallFunction(const Statement& statem
         *context->getTransactionContext(),
         [&]() -> void {
             auto funcName = standaloneCallFunc.getFunctionExpression()
-                                ->constPtrCast<parser::ParsedFunctionExpression>()
+                                ->constPtrCast<ParsedFunctionExpression>()
                                 ->getFunctionName();
             if (!context->getCatalog()->containsFunction(context->getTransaction(), funcName) &&
                 !singleStatement) {

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -131,14 +131,16 @@ void Transaction::pushCreateDropCatalogEntry(CatalogSet& catalogSet, CatalogEntr
             return;
         }
         switch (catalogEntry.getType()) {
-        // Eventually we probably want to merge these
+        // Eventually, we probably want to merge these
         case CatalogEntryType::NODE_TABLE_ENTRY:
         case CatalogEntryType::REL_GROUP_ENTRY:
         case CatalogEntryType::SEQUENCE_ENTRY: {
             wal->logDropCatalogEntryRecord(catalogEntry.getOID(), catalogEntry.getType());
         } break;
         case CatalogEntryType::INDEX_ENTRY:
-        case CatalogEntryType::SCALAR_FUNCTION_ENTRY: {
+        case CatalogEntryType::SCALAR_FUNCTION_ENTRY:
+        case CatalogEntryType::TABLE_FUNCTION_ENTRY:
+        case CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY: {
             // DO NOTHING. We don't persistent index/function entries.
         } break;
         case CatalogEntryType::SCALAR_MACRO_ENTRY:
@@ -150,8 +152,10 @@ void Transaction::pushCreateDropCatalogEntry(CatalogSet& catalogSet, CatalogEntr
         }
         }
     } break;
+    case CatalogEntryType::INDEX_ENTRY:
     case CatalogEntryType::SCALAR_FUNCTION_ENTRY:
-    case CatalogEntryType::INDEX_ENTRY: {
+    case CatalogEntryType::TABLE_FUNCTION_ENTRY:
+    case CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY: {
         // DO NOTHING. We don't persistent function/index entries.
     } break;
     default: {

--- a/tools/python_api/src_cpp/py_database.cpp
+++ b/tools/python_api/src_cpp/py_database.cpp
@@ -54,8 +54,9 @@ PyDatabase::PyDatabase(const std::string& databasePath, uint64_t bufferPoolSize,
         systemConfig.checkpointThreshold = static_cast<uint64_t>(checkpointThreshold);
     }
     database = std::make_unique<Database>(databasePath, systemConfig);
-    kuzu::extension::ExtensionUtils::addTableFunc<kuzu::PandasScanFunction>(*database);
-    storageDriver = std::make_unique<kuzu::main::StorageDriver>(database.get());
+    kuzu::extension::ExtensionUtils::addTableFunc<kuzu::PandasScanFunction>(
+        &kuzu::transaction::DUMMY_TRANSACTION, *database);
+    storageDriver = std::make_unique<StorageDriver>(database.get());
     py::gil_scoped_acquire acquire;
     if (kuzu::importCache.get() == nullptr) {
         kuzu::importCache = std::make_shared<kuzu::PythonCachedImport>();


### PR DESCRIPTION
# Description

We used to use `DUMMY_TRANSACTION` to register functions when loading an extension, which was done for simplicity. We're starting to introduce transactions to extensions in this release, so `DUMMY_TRANSACTION` won't work.