### PR TITLE
Add output message to create table as

### DIFF
--- a/src/binder/bind/bind_ddl.cpp
+++ b/src/binder/bind/bind_ddl.cpp
@@ -274,7 +274,7 @@ std::unique_ptr<BoundStatement> Binder::bindCreateTableAs(const Statement& state
             createInfo->tableName, createInfo->onConflict, std::move(boundExtraInfo),
             clientContext->useInternalCatalogEntry());
         auto boundCreateTable = std::make_unique<BoundCreateTable>(std::move(boundCreateInfo),
-            BoundStatementResult::createEmptyResult());
+            BoundStatementResult::createSingleStringColumnResult());
         boundCreateTable->setCopyInfo(std::move(boundCopyFromInfo));
         return boundCreateTable;
     }
@@ -301,7 +301,7 @@ std::unique_ptr<BoundStatement> Binder::bindCreateTableAs(const Statement& state
         boundCreateInfo.extraInfo->ptrCast<BoundExtraCreateTableInfo>()->propertyDefinitions =
             std::move(propertyDefinitions);
         auto boundCreateTable = std::make_unique<BoundCreateTable>(std::move(boundCreateInfo),
-            BoundStatementResult::createEmptyResult());
+            BoundStatementResult::createSingleStringColumnResult());
         boundCreateTable->setCopyInfo(std::move(boundCopyFromInfo));
         return boundCreateTable;
     }

--- a/src/include/planner/operator/logical_noop.h
+++ b/src/include/planner/operator/logical_noop.h
@@ -5,21 +5,29 @@
 namespace kuzu {
 namespace planner {
 
+// Serve as a dummy parent (usually root) for a set of children that doesn't have a well-defined
+// parent. E.g. CREATE TABLE AS, create table & copy.
 class LogicalNoop : public LogicalOperator {
     static constexpr LogicalOperatorType type_ = LogicalOperatorType::NOOP;
 
 public:
-    explicit LogicalNoop(std::vector<std::shared_ptr<LogicalOperator>> children)
-        : LogicalOperator{type_, {std::move(children)}} {}
+    explicit LogicalNoop(common::idx_t messageChildIdx, std::vector<std::shared_ptr<LogicalOperator>> children)
+        : LogicalOperator{type_, {std::move(children)}}, messageChildIdx{messageChildIdx} {}
 
     void computeFactorizedSchema() override { createEmptySchema(); }
     void computeFlatSchema() override { createEmptySchema(); }
 
+    common::idx_t getMessageChildIdx() const { return messageChildIdx; }
+
     std::string getExpressionsForPrinting() const override { return ""; }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return std::make_unique<LogicalNoop>(copyVector(children));
+        return std::make_unique<LogicalNoop>(messageChildIdx, copyVector(children));
     }
+
+private:
+    // For create table as. Dummy sink is the last operator and should propagate return message.
+    common::idx_t messageChildIdx;
 };
 
 } // namespace planner

