### PR TITLE
Enable extension loading in read-only database

### DIFF
--- a/extension/algo/src/main/algo_extension.cpp
+++ b/extension/algo/src/main/algo_extension.cpp
@@ -10,19 +10,17 @@ using namespace extension;
 
 void AlgoExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    ExtensionUtils::addTableFunc<SCCFunction>(context->getTransaction(), db);
-    ExtensionUtils::addTableFuncAlias<SCCAliasFunction>(context->getTransaction(), db);
-    ExtensionUtils::addTableFunc<SCCKosarajuFunction>(context->getTransaction(), db);
-    ExtensionUtils::addTableFuncAlias<SCCKosarajuAliasFunction>(context->getTransaction(), db);
-    ExtensionUtils::addTableFunc<WeaklyConnectedComponentsFunction>(context->getTransaction(), db);
-    ExtensionUtils::addTableFuncAlias<WeaklyConnectedComponentsAliasFunction>(
-        context->getTransaction(), db);
-    ExtensionUtils::addTableFunc<PageRankFunction>(context->getTransaction(), db);
-    ExtensionUtils::addTableFuncAlias<PageRankAliasFunction>(context->getTransaction(), db);
-    ExtensionUtils::addTableFunc<KCoreDecompositionFunction>(context->getTransaction(), db);
-    ExtensionUtils::addTableFuncAlias<KCoreDecompositionAliasFunction>(context->getTransaction(),
-        db);
-    ExtensionUtils::addTableFunc<LouvainFunction>(context->getTransaction(), db);
+    ExtensionUtils::addTableFunc<SCCFunction>(db);
+    ExtensionUtils::addTableFuncAlias<SCCAliasFunction>(db);
+    ExtensionUtils::addTableFunc<SCCKosarajuFunction>(db);
+    ExtensionUtils::addTableFuncAlias<SCCKosarajuAliasFunction>(db);
+    ExtensionUtils::addTableFunc<WeaklyConnectedComponentsFunction>(db);
+    ExtensionUtils::addTableFuncAlias<WeaklyConnectedComponentsAliasFunction>(db);
+    ExtensionUtils::addTableFunc<PageRankFunction>(db);
+    ExtensionUtils::addTableFuncAlias<PageRankAliasFunction>(db);
+    ExtensionUtils::addTableFunc<KCoreDecompositionFunction>(db);
+    ExtensionUtils::addTableFuncAlias<KCoreDecompositionAliasFunction>(db);
+    ExtensionUtils::addTableFunc<LouvainFunction>(db);
 }
 
 } // namespace algo_extension

--- a/extension/azure/src/main/azure_extension.cpp
+++ b/extension/azure/src/main/azure_extension.cpp
@@ -12,7 +12,7 @@ namespace azure_extension {
 
 void AzureExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    extension::ExtensionUtils::addTableFunc<AzureScanFunction>(context->getTransaction(), db);
+    extension::ExtensionUtils::addTableFunc<AzureScanFunction>(db);
     db.registerFileSystem(std::make_unique<AzureFileSystem>());
     auto config = AzureConfig::getDefault();
     config.registerExtensionOptions(context->getDatabase());

--- a/extension/delta/src/main/delta_extension.cpp
+++ b/extension/delta/src/main/delta_extension.cpp
@@ -10,7 +10,7 @@ namespace delta_extension {
 
 void DeltaExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    extension::ExtensionUtils::addTableFunc<DeltaScanFunction>(context->getTransaction(), db);
+    extension::ExtensionUtils::addTableFunc<DeltaScanFunction>(db);
     duckdb_extension::DuckdbExtension::loadRemoteFSOptions(context);
 }
 

--- a/extension/duckdb/src/include/storage/duckdb_storage.h
+++ b/extension/duckdb/src/include/storage/duckdb_storage.h
@@ -18,7 +18,7 @@ public:
 
     static constexpr bool SKIP_UNSUPPORTED_TABLE_DEFAULT_VAL = false;
 
-    DuckDBStorageExtension(transaction::Transaction* transaction, main::Database& db);
+    explicit DuckDBStorageExtension(main::Database& db);
 
     bool canHandleDB(std::string dbType_) const override;
 };

