### PR TITLE
Export and Import from Prev Release

### DIFF
--- a/scripts/export-dbs.py
+++ b/scripts/export-dbs.py
@@ -91,7 +91,7 @@ def main():
         copyCommands = createCypherQueries(os.path.join(datasetPath, "copy.cypher"))
         combinedCommands = schemaCommands + copyCommands
         datasetName = os.path.relpath(datasetPath, argDatasetPath)
-        exportPath = os.path.join(outputDir, datasetName)
+        exportPath = os.path.join(outputDir, version, datasetName)
         exportCommand = f"EXPORT DATABASE '{exportPath}' (format=\"csv\", header=true);"
         combinedCommands.append(exportCommand)
         combinedCommands.insert(0, "CALL threads=1;")

--- a/scripts/export-dbs.py
+++ b/scripts/export-dbs.py
@@ -109,6 +109,7 @@ def main():
         exportPath = os.path.join(argDatasetPath, "tmp", version, datasetName)
         exportCommand = f"EXPORT DATABASE '{exportPath}' (format=\"csv\", header=true);"
         combinedCommands.append(exportCommand)
+        combinedCommands.insert(0, "CALL threads=1;")
         print(f"Exporting {datasetPath} to {exportPath}")
 
         process = subprocess.Popen(

--- a/scripts/export-dbs.py
+++ b/scripts/export-dbs.py
@@ -69,16 +69,13 @@ def main():
     output_dir = os.path.abspath(args.output_dir)
 
     if not os.path.isfile(arg_executable_path):
-        print(f"Error: Executable not found at {arg_executable_path}")
-        return 1
+        raise Exception(f"Error: Executable not found at {arg_executable_path}")
     if not os.path.exists(arg_dataset_path):
-        print(f"Error: Dataset path not found at {arg_dataset_path}")
-        return 1
+        raise Exception(f"Error: Dataset path not found at {arg_dataset_path}")
 
     version = get_version(arg_executable_path)
     if not version:
-        print(f"Could not pull version number from {arg_executable_path}")
-        return 1
+        raise Exception(f"Could not pull version number from {arg_executable_path}")
 
     valid_datasets = find_valid_dataset_dirs(arg_dataset_path)
     # This is done to construct a full path to replace the relative paths found

--- a/scripts/export-dbs.py
+++ b/scripts/export-dbs.py
@@ -62,10 +62,12 @@ def main():
 
     parser.add_argument("executablePath", help="Path to the KUZU shell")
     parser.add_argument("datasetPath", help="Path to the dataset directory")
+    parser.add_argument("outputDir", help="Path to export the datasets")
     args = parser.parse_args()
 
     argExecutablePath = os.path.abspath(args.executablePath)
     argDatasetPath = os.path.abspath(args.datasetPath)
+    outputDir = os.path.abspath(args.outputDir)
 
     if not os.path.isfile(argExecutablePath):
         print(f"Error: Executable not found at {argExecutablePath}")
@@ -89,7 +91,7 @@ def main():
         copyCommands = createCypherQueries(os.path.join(datasetPath, "copy.cypher"))
         combinedCommands = schemaCommands + copyCommands
         datasetName = os.path.relpath(datasetPath, argDatasetPath)
-        exportPath = os.path.join(argDatasetPath, "tmp", version, datasetName)
+        exportPath = os.path.join(outputDir, datasetName)
         exportCommand = f"EXPORT DATABASE '{exportPath}' (format=\"csv\", header=true);"
         combinedCommands.append(exportCommand)
         combinedCommands.insert(0, "CALL threads=1;")

--- a/scripts/export-dbs.py
+++ b/scripts/export-dbs.py
@@ -5,10 +5,10 @@ import subprocess
 
 
 # Get version number like 0.10.0.5.
-def getVersion(executablePath):
+def get_version(executable_path):
     try:
         result = subprocess.run(
-            [executablePath, "--version"],
+            [executable_path, "--version"],
             capture_output=True, text=True, check=True)
         output = result.stdout.strip()
         if output.startswith("Kuzu "):
@@ -22,10 +22,10 @@ def getVersion(executablePath):
 
 
 # Parse schema.cypher and copy.cypher files.
-def createCypherQueries(filePath):
+def create_cypher_queries(file_path):
     commands = []
     try:
-        with open(filePath, "r") as f:
+        with open(file_path, "r") as f:
             for line in f:
                 stripped = line.strip()
                 if not stripped:
@@ -39,20 +39,20 @@ def createCypherQueries(filePath):
 
 
 # Find all datasets that have a schema.cypher and copy.cypher file.
-def findValidDatasetDirs(datasetRoot):
-    validDirs = []
+def find_valid_dataset_dirs(dataset_root):
+    valid_dirs = []
 
-    for root, dirs, files in os.walk(datasetRoot):
+    for root, dirs, files in os.walk(dataset_root):
         # This script creates a tmp directory with the exported dbs, we should
         # skip it in our search.
         if "tmp" in root.split(os.sep):
             continue
-        fileSet = set(files)
+        file_set = set(files)
 
-        if "schema.cypher" in fileSet:
-            validDirs.append(root)
+        if "schema.cypher" in file_set:
+            valid_dirs.append(root)
 
-    return validDirs
+    return valid_dirs
 
 
 # Example scripts/export-dbs.py build/debug/tools/shell/kuzu dataset.
@@ -64,45 +64,44 @@ def main():
     parser.add_argument("--output-dir", required=True, help="Path to export the datasets")
     args = parser.parse_args()
 
-    argExecutablePath = os.path.abspath(args.executable)
-    argDatasetPath = os.path.abspath(args.dataset_dir)
-    outputDir = os.path.abspath(args.output_dir)
+    arg_executable_path = os.path.abspath(args.executable)
+    arg_dataset_path = os.path.abspath(args.dataset_dir)
+    output_dir = os.path.abspath(args.output_dir)
 
-
-    if not os.path.isfile(argExecutablePath):
-        print(f"Error: Executable not found at {argExecutablePath}")
+    if not os.path.isfile(arg_executable_path):
+        print(f"Error: Executable not found at {arg_executable_path}")
         return 1
-    if not os.path.exists(argDatasetPath):
-        print(f"Error: Dataset path not found at {argDatasetPath}")
+    if not os.path.exists(arg_dataset_path):
+        print(f"Error: Dataset path not found at {arg_dataset_path}")
         return 1
 
-    version = getVersion(argExecutablePath)
+    version = get_version(arg_executable_path)
     if not version:
-        print(f"Could not pull version number from {argExecutablePath}")
+        print(f"Could not pull version number from {arg_executable_path}")
         return 1
 
-    validDatasets = findValidDatasetDirs(argDatasetPath)
+    valid_datasets = find_valid_dataset_dirs(arg_dataset_path)
     # This is done to construct a full path to replace the relative paths found
     # in copy.cypher files.
-    scriptDir = os.path.dirname(os.path.realpath(__file__))
-    rootDir = os.path.abspath(os.path.join(scriptDir, ".."))
-    for datasetPath in validDatasets:
-        schemaCommands = createCypherQueries(os.path.join(datasetPath, "schema.cypher"))
-        copyCommands = createCypherQueries(os.path.join(datasetPath, "copy.cypher"))
-        combinedCommands = schemaCommands + copyCommands
-        datasetName = os.path.relpath(datasetPath, argDatasetPath)
-        exportPath = os.path.join(outputDir, version, datasetName)
-        exportCommand = f"EXPORT DATABASE '{exportPath}' (format=\"csv\", header=true);"
-        combinedCommands.append(exportCommand)
-        combinedCommands.insert(0, "CALL threads=1;")
-        print(f"Exporting {datasetPath} to {exportPath}")
-        joinedCommands = "\n".join(cmd.strip() for cmd in combinedCommands)
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    root_dir = os.path.abspath(os.path.join(script_dir, ".."))
+    for dataset_path in valid_datasets:
+        schema_commands = create_cypher_queries(os.path.join(dataset_path, "schema.cypher"))
+        copy_commands = create_cypher_queries(os.path.join(dataset_path, "copy.cypher"))
+        combined_commands = schema_commands + copy_commands
+        dataset_name = os.path.relpath(dataset_path, arg_dataset_path)
+        export_path = os.path.join(output_dir, version, dataset_name)
+        export_command = f"EXPORT DATABASE '{export_path}' (format=\"csv\", header=true);"
+        combined_commands.append(export_command)
+        combined_commands.insert(0, "CALL threads=1;")
+        print(f"Exporting {dataset_path} to {export_path}")
+        joined_commands = "\n".join(cmd.strip() for cmd in combined_commands)
 
         subprocess.run(
-            [argExecutablePath],
-            input=joinedCommands,
+            [arg_executable_path],
+            input=joined_commands,
             text=True,
-            cwd=rootDir,
+            cwd=root_dir,
             check=True
         )
 

--- a/scripts/export-dbs.py
+++ b/scripts/export-dbs.py
@@ -91,6 +91,7 @@ def main():
             text=True,
             cwd=root_dir,
             check=True,
+            shell=True,
         )
 
     return 0

