### PR TITLE
Fix list_contains type sniffing

### DIFF
--- a/src/function/list/list_contains_function.cpp
+++ b/src/function/list/list_contains_function.cpp
@@ -1,9 +1,9 @@
 #include "binder/expression/expression_util.h"
+#include "common/exception/binder.h"
 #include "common/type_utils.h"
 #include "function/list/functions/list_position_function.h"
 #include "function/list/vector_list_functions.h"
 #include "function/scalar_function.h"
-#include "common/exception/binder.h"
 
 using namespace kuzu::common;
 using namespace kuzu::binder;
@@ -37,7 +37,9 @@ static std::unique_ptr<FunctionBindData> bindFunc(const ScalarBindFuncInput& inp
         auto& listChildType = ListType::getChildType(listExpr->getDataType());
         auto& elementType = elementExpr->getDataType();
         if (!LogicalTypeUtils::tryGetMaxLogicalType(listChildType, elementType, childType)) {
-            throw BinderException(stringFormat("Cannot compare {} and {} in list_contains function.", listChildType.toString(), elementType.toString()));
+            throw BinderException(
+                stringFormat("Cannot compare {} and {} in list_contains function.",
+                    listChildType.toString(), elementType.toString()));
         }
     }
     if (childType.getLogicalTypeID() == LogicalTypeID::ANY) {

--- a/test/test_files/function/list.test
+++ b/test/test_files/function/list.test
@@ -692,6 +692,29 @@ True|True
 8|[2]|False
 9|[3,4,5,6,7]|False
 
+-LOG ListContains
+-STATEMENT RETURN 2.0 IN [1, 2]
+---- 1
+True
+-STATEMENT RETURN  [1.0] IN [[1], [2]]
+---- 1
+True
+-STATEMENT RETURN {a:1} IN [2,3]
+---- error
+Binder exception: Cannot compare INT64 and STRUCT(a INT64) in list_contains function.
+-STATEMENT RETURN NULL in [1,2]
+---- 1
+
+-STATEMENT RETURN 1 IN [null]
+---- 1
+False
+-STATEMENT RETURN null in []
+---- 1
+
+-STATEMENT RETURN null in [null]
+---- 1
+
+
 -LOG ListContainsListOfInts
 -STATEMENT MATCH (a:person) RETURN list_contains(a.workedHours, 5)
 ---- 8

--- a/tools/python_api/test/test_issue.py
+++ b/tools/python_api/test/test_issue.py
@@ -111,6 +111,7 @@ def test_empty_map(conn_db_readwrite: ConnDB) -> None:
     assert not result.has_next()
     result.close()
 
+
 def test_int8_type_sniffing(conn_db_readwrite: ConnDB) -> None:
     conn, _ = conn_db_readwrite
     conn.execute("CREATE NODE TABLE Chunk(id INT64, PRIMARY KEY(id))")

--- a/tools/python_api/test/test_issue.py
+++ b/tools/python_api/test/test_issue.py
@@ -111,6 +111,19 @@ def test_empty_map(conn_db_readwrite: ConnDB) -> None:
     assert not result.has_next()
     result.close()
 
+def test_int8_type_sniffing(conn_db_readwrite: ConnDB) -> None:
+    conn, _ = conn_db_readwrite
+    conn.execute("CREATE NODE TABLE Chunk(id INT64, PRIMARY KEY(id))")
+
+    conn.execute("CREATE (c:Chunk {id:259})")
+
+    result = conn.execute(
+        "MATCH (node:Chunk) WHERE node.id IN $chunk_ids RETURN node.id",
+        {"chunk_ids": [1]},
+    )
+    assert result.get_num_tuples() == 0
+    result.close()
+
 
 # TODO(Maxwell): check if we should change getCastCost() for the following test
 # def test_issue_3248(conn_db_readwrite: ConnDB) -> None:


### PR DESCRIPTION
# Description

The type sniffing for list_contains is incorrect, we blindly use the child type of list as the comparison type. For cases like `INT64 IN LIST[INT8]`, we will try to cast INT64 to INT8 which may not succeed. This PR extracts the common type between list and input element.

Fixes #5734
Associated docs (issue or PR):

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
