### PR TITLE
8 Byte hash slot for AggregateHashTable

### DIFF
--- a/src/processor/result/pattern_creation_info_table.cpp
+++ b/src/processor/result/pattern_creation_info_table.cpp
@@ -49,7 +49,7 @@ uint64_t PatternCreationInfoTable::matchFTEntries(std::span<const common::ValueV
     KU_ASSERT(numMayMatches <= 1);
     // If we found the entry for the target key, we set tuple to the key tuple. Otherwise, simply
     // set tuple to nullptr.
-    tuple = numMayMatches != 0 ? hashSlotsToUpdateAggState[mayMatchIdxes[0]]->entry : nullptr;
+    tuple = numMayMatches != 0 ? hashSlotsToUpdateAggState[mayMatchIdxes[0]]->getEntry() : nullptr;
     return numNoMatches;
 }
 


### PR DESCRIPTION
I've reduced the slot size in the AggregateHashTable from 16 bytes to 8 bytes by using the most significant 7 bits of the entry pointer to store a fingerprint (rather than the full hash). This generally should be fine since most operating systems don't use more than 48 bits as far as I can tell. The largest is [Intel's 5-level paging](https://en.wikipedia.org/wiki/Intel_5-level_paging) which increases the size of pointers to 57 bits (also supported by some AMD processors). As far as I can tell is an optional feature on processors that support it, so I'm not sure if we need to handle this case, but since there was no noticeable performance difference between the 7 and 8 bit versions I thought it would be prudent to use a 7 bit fingerprint.

Clickbench on 128 threads 2x AMD EPYC 7551:

`MATCH (h:hits) RETURN h.UserID, h.SearchPhrase, COUNT(*) LIMIT 10`: before: 3.1s 5.5GB peak memory, after: 2.7s, 5.0GB peak memory

`MATCH (h:hits) RETURN h.URL, COUNT(*) as c ORDER BY c DESC LIMIT 10;`: before: 6.4s, 13.3GB peak memory, after:5.4s, 13.0GB peak memory