### PR TITLE
Fix attempting to free mmapped memory when spilling to disk

### DIFF
--- a/src/include/storage/buffer_manager/memory_manager.h
+++ b/src/include/storage/buffer_manager/memory_manager.h
@@ -24,6 +24,11 @@ class ChunkedNodeGroup;
 template<class T>
 class MmAllocator;
 
+struct SpillResult {
+    uint64_t memoryFreed = 0;
+    uint64_t memoryNowEvictable = 0;
+};
+
 class MemoryBuffer {
     friend class Spiller;
 
@@ -49,7 +54,7 @@ private:
     void prepareLoadFromDisk();
 
     // Must only be called once before loading from disk
-    void setSpilledToDisk(uint64_t filePosition);
+    SpillResult setSpilledToDisk(uint64_t filePosition);
 
 private:
     std::span<uint8_t> buffer;
@@ -92,6 +97,7 @@ public:
 
 private:
     void freeBlock(common::page_idx_t pageIdx, std::span<uint8_t> buffer);
+    void updateUsedMemoryForFreedBlock(common::page_idx_t pageIdx, std::span<uint8_t> buffer);
     std::span<uint8_t> mallocBuffer(bool initializeToZero, uint64_t size);
 
 private:

--- a/src/include/storage/buffer_manager/memory_manager.h
+++ b/src/include/storage/buffer_manager/memory_manager.h
@@ -7,6 +7,7 @@
 
 #include "common/system_config.h"
 #include "common/types/types.h"
+#include "storage/buffer_manager/spill_result.h"
 #include <span>
 
 namespace kuzu {
@@ -23,7 +24,6 @@ class BufferManager;
 class ChunkedNodeGroup;
 template<class T>
 class MmAllocator;
-struct SpillResult;
 
 class MemoryBuffer {
     friend class Spiller;

--- a/src/include/storage/buffer_manager/memory_manager.h
+++ b/src/include/storage/buffer_manager/memory_manager.h
@@ -23,11 +23,7 @@ class BufferManager;
 class ChunkedNodeGroup;
 template<class T>
 class MmAllocator;
-
-struct SpillResult {
-    uint64_t memoryFreed = 0;
-    uint64_t memoryNowEvictable = 0;
-};
+struct SpillResult;
 
 class MemoryBuffer {
     friend class Spiller;

--- a/src/include/storage/buffer_manager/spill_result.h
+++ b/src/include/storage/buffer_manager/spill_result.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstdint>
+
+namespace kuzu {
+namespace storage {
+
+struct SpillResult {
+    uint64_t memoryFreed = 0;
+    uint64_t memoryNowEvictable = 0;
+};
+
+} // namespace storage
+} // namespace kuzu

--- a/src/include/storage/buffer_manager/spiller.h
+++ b/src/include/storage/buffer_manager/spiller.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <cstdint>
-
 #include "storage/buffer_manager/memory_manager.h"
 #include "storage/file_handle.h"
 

--- a/src/include/storage/buffer_manager/spiller.h
+++ b/src/include/storage/buffer_manager/spiller.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 
+#include "storage/buffer_manager/memory_manager.h"
 #include "storage/file_handle.h"
 
 namespace kuzu {
@@ -20,12 +21,12 @@ public:
     Spiller(std::string tmpFilePath, BufferManager& bufferManager, common::VirtualFileSystem* vfs);
     void addUnusedChunk(ChunkedNodeGroup* nodeGroup);
     void clearUnusedChunk(ChunkedNodeGroup* nodeGroup);
-    uint64_t spillToDisk(ColumnChunkData& chunk) const;
+    SpillResult spillToDisk(ColumnChunkData& chunk) const;
     void loadFromDisk(ColumnChunkData& chunk) const;
     // reclaims memory from the next full partitioner group in the set
     // and returns the amount of memory reclaimed
     // If the set is empty, returns zero
-    uint64_t claimNextGroup();
+    SpillResult claimNextGroup();
     // Must only be used once all chunks have been loaded from disk.
     void clearFile();
     ~Spiller();

--- a/src/include/storage/table/chunked_node_group.h
+++ b/src/include/storage/table/chunked_node_group.h
@@ -5,6 +5,7 @@
 #include <mutex>
 
 #include "common/enums/rel_multiplicity.h"
+#include "storage/buffer_manager/memory_manager.h"
 #include "storage/enums/residency_state.h"
 #include "storage/table/column_chunk.h"
 #include "storage/table/column_chunk_data.h"
@@ -176,7 +177,7 @@ public:
     void loadFromDisk(const MemoryManager& mm);
 
     // returns the amount of space reclaimed in bytes
-    uint64_t spillToDisk();
+    SpillResult spillToDisk();
 
     void setUnused(const MemoryManager& mm);
 

--- a/src/include/storage/table/column_chunk.h
+++ b/src/include/storage/table/column_chunk.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "storage/buffer_manager/memory_manager.h"
 #include "storage/table/column_chunk_data.h"
 #include "storage/table/update_info.h"
 
@@ -96,7 +97,7 @@ public:
     }
 
     void loadFromDisk() { data->loadFromDisk(); }
-    uint64_t spillToDisk() { return data->spillToDisk(); }
+    SpillResult spillToDisk() { return data->spillToDisk(); }
 
     MergedColumnChunkStats getMergedColumnChunkStats(
         const transaction::Transaction* transaction) const;

--- a/src/include/storage/table/column_chunk.h
+++ b/src/include/storage/table/column_chunk.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "storage/buffer_manager/memory_manager.h"
+#include "storage/buffer_manager/spill_result.h"
 #include "storage/table/column_chunk_data.h"
 #include "storage/table/update_info.h"
 

--- a/src/include/storage/table/column_chunk_data.h
+++ b/src/include/storage/table/column_chunk_data.h
@@ -10,6 +10,7 @@
 #include "common/system_config.h"
 #include "common/types/types.h"
 #include "common/vector/value_vector.h"
+#include "storage/buffer_manager/memory_manager.h"
 #include "storage/compression/compression.h"
 #include "storage/enums/residency_state.h"
 #include "storage/table/column_chunk_metadata.h"
@@ -233,7 +234,7 @@ public:
     MemoryManager& getMemoryManager() const;
 
     void loadFromDisk();
-    uint64_t spillToDisk();
+    SpillResult spillToDisk();
 
     MergedColumnChunkStats getMergedColumnChunkStats() const;
 

--- a/src/storage/buffer_manager/buffer_manager.cpp
+++ b/src/storage/buffer_manager/buffer_manager.cpp
@@ -14,7 +14,6 @@
 #include "common/file_system/virtual_file_system.h"
 #include "common/types/types.h"
 #include "main/db_config.h"
-#include "storage/buffer_manager/spill_result.h"
 #include "storage/buffer_manager/spiller.h"
 #include "storage/file_handle.h"
 #include "storage/table/column_chunk_data.h"

--- a/src/storage/buffer_manager/buffer_manager.cpp
+++ b/src/storage/buffer_manager/buffer_manager.cpp
@@ -14,6 +14,7 @@
 #include "common/file_system/virtual_file_system.h"
 #include "common/types/types.h"
 #include "main/db_config.h"
+#include "storage/buffer_manager/spill_result.h"
 #include "storage/buffer_manager/spiller.h"
 #include "storage/file_handle.h"
 #include "storage/table/column_chunk_data.h"

--- a/src/storage/buffer_manager/memory_manager.cpp
+++ b/src/storage/buffer_manager/memory_manager.cpp
@@ -9,6 +9,7 @@
 #include "common/file_system/virtual_file_system.h"
 #include "common/types/types.h"
 #include "storage/buffer_manager/buffer_manager.h"
+#include "storage/buffer_manager/spill_result.h"
 #include "storage/file_handle.h"
 
 using namespace kuzu::common;

--- a/src/storage/buffer_manager/memory_manager.cpp
+++ b/src/storage/buffer_manager/memory_manager.cpp
@@ -9,7 +9,6 @@
 #include "common/file_system/virtual_file_system.h"
 #include "common/types/types.h"
 #include "storage/buffer_manager/buffer_manager.h"
-#include "storage/buffer_manager/spill_result.h"
 #include "storage/file_handle.h"
 
 using namespace kuzu::common;

--- a/src/storage/buffer_manager/spiller.cpp
+++ b/src/storage/buffer_manager/spiller.cpp
@@ -1,6 +1,5 @@
 #include "storage/buffer_manager/spiller.h"
 
-#include <cstdint>
 #include <mutex>
 
 #include "common/assert.h"

--- a/src/storage/table/column_chunk_data.cpp
+++ b/src/storage/table/column_chunk_data.cpp
@@ -998,11 +998,11 @@ void ColumnChunkData::loadFromDisk() {
         [&](auto& spiller) { spiller.loadFromDisk(*this); });
 }
 
-uint64_t ColumnChunkData::spillToDisk() {
-    uint64_t spilledBytes = 0;
+SpillResult ColumnChunkData::spillToDisk() {
+    SpillResult spilled{};
     buffer->getMemoryManager()->getBufferManager()->getSpillerOrSkip(
-        [&](auto& spiller) { spilledBytes = spiller.spillToDisk(*this); });
-    return spilledBytes;
+        [&](auto& spiller) { spilled = spiller.spillToDisk(*this); });
+    return spilled;
 }
 
 void ColumnChunkData::reclaimStorage(PageAllocator& pageAllocator) {

--- a/src/storage/table/column_chunk_data.cpp
+++ b/src/storage/table/column_chunk_data.cpp
@@ -14,6 +14,7 @@
 #include "expression_evaluator/expression_evaluator.h"
 #include "storage/buffer_manager/buffer_manager.h"
 #include "storage/buffer_manager/memory_manager.h"
+#include "storage/buffer_manager/spill_result.h"
 #include "storage/buffer_manager/spiller.h"
 #include "storage/compression/compression.h"
 #include "storage/compression/float_compression.h"


### PR DESCRIPTION
`MemoryBuffer::setSpilledToDisk` was always using `std::free` to free the memory, even if it was allocated using our buffer manager.

I don't think this is currently reproduce-able since we only spill data in the partitioner and that data has a fixed capacity of 2048 which even for a 16 byte value is going to be much smaller than the 256KB `TEMP_PAGE_SIZE` (which is the only size for which the memory manager will use the buffer manager to allocate space).

But since we plan to extend the spilling system to more situations I thought I should address this before it becomes a problem.

The way the buffer manager frees data makes this more complicated than it was before, as spilling will just unpin the pages to be evicted via the eviction queue, instead of freeing the memory directly.