### PR TITLE
Use OverflowFileHandle::equals when doing hash index comparisons

### DIFF
--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -290,14 +290,8 @@ common::hash_t HashIndex<common::ku_string_t>::hashStored(
     const transaction::Transaction* transaction, const common::ku_string_t& key) const;
 
 template<>
-inline bool HashIndex<common::ku_string_t>::equals(const transaction::Transaction* transaction,
-    std::string_view keyToLookup, const common::ku_string_t& keyInEntry) const {
-    if (HashIndexUtils::areStringPrefixAndLenEqual(keyToLookup, keyInEntry)) {
-        auto entryKeyString = overflowFileHandle->readString(transaction->getType(), keyInEntry);
-        return memcmp(keyToLookup.data(), entryKeyString.c_str(), entryKeyString.length()) == 0;
-    }
-    return false;
-}
+bool HashIndex<common::ku_string_t>::equals(const transaction::Transaction* transaction,
+    std::string_view keyToLookup, const common::ku_string_t& keyInEntry) const;
 
 struct PrimaryKeyIndexStorageInfo final : IndexStorageInfo {
     common::page_idx_t firstHeaderPage;

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -414,6 +414,25 @@ void HashIndex<T>::bulkReserve(uint64_t newEntries) {
 template<typename T>
 HashIndex<T>::~HashIndex() = default;
 
+template<>
+bool HashIndex<common::ku_string_t>::equals(const transaction::Transaction* transaction,
+    std::string_view keyToLookup, const common::ku_string_t& keyInEntry) const {
+    if (!HashIndexUtils::areStringPrefixAndLenEqual(keyToLookup, keyInEntry)) {
+        return false;
+    }
+    if (keyInEntry.len <= common::ku_string_t::PREFIX_LENGTH) {
+        // For strings shorter than PREFIX_LENGTH, the result must be true.
+        return true;
+    } else if (keyInEntry.len <= common::ku_string_t::SHORT_STR_LENGTH) {
+        // For short strings, whose lengths are larger than PREFIX_LENGTH, check if their
+        // actual values are equal.
+        return memcmp(keyToLookup.data(), keyInEntry.prefix, keyInEntry.len) == 0;
+    } else {
+        // For long strings, compare with overflow data
+        return overflowFileHandle->equals(transaction->getType(), keyToLookup, keyInEntry);
+    }
+}
+
 template class HashIndex<int64_t>;
 template class HashIndex<int32_t>;
 template class HashIndex<int16_t>;


### PR DESCRIPTION
I've copied the implementation from `InMemHashIndex::equals` instead of unifying them since it's being removed from the InMemHashIndex in #5638.

This will remove some unnecessary string allocations when comparing entries in the index, as well as allow for an early comparison failure for strings that span multiple pages and are more expensive to read.
A similar thing could be done for the hash function with some additional work (though it wouldn't be able to fail early).