--- a/scripts/export-dbs.py
+++ b/scripts/export-dbs.py
@@ -57,17 +57,17 @@ def findValidDatasetDirs(datasetRoot):
 
 # Example scripts/export-dbs.py build/debug/tools/shell/kuzu dataset.
 def main():
-    parser = argparse.ArgumentParser(description="""Export DBS with
-    KUZU shell and dataset paths""")
+    parser = argparse.ArgumentParser(description="Export DBs with KUZU shell and dataset paths")
 
-    parser.add_argument("executablePath", help="Path to the KUZU shell")
-    parser.add_argument("datasetPath", help="Path to the dataset directory")
-    parser.add_argument("outputDir", help="Path to export the datasets")
+    parser.add_argument("--executable", required=True, help="Path to the KUZU shell executable")
+    parser.add_argument("--dataset-dir", required=True, help="Path to the dataset directory")
+    parser.add_argument("--output-dir", required=True, help="Path to export the datasets")
     args = parser.parse_args()
 
-    argExecutablePath = os.path.abspath(args.executablePath)
-    argDatasetPath = os.path.abspath(args.datasetPath)
-    outputDir = os.path.abspath(args.outputDir)
+    argExecutablePath = os.path.abspath(args.executable)
+    argDatasetPath = os.path.abspath(args.dataset_dir)
+    outputDir = os.path.abspath(args.output_dir)
+
 
     if not os.path.isfile(argExecutablePath):
         print(f"Error: Executable not found at {argExecutablePath}")