--- a/src/include/planner/operator/logical_noop.h
+++ b/src/include/planner/operator/logical_noop.h
@@ -11,7 +11,8 @@ class LogicalNoop : public LogicalOperator {
     static constexpr LogicalOperatorType type_ = LogicalOperatorType::NOOP;
 
 public:
-    explicit LogicalNoop(common::idx_t messageChildIdx, std::vector<std::shared_ptr<LogicalOperator>> children)
+    explicit LogicalNoop(common::idx_t messageChildIdx,
+        std::vector<std::shared_ptr<LogicalOperator>> children)
         : LogicalOperator{type_, {std::move(children)}}, messageChildIdx{messageChildIdx} {}
 
     void computeFactorizedSchema() override { createEmptySchema(); }

--- a/src/planner/plan/append_simple.cpp
+++ b/src/planner/plan/append_simple.cpp
@@ -45,7 +45,6 @@ static LogicalPlan getSimplePlan(std::shared_ptr<LogicalOperator> op) {
 LogicalPlan Planner::planCreateTable(const BoundStatement& statement) {
     auto& createTable = statement.constCast<BoundCreateTable>();
     auto& info = createTable.getInfo();
-
     // If it is a CREATE NODE TABLE AS, then copy as well
     if (createTable.hasCopyInfo()) {
         std::vector<std::shared_ptr<LogicalOperator>> children;
@@ -62,7 +61,7 @@ LogicalPlan Planner::planCreateTable(const BoundStatement& statement) {
         }
         auto create = std::make_shared<LogicalCreateTable>(info.copy());
         children.push_back(std::move(create));
-        auto noop = std::make_shared<LogicalNoop>(children);
+        auto noop = std::make_shared<LogicalNoop>(children.size() - 1, children);
         return getSimplePlan(std::move(noop));
     }
     auto op = std::make_shared<LogicalCreateTable>(info.copy());

--- a/src/processor/map/map_noop.cpp
+++ b/src/processor/map/map_noop.cpp
@@ -1,5 +1,5 @@
-#include "processor/plan_mapper.h"
 #include "planner/operator/logical_noop.h"
+#include "processor/plan_mapper.h"
 
 using namespace kuzu::planner;
 
@@ -17,7 +17,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapNoop(const LogicalOperator* log
     auto child = children[idx].get();
     // LCOV_EXCL_START
     if (!child->isSink()) {
-        throw common::InternalException(common::stringFormat("Trying to propagate result table from a non sink operator. This should never happen."));
+        throw common::InternalException(
+            common::stringFormat("Trying to propagate result table from a non sink operator. This "
+                                 "should never happen."));
     }
     // LCOV_EXCL_STOP
     auto fTable = child->ptrCast<Sink>()->getResultFTable();

--- a/src/processor/map/map_noop.cpp
+++ b/src/processor/map/map_noop.cpp
@@ -1,4 +1,5 @@
 #include "processor/plan_mapper.h"
+#include "planner/operator/logical_noop.h"
 
 using namespace kuzu::planner;
 
@@ -6,10 +7,23 @@ namespace kuzu {
 namespace processor {
 
 std::unique_ptr<PhysicalOperator> PlanMapper::mapNoop(const LogicalOperator* logicalOperator) {
-    auto op =
-        createEmptyFTableScan(FactorizedTable::EmptyTable(clientContext->getMemoryManager()), 1);
+    std::vector<std::unique_ptr<PhysicalOperator>> children;
     for (auto child : logicalOperator->getChildren()) {
-        op->addChild(mapOperator(child.get()));
+        children.push_back(mapOperator(child.get()));
+    }
+    auto noop = logicalOperator->constPtrCast<LogicalNoop>();
+    auto idx = noop->getMessageChildIdx();
+    KU_ASSERT(idx < children.size());
+    auto child = children[idx].get();
+    // LCOV_EXCL_START
+    if (!child->isSink()) {
+        throw common::InternalException(common::stringFormat("Trying to propagate result table from a non sink operator. This should never happen."));
+    }
+    // LCOV_EXCL_STOP
+    auto fTable = child->ptrCast<Sink>()->getResultFTable();
+    auto op = std::make_unique<DummySimpleSink>(fTable, getOperatorID());
+    for (auto& childOp : children) {
+        op->addChild(std::move(childOp));
     }
     return op;
 }

--- a/test/test_files/ddl/ddl.test
+++ b/test/test_files/ddl/ddl.test
@@ -596,7 +596,8 @@ Binder exception: Expression ABC has data type STRING but expected INT64[3]. Imp
 
 -CASE CreateNodeTableAs
 -STATEMENT CREATE NODE TABLE Test AS LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv" WHERE ISStudent = True RETURN id, Gender, fname;
----- ok
+---- 1
+Table Test has been created.
 -STATEMENT MATCH (a:Test) RETURN a.*;
 ---- 2
 0|1|Alice
@@ -625,7 +626,8 @@ Binder exception: RETURN or WITH * is not allowed when there are no variables in
 
 -CASE CreateRelTableAs
 -STATEMENT CREATE NODE TABLE Person2 AS LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv" RETURN *;
----- ok
+---- 1
+Table Person2 has been created.
 -STATEMENT COPY Person2 FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson2.csv";
 ---- ok
 -STATEMENT CREATE REL TABLE Knows2 (FROM Person2 TO Person2) AS LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eKnows.csv" RETURN *;


### PR DESCRIPTION
# Description

This PR add output message to `CREATE TABLE AS`. Since there is no standard on what the message should be (e.g. relational system may just return true false). We simply propagate the message from `CREATE TABLE`