### PR TITLE
Implement `top` option in queryFTS

### DIFF
--- a/extension/fts/src/function/fts_config.cpp
+++ b/extension/fts/src/function/fts_config.cpp
@@ -185,8 +185,8 @@ QueryFTSConfig::QueryFTSConfig(const function::optional_params_t& optionalParams
         } else if (Conjunctive::NAME == lowerCaseName) {
             value.validateType(Conjunctive::TYPE);
             isConjunctive = value.getValue<bool>();
-        } else if (Top::NAME == lowerCaseName) {
-            value.validateType(Top::TYPE);
+        } else if (TopK::NAME == lowerCaseName) {
+            value.validateType(TopK::TYPE);
             topK = value.getValue<int64_t>();
         } else {
             throw common::BinderException{"Unrecognized optional parameter: " + name};

--- a/extension/fts/src/function/fts_config.cpp
+++ b/extension/fts/src/function/fts_config.cpp
@@ -185,6 +185,9 @@ QueryFTSConfig::QueryFTSConfig(const function::optional_params_t& optionalParams
         } else if (Conjunctive::NAME == lowerCaseName) {
             value.validateType(Conjunctive::TYPE);
             isConjunctive = value.getValue<bool>();
+        } else if (Top::NAME == lowerCaseName) {
+            value.validateType(Top::TYPE);
+            top = value.getValue<int64_t>();
         } else {
             throw common::BinderException{"Unrecognized optional parameter: " + name};
         }

--- a/extension/fts/src/function/fts_config.cpp
+++ b/extension/fts/src/function/fts_config.cpp
@@ -187,7 +187,7 @@ QueryFTSConfig::QueryFTSConfig(const function::optional_params_t& optionalParams
             isConjunctive = value.getValue<bool>();
         } else if (Top::NAME == lowerCaseName) {
             value.validateType(Top::TYPE);
-            top = value.getValue<int64_t>();
+            topK = value.getValue<int64_t>();
         } else {
             throw common::BinderException{"Unrecognized optional parameter: " + name};
         }

--- a/extension/fts/src/function/fts_config.cpp
+++ b/extension/fts/src/function/fts_config.cpp
@@ -187,7 +187,7 @@ QueryFTSConfig::QueryFTSConfig(const function::optional_params_t& optionalParams
             isConjunctive = value.getValue<bool>();
         } else if (TopK::NAME == lowerCaseName) {
             value.validateType(TopK::TYPE);
-            topK = value.getValue<int64_t>();
+            topK = value.getValue<uint64_t>();
         } else {
             throw common::BinderException{"Unrecognized optional parameter: " + name};
         }

--- a/extension/fts/src/function/query_fts_bind_data.cpp
+++ b/extension/fts/src/function/query_fts_bind_data.cpp
@@ -48,7 +48,7 @@ QueryFTSConfig QueryFTSOptionalParams::getConfig() const {
             ExpressionUtil::evaluateLiteral<bool>(*conjunctive, LogicalType::BOOL());
     }
     if (topK != nullptr) {
-        config.topK = ExpressionUtil::evaluateLiteral<int64_t>(*topK, LogicalType::INT64());
+        config.topK = ExpressionUtil::evaluateLiteral<uint64_t>(*topK, LogicalType::UINT64());
     }
     return config;
 }