--- a/scripts/export-dbs.py
+++ b/scripts/export-dbs.py
@@ -2,7 +2,6 @@ import argparse
 import os
 import sys
 import subprocess
-import re
 
 
 # Get version number like 0.10.0.5.

--- a/scripts/export-dbs.py
+++ b/scripts/export-dbs.py
@@ -96,19 +96,17 @@ def main():
         combinedCommands.append(exportCommand)
         combinedCommands.insert(0, "CALL threads=1;")
         print(f"Exporting {datasetPath} to {exportPath}")
+        joinedCommands = "\n".join(cmd.strip() for cmd in combinedCommands)
 
-        process = subprocess.Popen(
+        subprocess.run(
             [argExecutablePath],
-            stdin=subprocess.PIPE,
+            input=joinedCommands,
             text=True,
-            cwd=rootDir
+            cwd=rootDir,
+            check=True
         )
 
-        for cmd in combinedCommands:
-            process.stdin.write(cmd.strip() + "\n")
-        process.stdin.close()
-        process.wait()
-    return 0
+        return 0
 
 
 if __name__ == '__main__':

--- a/scripts/export-dbs.py
+++ b/scripts/export-dbs.py
@@ -12,11 +12,10 @@ def getVersion(executablePath):
             [executablePath, "--version"],
             capture_output=True, text=True, check=True)
         output = result.stdout.strip()
-        match = re.search(r"\b(\d+\.\d+\.\d+\.\d+)\b", output)
-        if match:
-            return match.group(1)
+        if output.startswith("Kuzu "):
+            return output.split(" ", 1)[1]
         else:
-            print("Version number not found in output.")
+            print("Unexpected version format.")
             return None
     except subprocess.CalledProcessError as e:
         print(f"Error running executable: {e}")

--- a/scripts/export-dbs.py
+++ b/scripts/export-dbs.py
@@ -93,7 +93,7 @@ def main():
             check=True,
         )
 