--- a/extension/duckdb/src/main/duckdb_extension.cpp
+++ b/extension/duckdb/src/main/duckdb_extension.cpp
@@ -10,8 +10,7 @@ namespace duckdb_extension {
 
 void DuckdbExtension::load(main::ClientContext* context) {
     auto db = context->getDatabase();
-    db->registerStorageExtension(EXTENSION_NAME,
-        std::make_unique<DuckDBStorageExtension>(context->getTransaction(), *db));
+    db->registerStorageExtension(EXTENSION_NAME, std::make_unique<DuckDBStorageExtension>(*db));
     loadRemoteFSOptions(context);
 }
 

--- a/extension/duckdb/src/storage/duckdb_storage.cpp
+++ b/extension/duckdb/src/storage/duckdb_storage.cpp
@@ -36,10 +36,9 @@ std::unique_ptr<main::AttachedDatabase> attachDuckDB(std::string dbName, std::st
         std::move(duckdbCatalog), std::move(connector));
 }
 
-DuckDBStorageExtension::DuckDBStorageExtension(transaction::Transaction* transaction,
-    main::Database& db)
+DuckDBStorageExtension::DuckDBStorageExtension(main::Database& db)
     : StorageExtension{attachDuckDB} {
-    extension::ExtensionUtils::addStandaloneTableFunc<ClearCacheFunction>(transaction, db);
+    extension::ExtensionUtils::addStandaloneTableFunc<ClearCacheFunction>(db);
 }
 
 bool DuckDBStorageExtension::canHandleDB(std::string dbType_) const {

--- a/extension/fts/src/main/fts_extension.cpp
+++ b/extension/fts/src/main/fts_extension.cpp
@@ -34,14 +34,12 @@ static void initFTSEntries(main::ClientContext* context, catalog::Catalog& catal
 
 void FtsExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    ExtensionUtils::addScalarFunc<StemFunction>(context->getTransaction(), db);
-    ExtensionUtils::addTableFunc<QueryFTSFunction>(context->getTransaction(), db);
-    ExtensionUtils::addStandaloneTableFunc<CreateFTSFunction>(context->getTransaction(), db);
-    ExtensionUtils::addInternalStandaloneTableFunc<InternalCreateFTSFunction>(
-        context->getTransaction(), db);
-    ExtensionUtils::addStandaloneTableFunc<DropFTSFunction>(context->getTransaction(), db);
-    ExtensionUtils::addInternalStandaloneTableFunc<InternalDropFTSFunction>(
-        context->getTransaction(), db);
+    ExtensionUtils::addScalarFunc<StemFunction>(db);
+    ExtensionUtils::addTableFunc<QueryFTSFunction>(db);
+    ExtensionUtils::addStandaloneTableFunc<CreateFTSFunction>(db);
+    ExtensionUtils::addInternalStandaloneTableFunc<InternalCreateFTSFunction>(db);
+    ExtensionUtils::addStandaloneTableFunc<DropFTSFunction>(db);
+    ExtensionUtils::addInternalStandaloneTableFunc<InternalDropFTSFunction>(db);
     ExtensionUtils::registerIndexType(db, FTSIndex::getIndexType());
     initFTSEntries(context, *db.getCatalog());
 }

--- a/extension/iceberg/src/main/iceberg_extension.cpp
+++ b/extension/iceberg/src/main/iceberg_extension.cpp
@@ -12,9 +12,9 @@ using namespace kuzu::extension;
 
 void IcebergExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    ExtensionUtils::addTableFunc<IcebergScanFunction>(context->getTransaction(), db);
-    ExtensionUtils::addTableFunc<IcebergMetadataFunction>(context->getTransaction(), db);
-    ExtensionUtils::addTableFunc<IcebergSnapshotsFunction>(context->getTransaction(), db);
+    ExtensionUtils::addTableFunc<IcebergScanFunction>(db);
+    ExtensionUtils::addTableFunc<IcebergMetadataFunction>(db);
+    ExtensionUtils::addTableFunc<IcebergSnapshotsFunction>(db);
     duckdb_extension::DuckdbExtension::loadRemoteFSOptions(context);
 }
 

