### PR TITLE
Fix OnDiskGraph scanVertices

### DIFF
--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -317,6 +317,10 @@ void OnDiskGraphVertexScanState::startScan(offset_t beginOffset, offset_t endOff
     numNodesToScan = 0;
     this->currentOffset = beginOffset;
     this->endOffsetExclusive = endOffsetExclusive;
+    tableScanState->nodeIDVector->getSelVectorPtr()->setToUnfiltered(0);
+    for (auto& vector : tableScanState->outputVectors) {
+        vector->resetAuxiliaryBuffer();
+    }
     nodeTable.initScanState(context.getTransaction(), *tableScanState, nodeTable.getTableID(),
         beginOffset);
 }

--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -291,7 +291,7 @@ OnDiskGraphVertexScanState::OnDiskGraphVertexScanState(ClientContext& context,
     const TableCatalogEntry* tableEntry, const std::vector<std::string>& propertyNames)
     : context{context}, nodeTable{ku_dynamic_cast<const NodeTable&>(
                             *context.getStorageManager()->getTable(tableEntry->getTableID()))},
-      numNodesScanned{0}, currentOffset{0}, endOffsetExclusive{0} {
+      numNodesToScan{0}, currentOffset{0}, endOffsetExclusive{0} {
     std::vector<column_id_t> propertyColumnIDs;
     propertyColumnIDs.reserve(propertyNames.size());
     std::vector<LogicalType> types;
@@ -314,7 +314,7 @@ OnDiskGraphVertexScanState::OnDiskGraphVertexScanState(ClientContext& context,
 }
 
 void OnDiskGraphVertexScanState::startScan(offset_t beginOffset, offset_t endOffsetExclusive) {
-    numNodesScanned = 0;
+    numNodesToScan = 0;
     this->currentOffset = beginOffset;
     this->endOffsetExclusive = endOffsetExclusive;
     nodeTable.initScanState(context.getTransaction(), *tableScanState, nodeTable.getTableID(),
@@ -332,11 +332,10 @@ bool OnDiskGraphVertexScanState::next() {
 
     auto endOffset = std::min(endOffsetExclusive,
         StorageUtils::getStartOffsetOfNodeGroup(tableScanState->nodeGroupIdx + 1));
-    numNodesScanned = std::min(endOffset - currentOffset, DEFAULT_VECTOR_CAPACITY);
-    auto result =
-        tableScanState->scanNext(context.getTransaction(), currentOffset, numNodesScanned);
-    currentOffset += numNodesScanned;
-    return result;
+    numNodesToScan = std::min(endOffset - currentOffset, DEFAULT_VECTOR_CAPACITY);
+    auto result = tableScanState->scanNext(context.getTransaction(), currentOffset, numNodesToScan);
+    currentOffset += result.numRows;
+    return result != NODE_GROUP_SCAN_EMMPTY_RESULT;
 }
 
 } // namespace graph

--- a/src/include/graph/on_disk_graph.h
+++ b/src/include/graph/on_disk_graph.h
@@ -103,7 +103,8 @@ public:
 
     bool next() override;
     Chunk getChunk() override {
-        return createChunk(std::span(&nodeIDVector->getValue<common::nodeID_t>(0), numNodesScanned),
+        return createChunk(std::span(&nodeIDVector->getValue<common::nodeID_t>(0),
+                               nodeIDVector->getSelVectorPtr()->getSelSize()),
             std::span(propertyVectors.valueVectors));
     }
 
@@ -115,7 +116,7 @@ private:
     std::unique_ptr<common::ValueVector> nodeIDVector;
     std::unique_ptr<storage::NodeTableScanState> tableScanState;
 
-    common::offset_t numNodesScanned;
+    common::offset_t numNodesToScan;
     common::offset_t currentOffset;
     common::offset_t endOffsetExclusive;
 };

--- a/src/include/storage/table/node_table.h
+++ b/src/include/storage/table/node_table.h
@@ -35,8 +35,8 @@ struct KUZU_API NodeTableScanState : TableScanState {
 
     bool scanNext(transaction::Transaction* transaction) override;
 
-    NodeGroupScanResult scanNext(transaction::Transaction* transaction, common::offset_t startOffset,
-        common::offset_t numNodes);
+    NodeGroupScanResult scanNext(transaction::Transaction* transaction,
+        common::offset_t startOffset, common::offset_t numNodes);
 };
 
 // There is a vtable bug related to the Apple clang v15.0.0+. Adding the `FINAL` specifier to

--- a/src/include/storage/table/node_table.h
+++ b/src/include/storage/table/node_table.h
@@ -35,7 +35,7 @@ struct KUZU_API NodeTableScanState : TableScanState {
 
     bool scanNext(transaction::Transaction* transaction) override;
 
-    bool scanNext(transaction::Transaction* transaction, common::offset_t startOffset,
+    NodeGroupScanResult scanNext(transaction::Transaction* transaction, common::offset_t startOffset,
         common::offset_t numNodes);
 };
 

--- a/src/storage/table/node_group.cpp
+++ b/src/storage/table/node_group.cpp
@@ -254,21 +254,15 @@ NodeGroupScanResult NodeGroup::scanInternal(const UniqLock& lock, Transaction* t
     }
 
     uint64_t numRowsScanned = 0;
-    do {
-        const auto rowIdxInChunkToScan =
-            (startOffsetInGroup + numRowsScanned) - chunkedGroupToScan->getStartRowIdx();
+    const auto rowIdxInChunkToScan =
+        (startOffsetInGroup + numRowsScanned) - chunkedGroupToScan->getStartRowIdx();
 
-        uint64_t numRowsToScanInChunk = std::min(numRowsToScan - numRowsScanned,
-            chunkedGroupToScan->getNumRows() - rowIdxInChunkToScan);
-        chunkedGroupToScan->scan(transaction, state, nodeGroupScanState, rowIdxInChunkToScan,
-            numRowsToScanInChunk);
-        numRowsScanned += numRowsToScanInChunk;
-        nodeGroupScanState.nextRowToScan += numRowsToScanInChunk;
-        if (numRowsScanned < numRowsToScan) {
-            nodeGroupScanState.chunkedGroupIdx++;
-            chunkedGroupToScan = chunkedGroups.getGroup(lock, nodeGroupScanState.chunkedGroupIdx);
-        }
-    } while (numRowsScanned < numRowsToScan);
+    uint64_t numRowsToScanInChunk = std::min(numRowsToScan - numRowsScanned,
+        chunkedGroupToScan->getNumRows() - rowIdxInChunkToScan);
+    chunkedGroupToScan->scan(transaction, state, nodeGroupScanState, rowIdxInChunkToScan,
+        numRowsToScanInChunk);
+    numRowsScanned += numRowsToScanInChunk;
+    nodeGroupScanState.nextRowToScan += numRowsToScanInChunk;
 
     return NodeGroupScanResult{startOffsetInGroup, numRowsScanned};
 }

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -575,7 +575,7 @@ void NodeTable::commit(main::ClientContext* context, TableCatalogEntry* tableEnt
     // 2. Set deleted flag for tuples that are deleted in local storage.
     row_idx_t numLocalRows = 0u;
     for (auto localNodeGroupIdx = 0u; localNodeGroupIdx < localNodeTable.getNumNodeGroups();
-        localNodeGroupIdx++) {
+         localNodeGroupIdx++) {
         const auto localNodeGroup = localNodeTable.getNodeGroup(localNodeGroupIdx);
         if (localNodeGroup->hasDeletions(transaction)) {
             // TODO(Guodong): Assume local storage is small here. Should optimize the loop away by
@@ -725,7 +725,7 @@ void NodeTable::scanIndexColumns(main::ClientContext* context, IndexScanHelper& 
 
     const auto numNodeGroups = nodeGroups_.getNumNodeGroups();
     for (node_group_idx_t nodeGroupToScan = 0u; nodeGroupToScan < numNodeGroups;
-        ++nodeGroupToScan) {
+         ++nodeGroupToScan) {
         scanState->nodeGroup = nodeGroups_.getNodeGroupNoLock(nodeGroupToScan);
 
         // It is possible for the node group to have no chunked groups if we are rolling back due to

--- a/test/storage/rel_scan_test.cpp
+++ b/test/storage/rel_scan_test.cpp
@@ -177,10 +177,10 @@ TEST_F(RelScanTest, ScanVertexProperties) {
     auto entry = catalog->getTableCatalogEntry(context->getTransaction(), "person");
     std::vector<std::string> properties = {"fname", "height"};
 
+    auto scanState = graph->prepareVertexScan(entry, properties);
     const auto compare = [&](offset_t startNodeOffset, offset_t endNodeOffset,
                              std::vector<std::tuple<offset_t, std::string, float>> expectedNames) {
         std::vector<std::tuple<offset_t, std::string, float>> results;
-        auto scanState = graph->prepareVertexScan(entry, properties);
         for (auto chunk : graph->scanVertices(startNodeOffset, endNodeOffset, *scanState)) {
             for (size_t i = 0; i < chunk.size(); i++) {
                 results.push_back(std::make_tuple(chunk.getNodeIDs()[i].offset,
@@ -198,9 +198,9 @@ TEST_F(RelScanTest, ScanVertexProperties) {
 TEST_F(VertexScanTest, ScanVertexProperties) {
     auto entry = catalog->getTableCatalogEntry(context->getTransaction(), "account");
     std::vector<std::string> properties = {"id"};
+    auto scanState = graph->prepareVertexScan(entry, properties);
     const auto compare = [&](offset_t startNode, offset_t endNode) {
         common::idx_t idx = 0;
-        auto scanState = graph->prepareVertexScan(entry, properties);
         for (auto chunk : graph->scanVertices(startNode, endNode, *scanState)) {
             for (auto i = 0u; i < chunk.size(); i++) {
                 auto nodeID = chunk.getNodeIDs()[i];

--- a/test/storage/rel_scan_test.cpp
+++ b/test/storage/rel_scan_test.cpp
@@ -1,4 +1,3 @@
-#include <cstdint>
 #include <vector>
 
 #include "api_test/private_api_test.h"
@@ -48,10 +47,36 @@ public:
     bool fwdStorageOnly;
 };
 
-class RelScanTestAmazon : public RelScanTest {
-    std::string getInputDir() override {
-        return TestHelper::appendKuzuRootPath("dataset/snap/amazon0601/csv/");
+class VertexScanTest : public PrivateApiTest {
+public:
+    void SetUp() override {
+        PrivateApiTest::SetUp();
+        auto res = conn->query("CREATE NODE TABLE account(id INT64 PRIMARY KEY);");
+        ASSERT_TRUE(res->isSuccess());
+        conn->query("CALL threads=1;");
+        res = conn->query("UNWIND range(0, 10000) AS i CREATE (a:account {ID: i});");
+        ASSERT_TRUE(res->isSuccess());
+        res = conn->query("UNWIND range(10001, 20000) AS i CREATE (a:account {ID: i});");
+        ASSERT_TRUE(res->isSuccess());
+        res = conn->query("UNWIND range(20001, 30000) AS i CREATE (a:account {ID: i});");
+        ASSERT_TRUE(res->isSuccess());
+        conn->query("BEGIN TRANSACTION");
+        context = getClientContext(*conn);
+        catalog = context->getCatalog();
+        auto transaction = context->getTransaction();
+        std::vector<catalog::TableCatalogEntry*> nodeEntries;
+        for (auto& entry : catalog->getNodeTableEntries(transaction)) {
+            nodeEntries.push_back(entry);
+        }
+        auto entry = graph::NativeGraphEntry(nodeEntries, {});
+        graph = std::make_unique<graph::OnDiskGraph>(context, std::move(entry));
     }
+
+    std::string getInputDir() override { return "empty"; }
+
+    std::unique_ptr<graph::OnDiskGraph> graph;
+    main::ClientContext* context = nullptr;
+    catalog::Catalog* catalog = nullptr;
 };
 
 // Test correctness of scan fwd
@@ -151,11 +176,11 @@ TEST_F(RelScanTest, ScanFwd) {
 TEST_F(RelScanTest, ScanVertexProperties) {
     auto entry = catalog->getTableCatalogEntry(context->getTransaction(), "person");
     std::vector<std::string> properties = {"fname", "height"};
-    auto scanState = graph->prepareVertexScan(entry, properties);
 
     const auto compare = [&](offset_t startNodeOffset, offset_t endNodeOffset,
                              std::vector<std::tuple<offset_t, std::string, float>> expectedNames) {
         std::vector<std::tuple<offset_t, std::string, float>> results;
+        auto scanState = graph->prepareVertexScan(entry, properties);
         for (auto chunk : graph->scanVertices(startNodeOffset, endNodeOffset, *scanState)) {
             for (size_t i = 0; i < chunk.size(); i++) {
                 results.push_back(std::make_tuple(chunk.getNodeIDs()[i].offset,
@@ -168,6 +193,30 @@ TEST_F(RelScanTest, ScanVertexProperties) {
     compare(0, 3, {{0, "Alice", 1.731}, {1, "Bob", 0.99}, {2, "Carol", 1.0}});
     compare(1, 3, {{1, "Bob", 0.99}, {2, "Carol", 1.0}});
     compare(2, 4, {{2, "Carol", 1.0}, {3, "Dan", 1.3}});
+}
+
+TEST_F(VertexScanTest, ScanVertexProperties) {
+    auto entry = catalog->getTableCatalogEntry(context->getTransaction(), "account");
+    std::vector<std::string> properties = {"id"};
+    const auto compare = [&](offset_t startNode, offset_t endNode) {
+        common::idx_t idx = 0;
+        auto scanState = graph->prepareVertexScan(entry, properties);
+        for (auto chunk : graph->scanVertices(startNode, endNode, *scanState)) {
+            for (auto i = 0u; i < chunk.size(); i++) {
+                auto nodeID = chunk.getNodeIDs()[i];
+                auto id = chunk.getProperties<int64_t>(0)[i];
+                ASSERT_EQ(nodeID.offset, idx + startNode);
+                ASSERT_EQ(id, idx + startNode);
+                idx++;
+            }
+        }
+        ASSERT_EQ(idx, endNode - startNode);
+    };
+
+    compare(0, 1000);
+    compare(1, 20000);
+    compare(14444, 20000);
+    compare(24444, 29889);
 }
 
 } // namespace testing


### PR DESCRIPTION
# Description

We didn't cover the case that `scanVertices` can scan over multiple ChunkedNodeGroups in a NodeGroup.
This PR added a test case for that, and also fixed the related bug: we were trying to scan over multiple ChunkedNodeGroups within a single while loop, however the second scan overwrites values in outputVector from its previous scan. The fix is to get rid of the while loop, instead scan from one ChunkedNodeGroup at a time.