-        return 0
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/export-dbs.py
+++ b/scripts/export-dbs.py
@@ -87,7 +87,7 @@ def main():
         copy_commands = create_cypher_queries(os.path.join(dataset_path, "copy.cypher"))
         combined_commands = schema_commands + copy_commands
         dataset_name = os.path.relpath(dataset_path, arg_dataset_path)
-        export_path = os.path.join(output_dir, version, dataset_name)
+        export_path = os.path.join(output_dir, dataset_name)
         export_command = f"EXPORT DATABASE '{export_path}' (format=\"csv\", header=true);"
         combined_commands.append(export_command)
         combined_commands.insert(0, "CALL threads=1;")

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -90,8 +90,6 @@ def main():
                 cwd=kuzu_root,
             )
             os.rename(inprogress_path, export_path + os.sep)
-        # Switch back to working branch (to use the latest script)
-        run_command(f"git checkout {current_branch}", cwd=kuzu_root)
 
         # Checkout commit B and run tests
         run_command(f"git checkout {test_commit}", cwd=kuzu_root)

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -81,6 +81,7 @@ def main():
             # JSON support to ensure the export works correctly.
             run_command("make extension-build EXTENSION_LIST=json", cwd=kuzu_root)
             inprogress_path = f"{export_path}_inprogress" + os.sep