--- a/extension/json/src/main/json_extension.cpp
+++ b/extension/json/src/main/json_extension.cpp
@@ -15,38 +15,38 @@ namespace json_extension {
 
 using namespace kuzu::extension;
 
-static void addJsonCreationFunction(transaction::Transaction* transaction, main::Database& db) {
-    ExtensionUtils::addScalarFunc<ToJsonFunction>(transaction, db);
-    ExtensionUtils::addScalarFuncAlias<JsonQuoteFunction>(transaction, db);
-    ExtensionUtils::addScalarFuncAlias<ArrayToJsonFunction>(transaction, db);
-    ExtensionUtils::addScalarFuncAlias<RowToJsonFunction>(transaction, db);
-    ExtensionUtils::addScalarFunc<CastToJsonFunction>(transaction, db);
-    ExtensionUtils::addScalarFunc<JsonArrayFunction>(transaction, db);
-    ExtensionUtils::addScalarFunc<JsonObjectFunction>(transaction, db);
-    ExtensionUtils::addScalarFunc<JsonMergePatchFunction>(transaction, db);
+static void addJsonCreationFunction(main::Database& db) {
+    ExtensionUtils::addScalarFunc<ToJsonFunction>(db);
+    ExtensionUtils::addScalarFuncAlias<JsonQuoteFunction>(db);
+    ExtensionUtils::addScalarFuncAlias<ArrayToJsonFunction>(db);
+    ExtensionUtils::addScalarFuncAlias<RowToJsonFunction>(db);
+    ExtensionUtils::addScalarFunc<CastToJsonFunction>(db);
+    ExtensionUtils::addScalarFunc<JsonArrayFunction>(db);
+    ExtensionUtils::addScalarFunc<JsonObjectFunction>(db);
+    ExtensionUtils::addScalarFunc<JsonMergePatchFunction>(db);
 }
 
-static void addJsonExtractFunction(transaction::Transaction* transaction, main::Database& db) {
-    ExtensionUtils::addScalarFunc<JsonExtractFunction>(transaction, db);
+static void addJsonExtractFunction(main::Database& db) {
+    ExtensionUtils::addScalarFunc<JsonExtractFunction>(db);
 }
 
-static void addJsonScalarFunction(transaction::Transaction* transaction, main::Database& db) {
-    ExtensionUtils::addScalarFunc<JsonArrayLengthFunction>(transaction, db);
-    ExtensionUtils::addScalarFunc<JsonContainsFunction>(transaction, db);
-    ExtensionUtils::addScalarFunc<JsonKeysFunction>(transaction, db);
-    ExtensionUtils::addScalarFunc<JsonStructureFunction>(transaction, db);
-    ExtensionUtils::addScalarFunc<JsonValidFunction>(transaction, db);
-    ExtensionUtils::addScalarFunc<MinifyJsonFunction>(transaction, db);
+static void addJsonScalarFunction(main::Database& db) {
+    ExtensionUtils::addScalarFunc<JsonArrayLengthFunction>(db);
+    ExtensionUtils::addScalarFunc<JsonContainsFunction>(db);
+    ExtensionUtils::addScalarFunc<JsonKeysFunction>(db);
+    ExtensionUtils::addScalarFunc<JsonStructureFunction>(db);
+    ExtensionUtils::addScalarFunc<JsonValidFunction>(db);
+    ExtensionUtils::addScalarFunc<MinifyJsonFunction>(db);
 }
 
 void JsonExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    db.getCatalog()->createType(context->getTransaction(), JSON_TYPE_NAME, JsonType::getJsonType());
-    addJsonCreationFunction(context->getTransaction(), db);
-    addJsonExtractFunction(context->getTransaction(), db);
-    addJsonScalarFunction(context->getTransaction(), db);
-    ExtensionUtils::addScalarFunc<JsonExportFunction>(context->getTransaction(), db);
-    ExtensionUtils::addTableFunc<JsonScan>(context->getTransaction(), db);
+    db.getCatalog()->createType(&transaction::DUMMY_TRANSACTION, JSON_TYPE_NAME, JsonType::getJsonType());
+    addJsonCreationFunction(db);
+    addJsonExtractFunction(db);
+    addJsonScalarFunction(db);
+    ExtensionUtils::addScalarFunc<JsonExportFunction>(db);
+    ExtensionUtils::addTableFunc<JsonScan>(db);
 }
 
 } // namespace json_extension

--- a/extension/json/src/main/json_extension.cpp
+++ b/extension/json/src/main/json_extension.cpp
@@ -41,7 +41,8 @@ static void addJsonScalarFunction(main::Database& db) {
 
 void JsonExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    db.getCatalog()->createType(&transaction::DUMMY_TRANSACTION, JSON_TYPE_NAME, JsonType::getJsonType());
+    db.getCatalog()->createType(&transaction::DUMMY_TRANSACTION, JSON_TYPE_NAME,
+        JsonType::getJsonType());
     addJsonCreationFunction(db);
     addJsonExtractFunction(db);
     addJsonScalarFunction(db);

--- a/extension/llm/src/main/llm_extension.cpp
+++ b/extension/llm/src/main/llm_extension.cpp
@@ -17,7 +17,7 @@ namespace llm_extension {
 void LlmExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
 
-    extension::ExtensionUtils::addScalarFunc<CreateEmbedding>(context->getTransaction(), db);
+    extension::ExtensionUtils::addScalarFunc<CreateEmbedding>(db);
 }
 
 } // namespace llm_extension

--- a/extension/neo4j/src/main/neo4j_extension.cpp
+++ b/extension/neo4j/src/main/neo4j_extension.cpp
@@ -10,7 +10,7 @@ using namespace extension;
 
 void Neo4jExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    ExtensionUtils::addStandaloneTableFunc<Neo4jMigrateFunction>(context->getTransaction(), db);
+    ExtensionUtils::addStandaloneTableFunc<Neo4jMigrateFunction>(db);
 }
 
 } // namespace neo4j_extension

