### PR TITLE
Fix empty unique_ptr dereference

### DIFF
--- a/src/include/processor/operator/hash_join/join_hash_table.h
+++ b/src/include/processor/operator/hash_join/join_hash_table.h
@@ -26,8 +26,9 @@ public:
     void allocateHashSlots(uint64_t numTuples);
     void buildHashSlots();
 
+    // The tmpHashResultVector may be null if there is only one keyVector
     void probe(const std::vector<common::ValueVector*>& keyVectors, common::ValueVector& hashVector,
-        common::SelectionVector& hashSelVec, common::ValueVector& tmpHashResultVector,
+        common::SelectionVector& hashSelVec, common::ValueVector* tmpHashResultVector,
         uint8_t** probedTuples);
     // All key vectors must be flat. Thus input is a tuple, multiple matches can be found for the
     // given key tuple.

--- a/src/processor/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/operator/hash_join/hash_join_probe.cpp
@@ -56,7 +56,7 @@ bool HashJoinProbe::getMatchedTuplesForFlatKey(ExecutionContext* context) {
             return false;
         }
         saveSelVector(*keyVectors[0]->state);
-        sharedState->getHashTable()->probe(keyVectors, *hashVector, hashSelVec, *tmpHashVector,
+        sharedState->getHashTable()->probe(keyVectors, *hashVector, hashSelVec, tmpHashVector.get(),
             probeState->probedTuples.get());
     }
     auto numMatchedTuples = sharedState->getHashTable()->matchFlatKeys(keyVectors,
@@ -74,7 +74,7 @@ bool HashJoinProbe::getMatchedTuplesForUnFlatKey(ExecutionContext* context) {
         return false;
     }
     saveSelVector(*keyVector->state);
-    sharedState->getHashTable()->probe(keyVectors, *hashVector, hashSelVec, *tmpHashVector,
+    sharedState->getHashTable()->probe(keyVectors, *hashVector, hashSelVec, tmpHashVector.get(),
         probeState->probedTuples.get());
     auto numMatchedTuples =
         sharedState->getHashTable()->matchUnFlatKey(keyVector, probeState->probedTuples.get(),

--- a/src/processor/operator/hash_join/join_hash_table.cpp
+++ b/src/processor/operator/hash_join/join_hash_table.cpp
@@ -127,7 +127,7 @@ void JoinHashTable::buildHashSlots() {
 }
 
 void JoinHashTable::probe(const std::vector<ValueVector*>& keyVectors, ValueVector& hashVector,
-    SelectionVector& hashSelVec, ValueVector& tmpHashResultVector, uint8_t** probedTuples) {
+    SelectionVector& hashSelVec, ValueVector* tmpHashResultVector, uint8_t** probedTuples) {
     KU_ASSERT(keyVectors.size() == keyTypes.size());
     if (getNumEntries() == 0) {
         return;
@@ -141,8 +141,8 @@ void JoinHashTable::probe(const std::vector<ValueVector*>& keyVectors, ValueVect
     for (auto i = 1u; i < keyVectors.size(); i++) {
         hashSelVec.setSelSize(keyVectors[i]->state->getSelVector().getSelSize());
         function::VectorHashFunction::computeHash(*keyVectors[i],
-            keyVectors[i]->state->getSelVector(), tmpHashResultVector, hashSelVec);
-        function::VectorHashFunction::combineHash(hashVector, hashSelVec, tmpHashResultVector,
+            keyVectors[i]->state->getSelVector(), *tmpHashResultVector, hashSelVec);
+        function::VectorHashFunction::combineHash(hashVector, hashSelVec, *tmpHashResultVector,
             hashSelVec, hashVector, hashSelVec);
     }
     for (auto i = 0u; i < hashSelVec.getSelSize(); i++) {


### PR DESCRIPTION
Only in practice seems to be an issue in debug mode since there's an extra assertion when de-referencing, as the parameter is only accessed in cases where it is non-empty. However the behaviour is technically undefined.