+            run_command(f"git checkout {current_branch}", cwd=kuzu_root)
             run_command(
                 f"""python3 {export_script_path} \
                 --executable {exec_path} \

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -56,7 +56,7 @@ def main():
         action="store_false",
         help="Do not delete exported DBs after test",
     )
-    parser.set_defaults(cleanup=True)  # Default is cleanup enabled
+    parser.set_defaults(cleanup=True)
     args = parser.parse_args()
 
     base_commit = args.base_commit
@@ -100,16 +100,11 @@ def main():
             )
             os.rename(inprogress_path, export_path + os.sep)
 
-        # Checkout commit B and run tests
         run_command(f"git checkout {test_commit}", cwd=kuzu_root)
         # appends / so that datasets can be found correctly
         export_path += os.sep
         os.environ["E2E_IMPORT_DB_DIR"] = export_path
         run_command("make test", cwd=kuzu_root)
-
-        # Restore original branch
-        run_command(f"git checkout {current_branch}", cwd=kuzu_root)
-
         return 0
     finally:
         if cleanup:

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -2,6 +2,7 @@ import sys
 import argparse
 import subprocess
 import os
+import shutil
 
 
 def getVersion(executablePath):
@@ -107,7 +108,7 @@ def main():
         tmpDir = os.path.join(datasetDir, "tmp")
         if os.path.exists(tmpDir):
             print(f"Cleaning up tmp directory: {tmpDir}")
-            runCommand(["rm", "-rf", tmpDir])
+            shutil.rmtree(tmpDir)
 
         print(f"Restoring original git branch: {currentBranch}")
         try:

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -24,20 +24,19 @@ def get_version(executable_path):
         return None
 
 
-def run_command(cmd, cwd=None, env=None, capture_output=False):
+def run_command(cmd, cwd=None, capture_output=False):
     if isinstance(cmd, str):
         cmd = cmd.split()
 
     print(f"> Running: {' '.join(cmd)} (cwd={cwd})")
 
     if capture_output:
-        result = subprocess.run(cmd, cwd=cwd, env=env, text=True, capture_output=True, check=True)
+        result = subprocess.run(cmd, cwd=cwd, text=True, capture_output=True, check=True)
         return result.stdout.strip()
     else:
         process = subprocess.Popen(
             cmd,
             cwd=cwd,
-            env=env,
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -99,9 +98,8 @@ def main():
 
         # Checkout commit B and run tests
         run_command(["git", "checkout", test_commit], cwd=kuzu_root)
-        env = os.environ.copy()
-        env["E2_e_IMPORT_DB_DIR"] = export_path
-        run_command(["make", "test"], cwd=kuzu_root, env=env)
+        os.environ["E2E_IMPORT_DB_DIR"] = export_path
+        run_command(["make", "test"], cwd=kuzu_root)
 
         # Restore original branch
         run_command(["git", "checkout", current_branch], cwd=kuzu_root)

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -23,29 +23,36 @@ def getVersion(executablePath):
         return None
 
 
-def runCommand(cmd, cwd=None, env=None):
+def runCommand(cmd, cwd=None, env=None, capture_output=False):
     if isinstance(cmd, str):
         cmd = cmd.split()
 
     print(f"> Running: {' '.join(cmd)} (cwd={cwd})")
-    process = subprocess.Popen(
-        cmd,
-        cwd=cwd,
-        env=env,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        bufsize=1,
-        universal_newlines=True
-    )
 
-    for line in process.stdout:
-        print(line, end='')
+    if capture_output:
+        result = subprocess.run(cmd, cwd=cwd, env=env, text=True, capture_output=True, check=True)
+        print(result.stdout)
+        return result.stdout.strip()
+    else:
+        process = subprocess.Popen(
+            cmd,
+            cwd=cwd,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=1,
+            universal_newlines=True
+        )
 
-    process.stdout.close()
-    retcode = process.wait()
-    if retcode != 0:
-        raise subprocess.CalledProcessError(retcode, cmd)
+        for line in process.stdout:
+            print(line, end='')
+
+        process.stdout.close()
+        retcode = process.wait()
+        if retcode != 0:
+            raise subprocess.CalledProcessError(retcode, cmd)
+        return None
 
 
 def main():
@@ -63,7 +70,7 @@ def main():
 
     scriptDir = os.path.dirname(os.path.realpath(__file__))
     kuzuRoot = os.path.abspath(os.path.join(scriptDir, ".."))
-    currentBranch = runCommand(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=kuzuRoot)
+    currentBranch = runCommand(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=kuzuRoot, capture_output=True)
 
     # Checkout commit A and build
     runCommand(["git", "checkout", commitA], cwd=kuzuRoot)

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -83,6 +83,9 @@ def main():
     try:
         # Checkout commit A and build
         run_command(f"git checkout {base_commit}", cwd=kuzu_root)
+        # Some datasets, like tinysnb_json, have a dependency on the JSON
+        # extension in their copy.cypher files. Therefore, we must build with
+        # JSON support to ensure the export works correctly.
         run_command("make extension-build EXTENSION_LIST=json", cwd=kuzu_root)
 
         # Switch back to working branch (to use the latest script)

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -30,6 +30,11 @@ def run_command(cmd, cwd=None, capture_output=False):
 
     print(f"> Running: {' '.join(cmd)} (cwd={cwd})")
 
+    # We redirect stdin to devnull in an attempt
+    # to stop the proccess from intefering with the terminal's input buffer.
+    # This needs some work. After running the script I found that my buffer
+    # was filled with a sequence like 8;1R8;1R8;1R8;1R8;... This doesn't seem
+    # to affect the script but is annoying.
     result = subprocess.run(
         cmd,
         cwd=cwd,

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -25,10 +25,7 @@ def get_version(executable_path):
 
 
 def run_command(cmd, cwd=None, capture_output=False):
-    if isinstance(cmd, str):
-        cmd = cmd.split()
-
-    print(f"> Running: {' '.join(cmd)} (cwd={cwd})")
+    print(f"> Running: {cmd} (cwd={cwd})")
 
     # We redirect stdin to devnull in an attempt
     # to stop the proccess from intefering with the terminal's input buffer.

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -86,7 +86,7 @@ def main():
         # Export databases
         exportScriptPath = os.path.join(kuzuRoot, "scripts", "export-dbs.py")
         execPath = os.path.join(kuzuRoot, "build", "relwithdebinfo", "tools", "shell", "kuzu")
-        runCommand(["python3", exportScriptPath, execPath, datasetDir, outputDir], cwd=kuzuRoot)
+        runCommand(["python3", exportScriptPath, "--executable", execPath, "--dataset-dir", datasetDir, "--output-dir", outputDir], cwd=kuzuRoot)
 
         # Determine export path based on version (taken from exportScript)
         version = getVersion(execPath)

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -91,7 +91,6 @@ def main():
         # Switch back to working branch (to use the latest script)
         run_command(f"git checkout {current_branch}", cwd=kuzu_root)
 
-        # Export databases
         export_script_path = os.path.join(kuzu_root, "scripts", "export-dbs.py")
         exec_path = os.path.join(
             kuzu_root, "build", "relwithdebinfo", "tools", "shell", "kuzu"
@@ -104,6 +103,7 @@ def main():
 
         # Only run export if export_path does not exist
         if not os.path.exists(export_path + os.sep):
+            # Export databases
             inprogress_path = f"{export_path}_inprogress" + os.sep
             run_command(
                 f"""python3 {export_script_path} \

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -87,14 +87,17 @@ def main():
         # Export databases
         export_script_path = os.path.join(kuzu_root, "scripts", "export-dbs.py")
         exec_path = os.path.join(kuzu_root, "build", "relwithdebinfo", "tools", "shell", "kuzu")
-        run_command(["python3", export_script_path, "--executable", exec_path, "--dataset-dir", dataset_dir, "--output-dir", output_dir], cwd=kuzu_root)
-
         # Determine export path based on version (taken from export_script)
         version = get_version(exec_path)
         if version is None:
-            print("Failed to determine version. Aborting.")
-            return 1
-        export_path = os.path.join(dataset_dir, "tmp", version) + os.sep
+            raise Exception("Failed to determine version. Aborting.")
+        export_path = os.path.join(output_dir, version) + os.sep
+
+        # Only run export if export_path DNE
+        if not os.path.exists(export_path):
+            inprogress_path = export_path + "_inprogress" + os.sep
+            run_command(["python3", export_script_path, "--executable", exec_path, "--dataset-dir", dataset_dir, "--output-dir", inprogress_path], cwd=kuzu_root)
+            os.rename(inprogress_path, export_path)
 
         # Checkout commit B and run tests
         run_command(["git", "checkout", test_commit], cwd=kuzu_root)

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -27,20 +27,25 @@ def runCommand(cmd, cwd=None, env=None):
     if isinstance(cmd, str):
         cmd = cmd.split()
 
-    try:
-        result = subprocess.run(
-            cmd,
-            cwd=cwd,
-            env=env,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            check=True
-        )
-        return result.stdout.strip()
-    except subprocess.CalledProcessError as e:
-        print(f"[ERROR] Command failed: {' '.join(cmd)}\n{e.stderr}")
-        raise
+    print(f"> Running: {' '.join(cmd)} (cwd={cwd})")
+    process = subprocess.Popen(
+        cmd,
+        cwd=cwd,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
+        universal_newlines=True
+    )
+
+    for line in process.stdout:
+        print(line, end='')
+
+    process.stdout.close()
+    retcode = process.wait()
+    if retcode != 0:
+        raise subprocess.CalledProcessError(retcode, cmd)
 
 
 def main():

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -8,7 +8,8 @@ import shutil
 def get_version(executable_path):
     try:
         result = subprocess.run(
-            executable_path + " --version", capture_output=True, text=True, check=True
+            executable_path + " --version", capture_output=True, text=True,
+            check=True, shell=True
         )
         output = result.stdout.strip()
         if output.startswith("Kuzu "):

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -27,30 +27,18 @@ def run_command(cmd, cwd=None, capture_output=False):
 
     print(f"> Running: {' '.join(cmd)} (cwd={cwd})")
 
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        text=True,
+        capture_output=capture_output,
+        check=True,
+        stdin=subprocess.DEVNULL,
+    )
     if capture_output:
