### PR TITLE
Support export database with schema only

### DIFF
--- a/src/binder/bind/bind_import_database.cpp
+++ b/src/binder/bind/bind_import_database.cpp
@@ -18,6 +18,9 @@ static std::string getQueryFromFile(VirtualFileSystem* vfs, const std::string& b
     const std::string& fileName, main::ClientContext* context) {
     auto filePath = vfs->joinPath(boundFilePath, fileName);
     if (!vfs->fileOrPathExists(filePath, context)) {
+        if (fileName == PortDBConstants::COPY_FILE_NAME) {
+            return "";
+        }
         if (fileName == PortDBConstants::INDEX_FILE_NAME) {
             return "";
         }

--- a/src/include/binder/bound_export_database.h
+++ b/src/include/binder/bound_export_database.h
@@ -24,10 +24,11 @@ class BoundExportDatabase final : public BoundStatement {
 public:
     BoundExportDatabase(std::string filePath, common::FileTypeInfo fileTypeInfo,
         std::vector<ExportedTableData> exportData,
-        common::case_insensitive_map_t<common::Value> csvOption)
+        common::case_insensitive_map_t<common::Value> csvOption, bool schemaOnly)
         : BoundStatement{type_, BoundStatementResult::createSingleStringColumnResult()},
           exportData(std::move(exportData)),
-          boundFileInfo(std::move(fileTypeInfo), std::vector{std::move(filePath)}) {
+          boundFileInfo(std::move(fileTypeInfo), std::vector{std::move(filePath)}),
+          schemaOnly{schemaOnly} {
         boundFileInfo.options = std::move(csvOption);
     }
 
@@ -38,10 +39,12 @@ public:
     }
     const common::FileScanInfo* getBoundFileInfo() const { return &boundFileInfo; }
     const std::vector<ExportedTableData>* getExportData() const { return &exportData; }
+    bool exportSchemaOnly() const { return schemaOnly; }
 
 private:
     std::vector<ExportedTableData> exportData;
     common::FileScanInfo boundFileInfo;
+    bool schemaOnly;
 };
 
 } // namespace binder

--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -207,6 +207,9 @@ struct PortDBConstants {
     static constexpr char INDEX_FILE_NAME[] = "index.cypher";
     static constexpr char SCHEMA_FILE_NAME[] = "schema.cypher";
     static constexpr char COPY_FILE_NAME[] = "copy.cypher";
+    static constexpr const char* SCHEMA_ONLY_OPTION = "SCHEMA_ONLY";
+    static constexpr const char* EXPORT_FORMAT_OPTION = "FORMAT";
+    static constexpr const char* DEFAULT_EXPORT_FORMAT_OPTION = "PARQUET";
 };
 
 struct WarningConstants {

--- a/src/include/planner/operator/simple/logical_export_db.h
+++ b/src/include/planner/operator/simple/logical_export_db.h
@@ -13,9 +13,9 @@ class LogicalExportDatabase final : public LogicalSimple {
 public:
     LogicalExportDatabase(common::FileScanInfo boundFileInfo,
         std::shared_ptr<binder::Expression> outputExpression,
-        const std::vector<std::shared_ptr<LogicalOperator>>& plans)
+        const std::vector<std::shared_ptr<LogicalOperator>>& plans, bool exportSchemaOnly)
         : LogicalSimple{type_, plans, std::move(outputExpression)},
-          boundFileInfo{std::move(boundFileInfo)} {}
+          boundFileInfo{std::move(boundFileInfo)}, schemaOnly{exportSchemaOnly} {}
 
     std::string getFilePath() const { return boundFileInfo.filePaths[0]; }
     common::FileType getFileType() const { return boundFileInfo.fileTypeInfo.fileType; }
@@ -26,13 +26,16 @@ public:
     const common::FileScanInfo* getBoundFileInfo() const { return &boundFileInfo; }
     std::string getExpressionsForPrinting() const override { return std::string{}; }
 
+    bool exportSchemaOnly() const { return schemaOnly; }
+
     std::unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalExportDatabase>(std::move(boundFileInfo),
-            std::move(outputExpression), std::move(children));
+            std::move(outputExpression), std::move(children), schemaOnly);
     }
 
 private:
     common::FileScanInfo boundFileInfo;
