### PR TITLE
Implement optional parameter implicit casting for fts

### DIFF
--- a/extension/fts/src/function/query_fts_bind_data.cpp
+++ b/extension/fts/src/function/query_fts_bind_data.cpp
@@ -70,12 +70,12 @@ std::vector<std::string> QueryFTSBindData::getTerms(main::ClientContext& context
     FTSUtils::normalizeQuery(queryInStr);
     auto terms = StringUtils::split(queryInStr, " ");
     auto config = entry.getAuxInfo().cast<FTSIndexAuxInfo>().config;
-    auto stopWordsTable =
-        context.getStorageManager()
-            ->getTable(context.getCatalog()
-                    ->getTableCatalogEntry(context.getTransaction(), config.stopWordsTableName)
-                    ->getTableID())
-            ->ptrCast<NodeTable>();
+    auto stopWordsTable = context.getStorageManager()
+                              ->getTable(context.getCatalog()
+                                             ->getTableCatalogEntry(context.getTransaction(),
+                                                 config.stopWordsTableName)
+                                             ->getTableID())
+                              ->ptrCast<NodeTable>();
     return FTSUtils::stemTerms(terms, entry.getAuxInfo().cast<FTSIndexAuxInfo>().config,
         context.getMemoryManager(), stopWordsTable, context.getTransaction(),
         getConfig().isConjunctive);

--- a/extension/fts/src/function/query_fts_bind_data.cpp
+++ b/extension/fts/src/function/query_fts_bind_data.cpp
@@ -1,10 +1,10 @@
 #include "function/query_fts_bind_data.h"
 
+#include "binder/binder.h"
 #include "binder/expression/expression_util.h"
 #include "catalog/fts_index_catalog_entry.h"
 #include "common/exception/binder.h"
 #include "common/string_utils.h"
-#include "function/stem.h"
 #include "libstemmer.h"
 #include "re2.h"
 #include "storage/storage_manager.h"
@@ -18,17 +18,29 @@ using namespace kuzu::common;
 using namespace kuzu::binder;
 using namespace kuzu::storage;
 
-QueryFTSOptionalParams::QueryFTSOptionalParams(const binder::expression_vector& optionalParams) {
+static std::shared_ptr<Expression> applyImplicitCastingIfNecessary(main::ClientContext* context,
+    std::shared_ptr<Expression> expr, LogicalType targetType) {
+    if (expr->getDataType() != targetType) {
+        Binder binder{context};
+        expr = binder.getExpressionBinder()->implicitCastIfNecessary(expr, targetType);
+        expr = binder.getExpressionBinder()->foldExpression(expr);
+    }
+    return expr;
+}
+
+QueryFTSOptionalParams::QueryFTSOptionalParams(main::ClientContext* context,
+    const binder::expression_vector& optionalParams) {
     for (auto& optionalParam : optionalParams) {
         auto paramName = StringUtils::getLower(optionalParam->getAlias());
         if (paramName == K::NAME) {
-            k = optionalParam;
+            k = applyImplicitCastingIfNecessary(context, optionalParam, LogicalType{K::TYPE});
         } else if (paramName == B::NAME) {
-            b = optionalParam;
+            b = applyImplicitCastingIfNecessary(context, optionalParam, LogicalType{B::TYPE});
         } else if (paramName == Conjunctive::NAME) {
-            conjunctive = optionalParam;
+            conjunctive = applyImplicitCastingIfNecessary(context, optionalParam,
+                LogicalType{Conjunctive::TYPE});
         } else if (paramName == TopK::NAME) {
-            topK = optionalParam;
+            topK = applyImplicitCastingIfNecessary(context, optionalParam, LogicalType{TopK::TYPE});
         } else {
             throw common::BinderException{"Unknown optional parameter: " + paramName};
         }
@@ -58,12 +70,12 @@ std::vector<std::string> QueryFTSBindData::getTerms(main::ClientContext& context
     FTSUtils::normalizeQuery(queryInStr);
     auto terms = StringUtils::split(queryInStr, " ");
     auto config = entry.getAuxInfo().cast<FTSIndexAuxInfo>().config;
-    auto stopWordsTable = context.getStorageManager()
-                              ->getTable(context.getCatalog()
-                                             ->getTableCatalogEntry(context.getTransaction(),
-                                                 config.stopWordsTableName)
-                                             ->getTableID())
-                              ->ptrCast<NodeTable>();
+    auto stopWordsTable =
+        context.getStorageManager()
+            ->getTable(context.getCatalog()
+                    ->getTableCatalogEntry(context.getTransaction(), config.stopWordsTableName)
+                    ->getTableID())
+            ->ptrCast<NodeTable>();
     return FTSUtils::stemTerms(terms, entry.getAuxInfo().cast<FTSIndexAuxInfo>().config,
         context.getMemoryManager(), stopWordsTable, context.getTransaction(),
         getConfig().isConjunctive);

--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -409,10 +409,10 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     KU_ASSERT(index.has_value());
     auto& ftsIndex = index.value()->cast<FTSIndex>();
     auto& ftsStorageInfo = ftsIndex.getStorageInfo().constCast<FTSStorageInfo>();
-    auto bindData =
-        std::make_unique<QueryFTSBindData>(std::move(columns), std::move(graphEntry), nodeOutput,
-            std::move(query), *ftsIndexEntry, QueryFTSOptionalParams{input->optionalParamsLegacy},
-            ftsStorageInfo.numDocs, ftsStorageInfo.avgDocLen);
+    auto bindData = std::make_unique<QueryFTSBindData>(std::move(columns), std::move(graphEntry),
+        nodeOutput, std::move(query), *ftsIndexEntry,
+        QueryFTSOptionalParams{context, input->optionalParamsLegacy}, ftsStorageInfo.numDocs,
+        ftsStorageInfo.avgDocLen);
     context->setUseInternalCatalogEntry(false /* useInternalCatalogEntry */);
     return bindData;
 }

--- a/extension/fts/src/include/function/query_fts_bind_data.h
+++ b/extension/fts/src/include/function/query_fts_bind_data.h
@@ -14,7 +14,8 @@ struct QueryFTSOptionalParams {
     std::shared_ptr<binder::Expression> conjunctive;
     std::shared_ptr<binder::Expression> topK;
 
-    explicit QueryFTSOptionalParams(const binder::expression_vector& optionalParams);
+    QueryFTSOptionalParams(main::ClientContext* context,
+        const binder::expression_vector& optionalParams);
 
     QueryFTSConfig getConfig() const;
 };

--- a/extension/fts/test/prepare_test.cpp
+++ b/extension/fts/test/prepare_test.cpp
@@ -8,10 +8,10 @@ namespace testing {
 TEST_F(ApiTest, PrepareFTSTest) {
     createDBAndConn();
 #ifdef __STATIC_LINK_EXTENSION_TEST__
-    ASSERT_TRUE(conn
-            ->query(common::stringFormat("LOAD EXTENSION '{}'",
-                TestHelper::appendKuzuRootPath("extension/fts/build/libfts.kuzu_extension")))
-            ->isSuccess());
+    ASSERT_TRUE(conn->query(common::stringFormat("LOAD EXTENSION '{}'",
+                                TestHelper::appendKuzuRootPath(
+                                    "extension/fts/build/libfts.kuzu_extension")))
+                    ->isSuccess());
 #endif
     ASSERT_TRUE(
         conn->query("CALL CREATE_FTS_INDEX('person', 'personIdx', ['fName'])")->isSuccess());

--- a/extension/fts/test/prepare_test.cpp
+++ b/extension/fts/test/prepare_test.cpp
@@ -7,10 +7,12 @@ namespace testing {
 
 TEST_F(ApiTest, PrepareFTSTest) {
     createDBAndConn();
-    ASSERT_TRUE(conn->query(common::stringFormat("LOAD EXTENSION '{}'",
-                                TestHelper::appendKuzuRootPath(
-                                    "extension/fts/build/libfts.kuzu_extension")))
-                    ->isSuccess());
+#ifdef __STATIC_LINK_EXTENSION_TEST__
+    ASSERT_TRUE(conn
+            ->query(common::stringFormat("LOAD EXTENSION '{}'",
+                TestHelper::appendKuzuRootPath("extension/fts/build/libfts.kuzu_extension")))
+            ->isSuccess());
+#endif
     ASSERT_TRUE(
         conn->query("CALL CREATE_FTS_INDEX('person', 'personIdx', ['fName'])")->isSuccess());
     auto prepared =

--- a/extension/fts/test/test_files/optional_param.test
+++ b/extension/fts/test/test_files/optional_param.test
@@ -1,0 +1,44 @@
+-DATASET CSV ms-passage
+
+--
+
+# These ground truth numbers were obtained from DuckDB and we double checked that
+# our results and DuckDB's results is within three decimal places.
+-CASE optionalParams
+-LOAD_DYNAMIC_EXTENSION fts
+-STATEMENT CALL CREATE_FTS_INDEX('doc', 'contentIdx', ['content'])
+---- ok
+-STATEMENT CALL query_fts_index('doc', 'contentIdx', 'dispossessed meaning', top:=-2) RETURN node.id, score order by score, node.id;
+---- error
+Overflow exception: Value -2 is not within UINT64 range
+-STATEMENT CALL query_fts_index('doc', 'contentIdx', 'dispossessed meaning', top:=-1-3) RETURN node.id, score order by score, node.id;
+---- error
+Overflow exception: Value -4 is not within UINT64 range
+-STATEMENT CALL query_fts_index('doc', 'contentIdx', 'dispossessed meaning', top:=2.7) RETURN node.id, score order by score, node.id;
+---- 3
+390|2.937742
+109|1.957072
+134|1.923814
+-STATEMENT CALL query_fts_index('doc', 'contentIdx', 'dispossessed meaning', top:=-5.2) RETURN node.id, score order by score, node.id;
+---- error
+Overflow exception: Value -5.200000 is not within UINT64 range
+-STATEMENT CALL query_fts_index('doc', 'contentIdx', 'dispossessed meaning', top:=1+3) RETURN node.id, score order by score, node.id;
+---- 4
+109|1.957072
+134|1.923814
+390|2.937742
+429|1.891667
+-STATEMENT CALL query_fts_index('doc', 'contentIdx', 'dispossessed meaning', top:=5) RETURN node.id, score order by score, node.id;
+---- 5
+109|1.957072
+134|1.923814
+390|2.937742
+429|1.891667
+202|1.875433
+-STATEMENT CALL query_fts_index('doc', 'contentIdx', 'dispossessed meaning', k:=cast(2.1 as float)) RETURN node.id, score order by score limit 3;
+---- 3
+389|1.785953
+432|1.785953
+437|1.821645
+-STATEMENT CALL query_fts_index('doc', 'contentIdx', 'dispossessed meaning', conjunctive:=cast(true as bool)) RETURN node.id, score order by score limit 2;
+---- 0

--- a/src/binder/expression/expression_util.cpp
+++ b/src/binder/expression/expression_util.cpp
@@ -1,5 +1,3 @@
-#include "binder/expression/expression_util.h"
-
 #include <algorithm>
 
 #include "binder/expression/literal_expression.h"

--- a/src/binder/expression/expression_util.cpp
+++ b/src/binder/expression/expression_util.cpp
@@ -1,3 +1,5 @@
+#include "binder/expression/expression_util.h"
+
 #include <algorithm>
 
 #include "binder/expression/literal_expression.h"
@@ -7,7 +9,6 @@
 #include "common/exception/runtime.h"
 #include "common/type_utils.h"
 #include "common/types/value/nested.h"
-#include "expression_evaluator/expression_evaluator_utils.h"
 
 using namespace kuzu::common;
 

--- a/src/binder/expression/expression_util.cpp
+++ b/src/binder/expression/expression_util.cpp
@@ -9,6 +9,7 @@
 #include "common/exception/runtime.h"
 #include "common/type_utils.h"
 #include "common/types/value/nested.h"
+#include "expression_evaluator/expression_evaluator_utils.h"
 
 using namespace kuzu::common;
 

--- a/src/include/binder/expression_binder.h
+++ b/src/include/binder/expression_binder.h
@@ -42,7 +42,8 @@ public:
     std::shared_ptr<Expression> bindExpression(const parser::ParsedExpression& parsedExpression);
 
     // TODO(Xiyang): move to an expression rewriter
-    KUZU_API std::shared_ptr<Expression> foldExpression(const std::shared_ptr<Expression>& expression) const;
+    KUZU_API std::shared_ptr<Expression> foldExpression(
+        const std::shared_ptr<Expression>& expression) const;
 
     // Boolean expressions.
     std::shared_ptr<Expression> bindBooleanExpression(

--- a/src/include/binder/expression_binder.h
+++ b/src/include/binder/expression_binder.h
@@ -42,7 +42,7 @@ public:
     std::shared_ptr<Expression> bindExpression(const parser::ParsedExpression& parsedExpression);
 
     // TODO(Xiyang): move to an expression rewriter
-    std::shared_ptr<Expression> foldExpression(const std::shared_ptr<Expression>& expression) const;
+    KUZU_API std::shared_ptr<Expression> foldExpression(const std::shared_ptr<Expression>& expression) const;
 
     // Boolean expressions.
     std::shared_ptr<Expression> bindBooleanExpression(


### PR DESCRIPTION
This PR implements optional parameter casting for `query_fts`. Users no longer needs to explicitly cast optional params while querying fts.