-        result = subprocess.run(
-            cmd, cwd=cwd, text=True, capture_output=True, check=True
-        )
         return result.stdout.strip()
     else:
-        process = subprocess.Popen(
-            cmd,
-            cwd=cwd,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            bufsize=1,
-            universal_newlines=True,
-            stdin=subprocess.DEVNULL,
-        )
-
-        for line in process.stdout:
-            print(line, end="")
-
-        process.stdout.close()
-        retcode = process.wait()
-        if retcode != 0:
-            raise subprocess.CalledProcessError(retcode, cmd)
+        print(result.stdout or "")
         return None
 
 

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -8,7 +8,7 @@ import shutil
 def get_version(executable_path):
     try:
         result = subprocess.run(
-            executable_path, " --version", capture_output=True, text=True, check=True
+            executable_path + " --version", capture_output=True, text=True, check=True
         )
         output = result.stdout.strip()
         if output.startswith("Kuzu "):

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -42,7 +42,8 @@ def runCommand(cmd, cwd=None, env=None, capture_output=False):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             bufsize=1,
-            universal_newlines=True
+            universal_newlines=True,
+            stdin=subprocess.DEVNULL
         )
 
         for line in process.stdout:

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -8,8 +8,11 @@ import shutil
 def get_version(executable_path):
     try:
         result = subprocess.run(
-            executable_path + " --version", capture_output=True, text=True,
-            check=True, shell=True
+            executable_path + " --version",
+            capture_output=True,
+            text=True,
+            check=True,
+            shell=True,
         )
         output = result.stdout.strip()
         if output.startswith("Kuzu "):

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -4,26 +4,6 @@ import os
 import shutil
 
 
