### PR TITLE
Improve vector index filtered search performance

### DIFF
--- a/src/include/planner/operator/logical_projection.h
+++ b/src/include/planner/operator/logical_projection.h
@@ -7,21 +7,25 @@
 namespace kuzu {
 namespace planner {
 
-class LogicalProjection : public LogicalOperator {
+class KUZU_API LogicalProjection : public LogicalOperator {
+    static constexpr LogicalOperatorType type_ = LogicalOperatorType::PROJECTION;
+
 public:
-    explicit LogicalProjection(binder::expression_vector expressions,
+    LogicalProjection(binder::expression_vector expressions,
         std::shared_ptr<LogicalOperator> child)
-        : LogicalOperator{LogicalOperatorType::PROJECTION, std::move(child)},
-          expressions{std::move(expressions)} {}
+        : LogicalOperator{type_, std::move(child)}, expressions{std::move(expressions)} {}
 
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
 
-    inline std::string getExpressionsForPrinting() const override {
+    std::string getExpressionsForPrinting() const override {
         return binder::ExpressionUtil::toString(expressions);
     }
 
-    inline binder::expression_vector getExpressionsToProject() const { return expressions; }
+    binder::expression_vector getExpressionsToProject() const { return expressions; }
+    void setExpressionsToProject(const binder::expression_vector& expressions) {
+        this->expressions = expressions;
+    }
 
     std::unordered_set<uint32_t> getDiscardedGroupsPos() const;
 


### PR DESCRIPTION
# Description

Avoid evaluating node expression on filter pipeline by rewriting node expression to its internal ID.

TODO: add benchmark number