### PR TITLE
LLM ollama endpoint config

### DIFF
--- a/extension/llm/src/function/create_embedding.cpp
+++ b/extension/llm/src/function/create_embedding.cpp
@@ -94,20 +94,20 @@ static uint64_t parseDimensions(std::shared_ptr<Expression> dimensionsExpr,
 
 static std::unique_ptr<FunctionBindData> bindFunc(const ScalarBindFuncInput& input) {
     std::optional<uint64_t> dimensions = std::nullopt;
-    std::optional<std::string> region = std::nullopt;
+    std::optional<std::string> regionOrEndpoint = std::nullopt;
     auto& provider = getInstance(StringUtils::getLower(input.arguments[1]->toString()));
     if (input.arguments.size() == 5) {
         dimensions = parseDimensions(input.arguments[3], input.context);
-        region = StringUtils::getLower(input.arguments[4]->toString());
+        regionOrEndpoint = StringUtils::getLower(input.arguments[4]->toString());
     } else if (input.arguments.size() == 4) {
         if (input.arguments[3]->dataType == LogicalType(LogicalTypeID::STRING)) {
-            region = StringUtils::getLower(input.arguments[3]->toString());
+            regionOrEndpoint = StringUtils::getLower(input.arguments[3]->toString());
         } else {
             dimensions = parseDimensions(input.arguments[3], input.context);
         }
     }
 
-    provider.configure(dimensions, region);
+    provider.configure(dimensions, regionOrEndpoint);
     return FunctionBindData::getSimpleBindData(input.arguments,
         LogicalType::LIST(LogicalType(LogicalTypeID::FLOAT)));
 }

--- a/extension/llm/src/include/providers/ollama.h
+++ b/extension/llm/src/include/providers/ollama.h
@@ -11,6 +11,7 @@ namespace llm_extension {
 class OllamaEmbedding final : public EmbeddingProvider {
     OllamaEmbedding() = default;
     DELETE_COPY_AND_MOVE(OllamaEmbedding);
+    std::optional<std::string> endpoint;
 
 public:
     ~OllamaEmbedding() override = default;
@@ -21,7 +22,7 @@ public:
     nlohmann::json getPayload(const std::string& model, const std::string& text) const override;
     std::vector<float> parseResponse(const httplib::Result& res) const override;
     void configure(const std::optional<uint64_t>& dimensions,
-        const std::optional<std::string>& region) override;
+        const std::optional<std::string>& endpoint) override;
 };
 
 } // namespace llm_extension

--- a/extension/llm/src/include/providers/provider.h
+++ b/extension/llm/src/include/providers/provider.h
@@ -19,7 +19,7 @@ public:
     virtual nlohmann::json getPayload(const std::string& model, const std::string& text) const = 0;
     virtual std::vector<float> parseResponse(const httplib::Result& res) const = 0;
     virtual void configure(const std::optional<uint64_t>& dimensions,
-        const std::optional<std::string>& region) = 0;
+        const std::optional<std::string>& regionOrEndpoint) = 0;
 };
 
 } // namespace llm_extension

--- a/extension/llm/src/providers/ollama.cpp
+++ b/extension/llm/src/providers/ollama.cpp
@@ -13,7 +13,7 @@ EmbeddingProvider& OllamaEmbedding::getInstance() {
 }
 
 std::string OllamaEmbedding::getClient() const {
-    return "http://localhost:11434";
+    return endpoint.value_or("http://localhost:11434");
 }
 
 std::string OllamaEmbedding::getPath(const std::string& /*model*/) const {
@@ -34,16 +34,13 @@ std::vector<float> OllamaEmbedding::parseResponse(const httplib::Result& res) co
 }
 
 void OllamaEmbedding::configure(const std::optional<uint64_t>& dimensions,
-    const std::optional<std::string>& region) {
+    const std::optional<std::string>& endpoint) {
     if (dimensions.has_value()) {
         throw(BinderException(
             "Ollama does not support the dimensions argument, but received dimension: " +
             std::to_string(dimensions.value()) + '\n' + std::string(referenceKuzuDocs)));
     }
-    if (region.has_value()) {
-        throw(BinderException("Ollama does not support the region argument, but received region: " +
-                              region.value() + '\n' + std::string(referenceKuzuDocs)));
-    }
+    this->endpoint = endpoint;
 }
 
 } // namespace llm_extension

--- a/extension/llm/test/test_files/googlegemini_error.test
+++ b/extension/llm/test/test_files/googlegemini_error.test
@@ -25,5 +25,5 @@ For more information, please refer to the official Kuzu documentation: https://d
 
 -STATEMENT return create_embedding('this better fail', 'google-gemini', 'gemini-embedding-exp-03-07', -50, 'badRegion')
 ---- error
-Binder exception: Failed to parse dimensions: NEGATE(50)
+Binder exception: Dimensions should be greater than 0, but found: NEGATE(50)
 For more information, please refer to the official Kuzu documentation: https://docs.kuzudb.com/extensions/llm/

--- a/extension/llm/test/test_files/ollama.test
+++ b/extension/llm/test/test_files/ollama.test
@@ -33,12 +33,12 @@ True
 True
 
 -LOG Dissimilar Text 1
--STATEMENT WITH create_embedding('How to train a dog', 'ollama', 'nomic-embed-text') AS t1, create_embedding('What is the capital of France', 'ollama', 'nomic-embed-text') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
+-STATEMENT WITH create_embedding('How to train a dog', 'ollama', 'nomic-embed-text', 'http://localhost:11434') AS t1, create_embedding('What is the capital of France', 'ollama', 'nomic-embed-text') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
 ---- 1
 False
 
 -LOG Dissimilar Text 2
