### PR TITLE
QUERY_FTS_INDEX throws an error for top := 0

### DIFF
--- a/extension/fts/src/function/fts_config.cpp
+++ b/extension/fts/src/function/fts_config.cpp
@@ -171,6 +171,13 @@ void B::validate(double value) {
     }
 }
 
+void TopK::validate(uint64_t value) {
+    if (value == 0) {
+        throw common::BinderException{
+            "QUERY_FTS_INDEX requires a positive non-zero value for the 'top' parameter."};
+    }
+}
+
 QueryFTSConfig::QueryFTSConfig(const function::optional_params_t& optionalParams) {
     for (auto& [name, value] : optionalParams) {
         auto lowerCaseName = common::StringUtils::getLower(name);

--- a/extension/fts/src/function/query_fts_bind_data.cpp
+++ b/extension/fts/src/function/query_fts_bind_data.cpp
@@ -60,7 +60,8 @@ QueryFTSConfig QueryFTSOptionalParams::getConfig() const {
             ExpressionUtil::evaluateLiteral<bool>(*conjunctive, LogicalType::BOOL());
     }
     if (topK != nullptr) {
-        config.topK = ExpressionUtil::evaluateLiteral<uint64_t>(*topK, LogicalType::UINT64());
+        config.topK =
+            ExpressionUtil::evaluateLiteral<uint64_t>(*topK, LogicalType::UINT64(), TopK::validate);
     }
     return config;
 }

--- a/extension/fts/src/include/function/fts_config.h
+++ b/extension/fts/src/include/function/fts_config.h
@@ -95,6 +95,7 @@ struct TopK {
     static constexpr const char* NAME = "top";
     static constexpr common::LogicalTypeID TYPE = common::LogicalTypeID::UINT64;
     static constexpr uint64_t DEFAULT_VALUE = UINT64_MAX;
+    static void validate(uint64_t value);
 };
 
 constexpr uint64_t INVALID_TOP_K = UINT64_MAX;

--- a/extension/fts/test/test_files/error.test
+++ b/extension/fts/test/test_files/error.test
@@ -188,4 +188,4 @@ Parser exception: DROP_FTS_INDEX must be called in a query which doesn't have ot
 ---- ok
 -STATEMENT CALL QUERY_FTS_INDEX('person', 'personIdx', 'Alice', top := 0) RETURN node.ID, score
 ---- error
-...
+Binder exception: QUERY_FTS_INDEX requires a positive non-zero value for the 'top' parameter.

--- a/extension/fts/test/test_files/error.test
+++ b/extension/fts/test/test_files/error.test
@@ -181,3 +181,11 @@ Parser exception: CREATE_FTS_INDEX must be called in a query which doesn't have 
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/fts/build/libfts.kuzu_extension";CALL DROP_FTS_INDEX('STUDENT', 'sIdx');
 ---- error
 Parser exception: DROP_FTS_INDEX must be called in a query which doesn't have other statements.
+
+-CASE TopParamZero
+-LOAD_DYNAMIC_EXTENSION fts
+-STATEMENT CALL CREATE_FTS_INDEX('person', 'personIdx', ['fName'])
+---- ok
+-STATEMENT CALL QUERY_FTS_INDEX('person', 'personIdx', 'Alice', top := 0) RETURN node.ID, score
+---- error
+...


### PR DESCRIPTION
# Description

Fixes https://github.com/kuzudb/kuzu/issues/5693. Adds a validation step to make sure that `top` for `QUERY_FTS_INDEX` is not 0.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