--- a/extension/postgres/src/include/storage/postgres_storage.h
+++ b/extension/postgres/src/include/storage/postgres_storage.h
@@ -15,8 +15,7 @@ public:
 
     static constexpr const char* DEFAULT_SCHEMA_NAME = "public";
 
-    explicit PostgresStorageExtension(transaction::Transaction* transaction,
-        main::Database& database);
+    explicit PostgresStorageExtension(main::Database& database);
 
     bool canHandleDB(std::string dbType_) const override;
 };

--- a/extension/postgres/src/main/postgres_extension.cpp
+++ b/extension/postgres/src/main/postgres_extension.cpp
@@ -10,9 +10,8 @@ namespace postgres_extension {
 
 void PostgresExtension::load(main::ClientContext* context) {
     auto db = context->getDatabase();
-    db->registerStorageExtension(EXTENSION_NAME,
-        std::make_unique<PostgresStorageExtension>(context->getTransaction(), *db));
-    extension::ExtensionUtils::addTableFunc<SqlQueryFunction>(context->getTransaction(), *db);
+    db->registerStorageExtension(EXTENSION_NAME, std::make_unique<PostgresStorageExtension>(*db));
+    extension::ExtensionUtils::addTableFunc<SqlQueryFunction>(*db);
 }
 
 } // namespace postgres_extension

--- a/extension/postgres/src/storage/postgres_storage.cpp
+++ b/extension/postgres/src/storage/postgres_storage.cpp
@@ -39,11 +39,10 @@ std::unique_ptr<main::AttachedDatabase> attachPostgres(std::string dbName, std::
         std::move(catalog), std::move(connector), catalogName);
 }
 
-PostgresStorageExtension::PostgresStorageExtension(transaction::Transaction* transaction,
-    main::Database& database)
+PostgresStorageExtension::PostgresStorageExtension(main::Database& database)
     : StorageExtension{attachPostgres} {
     extension::ExtensionUtils::addStandaloneTableFunc<duckdb_extension::ClearCacheFunction>(
-        transaction, database);
+        database);
 }
 
 bool PostgresStorageExtension::canHandleDB(std::string dbType_) const {

--- a/extension/sqlite/src/include/storage/sqlite_storage.h
+++ b/extension/sqlite/src/include/storage/sqlite_storage.h
@@ -12,7 +12,7 @@ public:
 
     static constexpr const char* DEFAULT_SCHEMA_NAME = "main";
 
-    SqliteStorageExtension(transaction::Transaction* transaction, main::Database& database);
+    explicit SqliteStorageExtension(main::Database& database);
 
     bool canHandleDB(std::string dbType_) const override;
 };

--- a/extension/sqlite/src/main/sqlite_extension.cpp
+++ b/extension/sqlite/src/main/sqlite_extension.cpp
@@ -9,8 +9,7 @@ namespace sqlite_extension {
 
 void SqliteExtension::load(main::ClientContext* context) {
     auto db = context->getDatabase();
-    db->registerStorageExtension(EXTENSION_NAME,
-        std::make_unique<SqliteStorageExtension>(context->getTransaction(), *db));
+    db->registerStorageExtension(EXTENSION_NAME, std::make_unique<SqliteStorageExtension>(*db));
     db->addExtensionOption("sqlite_all_varchar", common::LogicalTypeID::BOOL, common::Value{false});
 }
 

--- a/extension/sqlite/src/storage/sqlite_storage.cpp
+++ b/extension/sqlite/src/storage/sqlite_storage.cpp
@@ -33,11 +33,10 @@ std::unique_ptr<main::AttachedDatabase> attachSqlite(std::string dbName, std::st
         SqliteStorageExtension::DB_TYPE, std::move(catalog), std::move(connector));
 }
 
