### PR TITLE
Add option to render Kuzu logo in dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <div align="center">
-  <img src="https://kuzudb.com/img/kuzu-logo.png" height="100">
+  <picture>
+    <source srcset="https://kuzudb.com/img/kuzu-logo-dark.png" media="(prefers-color-scheme: dark)">
+    <img src="https://kuzudb.com/img/kuzu-logo.png" height="100" alt="Kuzu Logo">
+  </picture>
 </div>
 
 <br>


### PR DESCRIPTION
Requires this PR to be merged first: https://github.com/kuzudb/kuzudb.github.io/pull/202

# Description

In our main README, currently, the Kuzu logo in dark mode looks like this:
![image](https://github.com/user-attachments/assets/59087605-3776-4313-9c9e-e1dda76f8280)

This PR adds an optional media flag so that the dark mode logo will render on browsers that use dark mode, which will look a lot nicer.

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).