+    bool schemaOnly;
 };
 
 } // namespace planner

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -93,8 +93,8 @@ public:
         binder::expression_vector outExprs);
 
     // Plan export/import database
-    void planExportTableData(const binder::BoundStatement& boundExportDatabase,
-        std::vector<std::shared_ptr<LogicalOperator>>& logicalOperators);
+    std::vector<std::shared_ptr<LogicalOperator>> planExportTableData(
+        const binder::BoundStatement& boundExportDatabase);
     LogicalPlan planExportDatabase(const binder::BoundStatement& statement);
     LogicalPlan planImportDatabase(const binder::BoundStatement& statement);
 

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -93,6 +93,8 @@ public:
         binder::expression_vector outExprs);
 
     // Plan export/import database
+    void planExportTableData(const binder::BoundStatement& boundExportDatabase,
+        std::vector<std::shared_ptr<LogicalOperator>>& logicalOperators);
     LogicalPlan planExportDatabase(const binder::BoundStatement& statement);
     LogicalPlan planImportDatabase(const binder::BoundStatement& statement);
 

--- a/src/include/processor/operator/simple/export_db.h
+++ b/src/include/processor/operator/simple/export_db.h
@@ -28,10 +28,10 @@ class ExportDB final : public Simple {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::EXPORT_DATABASE;
 
 public:
-    ExportDB(common::FileScanInfo boundFileInfo, const DataPos& outputPos, uint32_t id,
-        std::unique_ptr<OPPrintInfo> printInfo)
+    ExportDB(common::FileScanInfo boundFileInfo, bool schemaOnly, const DataPos& outputPos,
+        uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
         : Simple{type_, outputPos, id, std::move(printInfo)},
-          boundFileInfo{std::move(boundFileInfo)} {}
+          boundFileInfo{std::move(boundFileInfo)}, schemaOnly{schemaOnly} {}
 
     void initGlobalStateInternal(ExecutionContext* context) override;
 
@@ -39,12 +39,13 @@ public:
     std::string getOutputMsg() override;
 
     std::unique_ptr<PhysicalOperator> copy() override {
-        return std::make_unique<ExportDB>(std::move(boundFileInfo), outputPos, id,
+        return std::make_unique<ExportDB>(std::move(boundFileInfo), schemaOnly, outputPos, id,
             printInfo->copy());
     }
 
 private:
     common::FileScanInfo boundFileInfo;
+    bool schemaOnly;
 };
 } // namespace processor
 } // namespace kuzu

