### PR TITLE
Handle null values in string concat

### DIFF
--- a/src/function/vector_string_functions.cpp
+++ b/src/function/vector_string_functions.cpp
@@ -112,7 +112,9 @@ void ConcatFunction::execFunc(const std::vector<std::shared_ptr<common::ValueVec
             const auto& parameter = *parameters[i];
             const auto& parameterSelVector = parameterSelVectors[i];
             auto paramPos = (*parameterSelVector)[parameter.state->isFlat() ? 0 : selectedPos];
-            strLen += parameter.getValue<ku_string_t>(paramPos).len;
+            if (!parameter.isNull(paramPos)) {
+                strLen += parameter.getValue<ku_string_t>(paramPos).len;
+            }
         }
         auto& resultStr = result.getValue<ku_string_t>(pos);
         StringVector::reserveString(&result, resultStr, strLen);
@@ -123,9 +125,11 @@ void ConcatFunction::execFunc(const std::vector<std::shared_ptr<common::ValueVec
             const auto& parameter = *parameters[i];
             const auto& parameterSelVector = parameterSelVectors[i];
             auto paramPos = (*parameterSelVector)[parameter.state->isFlat() ? 0 : selectedPos];
-            auto srcStr = parameter.getValue<ku_string_t>(paramPos);
-            memcpy(dstData, srcStr.getData(), srcStr.len);
-            dstData += srcStr.len;
+            if (!parameter.isNull(paramPos)) {
+                auto srcStr = parameter.getValue<ku_string_t>(paramPos);
+                memcpy(dstData, srcStr.getData(), srcStr.len);
+                dstData += srcStr.len;
+            }
         }
         if (strLen > ku_string_t::SHORT_STR_LENGTH) {
             memcpy(resultStr.prefix, resultStr.getData(), ku_string_t::PREFIX_LENGTH);

--- a/test/test_files/function/string_empty.test
+++ b/test/test_files/function/string_empty.test
@@ -1,0 +1,37 @@
+-DATASET CSV empty
+
+--
+
+-CASE StringConcatOnUncheckpointedProperties
+-STATEMENT call auto_checkpoint=false
+---- ok
+-STATEMENT create node table person (ID INt64, PRIMARY KEY (ID));
+---- ok
+-STATEMENT create rel table marries (FROM person TO person, note STRING);
+---- ok
+-STATEMENT  create (:person {id: 9});
+            create (:person {id: 11});
+            create (:person {id: 12});
+            create (:person {id: 13});
+---- ok
+---- ok
+---- ok
+-STATEMENT match (a:person), (b:person) where a.id = 9 and b.id = 11 create (a)-[:marries{note: "some note"}]->(b);
+            match (a:person), (b:person) where a.id = 12 and b.id = 13 create (a)-[:marries]->(b);
+---- ok
+---- ok
+-STATEMENT match (a)-[m:marries]->(b) return concat("note:'", m.note, "'")
+---- 2
+note:''
+note:'some note'
+
+-CASE StringConcatOnFlatOutputWithNull
+-STATEMENT create node table person (ID serial, val string, PRIMARY KEY (ID));
+---- ok
+# create output is guaranteed to be flat
+-STATEMENT UNWIND ["111", "222", null, "333"] as i create (p:person{val: i}) return concat("val:", p.val)
+---- 4
+val:
+val:111
+val:222
+val:333


### PR DESCRIPTION
# Description
Title is pretty self-explanatory, we weren't checking if values were null in the string concat function which caused the output to be incorrect sometimes if a position in an input vector was reused. This PR updates it so that null values are treated as empty strings.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
