### PR TITLE
Fix macOS ARM64 extension release

### DIFF
--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build precompiled extensions
-        run: env OPENSSL_ROOT_DIR=/opt/homebrew/Cellar/openssl@3/3.3.0 make extension-release NUM_THREADS=$(sysctl -n hw.logicalcpu)
+        run: make extension-release NUM_THREADS=$(sysctl -n hw.logicalcpu)
         env:
           MACOSX_DEPLOYMENT_TARGET: 11.0
           CMAKE_OSX_ARCHITECTURES: "arm64"


### PR DESCRIPTION
Now the OpenSSL version has been upgraded to 3.5.0. The outdated `OPENSSL_ROOT_DIR` causes CMake not able to resolve the path for OpenSSL. I figured that without it CMake can resolve OpenSSL automnatically, so it should be removed.

Vefified by https://github.com/kuzudb/kuzu/actions/runs/16077503113