### PR TITLE
Fix vertex scan when there are reclaimed tuples in a node group

### DIFF
--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -577,7 +577,7 @@ void NodeTable::commit(main::ClientContext* context, TableCatalogEntry* tableEnt
     // 2. Set deleted flag for tuples that are deleted in local storage.
     row_idx_t numLocalRows = 0u;
     for (auto localNodeGroupIdx = 0u; localNodeGroupIdx < localNodeTable.getNumNodeGroups();
-         localNodeGroupIdx++) {
+        localNodeGroupIdx++) {
         const auto localNodeGroup = localNodeTable.getNodeGroup(localNodeGroupIdx);
         if (localNodeGroup->hasDeletions(transaction)) {
             // TODO(Guodong): Assume local storage is small here. Should optimize the loop away by
@@ -727,7 +727,7 @@ void NodeTable::scanIndexColumns(main::ClientContext* context, IndexScanHelper& 
 
     const auto numNodeGroups = nodeGroups_.getNumNodeGroups();
     for (node_group_idx_t nodeGroupToScan = 0u; nodeGroupToScan < numNodeGroups;
-         ++nodeGroupToScan) {
+        ++nodeGroupToScan) {
         scanState->nodeGroup = nodeGroups_.getNodeGroupNoLock(nodeGroupToScan);
 
         // It is possible for the node group to have no chunked groups if we are rolling back due to

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -577,7 +577,7 @@ void NodeTable::commit(main::ClientContext* context, TableCatalogEntry* tableEnt
     // 2. Set deleted flag for tuples that are deleted in local storage.
     row_idx_t numLocalRows = 0u;
     for (auto localNodeGroupIdx = 0u; localNodeGroupIdx < localNodeTable.getNumNodeGroups();
-        localNodeGroupIdx++) {
+         localNodeGroupIdx++) {
         const auto localNodeGroup = localNodeTable.getNodeGroup(localNodeGroupIdx);
         if (localNodeGroup->hasDeletions(transaction)) {
             // TODO(Guodong): Assume local storage is small here. Should optimize the loop away by
@@ -727,7 +727,7 @@ void NodeTable::scanIndexColumns(main::ClientContext* context, IndexScanHelper& 
 
     const auto numNodeGroups = nodeGroups_.getNumNodeGroups();
     for (node_group_idx_t nodeGroupToScan = 0u; nodeGroupToScan < numNodeGroups;
-        ++nodeGroupToScan) {
+         ++nodeGroupToScan) {
         scanState->nodeGroup = nodeGroups_.getNodeGroupNoLock(nodeGroupToScan);
 
         // It is possible for the node group to have no chunked groups if we are rolling back due to

--- a/test/storage/rel_scan_test.cpp
+++ b/test/storage/rel_scan_test.cpp
@@ -181,7 +181,6 @@ TEST_F(RelScanTest, ScanVertexProperties) {
     const auto compare = [&](offset_t startNodeOffset, offset_t endNodeOffset,
                              std::vector<std::tuple<offset_t, std::string, float>> expectedNames) {
         std::vector<std::tuple<offset_t, std::string, float>> results;
-        auto scanState = graph->prepareVertexScan(entry, properties);
         for (auto chunk : graph->scanVertices(startNodeOffset, endNodeOffset, *scanState)) {
             for (size_t i = 0; i < chunk.size(); i++) {
                 results.push_back(std::make_tuple(chunk.getNodeIDs()[i].offset,

--- a/test/storage/rel_scan_test.cpp
+++ b/test/storage/rel_scan_test.cpp
@@ -181,6 +181,7 @@ TEST_F(RelScanTest, ScanVertexProperties) {
     const auto compare = [&](offset_t startNodeOffset, offset_t endNodeOffset,
                              std::vector<std::tuple<offset_t, std::string, float>> expectedNames) {
         std::vector<std::tuple<offset_t, std::string, float>> results;
+        auto scanState = graph->prepareVertexScan(entry, properties);
         for (auto chunk : graph->scanVertices(startNodeOffset, endNodeOffset, *scanState)) {
             for (size_t i = 0; i < chunk.size(); i++) {
                 results.push_back(std::make_tuple(chunk.getNodeIDs()[i].offset,


### PR DESCRIPTION
# Description

Fix #5671.