@@ -58,12 +58,12 @@ std::vector<std::string> QueryFTSBindData::getTerms(main::ClientContext& context
     FTSUtils::normalizeQuery(queryInStr);
     auto terms = StringUtils::split(queryInStr, " ");
     auto config = entry.getAuxInfo().cast<FTSIndexAuxInfo>().config;
-    auto stopWordsTable = context.getStorageManager()
-                              ->getTable(context.getCatalog()
-                                             ->getTableCatalogEntry(context.getTransaction(),
-                                                 config.stopWordsTableName)
-                                             ->getTableID())
-                              ->ptrCast<NodeTable>();
+    auto stopWordsTable =
+        context.getStorageManager()
+            ->getTable(context.getCatalog()
+                    ->getTableCatalogEntry(context.getTransaction(), config.stopWordsTableName)
+                    ->getTableID())
+            ->ptrCast<NodeTable>();
     return FTSUtils::stemTerms(terms, entry.getAuxInfo().cast<FTSIndexAuxInfo>().config,
         context.getMemoryManager(), stopWordsTable, context.getTransaction(),
         getConfig().isConjunctive);

--- a/extension/fts/src/function/query_fts_bind_data.cpp
+++ b/extension/fts/src/function/query_fts_bind_data.cpp
@@ -58,12 +58,12 @@ std::vector<std::string> QueryFTSBindData::getTerms(main::ClientContext& context
     FTSUtils::normalizeQuery(queryInStr);
     auto terms = StringUtils::split(queryInStr, " ");
     auto config = entry.getAuxInfo().cast<FTSIndexAuxInfo>().config;
-    auto stopWordsTable =
-        context.getStorageManager()
-            ->getTable(context.getCatalog()
-                    ->getTableCatalogEntry(context.getTransaction(), config.stopWordsTableName)
-                    ->getTableID())
-            ->ptrCast<NodeTable>();
+    auto stopWordsTable = context.getStorageManager()
+                              ->getTable(context.getCatalog()
+                                             ->getTableCatalogEntry(context.getTransaction(),
+                                                 config.stopWordsTableName)
+                                             ->getTableID())
+                              ->ptrCast<NodeTable>();
     return FTSUtils::stemTerms(terms, entry.getAuxInfo().cast<FTSIndexAuxInfo>().config,
         context.getMemoryManager(), stopWordsTable, context.getTransaction(),
         getConfig().isConjunctive);

--- a/extension/fts/src/function/query_fts_bind_data.cpp
+++ b/extension/fts/src/function/query_fts_bind_data.cpp
@@ -27,6 +27,8 @@ QueryFTSOptionalParams::QueryFTSOptionalParams(const binder::expression_vector& 
             b = optionalParam;
         } else if (paramName == Conjunctive::NAME) {
             conjunctive = optionalParam;
+        } else if (paramName == Top::NAME) {
+            top = optionalParam;
         } else {
             throw common::BinderException{"Unknown optional parameter: " + paramName};
         }
@@ -44,6 +46,9 @@ QueryFTSConfig QueryFTSOptionalParams::getConfig() const {
     if (conjunctive != nullptr) {
         config.isConjunctive =
             ExpressionUtil::evaluateLiteral<bool>(*conjunctive, LogicalType::BOOL());
+    }
+    if (top != nullptr) {
+        config.top = ExpressionUtil::evaluateLiteral<int64_t>(*top, LogicalType::INT64());
     }
     return config;
 }

--- a/extension/fts/src/function/query_fts_bind_data.cpp
+++ b/extension/fts/src/function/query_fts_bind_data.cpp
@@ -48,7 +48,7 @@ QueryFTSConfig QueryFTSOptionalParams::getConfig() const {
             ExpressionUtil::evaluateLiteral<bool>(*conjunctive, LogicalType::BOOL());
     }
     if (top != nullptr) {
-        config.top = ExpressionUtil::evaluateLiteral<int64_t>(*top, LogicalType::INT64());
+        config.topK = ExpressionUtil::evaluateLiteral<int64_t>(*top, LogicalType::INT64());
     }
     return config;
 }
@@ -58,12 +58,12 @@ std::vector<std::string> QueryFTSBindData::getTerms(main::ClientContext& context
     FTSUtils::normalizeQuery(queryInStr);
     auto terms = StringUtils::split(queryInStr, " ");
     auto config = entry.getAuxInfo().cast<FTSIndexAuxInfo>().config;
-    auto stopWordsTable = context.getStorageManager()
-                              ->getTable(context.getCatalog()
-                                             ->getTableCatalogEntry(context.getTransaction(),
-                                                 config.stopWordsTableName)
-                                             ->getTableID())
-                              ->ptrCast<NodeTable>();
+    auto stopWordsTable =
+        context.getStorageManager()
+            ->getTable(context.getCatalog()
+                    ->getTableCatalogEntry(context.getTransaction(), config.stopWordsTableName)
+                    ->getTableID())
+            ->ptrCast<NodeTable>();
     return FTSUtils::stemTerms(terms, entry.getAuxInfo().cast<FTSIndexAuxInfo>().config,
         context.getMemoryManager(), stopWordsTable, context.getTransaction(),
         getConfig().isConjunctive);

--- a/extension/fts/src/function/query_fts_bind_data.cpp
+++ b/extension/fts/src/function/query_fts_bind_data.cpp
@@ -27,8 +27,8 @@ QueryFTSOptionalParams::QueryFTSOptionalParams(const binder::expression_vector& 
             b = optionalParam;
         } else if (paramName == Conjunctive::NAME) {
             conjunctive = optionalParam;
-        } else if (paramName == Top::NAME) {
-            top = optionalParam;
+        } else if (paramName == TopK::NAME) {
+            topK = optionalParam;
         } else {
             throw common::BinderException{"Unknown optional parameter: " + paramName};
         }
@@ -47,8 +47,8 @@ QueryFTSConfig QueryFTSOptionalParams::getConfig() const {
         config.isConjunctive =
             ExpressionUtil::evaluateLiteral<bool>(*conjunctive, LogicalType::BOOL());
     }
-    if (top != nullptr) {
-        config.topK = ExpressionUtil::evaluateLiteral<int64_t>(*top, LogicalType::INT64());
+    if (topK != nullptr) {
+        config.topK = ExpressionUtil::evaluateLiteral<int64_t>(*topK, LogicalType::INT64());
     }
     return config;
 }

--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -47,7 +47,7 @@ struct QFTSSharedState : public GDSFuncSharedState {
         processor::FactorizedTable& localTable, DocScore docScore) {
         KU_ASSERT(vectors[0]->dataType.getLogicalTypeID() == LogicalTypeID::INTERNAL_ID);
         KU_ASSERT(vectors[1]->dataType.getLogicalTypeID() == LogicalTypeID::DOUBLE);
-        vectors[0]->setValue(0, docScore.offset);
+        vectors[0]->setValue(0, internalID_t{(common::offset_t)docScore.offset, outputTableID});
         vectors[1]->setValue(0, docScore.score);
         localTable.append(vectors);
     }

--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -1,5 +1,7 @@
 #include "function/query_fts_index.h"
 
+#include <queue>
+
 #include "binder/binder.h"
 #include "binder/expression/expression_util.h"
 #include "binder/expression/literal_expression.h"
@@ -93,7 +95,7 @@ struct QFTSTopKSharedState : public QFTSSharedState {
         auto globalTable = factorizedTablePool.getGlobalTable();
         while (!minHeap.empty()) {
             auto& docScore = minHeap.top();
-            docsVector.setValue(0, nodeID_t{docScore.offset, outputTableID});
+            docsVector.setValue(0, nodeID_t{(offset_t)docScore.offset, outputTableID});
             scoreVector.setValue(0, docScore.score);
             globalTable->append(vectors);
             minHeap.pop();

--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -95,12 +95,11 @@ public:
 
     void output(processor::FactorizedTable& table, int64_t top) {
         auto& outputScores = sharedState->outputScores;
-        if ((uint64_t)top > outputScores.size()) {
-            top = outputScores.size();
+        if ((uint64_t)top < outputScores.size()) {
+            std::partial_sort(outputScores.begin(), outputScores.begin() + top, outputScores.end(),
+                [](const auto& left, const auto& right) { return left.second > right.second; });
+            outputScores.resize(top);
         }
-        std::partial_sort(outputScores.begin(), outputScores.begin() + top, outputScores.end(),
-            [](const auto& a, const auto& b) { return a.second > b.second; });
-        outputScores.resize(top);
         for (auto& [offset, score] : sharedState->outputScores) {
             docsVector->setValue(0, nodeID_t{offset, bindData.outputTableID});
             scoreVector->setValue(0, score);

--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -3,6 +3,7 @@
 #include "binder/binder.h"
 #include "binder/expression/expression_util.h"
 #include "binder/expression/literal_expression.h"
+#include "binder/query/reading_clause/bound_table_function_call.h"
 #include "catalog/fts_index_catalog_entry.h"
 #include "common/exception/binder.h"
 #include "common/types/internal_id_util.h"
@@ -10,14 +11,13 @@
 #include "function/gds/gds_utils.h"
 #include "function/query_fts_bind_data.h"
 #include "index/fts_index.h"
+#include "planner/operator/logical_hash_join.h"
+#include "planner/operator/logical_table_function_call.h"
+#include "planner/planner.h"
 #include "processor/execution_context.h"
 #include "storage/storage_manager.h"
 #include "storage/table/node_table.h"
 #include "utils/fts_utils.h"
-#include "binder/query/reading_clause/bound_table_function_call.h"
-#include "planner/operator/logical_table_function_call.h"
-#include "planner/operator/logical_hash_join.h"
-#include "planner/planner.h"
 
 namespace kuzu {
 namespace fts_extension {

--- a/extension/fts/src/include/function/fts_config.h
+++ b/extension/fts/src/include/function/fts_config.h
@@ -91,6 +91,12 @@ struct Conjunctive {
     static constexpr bool DEFAULT_VALUE = false;
 };
 
+struct Top {
+    static constexpr const char* NAME = "top";
+    static constexpr common::LogicalTypeID TYPE = common::LogicalTypeID::INT64;
+    static constexpr uint64_t DEFAULT_VALUE = INT64_MAX;
+};
+
 struct QueryFTSConfig {
     // k: parameter controls the influence of term frequency saturation. It limits the effect of
     // additional occurrences of a term within a document.
@@ -99,6 +105,7 @@ struct QueryFTSConfig {
     // document length.
     double b = B::DEFAULT_VALUE;
     bool isConjunctive = Conjunctive::DEFAULT_VALUE;
+    uint64_t top = Top::DEFAULT_VALUE;
 
     QueryFTSConfig() = default;
     explicit QueryFTSConfig(const function::optional_params_t& optionalParams);

--- a/extension/fts/src/include/function/fts_config.h
+++ b/extension/fts/src/include/function/fts_config.h
@@ -91,10 +91,10 @@ struct Conjunctive {
     static constexpr bool DEFAULT_VALUE = false;
 };
 
-struct Top {
+struct TopK {
     static constexpr const char* NAME = "top";
-    static constexpr common::LogicalTypeID TYPE = common::LogicalTypeID::INT64;
-    static constexpr uint64_t DEFAULT_VALUE = INT64_MAX;
+    static constexpr common::LogicalTypeID TYPE = common::LogicalTypeID::UINT64;
+    static constexpr uint64_t DEFAULT_VALUE = UINT64_MAX;
 };
 
 constexpr uint64_t INVALID_TOP_K = UINT64_MAX;
@@ -107,7 +107,7 @@ struct QueryFTSConfig {
     // document length.
     double b = B::DEFAULT_VALUE;
     bool isConjunctive = Conjunctive::DEFAULT_VALUE;
-    uint64_t topK = Top::DEFAULT_VALUE;
+    uint64_t topK = TopK::DEFAULT_VALUE;
 
     QueryFTSConfig() = default;
     explicit QueryFTSConfig(const function::optional_params_t& optionalParams);

--- a/extension/fts/src/include/function/fts_config.h
+++ b/extension/fts/src/include/function/fts_config.h
@@ -97,6 +97,8 @@ struct Top {
     static constexpr uint64_t DEFAULT_VALUE = INT64_MAX;
 };
 
+constexpr uint64_t INVALID_TOP_K = UINT64_MAX;
+
 struct QueryFTSConfig {
     // k: parameter controls the influence of term frequency saturation. It limits the effect of
     // additional occurrences of a term within a document.
@@ -105,7 +107,7 @@ struct QueryFTSConfig {
     // document length.
     double b = B::DEFAULT_VALUE;
     bool isConjunctive = Conjunctive::DEFAULT_VALUE;
-    uint64_t top = Top::DEFAULT_VALUE;
+    uint64_t topK = Top::DEFAULT_VALUE;
 
     QueryFTSConfig() = default;
     explicit QueryFTSConfig(const function::optional_params_t& optionalParams);

--- a/extension/fts/src/include/function/query_fts_bind_data.h
+++ b/extension/fts/src/include/function/query_fts_bind_data.h
@@ -12,13 +12,11 @@ struct QueryFTSOptionalParams {
     std::shared_ptr<binder::Expression> k;
     std::shared_ptr<binder::Expression> b;
     std::shared_ptr<binder::Expression> conjunctive;
-    std::shared_ptr<binder::Expression> top;
+    std::shared_ptr<binder::Expression> topK;
 
     explicit QueryFTSOptionalParams(const binder::expression_vector& optionalParams);
 
     QueryFTSConfig getConfig() const;
-
-    bool isTopSet() const { return top != nullptr; }
 };
 
 struct QueryFTSBindData final : function::GDSBindData {

--- a/extension/fts/src/include/function/query_fts_bind_data.h
+++ b/extension/fts/src/include/function/query_fts_bind_data.h
@@ -17,6 +17,8 @@ struct QueryFTSOptionalParams {
     explicit QueryFTSOptionalParams(const binder::expression_vector& optionalParams);
 
     QueryFTSConfig getConfig() const;
+
+    bool isTopSet() const { return top != nullptr; }
 };
 
 struct QueryFTSBindData final : function::GDSBindData {

--- a/extension/fts/src/include/function/query_fts_bind_data.h
+++ b/extension/fts/src/include/function/query_fts_bind_data.h
@@ -12,6 +12,7 @@ struct QueryFTSOptionalParams {
     std::shared_ptr<binder::Expression> k;
     std::shared_ptr<binder::Expression> b;
     std::shared_ptr<binder::Expression> conjunctive;
+    std::shared_ptr<binder::Expression> top;
 
     explicit QueryFTSOptionalParams(const binder::expression_vector& optionalParams);
 

--- a/extension/fts/test/test_files/ms_passage_small.test
+++ b/extension/fts/test/test_files/ms_passage_small.test
@@ -21,6 +21,15 @@
 134|1.923814
 109|1.957072
 390|2.937742
+-LOG QueryKeywordsWithTOP5
+-STATEMENT CALL query_fts_index('doc', 'contentIdx', 'dispossessed meaning', top:=5) RETURN node.id, score;
+-CHECK_ORDER
+---- 5
+390|2.937742
+109|1.957072
+134|1.923814
+429|1.891667
+202|1.875433
 -LOG QuerySingleKeyWord
 -STATEMENT CALL query_fts_index('doc', 'contentIdx', 'normality') RETURN node.id, score order by score, node.id;
 -CHECK_ORDER
@@ -73,5 +82,18 @@
 176|2.261988
 4|2.519607
 456|2.618953
+-STATEMENT CALL query_fts_index('doc', 'contentIdx', 'how long does it take to recover from top wisdom teeth removal', top:=10) RETURN node.id, score
+-CHECK_ORDER
+---- 10
+456|2.618953
+4|2.519607
+176|2.261988
+438|2.211869
+207|2.181402
+435|2.163641
+410|2.063448
+240|2.051795
+87|1.973758
+249|1.973758
 -STATEMENT CALL DROP_FTS_INDEX('doc', 'contentIdx')
 ---- ok

--- a/extension/fts/test/test_files/ms_passage_small.test
+++ b/extension/fts/test/test_files/ms_passage_small.test
@@ -23,7 +23,6 @@
 390|2.937742
 -LOG QueryKeywordsWithTOP5
 -STATEMENT CALL query_fts_index('doc', 'contentIdx', 'dispossessed meaning', top:=5) RETURN node.id, score;
--CHECK_ORDER
 ---- 5
 390|2.937742
 109|1.957072
@@ -83,7 +82,6 @@
 4|2.519607
 456|2.618953
 -STATEMENT CALL query_fts_index('doc', 'contentIdx', 'how long does it take to recover from top wisdom teeth removal', top:=10) RETURN node.id, score
--CHECK_ORDER
 ---- 10
 456|2.618953
 4|2.519607

--- a/extension/fts/test/test_files/ms_passage_small.test
+++ b/extension/fts/test/test_files/ms_passage_small.test
@@ -22,7 +22,7 @@
 109|1.957072
 390|2.937742
 -LOG QueryKeywordsWithTOP5
--STATEMENT CALL query_fts_index('doc', 'contentIdx', 'dispossessed meaning', top:=5) RETURN node.id, score;
+-STATEMENT CALL query_fts_index('doc', 'contentIdx', 'dispossessed meaning', top:=cast(5 as uint64)) RETURN node.id, score;
 ---- 5
 390|2.937742
 109|1.957072
@@ -81,7 +81,7 @@
 176|2.261988
 4|2.519607
 456|2.618953
--STATEMENT CALL query_fts_index('doc', 'contentIdx', 'how long does it take to recover from top wisdom teeth removal', top:=10) RETURN node.id, score
+-STATEMENT CALL query_fts_index('doc', 'contentIdx', 'how long does it take to recover from top wisdom teeth removal', top:=cast(10 as uint64)) RETURN node.id, score
 ---- 10
 456|2.618953
 4|2.519607

--- a/src/binder/expression/expression_util.cpp
+++ b/src/binder/expression/expression_util.cpp
@@ -532,5 +532,8 @@ template KUZU_API int64_t ExpressionUtil::evaluateLiteral<int64_t>(const Express
 template KUZU_API bool ExpressionUtil::evaluateLiteral<bool>(const Expression& expression,
     const LogicalType& type, validate_param_func<bool> validateParamFunc);
 
+template KUZU_API uint64_t ExpressionUtil::evaluateLiteral<uint64_t>(const Expression& expression,
+    const LogicalType& type, validate_param_func<uint64_t> validateParamFunc);
+
 } // namespace binder
 } // namespace kuzu


### PR DESCRIPTION
This PR adds the`top` optional parameter to `queryFTS` function. The `top` parameter chooses the `top k` result from the queryFTS output.

Performance improvement:
Query:
```
CALL query_fts_index('doc', 'contentIdx', 'dispossessed meaning', top:=topK) RETURN node,score order by score desc;
```

Result:
4 threads:

| topk  | Master | This branch |
|-------|------------------|-----------------|
| 50    | 2.808s           | 1.398s          |
| 500   | 2.977s           | 1.496s          |
| 5000  | 2.906s           | 1.728s          |