--- a/src/planner/plan/plan_port_db.cpp
+++ b/src/planner/plan/plan_port_db.cpp
@@ -19,8 +19,9 @@ using namespace kuzu::transaction;
 namespace kuzu {
 namespace planner {
 
-void Planner::planExportTableData(const BoundStatement& statement,
-    std::vector<std::shared_ptr<LogicalOperator>>& logicalOperators) {
+std::vector<std::shared_ptr<LogicalOperator>> Planner::planExportTableData(
+    const BoundStatement& statement) {
+    std::vector<std::shared_ptr<LogicalOperator>> logicalOperators;
     auto& boundExportDatabase = statement.constCast<BoundExportDatabase>();
     auto fileTypeStr = FileTypeUtils::toString(boundExportDatabase.getFileType());
     StringUtils::toLower(fileTypeStr);
@@ -45,6 +46,7 @@ void Planner::planExportTableData(const BoundStatement& statement,
             tablePlan.getLastOperator());
         logicalOperators.push_back(std::move(copyTo));
     }
+    return logicalOperators;
 }
 
 LogicalPlan Planner::planExportDatabase(const BoundStatement& statement) {
@@ -52,7 +54,7 @@ LogicalPlan Planner::planExportDatabase(const BoundStatement& statement) {
     auto logicalOperators = std::vector<std::shared_ptr<LogicalOperator>>();
     auto plan = LogicalPlan();
     if (!boundExportDatabase.exportSchemaOnly()) {
-        planExportTableData(statement, logicalOperators);
+        logicalOperators = planExportTableData(statement);
     }
     auto exportDatabase = std::make_shared<LogicalExportDatabase>(
         boundExportDatabase.getBoundFileInfo()->copy(), statement.getSingleColumnExpr(),

--- a/src/planner/plan/plan_port_db.cpp
+++ b/src/planner/plan/plan_port_db.cpp
@@ -19,37 +19,44 @@ using namespace kuzu::transaction;
 namespace kuzu {
 namespace planner {
 
-LogicalPlan Planner::planExportDatabase(const BoundStatement& statement) {
+void Planner::planExportTableData(const BoundStatement& statement,
+    std::vector<std::shared_ptr<LogicalOperator>>& logicalOperators) {
     auto& boundExportDatabase = statement.constCast<BoundExportDatabase>();
-    auto filePath = boundExportDatabase.getFilePath();
-    auto fileType = boundExportDatabase.getFileType();
-    auto exportData = boundExportDatabase.getExportData();
-    auto logicalOperators = std::vector<std::shared_ptr<LogicalOperator>>();
-    auto plan = LogicalPlan();
-    auto fileTypeStr = FileTypeUtils::toString(fileType);
+    auto fileTypeStr = FileTypeUtils::toString(boundExportDatabase.getFileType());
     StringUtils::toLower(fileTypeStr);
     // TODO(Ziyi): Shouldn't these be done in Binder?
-    std::string name = stringFormat("COPY_{}", FileTypeUtils::toString(fileType));
+    std::string name =
+        stringFormat("COPY_{}", FileTypeUtils::toString(boundExportDatabase.getFileType()));
     auto entry =
         clientContext->getCatalog()->getFunctionEntry(clientContext->getTransaction(), name);
     auto func = function::BuiltInFunctionsUtils::matchFunction(name,
         entry->ptrCast<FunctionCatalogEntry>());
     KU_ASSERT(func != nullptr);
     auto exportFunc = *func->constPtrCast<function::ExportFunction>();
-    for (auto& exportTableData : *exportData) {
+    for (auto& exportTableData : *boundExportDatabase.getExportData()) {
         auto regularQuery = exportTableData.getRegularQuery();
         KU_ASSERT(regularQuery->getStatementType() == StatementType::QUERY);
         auto tablePlan = planStatement(*regularQuery);
-        auto path = clientContext->getVFSUnsafe()->joinPath(filePath, exportTableData.fileName);
+        auto path = clientContext->getVFSUnsafe()->joinPath(boundExportDatabase.getFilePath(),
+            exportTableData.fileName);
         function::ExportFuncBindInput bindInput{exportTableData.columnNames, std::move(path),
             boundExportDatabase.getExportOptions()};
         auto copyTo = std::make_shared<LogicalCopyTo>(exportFunc.bind(bindInput), exportFunc,
             tablePlan.getLastOperator());
         logicalOperators.push_back(std::move(copyTo));
     }
-    auto exportDatabase =
-        std::make_shared<LogicalExportDatabase>(boundExportDatabase.getBoundFileInfo()->copy(),
-            statement.getSingleColumnExpr(), std::move(logicalOperators));
+}
+
+LogicalPlan Planner::planExportDatabase(const BoundStatement& statement) {
+    auto& boundExportDatabase = statement.constCast<BoundExportDatabase>();
+    auto logicalOperators = std::vector<std::shared_ptr<LogicalOperator>>();
+    auto plan = LogicalPlan();
+    if (!boundExportDatabase.exportSchemaOnly()) {
+        planExportTableData(statement, logicalOperators);
+    }
+    auto exportDatabase = std::make_shared<LogicalExportDatabase>(
+        boundExportDatabase.getBoundFileInfo()->copy(), statement.getSingleColumnExpr(),
+        std::move(logicalOperators), boundExportDatabase.exportSchemaOnly());
     plan.setLastOperator(std::move(exportDatabase));
     return plan;
 }

--- a/src/processor/map/map_simple.cpp
+++ b/src/processor/map/map_simple.cpp
@@ -72,7 +72,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapExportDatabase(
     }
     auto printInfo = std::make_unique<ExportDBPrintInfo>(filePath, boundFileInfo->options);
     auto exportDB = std::make_unique<ExportDB>(exportDatabase->getBoundFileInfo()->copy(),
-        getOutputPos(exportDatabase), getOperatorID(), std::move(printInfo));
+        exportDatabase->exportSchemaOnly(), getOutputPos(exportDatabase), getOperatorID(),
+        std::move(printInfo));
     auto outputExpr = {exportDatabase->getOutputExpression()};
     auto resultCollector = createResultCollector(AccumulateType::REGULAR, outputExpr,
         exportDatabase->getSchema(), std::move(exportDB));

--- a/src/processor/operator/simple/export_db.cpp
+++ b/src/processor/operator/simple/export_db.cpp
@@ -181,6 +181,9 @@ void ExportDB::executeInternal(ExecutionContext* context) {
     // write the schema.cypher file
     writeStringStreamToFile(clientContext, getSchemaCypher(clientContext),
         boundFileInfo.filePaths[0] + "/" + PortDBConstants::SCHEMA_FILE_NAME);
+    if (schemaOnly) {
+        return;
+    }
     // write the copy.cypher file
     // for every table, we write COPY FROM statement
     writeStringStreamToFile(clientContext, getCopyCypher(clientContext, &boundFileInfo),

--- a/test/test_files/copy/export_import_db.test
+++ b/test/test_files/copy/export_import_db.test
@@ -288,3 +288,28 @@ Runtime exception: Import database failed: Binder exception: Table org does not 
 -STATEMENT MATCH (a:`N Table`)-[e:`R Table`]->(b:`N Table`) RETURN a.*, e.*, b.*;
 ---- 1
 0|A|Edge|1|B
+
+-CASE ExportDBSchemaOnly
+-SKIP_WASM
+-SKIP_IN_MEM
+-STATEMENT EXPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/special_property_name" (SCHEMA_ONLY=true, format='csv');
+---- error
+Binder exception: When 'SCHEMA_ONLY' option is set to true in export database, no other options are allowed.
+-STATEMENT EXPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/special_property_name" (SCHEMA_ONLY='abc');
+---- error
+Binder exception: The 'SCHEMA_ONLY' option must have a BOOL value.
+-STATEMENT EXPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/special_property_name" (SCHEMA_ONLY=false, format='csv');
+---- ok
+-STATEMENT CREATE NODE TABLE `N Table` (ID INT64 PRIMARY KEY, `PROP 1` STRING);
+---- ok
+-STATEMENT CREATE REL TABLE `R Table` (FROM `N Table` TO `N Table`, `PROP 1` STRING);
+---- ok
+-STATEMENT CREATE (a:`N Table` {id:0, `prop 1`: 'A'})-[:`R Table` {`prop 1`: 'Edge'}]->(b: `N Table` {id:1, `prop 1`: 'B'})
+---- ok
+-STATEMENT EXPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/special_property_name1" (SCHEMA_ONLY=true);
+---- ok
+-IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/special_property_name1"
+-STATEMENT IMPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/special_property_name1";
+---- ok
+-STATEMENT MATCH (a:`N Table`)-[e:`R Table`]->(b:`N Table`) RETURN a.*, e.*, b.*;
+---- 0

--- a/test/test_files/copy/export_import_db.test
+++ b/test/test_files/copy/export_import_db.test
@@ -313,3 +313,16 @@ Binder exception: The 'SCHEMA_ONLY' option must have a BOOL value.
 ---- ok
 -STATEMENT MATCH (a:`N Table`)-[e:`R Table`]->(b:`N Table`) RETURN a.*, e.*, b.*;
 ---- 0
+
+-CASE ExportEmptyDBSchemaOnly
+-SKIP_WASM
+-SKIP_IN_MEM
+-STATEMENT EXPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/empty-db-schema-only" (SCHEMA_ONLY=true);
+---- ok
+-IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/empty-db-schema-only"
+-STATEMENT IMPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/empty-db-schema-only";
+---- ok
+-STATEMENT MATCH (a) return a
+---- 0
+-STATEMENT MATCH (a)-[e]->(b) return e
+---- 0


### PR DESCRIPTION
Closes #5563 
This PR adds a new option: `schema_only` to the `export database` command. This option allows user to only export schemas.