--STATEMENT WITH create_embedding('How do Unix file permissions work?', 'ollama', 'nomic-embed-text') AS t1, create_embedding('History of the Roman Empire', 'ollama', 'nomic-embed-text') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
+-STATEMENT WITH create_embedding('How do Unix file permissions work?', 'ollama', 'nomic-embed-text', 'http://localhost:11434') AS t1, create_embedding('History of the Roman Empire', 'ollama', 'nomic-embed-text') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
 ---- 1
 False
 

--- a/extension/llm/test/test_files/ollama_error.test
+++ b/extension/llm/test/test_files/ollama_error.test
@@ -60,15 +60,6 @@ Conversion exception: Unsupported casting LIST with incorrect list entry to ARRA
 -STATEMENT CREATE (b:Book {title: 'The Quantum World', published_year: 2004});
 ---- ok
 
--CASE BadEndpoint
--STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
----- ok
-
--STATEMENT return create_embedding('this should fail', 'ollama', 'nomic-embed-text', 'http://nonexisting.xx:11434');
----- error
-Connection exception: Request failed: Could not connect to server <http://nonexisting.xx:11434> 
-For more information, please refer to the official Kuzu documentation: https://docs.kuzudb.com/extensions/llm/
-
 -CASE UnsupportedParams
 
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"

--- a/extension/llm/test/test_files/ollama_error.test
+++ b/extension/llm/test/test_files/ollama_error.test
@@ -60,13 +60,13 @@ Conversion exception: Unsupported casting LIST with incorrect list entry to ARRA
 -STATEMENT CREATE (b:Book {title: 'The Quantum World', published_year: 2004});
 ---- ok
 
-# This test requires not having Ollama running. This test may need to be moved
-# out of this file so that CI can process the requirements before running.
--CASE OllamaNotRunning
--LOG Run Without Having Ollama at http://localhost:11434
--STATEMENT MATCH (b:Book) WITH b, create_embedding(b.title, 'ollama', 'nomic-embed-text') AS emb SET b.title_embedding = emb;
+-CASE BadEndpoint
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
+---- ok
+
+-STATEMENT return create_embedding('this should fail', 'ollama', 'nomic-embed-text', 'http://nonexisting.xx:11434');
 ---- error
-Connection exception: Request failed: Could not connect to server <http://localhost:11434> 
+Connection exception: Request failed: Could not connect to server <http://nonexisting.xx:11434> 
 For more information, please refer to the official Kuzu documentation: https://docs.kuzudb.com/extensions/llm/
 
 -CASE UnsupportedParams
@@ -81,7 +81,7 @@ For more information, please refer to the official Kuzu documentation: https://d
 
 -STATEMENT return create_embedding('this better fail', 'ollama', 'nomic-embed-text', 'badRegion')
 ---- error
-Binder exception: Ollama does not support the region argument, but received region: badregion
+Connection exception: Request failed: Could not connect to server <badregion> 
 For more information, please refer to the official Kuzu documentation: https://docs.kuzudb.com/extensions/llm/
 
 -STATEMENT return create_embedding('this better fail', 'ollama', 'nomic-embed-text', 50, 'badRegion')
@@ -91,5 +91,5 @@ For more information, please refer to the official Kuzu documentation: https://d
 
 -STATEMENT return create_embedding('this better fail', 'ollama', 'nomic-embed-text', -50, 'badRegion')
 ---- error
-Binder exception: Failed to parse dimensions: NEGATE(50)
+Binder exception: Dimensions should be greater than 0, but found: NEGATE(50)
 For more information, please refer to the official Kuzu documentation: https://docs.kuzudb.com/extensions/llm/

--- a/extension/llm/test/test_files/openai_error.test
+++ b/extension/llm/test/test_files/openai_error.test
@@ -20,5 +20,5 @@ For more information, please refer to the official Kuzu documentation: https://d
 
 -STATEMENT return create_embedding('this better fail', 'open-ai', 'text-embedding-3-small', -50, 'badRegion')
 ---- error
-Binder exception: Failed to parse dimensions: NEGATE(50)
+Binder exception: Dimensions should be greater than 0, but found: NEGATE(50)
 For more information, please refer to the official Kuzu documentation: https://docs.kuzudb.com/extensions/llm/

--- a/extension/llm/test/test_files/voyageai_error.test
+++ b/extension/llm/test/test_files/voyageai_error.test
@@ -32,5 +32,5 @@ For more information, please refer to the official Kuzu documentation: https://d
 
 -STATEMENT return create_embedding('this better fail', 'voyage-ai', 'voyage-3-large', -50, 'badRegion')
 ---- error
-Binder exception: Failed to parse dimensions: NEGATE(50)
+Binder exception: Dimensions should be greater than 0, but found: NEGATE(50)
 For more information, please refer to the official Kuzu documentation: https://docs.kuzudb.com/extensions/llm/


### PR DESCRIPTION
# Description

Implements endpoint config for the Ollama provider. Default is now the Ollama default of `http://localhost:11434`. Scalar functions in kuzu do not support optional configuration like GDS functions do. I had to update the region variable to be `regionOrEndpoint` this is ugly but I don't see it changing until scalar functions support` option_name := option_value` syntax. 
Fixes tests with outdated error messages from error test. 

- [X] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).