### PR TITLE
Move cached_file_manager path under extension directory.

### DIFF
--- a/extension/httpfs/src/cached_file_manager.cpp
+++ b/extension/httpfs/src/cached_file_manager.cpp
@@ -1,6 +1,8 @@
 #include "cached_file_manager.h"
 
+#include "common/string_utils.h"
 #include "httpfs.h"
+#include "httpfs_extension.h"
 
 namespace kuzu {
 namespace httpfs_extension {
@@ -8,7 +10,10 @@ namespace httpfs_extension {
 using namespace common;
 
 CachedFileManager::CachedFileManager(main::ClientContext* context) : vfs{context->getVFSUnsafe()} {
-    cacheDir = context->getDatabasePath() + "/.cached_files";
+    cacheDir = common::stringFormat("{}/{}",
+        extension::ExtensionUtils::getLocalDirForExtension(context,
+            StringUtils::getLower(HttpfsExtension::EXTENSION_NAME)),
+        ".cached_files");
     if (!vfs->fileOrPathExists(cacheDir, context)) {
         vfs->createDir(cacheDir);
     }
@@ -35,7 +40,7 @@ std::unique_ptr<FileInfo> CachedFileManager::getCachedFileInfo(HTTPFileInfo* htt
 
 void CachedFileManager::cleanUP(main::ClientContext* context) {
     auto cacheDirForTrx = getCachedDirForTrx(context->getTransaction()->getID());
-    vfs->removeFileIfExists(cacheDirForTrx);
+    vfs->removeFileIfExists(cacheDirForTrx, context);
 }
 
 std::string CachedFileManager::getCachedFilePath(const std::string& originalFileName,

--- a/extension/httpfs/src/include/httpfs_extension.h
+++ b/extension/httpfs/src/include/httpfs_extension.h
@@ -3,7 +3,7 @@
 #include "extension/extension.h"
 
 namespace kuzu {
-namespace httpfs {
+namespace httpfs_extension {
 
 class HttpfsExtension : public extension::Extension {
 public:
@@ -13,5 +13,5 @@ public:
     static void load(main::ClientContext* context);
 };
 
-} // namespace httpfs
+} // namespace httpfs_extension
 } // namespace kuzu

--- a/extension/httpfs/test/test_files/gcs_download.test
+++ b/extension/httpfs/test/test_files/gcs_download.test
@@ -47,9 +47,8 @@ Adam|Zhang|2020
 Karissa|Zhang|2021
 Zhang|Noura|2022
 -LOG LoadFromWithCache
-# TODO(Ziyi): FIX-ME.
-# -STATEMENT CALL HTTP_CACHE_FILE=TRUE;
-# ---- ok
+-STATEMENT CALL HTTP_CACHE_FILE=TRUE;
+---- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT load from 'gs://kuzudb-test/user.csv' return *;

--- a/extension/httpfs/test/test_files/s3_download.test
+++ b/extension/httpfs/test/test_files/s3_download.test
@@ -51,9 +51,8 @@ Adam|Karissa|2020
 Adam|Zhang|2020
 Karissa|Zhang|2021
 Zhang|Noura|2022
-# TODO(Ziyi): FIX-ME.
-# -STATEMENT CALL HTTP_CACHE_FILE=TRUE;
-# ---- ok
+-STATEMENT CALL HTTP_CACHE_FILE=TRUE;
+---- ok
 -STATEMENT load from 's3://kuzu-test/user.csv.gz' return *;
 ---- 2
 Adam|30|2020-06-22
@@ -65,9 +64,8 @@ Adam|30|2020-06-22
 Karissa|40|2019-05-12
 
 -LOG LoadFromWithCache
-# TODO(Ziyi): FIX-ME.
-# -STATEMENT CALL HTTP_CACHE_FILE=TRUE;
-# ---- ok
+-STATEMENT CALL HTTP_CACHE_FILE=TRUE;
+---- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT load from 's3://kuzu-test/user.csv' return *;

--- a/extension/httpfs/test/test_files/s3_remote_database.test
+++ b/extension/httpfs/test/test_files/s3_remote_database.test
@@ -21,9 +21,8 @@
 -CASE UWS3RemoteDB
 -SKIP
 -INSERT_STATEMENT_BLOCK UW_S3_SETUP
-# TODO(Ziyi): FIX-ME.
-# -STATEMENT CALL HTTP_CACHE_FILE=TRUE
-# ---- ok
+-STATEMENT CALL HTTP_CACHE_FILE=TRUE
+---- ok
 -STATEMENT ATTACH 's3://kuzu-test/ldbc01' as ldbc (dbtype kuzu)
 ---- 1
 Attached database successfully.

--- a/src/common/file_system/file_system.cpp
+++ b/src/common/file_system/file_system.cpp
@@ -17,7 +17,7 @@ void FileSystem::createDir(const std::string& /*dir*/) const {
     KU_UNREACHABLE;
 }
 
-void FileSystem::removeFileIfExists(const std::string&) {
+void FileSystem::removeFileIfExists(const std::string&, const main::ClientContext* /*context*/) {
     KU_UNREACHABLE;
 }
 

--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -23,7 +23,6 @@
 
 #include <cstring>
 
-#include "extension/extension.h"
 #include "storage/storage_utils.h"
 
 namespace kuzu {

--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -134,7 +134,7 @@ std::unique_ptr<FileInfo> LocalFileSystem::openFile(const std::string& path, Fil
         throw IOException(stringFormat("Cannot open file {}: {}", fullPath, posixErrMessage()));
     }
     if (flags.lockType != FileLockType::NO_LOCK) {
-        struct flock fl {};
+        struct flock fl{};
         memset(&fl, 0, sizeof fl);
         fl.l_type = flags.lockType == FileLockType::READ_LOCK ? F_RDLCK : F_WRLCK;
         fl.l_whence = SEEK_SET;
@@ -267,15 +267,26 @@ static std::unordered_set<std::string> getDatabaseFileSet(const std::string& pat
     return result;
 }
 
-static bool isExtensionFile(const std::filesystem::path& path) {
-    return path.extension() == extension::ExtensionUtils::EXTENSION_FILE_SUFFIX;
+static bool isExtensionFile(const main::ClientContext* context, const std::string& path) {
+    if (context == nullptr) {
+        return false;
+    }
+    auto extensionDir = context->getExtensionDir();
+    std::filesystem::path rel = std::filesystem::relative(path, extensionDir);
+    for (const auto& part : rel) {
+        if (part == "..") {
+            return false;
+        }
+    }
+    return true;
 }
 
-void LocalFileSystem::removeFileIfExists(const std::string& path) {
+void LocalFileSystem::removeFileIfExists(const std::string& path,
+    const main::ClientContext* context) {
     if (!fileOrPathExists(path)) {
         return;
     }
-    if (!getDatabaseFileSet(dbPath).contains(path) && !isExtensionFile(path)) {
+    if (!getDatabaseFileSet(dbPath).contains(path) && !isExtensionFile(context, path)) {
         throw IOException(stringFormat(
             "Error: Path {} is not within the allowed list of files to be removed.", path));
     }
@@ -506,7 +517,7 @@ uint64_t LocalFileSystem::getFileSize(const FileInfo& fileInfo) const {
     }
     return size.QuadPart;
 #else
-    struct stat s {};
+    struct stat s{};
     if (fstat(localFileInfo->fd, &s) == -1) {
         throw IOException(stringFormat("Cannot read size of file. path: {} - Error {}: {}",
             fileInfo.path, errno, posixErrMessage()));

--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -134,7 +134,7 @@ std::unique_ptr<FileInfo> LocalFileSystem::openFile(const std::string& path, Fil
         throw IOException(stringFormat("Cannot open file {}: {}", fullPath, posixErrMessage()));
     }
     if (flags.lockType != FileLockType::NO_LOCK) {
-        struct flock fl{};
+        struct flock fl {};
         memset(&fl, 0, sizeof fl);
         fl.l_type = flags.lockType == FileLockType::READ_LOCK ? F_RDLCK : F_WRLCK;
         fl.l_whence = SEEK_SET;
@@ -517,7 +517,7 @@ uint64_t LocalFileSystem::getFileSize(const FileInfo& fileInfo) const {
     }
     return size.QuadPart;
 #else
-    struct stat s{};
+    struct stat s {};
     if (fstat(localFileInfo->fd, &s) == -1) {
         throw IOException(stringFormat("Cannot read size of file. path: {} - Error {}: {}",
             fileInfo.path, errno, posixErrMessage()));

--- a/src/common/file_system/virtual_file_system.cpp
+++ b/src/common/file_system/virtual_file_system.cpp
@@ -62,8 +62,9 @@ void VirtualFileSystem::createDir(const std::string& dir) const {
     findFileSystem(dir)->createDir(dir);
 }
 
-void VirtualFileSystem::removeFileIfExists(const std::string& path) {
-    findFileSystem(path)->removeFileIfExists(path);
+void VirtualFileSystem::removeFileIfExists(const std::string& path,
+    const main::ClientContext* context) {
+    findFileSystem(path)->removeFileIfExists(path, context);
 }
 
 bool VirtualFileSystem::fileOrPathExists(const std::string& path, main::ClientContext* context) {

--- a/src/include/common/file_system/file_system.h
+++ b/src/include/common/file_system/file_system.h
@@ -68,7 +68,8 @@ public:
 
     virtual void createDir(const std::string& dir) const;
 
-    virtual void removeFileIfExists(const std::string& path);
+    virtual void removeFileIfExists(const std::string& path,
+        const main::ClientContext* context = nullptr);
 
     virtual bool fileOrPathExists(const std::string& path, main::ClientContext* context = nullptr);
 

--- a/src/include/common/file_system/local_file_system.h
+++ b/src/include/common/file_system/local_file_system.h
@@ -41,7 +41,8 @@ public:
 
     void createDir(const std::string& dir) const override;
 
-    void removeFileIfExists(const std::string& path) override;
+    void removeFileIfExists(const std::string& path,
+        const main::ClientContext* context = nullptr) override;
 
     bool fileOrPathExists(const std::string& path, main::ClientContext* context = nullptr) override;
 

--- a/src/include/common/file_system/virtual_file_system.h
+++ b/src/include/common/file_system/virtual_file_system.h
@@ -38,7 +38,8 @@ public:
 
     void createDir(const std::string& dir) const override;
 
-    void removeFileIfExists(const std::string& path) override;
+    void removeFileIfExists(const std::string& path,
+        const main::ClientContext* context = nullptr) override;
 
     bool fileOrPathExists(const std::string& path, main::ClientContext* context = nullptr) override;
 


### PR DESCRIPTION
This PR fixes disabled `cached_file_manager` tests by moving the cache directory under the extension directory.