-def get_version(executable_path):
-    try:
-        result = subprocess.run(
-            f"{executable_path} --version",
-            capture_output=True,
-            text=True,
-            check=True,
-            shell=True,
-        )
-        output = result.stdout.strip()
-        if output.startswith("Kuzu "):
-            return output.split(" ", 1)[1]
-        else:
-            print("Unexpected version format:", output)
-            return None
-    except subprocess.CalledProcessError as e:
-        print(f"Error running '{executable_path} --version': {e}")
-        return None
-
-
 def run_command(cmd, cwd=None, capture_output=False):
     print(f"> Running: {cmd} (cwd={cwd})")
 
@@ -38,6 +18,7 @@ def run_command(cmd, cwd=None, capture_output=False):
         text=True,
         capture_output=capture_output,
         check=True,
+        shell=True,
         stdin=subprocess.DEVNULL,
     )
     if capture_output:

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -89,7 +89,7 @@ def main():
     if version is None:
         print("Failed to determine version. Aborting.")
         return 1
-    exportPath = os.path.join(datasetDir, "tmp", version)
+    exportPath = os.path.join(datasetDir, "tmp", version) + os.sep
 
     # Checkout commit B and run tests
     runCommand(["git", "checkout", commitB], cwd=kuzuRoot)

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -66,7 +66,9 @@ def main():
     try:
         run_command(f"git checkout {base_commit}", cwd=kuzu_root)
 
-        version = run_command(f"python3 benchmark/version.py", cwd=kuzu_root, capture_output=True)
+        version = run_command(
+            f"python3 benchmark/version.py", cwd=kuzu_root, capture_output=True
+        )
         if version == "0":
             raise Exception("Failed to determine version. Aborting.")
         export_path = os.path.join(output_dir, version)

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -45,11 +45,18 @@ def main():
         "--output-dir", required=True, help="Path to output the exported databases"
     )
     parser.add_argument(
-        "--cleanup",
-        type=bool,
-        default=True,
-        help="Delete exported DBs after test (default: True)",
+    "--cleanup",
+    dest="cleanup",
+    action="store_true",
+    help="Delete exported DBs after test",
     )
