### PR TITLE
Correctly set entry point when inserting to on-disk HNSW upper layer 

### DIFF
--- a/extension/vector/src/index/hnsw_index.cpp
+++ b/extension/vector/src/index/hnsw_index.cpp
@@ -915,12 +915,14 @@ void OnDiskHNSWIndex::insertToLayer(Transaction* transaction, common::offset_t o
     bool isUpperLayer) {
     auto& hnswStorageInfo = storageInfo->cast<HNSWStorageInfo>();
     if (entryPoint == common::INVALID_OFFSET) {
-        if (hnswStorageInfo.lowerEntryPoint == common::INVALID_OFFSET) {
-            // The lower layer is empty. Set the entry point to the current offset.
-            hnswStorageInfo.lowerEntryPoint = offset;
+        auto& entryPointToSet =
+            isUpperLayer ? hnswStorageInfo.upperEntryPoint : hnswStorageInfo.lowerEntryPoint;
+        if (entryPointToSet == common::INVALID_OFFSET) {
+            // The layer is empty. Set the entry point to the current offset.
+            entryPointToSet = offset;
             return;
         }
-        entryPoint = hnswStorageInfo.lowerEntryPoint;
+        entryPoint = entryPointToSet;
     }
     const auto closest = searchKNNInLayer(transaction, queryVector, entryPoint,
         insertState.searchState, isUpperLayer);

--- a/extension/vector/test/test_files/filter.test
+++ b/extension/vector/test/test_files/filter.test
@@ -382,3 +382,29 @@ Binder exception: In vector filtered search, projected graph G9 must contain exa
 333
 444
 146
+
+-CASE CopyAfterCreateIndexWithFilter
+-LOAD_DYNAMIC_EXTENSION vector
+-STATEMENT create node table tab(id uint64, vec float[2], primary key (id))
+---- ok
+-STATEMENT call create_vector_index('tab', 'tbl_hnsw_index', 'vec', metric := 'l2', ml := 60)
+---- ok
+-STATEMENT copy tab from (unwind range(1, 5000) as i return i, [1.0, cast(i, 'float')])
+---- ok
+-STATEMENT call query_vector_index("tab", "tbl_hnsw_index", [0.0, 1.0], 3) return node.id, distance order by distance asc, node.id asc
+---- 3
+1|1.000000
+2|1.414214
+3|2.236068
+
+-STATEMENT CALL PROJECT_GRAPH(
+        'filtered_tab',
+        {'tab': 'n.id >= 3'},
+        []
+    )
+---- ok
+-STATEMENT call query_vector_index("filtered_tab", "tbl_hnsw_index", [0.0, 1.0], 3) return node.id, distance order by distance
+---- 3
+3|2.236068
+4|3.162278
+5|4.123106


### PR DESCRIPTION
# Description

We were always setting the lower entry point before, this PR makes sure we're updating the upper entry point for the upper layer.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