-SqliteStorageExtension::SqliteStorageExtension(transaction::Transaction* transaction,
-    main::Database& database)
+SqliteStorageExtension::SqliteStorageExtension(main::Database& database)
     : StorageExtension{attachSqlite} {
     extension::ExtensionUtils::addStandaloneTableFunc<duckdb_extension::ClearCacheFunction>(
-        transaction, database);
+        database);
 }
 
 bool SqliteStorageExtension::canHandleDB(std::string dbType_) const {

--- a/extension/unity_catalog/src/include/storage/unity_catalog_storage.h
+++ b/extension/unity_catalog/src/include/storage/unity_catalog_storage.h
@@ -15,8 +15,7 @@ public:
 
     static constexpr const char* DEFAULT_SCHEMA_NAME = "default";
 
-    explicit UnityCatalogStorageExtension(transaction::Transaction* transaction,
-        main::Database& database);
+    explicit UnityCatalogStorageExtension(main::Database& database);
 
     bool canHandleDB(std::string dbType) const override;
 };

--- a/extension/unity_catalog/src/main/unity_catalog_extension.cpp
+++ b/extension/unity_catalog/src/main/unity_catalog_extension.cpp
@@ -10,8 +10,7 @@ namespace unity_catalog_extension {
 
 void UnityCatalogExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    db.registerStorageExtension(EXTENSION_NAME,
-        std::make_unique<UnityCatalogStorageExtension>(context->getTransaction(), db));
+    db.registerStorageExtension(EXTENSION_NAME, std::make_unique<UnityCatalogStorageExtension>(db));
     UnityCatalogOptions::registerExtensionOptions(&db);
     UnityCatalogOptions::setEnvValue(context);
 }

--- a/extension/unity_catalog/src/storage/unity_catalog_storage.cpp
+++ b/extension/unity_catalog/src/storage/unity_catalog_storage.cpp
@@ -25,11 +25,10 @@ std::unique_ptr<main::AttachedDatabase> attachUnityCatalog(std::string dbName, s
         UnityCatalogStorageExtension::DB_TYPE, std::move(catalog), std::move(connector));
 }
 