+    parser.add_argument(
+        "--no-cleanup",
+        dest="cleanup",
+        action="store_false",
+        help="Do not delete exported DBs after test",
+    )
+    parser.set_defaults(cleanup=True)  # Default is cleanup enabled
     args = parser.parse_args()
 
     base_commit = args.base_commit

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -1,0 +1,95 @@
+import sys
+import argparse
+import subprocess
+import os
+
+
+def getVersion(executablePath):
+    try:
+        result = subprocess.run(
+            [executablePath, "--version"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        output = result.stdout.strip()
+        if output.startswith("Kuzu "):
+            return output.split(" ", 1)[1]
+        else:
+            print("Unexpected version format:", output)
+            return None
+    except subprocess.CalledProcessError as e:
+        print(f"Error running '{executablePath} --version': {e}")
+        return None
+
+
+def runCommand(cmd, cwd=None, env=None):
+    if isinstance(cmd, str):
+        cmd = cmd.split()
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=cwd,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"[ERROR] Command failed: {' '.join(cmd)}\n{e.stderr}")
+        raise
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Export DBs from datasetDir using commitA and test in commitB"
+    )
+    parser.add_argument("commitA", help="Git commit to export databases from")
+    parser.add_argument("commitB", help="Git commit to test against")
+    parser.add_argument("datasetDir", help="Path to the dataset directory")
+    args = parser.parse_args()
+
+    commitA = args.commitA
+    commitB = args.commitB
+    datasetDir = args.datasetDir
+
+    scriptDir = os.path.dirname(os.path.realpath(__file__))
+    kuzuRoot = os.path.abspath(os.path.join(scriptDir, ".."))
+    currentBranch = runCommand(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=kuzuRoot)
+
+    # Checkout commit A and build
+    runCommand(["git", "checkout", commitA], cwd=kuzuRoot)
+    runCommand(["make", "extension-build", "EXTENSION_LIST=json"], cwd=kuzuRoot)
+
+    # Switch back to working branch (to use the following script)
+    runCommand(["git", "checkout", currentBranch], cwd=kuzuRoot)
+
+    # Export databases
+    exportScriptPath = os.path.join(kuzuRoot, "scripts", "export-dbs.py")
+    execPath = os.path.join(kuzuRoot, "build", "relwithdebinfo", "tools", "shell", "kuzu")
+    runCommand(["python3", exportScriptPath, execPath, datasetDir], cwd=kuzuRoot)
+
+    # Determine export path based on version (taken from exportScript)
+    version = getVersion(execPath)
+    if version is None:
+        print("Failed to determine version. Aborting.")
+        return 1
+    exportPath = os.path.join(datasetDir, "tmp", version)
+
+    # Checkout commit B and run tests
+    runCommand(["git", "checkout", commitB], cwd=kuzuRoot)
+    env = os.environ.copy()
+    env["E2E_IMPORT_DB_DIR"] = exportPath
+    runCommand(["make", "test"], cwd=kuzuRoot, env=env)
+
+    # Restore original branch
+    runCommand(["git", "checkout", currentBranch], cwd=kuzuRoot)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -79,7 +79,7 @@ def main():
         runCommand(["git", "checkout", commitA], cwd=kuzuRoot)
         runCommand(["make", "extension-build", "EXTENSION_LIST=json"], cwd=kuzuRoot)
 
-        # Switch back to working branch (to use the following script)
+        # Switch back to working branch (to use the latest script)
         runCommand(["git", "checkout", currentBranch], cwd=kuzuRoot)
 
         # Export databases

--- a/scripts/export-import-test.py
+++ b/scripts/export-import-test.py
@@ -111,7 +111,16 @@ def main():
                 + inprogress_path,
                 cwd=kuzu_root,
             )
-            os.rename(inprogress_path, export_path)
+            for item in os.listdir(inprogress_path):
+                src = os.path.join(inprogress_path, item)
+                dst = os.path.join(export_path, item)
+                if os.path.exists(dst):
+                    if os.path.isdir(dst):
+                        shutil.rmtree(dst)
+                    else:
+                        os.remove(dst)
+                shutil.move(src, dst)
+            os.rmdir(inprogress_path)
 
         # Checkout commit B and run tests
         run_command("git checkout " + test_commit, cwd=kuzu_root)


### PR DESCRIPTION
# Description
Provides a script that builds Kuzu from `base-commit` and exports all datasets in `dataset-dir` using `scripts/export-dbs.py`. The datasets are placed in `output-dir/{base-commit-version}`. The script then runs the test suite in `test-commit` using `make test` and the exported datasets. Cleans by removing `output-dir/{base-commit-version}` and checking out to the commit where the script was initially ran. 

```
Export DBs from dataset-dir to output-dir using base-commit and test in test-commit

options:
  -h, --help            show this help message and exit
  --base-commit BASE_COMMIT
                        Git commit to export databases from
  --test-commit TEST_COMMIT
                        Git commit to test against
  --dataset-dir DATASET_DIR
                        Path to the dataset directory
  --output-dir OUTPUT_DIR
                        Path to output the exported databases
  --cleanup CLEANUP     Delete exported DBs after test (default: True)
```
  

I am attaching a log file from a test run of the script. 

`python -u scripts/export-import-test.py --base-commit de79e0b --test-commit master --dataset-dir dataset --output-dir dataset`

[out.txt](https://github.com/user-attachments/files/21109601/out.txt)


# Contributor agreement

- [X] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