-UnityCatalogStorageExtension::UnityCatalogStorageExtension(transaction::Transaction* transaction,
-    main::Database& database)
+UnityCatalogStorageExtension::UnityCatalogStorageExtension(main::Database& database)
     : StorageExtension{attachUnityCatalog} {
     extension::ExtensionUtils::addStandaloneTableFunc<duckdb_extension::ClearCacheFunction>(
-        transaction, database);
+        database);
 }
 
 bool UnityCatalogStorageExtension::canHandleDB(std::string dbType_) const {

--- a/extension/vector/src/main/vector_extension.cpp
+++ b/extension/vector/src/main/vector_extension.cpp
@@ -30,18 +30,13 @@ static void initHNSWEntries(main::ClientContext* context) {
 
 void VectorExtension::load(main::ClientContext* context) {
     auto& db = *context->getDatabase();
-    extension::ExtensionUtils::addTableFunc<QueryVectorIndexFunction>(context->getTransaction(),
-        db);
-    extension::ExtensionUtils::addInternalStandaloneTableFunc<InternalCreateHNSWIndexFunction>(
-        context->getTransaction(), db);
+    extension::ExtensionUtils::addTableFunc<QueryVectorIndexFunction>(db);
+    extension::ExtensionUtils::addInternalStandaloneTableFunc<InternalCreateHNSWIndexFunction>(db);
     extension::ExtensionUtils::addInternalStandaloneTableFunc<InternalFinalizeHNSWIndexFunction>(
-        context->getTransaction(), db);
-    extension::ExtensionUtils::addStandaloneTableFunc<CreateVectorIndexFunction>(
-        context->getTransaction(), db);
-    extension::ExtensionUtils::addInternalStandaloneTableFunc<InternalDropHNSWIndexFunction>(
-        context->getTransaction(), db);
-    extension::ExtensionUtils::addStandaloneTableFunc<DropVectorIndexFunction>(
-        context->getTransaction(), db);
+        db);
+    extension::ExtensionUtils::addStandaloneTableFunc<CreateVectorIndexFunction>(db);
+    extension::ExtensionUtils::addInternalStandaloneTableFunc<InternalDropHNSWIndexFunction>(db);
+    extension::ExtensionUtils::addStandaloneTableFunc<DropVectorIndexFunction>(db);
     extension::ExtensionUtils::registerIndexType(db, OnDiskHNSWIndex::getIndexType());
     initHNSWEntries(context);
 }

--- a/src/include/extension/extension.h
+++ b/src/include/extension/extension.h
@@ -53,14 +53,14 @@ struct ExtensionSourceUtils {
 };
 
 template<typename T>
-void addFunc(transaction::Transaction* transaction, main::Database& database, std::string name,
-    catalog::CatalogEntryType functionType, bool isInternal = false) {
+void addFunc(main::Database& database, std::string name, catalog::CatalogEntryType functionType,
+    bool isInternal = false) {
     auto catalog = database.getCatalog();
-    if (catalog->containsFunction(transaction, name, isInternal)) {
+    if (catalog->containsFunction(&transaction::DUMMY_TRANSACTION, name, isInternal)) {
         return;
     }
-    catalog->addFunction(transaction, functionType, std::move(name), T::getFunctionSet(),
-        isInternal);
+    catalog->addFunction(&transaction::DUMMY_TRANSACTION, functionType, std::move(name),
+        T::getFunctionSet(), isInternal);
 }
 
 struct KUZU_API ExtensionUtils {
@@ -117,39 +117,35 @@ struct KUZU_API ExtensionUtils {
     static bool isOfficialExtension(const std::string& extension);
 
     template<typename T>
-    static void addTableFunc(transaction::Transaction* transaction, main::Database& database) {
-        addFunc<T>(transaction, database, T::name, catalog::CatalogEntryType::TABLE_FUNCTION_ENTRY);
+    static void addTableFunc(main::Database& database) {
+        addFunc<T>(database, T::name, catalog::CatalogEntryType::TABLE_FUNCTION_ENTRY);
     }
 
     template<typename T>
-    static void addTableFuncAlias(transaction::Transaction* transaction, main::Database& database) {
-        addFunc<typename T::alias>(transaction, database, T::name,
+    static void addTableFuncAlias(main::Database& database) {
+        addFunc<typename T::alias>(database, T::name,
             catalog::CatalogEntryType::TABLE_FUNCTION_ENTRY);
     }
 
     template<typename T>
-    static void addStandaloneTableFunc(transaction::Transaction* transaction,
-        main::Database& database) {
-        addFunc<T>(transaction, database, T::name,
-            catalog::CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY, false /* isInternal */);
+    static void addStandaloneTableFunc(main::Database& database) {
+        addFunc<T>(database, T::name, catalog::CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY,
+            false /* isInternal */);
     }
     template<typename T>
-    static void addInternalStandaloneTableFunc(transaction::Transaction* transaction,
-        main::Database& database) {
-        addFunc<T>(transaction, database, T::name,
-            catalog::CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY, true /* isInternal */);
+    static void addInternalStandaloneTableFunc(main::Database& database) {
+        addFunc<T>(database, T::name, catalog::CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY,
+            true /* isInternal */);
     }
 
     template<typename T>
-    static void addScalarFunc(transaction::Transaction* transaction, main::Database& database) {
-        addFunc<T>(transaction, database, T::name,
-            catalog::CatalogEntryType::SCALAR_FUNCTION_ENTRY);
+    static void addScalarFunc(main::Database& database) {
+        addFunc<T>(database, T::name, catalog::CatalogEntryType::SCALAR_FUNCTION_ENTRY);
     }
 
     template<typename T>
-    static void addScalarFuncAlias(transaction::Transaction* transaction,
-        main::Database& database) {
-        addFunc<typename T::alias>(transaction, database, T::name,
+    static void addScalarFuncAlias(main::Database& database) {
+        addFunc<typename T::alias>(database, T::name,
             catalog::CatalogEntryType::SCALAR_FUNCTION_ENTRY);
     }
 

--- a/src/include/parser/visitor/statement_read_write_analyzer.h
+++ b/src/include/parser/visitor/statement_read_write_analyzer.h
@@ -23,7 +23,7 @@ private:
     void visitStandaloneCall(const Statement& /*statement*/) override { readOnly = true; }
     void visitStandaloneCallFunction(const Statement& /*statement*/) override { readOnly = false; }
     void visitCreateMacro(const Statement& /*statement*/) override { readOnly = false; }
-    void visitExtension(const Statement& /*statement*/) override { readOnly = false; }
+    void visitExtension(const Statement& /*statement*/) override;
 
     void visitReadingClause(const ReadingClause* readingClause) override;
     void visitWithClause(const WithClause* withClause) override;

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -323,7 +323,7 @@ void ClientContext::cleanUp() {
 }
 
 std::unique_ptr<PreparedStatement> ClientContext::prepareWithParams(std::string_view query,
-    std::unordered_map<std::string, std::unique_ptr<common::Value>> inputParams) {
+    std::unordered_map<std::string, std::unique_ptr<Value>> inputParams) {
     std::unique_lock lck{mtx};
     auto parsedStatements = std::vector<std::shared_ptr<Statement>>();
     try {
@@ -338,9 +338,9 @@ std::unique_ptr<PreparedStatement> ClientContext::prepareWithParams(std::string_
 
     // The binder deals with the parameter values as shared ptrs
     // Copy the params to a new map that matches the format that the binder expects
-    std::unordered_map<std::string, std::shared_ptr<common::Value>> inputParamsTmp;
+    std::unordered_map<std::string, std::shared_ptr<Value>> inputParamsTmp;
     for (auto& [key, value] : inputParams) {
-        inputParamsTmp.insert(std::make_pair(key, std::make_shared<common::Value>(*value)));
+        inputParamsTmp.insert(std::make_pair(key, std::make_shared<Value>(*value)));
     }
     auto result = prepareNoLock(parsedStatements[0], true /*shouldCommitNewTransaction*/,
         std::move(inputParamsTmp));
@@ -665,7 +665,7 @@ bool ClientContext::canExecuteWriteQuery() const {
     // remote kuzu database can be attached.
     const auto dbManager = localDatabase->databaseManager.get();
     for (const auto& attachedDB : dbManager->getAttachedDatabases()) {
-        if (attachedDB->getDBType() == common::ATTACHED_KUZU_DB_TYPE) {
+        if (attachedDB->getDBType() == ATTACHED_KUZU_DB_TYPE) {
             return false;
         }
     }

--- a/src/parser/visitor/statement_read_write_analyzer.cpp
+++ b/src/parser/visitor/statement_read_write_analyzer.cpp
@@ -1,11 +1,22 @@
 #include "parser/visitor/statement_read_write_analyzer.h"
 
+#include "main/client_context.h"
+#include "main/db_config.h"
 #include "parser/expression/parsed_expression_visitor.h"
 #include "parser/query/reading_clause/reading_clause.h"
 #include "parser/query/return_with_clause/with_clause.h"
 
 namespace kuzu {
 namespace parser {
+
+void StatementReadWriteAnalyzer::visitExtension(const Statement& /*statement*/) {
+    // We allow LOAD EXTENSION to run in read-only mode.
+    if (context->getDBConfig()->readOnly) {
+        readOnly = true;
+    } else {
+        readOnly = false;
+    }
+}
 
 void StatementReadWriteAnalyzer::visitReadingClause(const ReadingClause* readingClause) {
     if (readingClause->hasWherePredicate()) {

--- a/tools/python_api/src_cpp/py_database.cpp
+++ b/tools/python_api/src_cpp/py_database.cpp
@@ -54,8 +54,7 @@ PyDatabase::PyDatabase(const std::string& databasePath, uint64_t bufferPoolSize,
         systemConfig.checkpointThreshold = static_cast<uint64_t>(checkpointThreshold);
     }
     database = std::make_unique<Database>(databasePath, systemConfig);
-    kuzu::extension::ExtensionUtils::addTableFunc<kuzu::PandasScanFunction>(
-        &kuzu::transaction::DUMMY_TRANSACTION, *database);
+    kuzu::extension::ExtensionUtils::addTableFunc<kuzu::PandasScanFunction>(*database);
     storageDriver = std::make_unique<StorageDriver>(database.get());
     py::gil_scoped_acquire acquire;
     if (kuzu::importCache.get() == nullptr) {


### PR DESCRIPTION
# Description

The previous change to extension transaction accidentally break extension loading under read-only mode. This PR fixes the issue.