### PR TITLE
Llm fix 2

### DIFF
--- a/extension/llm/src/providers/ollama.cpp
+++ b/extension/llm/src/providers/ollama.cpp
@@ -48,7 +48,7 @@ void OllamaEmbedding::configure(const std::optional<uint64_t>& dimensions,
     }
     auto envOllamaUrl = main::ClientContext::getEnvVariable(envVarOllamaUrl);
     if (!envOllamaUrl.empty()) {
-        this->endpoint = endpoint;
+        this->endpoint = envOllamaUrl;
     }
 }
 

--- a/extension/llm/src/providers/ollama.cpp
+++ b/extension/llm/src/providers/ollama.cpp
@@ -1,6 +1,7 @@
 #include "providers/ollama.h"
 
 #include "function/llm_functions.h"
+#include "main/client_context.h"
 
 using namespace kuzu::common;
 
@@ -35,12 +36,20 @@ std::vector<float> OllamaEmbedding::parseResponse(const httplib::Result& res) co
 
 void OllamaEmbedding::configure(const std::optional<uint64_t>& dimensions,
     const std::optional<std::string>& endpoint) {
+    static const std::string envVarOllamaUrl = "OLLAMA_URL";
     if (dimensions.has_value()) {
         static const auto functionSignatures = CreateEmbedding::getFunctionSet();
         throw(functionSignatures[0]->signatureToString() + '\n' +
               functionSignatures[1]->signatureToString());
     }
     this->endpoint = endpoint;
+    if (endpoint.has_value()) {
+        return;
+    }
+    auto envOllamaUrl = main::ClientContext::getEnvVariable(envVarOllamaUrl);
+    if (!envOllamaUrl.empty()) {
+        this->endpoint = endpoint;
+    }
 }
 
 } // namespace llm_extension

--- a/extension/llm/test/test_files/amazonbedrock.test
+++ b/extension/llm/test/test_files/amazonbedrock.test
@@ -42,71 +42,33 @@ False
 
 -CASE UseWithVectorExtension
 
--LOAD_DYNAMIC_EXTENSION llm
-
--LOAD_DYNAMIC_EXTENSION vector
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
+---- ok
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/vector/build/libvector.kuzu_extension"
+---- ok
 
 -STATEMENT CREATE NODE TABLE Book(id SERIAL PRIMARY KEY, title STRING, title_embedding FLOAT[1536], published_year INT64);
 ---- ok
-
--STATEMENT CREATE NODE TABLE Publisher(name STRING PRIMARY KEY);
+-STATEMENT CREATE
+    (:Book {title: 'The Quantum World', published_year: 2004}),
+    (:Book {title: 'Chronicles of the Universe', published_year: 2022}),
+    (:Book {title: 'Learning Machines', published_year: 2019}),
+    (:Book {title: 'Echoes of the Past', published_year: 2010}),
+    (:Book {title: 'The Dragon Call', published_year: 2015});
 ---- ok
-
--STATEMENT CREATE REL TABLE PublishedBy(FROM Book TO Publisher);
----- ok
-
--STATEMENT CREATE (b:Book {title: 'The Quantum World', published_year: 2004});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'Chronicles of the Universe', published_year: 2022});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'Learning Machines', published_year: 2019});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'Echoes of the Past', published_year: 2010});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'The Dragon Call', published_year: 2015});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "Harvard University Press"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "Independent Publisher"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "Pearson"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "McGraw-Hill Ryerson"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "O'Reilly"});
----- ok
-
--STATEMENT MATCH (b:Book {title: 'The Quantum World'}) MATCH (p:Publisher {name: 'Harvard University Press'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'Chronicles of the Universe'}) MATCH (p:Publisher {name: 'Independent Publisher'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'Learning Machines'}) MATCH (p:Publisher {name: 'Pearson'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'Echoes of the Past'}) MATCH (p:Publisher {name: 'McGraw-Hill Ryerson'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'The Dragon Call'}) MATCH (p:Publisher {name: "O'Reilly"}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
 -STATEMENT MATCH (b:Book) WITH b, create_embedding(b.title, 'amazon-bedrock', 'amazon.titan-embed-text-v1', 'us-east-1') AS emb SET b.title_embedding = emb;
 ---- ok
-
 -STATEMENT CALL CREATE_VECTOR_INDEX('Book', 'title_vec_index', 'title_embedding');
 ---- ok
 
--STATEMENT CALL QUERY_VECTOR_INDEX('Book', 'title_vec_index', create_embedding('quantum machine learning', 'amazon-bedrock', 'amazon.titan-embed-text-v1', 'us-east-1'), 2) RETURN node.title ORDER BY distance;
+-STATEMENT CALL QUERY_VECTOR_INDEX(
+        'Book',
+        'title_vec_index',
+        create_embedding('quantum machine learning', 'amazon-bedrock', 'amazon.titan-embed-text-v1', 'us-east-1'),
+        2
+    )
+    RETURN node.title
+    ORDER BY distance;
 -CHECK_ORDER
 ---- 2
 Learning Machines

--- a/extension/llm/test/test_files/badkeys.test
+++ b/extension/llm/test/test_files/badkeys.test
@@ -8,7 +8,7 @@
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
 ---- ok
 
--STATEMENT return create_embedding('Hello World', 'amazon-bedrock', 'amazon.titan-embed-text-v1');
+-STATEMENT return create_embedding('Hello World', 'amazon-bedrock', 'amazon.titan-embed-text-v1', 'us-east-1');
 ---- error(regex)
 ^Connection exception: Request failed with status \d{3}\n Body: \{[\s\S]+\}[\s\S]*
 
@@ -24,7 +24,7 @@
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
 ---- ok
 
--STATEMENT return create_embedding('Hello World', 'google-vertex', 'gemini-embedding-001');
+-STATEMENT return create_embedding('Hello World', 'google-vertex', 'gemini-embedding-001', 'us-central-1');
 ---- error(regex)
 ^Connection exception: Request failed with status \d{3}\n Body: \{[\s\S]+\}[\s\S]*
 

--- a/extension/llm/test/test_files/googlegemini.test
+++ b/extension/llm/test/test_files/googlegemini.test
@@ -3,20 +3,20 @@
 
 --
 
--CASE CreateEmbeddingGoogleGemini
-
--STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
----- ok
-
--STATEMENT MATCH (e:embedding) RETURN array_cosine_similarity(e.embedding, create_embedding(e.text, 'google-gemini', 'gemini-embedding-exp-03-07')) >= 0.9 AS similarity;
----- 6
-True
-True
-True
-True
-True
-True
-
+#-CASE CreateEmbeddingGoogleGemini
+#
+#-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
+#---- ok
+#
+#-STATEMENT MATCH (e:embedding) RETURN array_cosine_similarity(e.embedding, create_embedding(e.text, 'google-gemini', 'gemini-embedding-exp-03-07')) >= 0.9 AS similarity;
+#---- 6
+#True
+#True
+#True
+#True
+#True
+#True
+#
 -CASE SemanticDistanceCheck
 
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
@@ -27,93 +27,93 @@ True
 ---- 1
 True
 
--LOG Similar Text 2
--STATEMENT WITH create_embedding('What is the capital of France?', 'google-gemini', 'gemini-embedding-exp-03-07') AS t1, create_embedding('Which city is the capital of France?', 'google-gemini', 'gemini-embedding-exp-03-07') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
----- 1
-True
-
+#-LOG Similar Text 2
+#-STATEMENT WITH create_embedding('What is the capital of France?', 'google-gemini', 'gemini-embedding-exp-03-07') AS t1, create_embedding('Which city is the capital of France?', 'google-gemini', 'gemini-embedding-exp-03-07') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
+#---- 1
+#True
+#
 -LOG Dissimilar Text 1
 -STATEMENT WITH create_embedding('How to train a dog', 'google-gemini', 'gemini-embedding-exp-03-07') AS t1, create_embedding('What is the capital of France', 'google-gemini', 'gemini-embedding-exp-03-07') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
 ---- 1
 False
-
--LOG Dissimilar Text 2
--STATEMENT WITH create_embedding('How do Unix file permissions work?', 'google-gemini', 'gemini-embedding-exp-03-07') AS t1, create_embedding('History of the Roman Empire', 'google-gemini', 'gemini-embedding-exp-03-07') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
----- 1
-False
-
-# TODO(TANVIR)I have not been able to validate this result. I am on the free tier of
-# Google Gemini and rate limits do not let this test run to completion. This should
-# be validated when CI is setup.
--CASE UseWithVectorExtension
--STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
----- ok
-
--STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/vector/build/libvector.kuzu_extension"
----- ok
-
--STATEMENT CREATE NODE TABLE Book(id SERIAL PRIMARY KEY, title STRING, title_embedding FLOAT[3072], published_year INT64);
----- ok
-
--STATEMENT CREATE NODE TABLE Publisher(name STRING PRIMARY KEY);
----- ok
-
--STATEMENT CREATE REL TABLE PublishedBy(FROM Book TO Publisher);
----- ok
-
--STATEMENT CREATE (b:Book {title: 'The Quantum World', published_year: 2004});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'Chronicles of the Universe', published_year: 2022});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'Learning Machines', published_year: 2019});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'Echoes of the Past', published_year: 2010});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'The Dragon Call', published_year: 2015});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "Harvard University Press"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "Independent Publisher"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "Pearson"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "McGraw-Hill Ryerson"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "O'Reilly"});
----- ok
-
--STATEMENT MATCH (b:Book {title: 'The Quantum World'}) MATCH (p:Publisher {name: 'Harvard University Press'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'Chronicles of the Universe'}) MATCH (p:Publisher {name: 'Independent Publisher'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'Learning Machines'}) MATCH (p:Publisher {name: 'Pearson'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'Echoes of the Past'}) MATCH (p:Publisher {name: 'McGraw-Hill Ryerson'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'The Dragon Call'}) MATCH (p:Publisher {name: "O'Reilly"}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book) WITH b, create_embedding(b.title, 'google-gemini', 'gemini-embedding-exp-03-07') AS emb SET b.title_embedding = emb;
----- ok
-
--STATEMENT CALL CREATE_VECTOR_INDEX('Book', 'title_vec_index', 'title_embedding');
----- ok
-
--STATEMENT CALL QUERY_VECTOR_INDEX('Book', 'title_vec_index', create_embedding('quantum machine learning', 'google-gemini', 'gemini-embedding-exp-03-07'), 2) RETURN node.title ORDER BY distance;
--CHECK_ORDER
----- 2
-Learning Machines
-The Quantum World
+#
+#-LOG Dissimilar Text 2
+#-STATEMENT WITH create_embedding('How do Unix file permissions work?', 'google-gemini', 'gemini-embedding-exp-03-07') AS t1, create_embedding('History of the Roman Empire', 'google-gemini', 'gemini-embedding-exp-03-07') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
+#---- 1
+#False
+#
+## TODO(TANVIR)I have not been able to validate this result. I am on the free tier of
+## Google Gemini and rate limits do not let this test run to completion. This should
+## be validated when CI is setup.
+#-CASE UseWithVectorExtension
+#-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
+#---- ok
+#
+#-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/vector/build/libvector.kuzu_extension"
+#---- ok
+#
+#-STATEMENT CREATE NODE TABLE Book(id SERIAL PRIMARY KEY, title STRING, title_embedding FLOAT[3072], published_year INT64);
+#---- ok
+#
+#-STATEMENT CREATE NODE TABLE Publisher(name STRING PRIMARY KEY);
+#---- ok
+#
+#-STATEMENT CREATE REL TABLE PublishedBy(FROM Book TO Publisher);
+#---- ok
+#
+#-STATEMENT CREATE (b:Book {title: 'The Quantum World', published_year: 2004});
+#---- ok
+#
+#-STATEMENT CREATE (b:Book {title: 'Chronicles of the Universe', published_year: 2022});
+#---- ok
+#
+#-STATEMENT CREATE (b:Book {title: 'Learning Machines', published_year: 2019});
+#---- ok
+#
+#-STATEMENT CREATE (b:Book {title: 'Echoes of the Past', published_year: 2010});
+#---- ok
+#
+#-STATEMENT CREATE (b:Book {title: 'The Dragon Call', published_year: 2015});
+#---- ok
+#
+#-STATEMENT CREATE (p:Publisher {name: "Harvard University Press"});
+#---- ok
+#
+#-STATEMENT CREATE (p:Publisher {name: "Independent Publisher"});
+#---- ok
+#
+#-STATEMENT CREATE (p:Publisher {name: "Pearson"});
+#---- ok
+#
+#-STATEMENT CREATE (p:Publisher {name: "McGraw-Hill Ryerson"});
+#---- ok
+#
+#-STATEMENT CREATE (p:Publisher {name: "O'Reilly"});
+#---- ok
+#
+#-STATEMENT MATCH (b:Book {title: 'The Quantum World'}) MATCH (p:Publisher {name: 'Harvard University Press'}) CREATE (b)-[:PublishedBy]->(p);
+#---- ok
+#
+#-STATEMENT MATCH (b:Book {title: 'Chronicles of the Universe'}) MATCH (p:Publisher {name: 'Independent Publisher'}) CREATE (b)-[:PublishedBy]->(p);
+#---- ok
+#
+#-STATEMENT MATCH (b:Book {title: 'Learning Machines'}) MATCH (p:Publisher {name: 'Pearson'}) CREATE (b)-[:PublishedBy]->(p);
+#---- ok
+#
+#-STATEMENT MATCH (b:Book {title: 'Echoes of the Past'}) MATCH (p:Publisher {name: 'McGraw-Hill Ryerson'}) CREATE (b)-[:PublishedBy]->(p);
+#---- ok
+#
+#-STATEMENT MATCH (b:Book {title: 'The Dragon Call'}) MATCH (p:Publisher {name: "O'Reilly"}) CREATE (b)-[:PublishedBy]->(p);
+#---- ok
+#
+#-STATEMENT MATCH (b:Book) WITH b, create_embedding(b.title, 'google-gemini', 'gemini-embedding-exp-03-07') AS emb SET b.title_embedding = emb;
+#---- ok
+#
+#-STATEMENT CALL CREATE_VECTOR_INDEX('Book', 'title_vec_index', 'title_embedding');
+#---- ok
+#
+#-STATEMENT CALL QUERY_VECTOR_INDEX('Book', 'title_vec_index', create_embedding('quantum machine learning', 'google-gemini', 'gemini-embedding-exp-03-07'), 2) RETURN node.title ORDER BY distance;
+#-CHECK_ORDER
+#---- 2
+#Learning Machines
+#The Quantum World

--- a/extension/llm/test/test_files/googlegemini.test
+++ b/extension/llm/test/test_files/googlegemini.test
@@ -42,77 +42,38 @@ False
 #---- 1
 #False
 #
-## TODO(TANVIR)I have not been able to validate this result. I am on the free tier of
-## Google Gemini and rate limits do not let this test run to completion. This should
-## be validated when CI is setup.
+# Have not been able to validate this result. On the free tier of
+# Google Gemini rate limits do not let this test run to completion. This should
+# be validated when CI is setup.
 #-CASE UseWithVectorExtension
+#
 #-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
 #---- ok
-#
 #-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/vector/build/libvector.kuzu_extension"
 #---- ok
 #
-#-STATEMENT CREATE NODE TABLE Book(id SERIAL PRIMARY KEY, title STRING, title_embedding FLOAT[3072], published_year INT64);
+#-STATEMENT CREATE NODE TABLE Book(id SERIAL PRIMARY KEY, title STRING, title_embedding FLOAT[1536], published_year INT64);
 #---- ok
-#
-#-STATEMENT CREATE NODE TABLE Publisher(name STRING PRIMARY KEY);
+#-STATEMENT CREATE
+#    (:Book {title: 'The Quantum World', published_year: 2004}),
+#    (:Book {title: 'Chronicles of the Universe', published_year: 2022}),
+#    (:Book {title: 'Learning Machines', published_year: 2019}),
+#    (:Book {title: 'Echoes of the Past', published_year: 2010}),
+#    (:Book {title: 'The Dragon Call', published_year: 2015});
 #---- ok
-#
-#-STATEMENT CREATE REL TABLE PublishedBy(FROM Book TO Publisher);
-#---- ok
-#
-#-STATEMENT CREATE (b:Book {title: 'The Quantum World', published_year: 2004});
-#---- ok
-#
-#-STATEMENT CREATE (b:Book {title: 'Chronicles of the Universe', published_year: 2022});
-#---- ok
-#
-#-STATEMENT CREATE (b:Book {title: 'Learning Machines', published_year: 2019});
-#---- ok
-#
-#-STATEMENT CREATE (b:Book {title: 'Echoes of the Past', published_year: 2010});
-#---- ok
-#
-#-STATEMENT CREATE (b:Book {title: 'The Dragon Call', published_year: 2015});
-#---- ok
-#
-#-STATEMENT CREATE (p:Publisher {name: "Harvard University Press"});
-#---- ok
-#
-#-STATEMENT CREATE (p:Publisher {name: "Independent Publisher"});
-#---- ok
-#
-#-STATEMENT CREATE (p:Publisher {name: "Pearson"});
-#---- ok
-#
-#-STATEMENT CREATE (p:Publisher {name: "McGraw-Hill Ryerson"});
-#---- ok
-#
-#-STATEMENT CREATE (p:Publisher {name: "O'Reilly"});
-#---- ok
-#
-#-STATEMENT MATCH (b:Book {title: 'The Quantum World'}) MATCH (p:Publisher {name: 'Harvard University Press'}) CREATE (b)-[:PublishedBy]->(p);
-#---- ok
-#
-#-STATEMENT MATCH (b:Book {title: 'Chronicles of the Universe'}) MATCH (p:Publisher {name: 'Independent Publisher'}) CREATE (b)-[:PublishedBy]->(p);
-#---- ok
-#
-#-STATEMENT MATCH (b:Book {title: 'Learning Machines'}) MATCH (p:Publisher {name: 'Pearson'}) CREATE (b)-[:PublishedBy]->(p);
-#---- ok
-#
-#-STATEMENT MATCH (b:Book {title: 'Echoes of the Past'}) MATCH (p:Publisher {name: 'McGraw-Hill Ryerson'}) CREATE (b)-[:PublishedBy]->(p);
-#---- ok
-#
-#-STATEMENT MATCH (b:Book {title: 'The Dragon Call'}) MATCH (p:Publisher {name: "O'Reilly"}) CREATE (b)-[:PublishedBy]->(p);
-#---- ok
-#
 #-STATEMENT MATCH (b:Book) WITH b, create_embedding(b.title, 'google-gemini', 'gemini-embedding-exp-03-07') AS emb SET b.title_embedding = emb;
 #---- ok
-#
 #-STATEMENT CALL CREATE_VECTOR_INDEX('Book', 'title_vec_index', 'title_embedding');
 #---- ok
 #
-#-STATEMENT CALL QUERY_VECTOR_INDEX('Book', 'title_vec_index', create_embedding('quantum machine learning', 'google-gemini', 'gemini-embedding-exp-03-07'), 2) RETURN node.title ORDER BY distance;
+#-STATEMENT CALL QUERY_VECTOR_INDEX(
+#        'Book',
+#        'title_vec_index',
+#        create_embedding('quantum machine learning', 'google-gemini', 'gemini-embedding-exp-03-07'),
+#        2
+#    )
+#    RETURN node.title
+#    ORDER BY distance;
 #-CHECK_ORDER
 #---- 2
 #Learning Machines

--- a/extension/llm/test/test_files/googlevertex.test
+++ b/extension/llm/test/test_files/googlevertex.test
@@ -1,4 +1,3 @@
--SKIP
 -DATASET CSV llm/embeddings/googlevertex/
 
 --
@@ -51,73 +50,34 @@ False
 False
 
 -CASE UseWithVectorExtension
+
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
 ---- ok
-
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/vector/build/libvector.kuzu_extension"
 ---- ok
 
 -STATEMENT CREATE NODE TABLE Book(id SERIAL PRIMARY KEY, title STRING, title_embedding FLOAT[3072], published_year INT64);
 ---- ok
-
--STATEMENT CREATE NODE TABLE Publisher(name STRING PRIMARY KEY);
+-STATEMENT CREATE
+    (:Book {title: 'The Quantum World', published_year: 2004}),
+    (:Book {title: 'Chronicles of the Universe', published_year: 2022}),
+    (:Book {title: 'Learning Machines', published_year: 2019}),
+    (:Book {title: 'Echoes of the Past', published_year: 2010}),
+    (:Book {title: 'The Dragon Call', published_year: 2015});
 ---- ok
-
--STATEMENT CREATE REL TABLE PublishedBy(FROM Book TO Publisher);
----- ok
-
--STATEMENT CREATE (b:Book {title: 'The Quantum World', published_year: 2004});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'Chronicles of the Universe', published_year: 2022});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'Learning Machines', published_year: 2019});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'Echoes of the Past', published_year: 2010});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'The Dragon Call', published_year: 2015});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "Harvard University Press"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "Independent Publisher"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "Pearson"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "McGraw-Hill Ryerson"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "O'Reilly"});
----- ok
-
--STATEMENT MATCH (b:Book {title: 'The Quantum World'}) MATCH (p:Publisher {name: 'Harvard University Press'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'Chronicles of the Universe'}) MATCH (p:Publisher {name: 'Independent Publisher'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'Learning Machines'}) MATCH (p:Publisher {name: 'Pearson'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'Echoes of the Past'}) MATCH (p:Publisher {name: 'McGraw-Hill Ryerson'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'The Dragon Call'}) MATCH (p:Publisher {name: "O'Reilly"}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
 -STATEMENT MATCH (b:Book) WITH b, create_embedding(b.title, 'google-vertex', 'gemini-embedding-001', 'us-central1') AS emb SET b.title_embedding = emb;
 ---- ok
-
 -STATEMENT CALL CREATE_VECTOR_INDEX('Book', 'title_vec_index', 'title_embedding');
 ---- ok
 
--STATEMENT CALL QUERY_VECTOR_INDEX('Book', 'title_vec_index', create_embedding('quantum machine learning', 'google-vertex', 'gemini-embedding-001', 'us-central1'), 2) RETURN node.title ORDER BY distance;
+-STATEMENT CALL QUERY_VECTOR_INDEX(
+        'Book',
+        'title_vec_index',
+        create_embedding('quantum machine learning', 'google-vertex', 'gemini-embedding-001', 'us-central1'),
+        2
+    )
+    RETURN node.title
+    ORDER BY distance;
 -CHECK_ORDER
 ---- 2
 Learning Machines

--- a/extension/llm/test/test_files/googlevertex.test
+++ b/extension/llm/test/test_files/googlevertex.test
@@ -1,3 +1,4 @@
+-SKIP
 -DATASET CSV llm/embeddings/googlevertex/
 
 --

--- a/extension/llm/test/test_files/ollama.test
+++ b/extension/llm/test/test_files/ollama.test
@@ -8,7 +8,7 @@
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
 ---- ok
 
--STATEMENT return create_embedding('basic', 'ollama', 'nomic-embed-text', '${OLLAMA_URL}')
+-STATEMENT return create_embedding('basic', 'ollama', 'nomic-embed-text')
 ---- ok
 
 -CASE CreateEmbeddingFromNomicEmbedText
@@ -16,7 +16,7 @@
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
 ---- ok
 
--STATEMENT MATCH (e:embedding) RETURN array_cosine_similarity(e.embedding, create_embedding(e.text, 'ollama', 'nomic-embed-text', '${OLLAMA_URL}')) >= 0.9 AS similarity;
+-STATEMENT MATCH (e:embedding) RETURN array_cosine_similarity(e.embedding, create_embedding(e.text, 'ollama', 'nomic-embed-text')) >= 0.9 AS similarity;
 ---- 6
 True
 True
@@ -31,22 +31,22 @@ True
 ---- ok
 
 -LOG Similar Text 1
--STATEMENT WITH create_embedding('Who is the author of 1984?', 'ollama', 'nomic-embed-text', '${OLLAMA_URL}') AS t1, create_embedding('Who wrote the novel 1984?', 'ollama', 'nomic-embed-text', '${OLLAMA_URL}') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
+-STATEMENT WITH create_embedding('Who is the author of 1984?', 'ollama', 'nomic-embed-text') AS t1, create_embedding('Who wrote the novel 1984?', 'ollama', 'nomic-embed-text', '${OLLAMA_URL}') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
 ---- 1
 True
 
 -LOG Similar Text 2
--STATEMENT WITH create_embedding('What is the capital of France?', 'ollama', 'nomic-embed-text', '${OLLAMA_URL}') AS t1, create_embedding('Which city is the capital of France?', 'ollama', 'nomic-embed-text', '${OLLAMA_URL}') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
+-STATEMENT WITH create_embedding('What is the capital of France?', 'ollama', 'nomic-embed-text') AS t1, create_embedding('Which city is the capital of France?', 'ollama', 'nomic-embed-text', '${OLLAMA_URL}') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
 ---- 1
 True
 
 -LOG Dissimilar Text 1
--STATEMENT WITH create_embedding('How to train a dog', 'ollama', 'nomic-embed-text', '${OLLAMA_URL}') AS t1, create_embedding('What is the capital of France', 'ollama', 'nomic-embed-text', '${OLLAMA_URL}') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
+-STATEMENT WITH create_embedding('How to train a dog', 'ollama', 'nomic-embed-text') AS t1, create_embedding('What is the capital of France', 'ollama', 'nomic-embed-text', '${OLLAMA_URL}') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
 ---- 1
 False
 
 -LOG Dissimilar Text 2
--STATEMENT WITH create_embedding('How do Unix file permissions work?', 'ollama', 'nomic-embed-text', '${OLLAMA_URL}') AS t1, create_embedding('History of the Roman Empire', 'ollama', 'nomic-embed-text', '${OLLAMA_URL}') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
+-STATEMENT WITH create_embedding('How do Unix file permissions work?', 'ollama', 'nomic-embed-text') AS t1, create_embedding('History of the Roman Empire', 'ollama', 'nomic-embed-text', '${OLLAMA_URL}') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
 ---- 1
 False
 
@@ -66,7 +66,7 @@ False
     (:Book {title: 'Echoes of the Past', published_year: 2010}),
     (:Book {title: 'The Dragon Call', published_year: 2015});
 ---- ok
--STATEMENT MATCH (b:Book) WITH b, create_embedding(b.title, 'ollama', 'nomic-embed-text', '${OLLAMA_URL}') AS emb SET b.title_embedding = emb;
+-STATEMENT MATCH (b:Book) WITH b, create_embedding(b.title, 'ollama', 'nomic-embed-text') AS emb SET b.title_embedding = emb;
 ---- ok
 -STATEMENT CALL CREATE_VECTOR_INDEX('Book', 'title_vec_index', 'title_embedding');
 ---- ok
@@ -74,7 +74,7 @@ False
 -STATEMENT CALL QUERY_VECTOR_INDEX(
         'Book',
         'title_vec_index',
-        create_embedding('quantum machine learning', 'ollama', 'nomic-embed-text', '${OLLAMA_URL}'),
+        create_embedding('quantum machine learning', 'ollama', 'nomic-embed-text'),
         2
     )
     RETURN node.title

--- a/extension/llm/test/test_files/ollama.test
+++ b/extension/llm/test/test_files/ollama.test
@@ -54,71 +54,31 @@ False
 
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
 ---- ok
-
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/vector/build/libvector.kuzu_extension"
 ---- ok
 
 -STATEMENT CREATE NODE TABLE Book(id SERIAL PRIMARY KEY, title STRING, title_embedding FLOAT[768], published_year INT64);
 ---- ok
-
--STATEMENT CREATE NODE TABLE Publisher(name STRING PRIMARY KEY);
+-STATEMENT CREATE
+    (:Book {title: 'The Quantum World', published_year: 2004}),
+    (:Book {title: 'Chronicles of the Universe', published_year: 2022}),
+    (:Book {title: 'Learning Machines', published_year: 2019}),
+    (:Book {title: 'Echoes of the Past', published_year: 2010}),
+    (:Book {title: 'The Dragon Call', published_year: 2015});
 ---- ok
-
--STATEMENT CREATE REL TABLE PublishedBy(FROM Book TO Publisher);
----- ok
-
--STATEMENT CREATE (b:Book {title: 'The Quantum World', published_year: 2004});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'Chronicles of the Universe', published_year: 2022});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'Learning Machines', published_year: 2019});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'Echoes of the Past', published_year: 2010});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'The Dragon Call', published_year: 2015});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "Harvard University Press"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "Independent Publisher"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "Pearson"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "McGraw-Hill Ryerson"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "O'Reilly"});
----- ok
-
--STATEMENT MATCH (b:Book {title: 'The Quantum World'}) MATCH (p:Publisher {name: 'Harvard University Press'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'Chronicles of the Universe'}) MATCH (p:Publisher {name: 'Independent Publisher'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'Learning Machines'}) MATCH (p:Publisher {name: 'Pearson'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'Echoes of the Past'}) MATCH (p:Publisher {name: 'McGraw-Hill Ryerson'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'The Dragon Call'}) MATCH (p:Publisher {name: "O'Reilly"}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
 -STATEMENT MATCH (b:Book) WITH b, create_embedding(b.title, 'ollama', 'nomic-embed-text', '${OLLAMA_URL}') AS emb SET b.title_embedding = emb;
 ---- ok
-
 -STATEMENT CALL CREATE_VECTOR_INDEX('Book', 'title_vec_index', 'title_embedding');
 ---- ok
 
--STATEMENT CALL QUERY_VECTOR_INDEX('Book', 'title_vec_index', create_embedding('quantum machine learning', 'ollama', 'nomic-embed-text', '${OLLAMA_URL}'), 2) RETURN node.title ORDER BY distance;
+-STATEMENT CALL QUERY_VECTOR_INDEX(
+        'Book',
+        'title_vec_index',
+        create_embedding('quantum machine learning', 'ollama', 'nomic-embed-text', '${OLLAMA_URL}'),
+        2
+    )
+    RETURN node.title
+    ORDER BY distance;
 -CHECK_ORDER
 ---- 2
 Learning Machines

--- a/extension/llm/test/test_files/ollama_error.test
+++ b/extension/llm/test/test_files/ollama_error.test
@@ -32,7 +32,7 @@ Expected: (STRING,STRING,STRING) -> LIST
 Binder exception: Provider not found: olama
 For more information, please refer to the official Kuzu documentation: https://docs.kuzudb.com/extensions/llm/
 
--STATEMENT return create_embedding('hello', 'ollama', 'MODEL_DNE', '${OLLAMA_URL}')
+-STATEMENT return create_embedding('hello', 'ollama', 'MODEL_DNE')
 ---- error(regex)
 ^Connection exception: Request failed with status \d{3}\n Body: \{[\s\S]+\}[\s\S]*
 
@@ -47,7 +47,7 @@ For more information, please refer to the official Kuzu documentation: https://d
 -STATEMENT CREATE (b:Book {title: 'The Quantum World', published_year: 2004});
 ---- ok
 
--STATEMENT MATCH (b:Book) WITH b, create_embedding(b.title, 'ollama', 'nomic-embed-text', '${OLLAMA_URL}') AS emb SET b.title_embedding = emb;
+-STATEMENT MATCH (b:Book) WITH b, create_embedding(b.title, 'ollama', 'nomic-embed-text') AS emb SET b.title_embedding = emb;
 ---- error
 Conversion exception: Unsupported casting LIST with incorrect list entry to ARRAY. Expected: 766, Actual: 768.
 

--- a/extension/llm/test/test_files/openai.test
+++ b/extension/llm/test/test_files/openai.test
@@ -60,71 +60,31 @@ False
 
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
 ---- ok
-
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/vector/build/libvector.kuzu_extension"
 ---- ok
 
 -STATEMENT CREATE NODE TABLE Book(id SERIAL PRIMARY KEY, title STRING, title_embedding FLOAT[1536], published_year INT64);
 ---- ok
-
--STATEMENT CREATE NODE TABLE Publisher(name STRING PRIMARY KEY);
+-STATEMENT CREATE
+    (:Book {title: 'The Quantum World', published_year: 2004}),
+    (:Book {title: 'Chronicles of the Universe', published_year: 2022}),
+    (:Book {title: 'Learning Machines', published_year: 2019}),
+    (:Book {title: 'Echoes of the Past', published_year: 2010}),
+    (:Book {title: 'The Dragon Call', published_year: 2015});
 ---- ok
-
--STATEMENT CREATE REL TABLE PublishedBy(FROM Book TO Publisher);
----- ok
-
--STATEMENT CREATE (b:Book {title: 'The Quantum World', published_year: 2004});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'Chronicles of the Universe', published_year: 2022});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'Learning Machines', published_year: 2019});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'Echoes of the Past', published_year: 2010});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'The Dragon Call', published_year: 2015});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "Harvard University Press"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "Independent Publisher"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "Pearson"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "McGraw-Hill Ryerson"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "O'Reilly"});
----- ok
-
--STATEMENT MATCH (b:Book {title: 'The Quantum World'}) MATCH (p:Publisher {name: 'Harvard University Press'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'Chronicles of the Universe'}) MATCH (p:Publisher {name: 'Independent Publisher'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'Learning Machines'}) MATCH (p:Publisher {name: 'Pearson'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'Echoes of the Past'}) MATCH (p:Publisher {name: 'McGraw-Hill Ryerson'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'The Dragon Call'}) MATCH (p:Publisher {name: "O'Reilly"}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
 -STATEMENT MATCH (b:Book) WITH b, create_embedding(b.title, 'open-ai', 'text-embedding-3-small') AS emb SET b.title_embedding = emb;
 ---- ok
-
 -STATEMENT CALL CREATE_VECTOR_INDEX('Book', 'title_vec_index', 'title_embedding');
 ---- ok
 
--STATEMENT CALL QUERY_VECTOR_INDEX('Book', 'title_vec_index', create_embedding('quantum machine learning', 'open-ai', 'text-embedding-3-small'), 2) RETURN node.title ORDER BY distance;
+-STATEMENT CALL QUERY_VECTOR_INDEX(
+        'Book',
+        'title_vec_index',
+        create_embedding('quantum machine learning', 'open-ai', 'text-embedding-3-small'),
+        2
+    )
+    RETURN node.title
+    ORDER BY distance;
 -CHECK_ORDER
 ---- 2
 Learning Machines

--- a/extension/llm/test/test_files/voyageai.test
+++ b/extension/llm/test/test_files/voyageai.test
@@ -54,77 +54,38 @@
 #---- 1
 #False
 #
-## TODO(TANVIR) I have not been able to validate this result. I am on the free tier of
-## VoyageAI and rate limits do not let this test run to completion. This should
-## be validated when CI is setup.
+# Have not been able to validate this result. On the free tier of
+# VoyageAI rate limits do not let this test run to completion. This should
+# be validated when CI is setup.
 #-CASE UseWithVectorExtension
+#
 #-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
 #---- ok
-#
 #-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/vector/build/libvector.kuzu_extension"
 #---- ok
 #
-#-STATEMENT CREATE NODE TABLE Book(id SERIAL PRIMARY KEY, title STRING, title_embedding FLOAT[1024], published_year INT64);
+#-STATEMENT CREATE NODE TABLE Book(id SERIAL PRIMARY KEY, title STRING, title_embedding FLOAT[1536], published_year INT64);
 #---- ok
-#
-#-STATEMENT CREATE NODE TABLE Publisher(name STRING PRIMARY KEY);
+#-STATEMENT CREATE
+#    (:Book {title: 'The Quantum World', published_year: 2004}),
+#    (:Book {title: 'Chronicles of the Universe', published_year: 2022}),
+#    (:Book {title: 'Learning Machines', published_year: 2019}),
+#    (:Book {title: 'Echoes of the Past', published_year: 2010}),
+#    (:Book {title: 'The Dragon Call', published_year: 2015});
 #---- ok
-#
-#-STATEMENT CREATE REL TABLE PublishedBy(FROM Book TO Publisher);
-#---- ok
-#
-#-STATEMENT CREATE (b:Book {title: 'The Quantum World', published_year: 2004});
-#---- ok
-#
-#-STATEMENT CREATE (b:Book {title: 'Chronicles of the Universe', published_year: 2022});
-#---- ok
-#
-#-STATEMENT CREATE (b:Book {title: 'Learning Machines', published_year: 2019});
-#---- ok
-#
-#-STATEMENT CREATE (b:Book {title: 'Echoes of the Past', published_year: 2010});
-#---- ok
-#
-#-STATEMENT CREATE (b:Book {title: 'The Dragon Call', published_year: 2015});
-#---- ok
-#
-#-STATEMENT CREATE (p:Publisher {name: "Harvard University Press"});
-#---- ok
-#
-#-STATEMENT CREATE (p:Publisher {name: "Independent Publisher"});
-#---- ok
-#
-#-STATEMENT CREATE (p:Publisher {name: "Pearson"});
-#---- ok
-#
-#-STATEMENT CREATE (p:Publisher {name: "McGraw-Hill Ryerson"});
-#---- ok
-#
-#-STATEMENT CREATE (p:Publisher {name: "O'Reilly"});
-#---- ok
-#
-#-STATEMENT MATCH (b:Book {title: 'The Quantum World'}) MATCH (p:Publisher {name: 'Harvard University Press'}) CREATE (b)-[:PublishedBy]->(p);
-#---- ok
-#
-#-STATEMENT MATCH (b:Book {title: 'Chronicles of the Universe'}) MATCH (p:Publisher {name: 'Independent Publisher'}) CREATE (b)-[:PublishedBy]->(p);
-#---- ok
-#
-#-STATEMENT MATCH (b:Book {title: 'Learning Machines'}) MATCH (p:Publisher {name: 'Pearson'}) CREATE (b)-[:PublishedBy]->(p);
-#---- ok
-#
-#-STATEMENT MATCH (b:Book {title: 'Echoes of the Past'}) MATCH (p:Publisher {name: 'McGraw-Hill Ryerson'}) CREATE (b)-[:PublishedBy]->(p);
-#---- ok
-#
-#-STATEMENT MATCH (b:Book {title: 'The Dragon Call'}) MATCH (p:Publisher {name: "O'Reilly"}) CREATE (b)-[:PublishedBy]->(p);
-#---- ok
-#
 #-STATEMENT MATCH (b:Book) WITH b, create_embedding(b.title, 'voyage-ai', 'voyage-3-large') AS emb SET b.title_embedding = emb;
 #---- ok
-#
 #-STATEMENT CALL CREATE_VECTOR_INDEX('Book', 'title_vec_index', 'title_embedding');
 #---- ok
 #
-#-STATEMENT CALL QUERY_VECTOR_INDEX('Book', 'title_vec_index', create_embedding('quantum machine learning', 'voyage-ai', 'voyage-3-large'), 2) RETURN node.title ORDER BY distance;
+#-STATEMENT CALL QUERY_VECTOR_INDEX(
+#        'Book',
+#        'title_vec_index',
+#        create_embedding('quantum machine learning', 'voyage-ai', 'voyage-3-large'),
+#        2
+#    )
+#    RETURN node.title
+#    ORDER BY distance;
 #-CHECK_ORDER
 #---- 2
 #Learning Machines

--- a/extension/llm/test/test_files/voyageai.test
+++ b/extension/llm/test/test_files/voyageai.test
@@ -3,129 +3,133 @@
 
 --
 
--CASE CreateEmbeddingVoyageAILargeModel
-
--STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
----- ok
-
--STATEMENT MATCH (e:embedding) RETURN array_cosine_similarity(e.embedding, create_embedding(e.text, 'voyage-ai', 'voyage-3-large')) >= 0.9 AS similarity;
----- 4
-True
-True
-True
-True
-
+#-CASE CreateEmbeddingVoyageAILargeModel
+#
+#-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
+#---- ok
+#
+#-STATEMENT MATCH (e:embedding) RETURN array_cosine_similarity(e.embedding, create_embedding(e.text, 'voyage-ai', 'voyage-3-large')) >= 0.9 AS similarity;
+#---- 4
+#True
+#True
+#True
+#True
+#
 -CASE TryConfiguration
 
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
 ---- ok
 
 -STATEMENT return create_embedding('Hello World', 'voyage-ai', 'voyage-3-large', 512);
----- ok
-
--STATEMENT return create_embedding('Hello World', 'voyage-ai', 'voyage-3-large', 256);
----- ok
-
--CASE SemanticDistanceCheck
-
--STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
----- ok
-
--LOG Similar Text 1
--STATEMENT WITH create_embedding('Who is the author of 1984?', 'voyage-ai', 'voyage-3-large') AS t1, create_embedding('Who wrote the novel 1984?', 'voyage-ai', 'voyage-3-large') AS t2 RETURN array_cosine_similarity(t1, t2) >- 0.8;
----- 1
-True
+---- error
+Connection exception: Request failed with status 429
+ Body: {"detail":"You have not yet added your payment method in the billing page and will have reduced rate limits of 3 RPM and 10K TPM. To unlock our standard rate limits, please add a payment method in the billing page for the appropriate organization in the user dashboard (https://dashboard.voyageai.com/). Even with payment methods entered, the free tokens (200M tokens for Voyage series 3) will still apply. After adding a payment method, you should see your rate limits increase after several minutes. See our pricing docs (https://docs.voyageai.com/docs/pricing) for the free tokens for your model."}
+For more information, please refer to the official Kuzu documentation: https://docs.kuzudb.com/extensions/llm/
 
 
--LOG Similar Text 2
--STATEMENT WITH create_embedding('What is the capital of France?', 'voyage-ai', 'voyage-3-large') AS t1, create_embedding('Which city is the capital of France?', 'voyage-ai', 'voyage-3-large') AS t2 RETURN array_cosine_similarity(t1, t2) >- 0.8;
----- 1
-True
+#-STATEMENT return create_embedding('Hello World', 'voyage-ai', 'voyage-3-large', 256);
+#---- ok
+#
+#-CASE SemanticDistanceCheck
+#
+#-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
+#---- ok
+#
+#-LOG Similar Text 1
+#-STATEMENT WITH create_embedding('Who is the author of 1984?', 'voyage-ai', 'voyage-3-large') AS t1, create_embedding('Who wrote the novel 1984?', 'voyage-ai', 'voyage-3-large') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
+#---- 1
+#True
 
-
--LOG Dissimilar Text 1
--STATEMENT WITH create_embedding('How to train a dog', 'voyage-ai', 'voyage-3-large') AS t1, create_embedding('What is the capital of France', 'voyage-ai', 'voyage-3-large') AS t2 RETURN array_cosine_similarity(t1, t2) >- 0.8;
----- 1
-False
-
-
--LOG Dissimilar Text 2
--STATEMENT WITH create_embedding('How do Unix file permissions work?', 'voyage-ai', 'voyage-3-large') AS t1, create_embedding('History of the Roman Empire', 'voyage-ai', 'voyage-3-large') AS t2 RETURN array_cosine_similarity(t1, t2) >- 0.8;
----- 1
-False
-
-# TODO(TANVIR) I have not been able to validate this result. I am on the free tier of
-# VoyageAI and rate limits do not let this test run to completion. This should
-# be validated when CI is setup.
--CASE UseWithVectorExtension
--STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
----- ok
-
--STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/vector/build/libvector.kuzu_extension"
----- ok
-
--STATEMENT CREATE NODE TABLE Book(id SERIAL PRIMARY KEY, title STRING, title_embedding FLOAT[1024], published_year INT64);
----- ok
-
--STATEMENT CREATE NODE TABLE Publisher(name STRING PRIMARY KEY);
----- ok
-
--STATEMENT CREATE REL TABLE PublishedBy(FROM Book TO Publisher);
----- ok
-
--STATEMENT CREATE (b:Book {title: 'The Quantum World', published_year: 2004});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'Chronicles of the Universe', published_year: 2022});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'Learning Machines', published_year: 2019});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'Echoes of the Past', published_year: 2010});
----- ok
-
--STATEMENT CREATE (b:Book {title: 'The Dragon Call', published_year: 2015});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "Harvard University Press"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "Independent Publisher"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "Pearson"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "McGraw-Hill Ryerson"});
----- ok
-
--STATEMENT CREATE (p:Publisher {name: "O'Reilly"});
----- ok
-
--STATEMENT MATCH (b:Book {title: 'The Quantum World'}) MATCH (p:Publisher {name: 'Harvard University Press'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'Chronicles of the Universe'}) MATCH (p:Publisher {name: 'Independent Publisher'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'Learning Machines'}) MATCH (p:Publisher {name: 'Pearson'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'Echoes of the Past'}) MATCH (p:Publisher {name: 'McGraw-Hill Ryerson'}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book {title: 'The Dragon Call'}) MATCH (p:Publisher {name: "O'Reilly"}) CREATE (b)-[:PublishedBy]->(p);
----- ok
-
--STATEMENT MATCH (b:Book) WITH b, create_embedding(b.title, 'voyage-ai', 'voyage-3-large') AS emb SET b.title_embedding = emb;
----- ok
-
--STATEMENT CALL CREATE_VECTOR_INDEX('Book', 'title_vec_index', 'title_embedding');
----- ok
-
--STATEMENT CALL QUERY_VECTOR_INDEX('Book', 'title_vec_index', create_embedding('quantum machine learning', 'voyage-ai', 'voyage-3-large'), 2) RETURN node.title ORDER BY distance;
--CHECK_ORDER
----- 2
-Learning Machines
-The Quantum World
+#
+#-LOG Similar Text 2
+#-STATEMENT WITH create_embedding('What is the capital of France?', 'voyage-ai', 'voyage-3-large') AS t1, create_embedding('Which city is the capital of France?', 'voyage-ai', 'voyage-3-large') AS t2 RETURN array_cosine_similarity(t1, t2) >- 0.8;
+#---- 1
+#True
+#
+#
+#-LOG Dissimilar Text 1
+#-STATEMENT WITH create_embedding('How to train a dog', 'voyage-ai', 'voyage-3-large') AS t1, create_embedding('What is the capital of France', 'voyage-ai', 'voyage-3-large') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
+#---- 1
+#False
+#
+#
+#-LOG Dissimilar Text 2
+#-STATEMENT WITH create_embedding('How do Unix file permissions work?', 'voyage-ai', 'voyage-3-large') AS t1, create_embedding('History of the Roman Empire', 'voyage-ai', 'voyage-3-large') AS t2 RETURN array_cosine_similarity(t1, t2) >- 0.8;
+#---- 1
+#False
+#
+## TODO(TANVIR) I have not been able to validate this result. I am on the free tier of
+## VoyageAI and rate limits do not let this test run to completion. This should
+## be validated when CI is setup.
+#-CASE UseWithVectorExtension
+#-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
+#---- ok
+#
+#-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/vector/build/libvector.kuzu_extension"
+#---- ok
+#
+#-STATEMENT CREATE NODE TABLE Book(id SERIAL PRIMARY KEY, title STRING, title_embedding FLOAT[1024], published_year INT64);
+#---- ok
+#
+#-STATEMENT CREATE NODE TABLE Publisher(name STRING PRIMARY KEY);
+#---- ok
+#
+#-STATEMENT CREATE REL TABLE PublishedBy(FROM Book TO Publisher);
+#---- ok
+#
+#-STATEMENT CREATE (b:Book {title: 'The Quantum World', published_year: 2004});
+#---- ok
+#
+#-STATEMENT CREATE (b:Book {title: 'Chronicles of the Universe', published_year: 2022});
+#---- ok
+#
+#-STATEMENT CREATE (b:Book {title: 'Learning Machines', published_year: 2019});
+#---- ok
+#
+#-STATEMENT CREATE (b:Book {title: 'Echoes of the Past', published_year: 2010});
+#---- ok
+#
+#-STATEMENT CREATE (b:Book {title: 'The Dragon Call', published_year: 2015});
+#---- ok
+#
+#-STATEMENT CREATE (p:Publisher {name: "Harvard University Press"});
+#---- ok
+#
+#-STATEMENT CREATE (p:Publisher {name: "Independent Publisher"});
+#---- ok
+#
+#-STATEMENT CREATE (p:Publisher {name: "Pearson"});
+#---- ok
+#
+#-STATEMENT CREATE (p:Publisher {name: "McGraw-Hill Ryerson"});
+#---- ok
+#
+#-STATEMENT CREATE (p:Publisher {name: "O'Reilly"});
+#---- ok
+#
+#-STATEMENT MATCH (b:Book {title: 'The Quantum World'}) MATCH (p:Publisher {name: 'Harvard University Press'}) CREATE (b)-[:PublishedBy]->(p);
+#---- ok
+#
+#-STATEMENT MATCH (b:Book {title: 'Chronicles of the Universe'}) MATCH (p:Publisher {name: 'Independent Publisher'}) CREATE (b)-[:PublishedBy]->(p);
+#---- ok
+#
+#-STATEMENT MATCH (b:Book {title: 'Learning Machines'}) MATCH (p:Publisher {name: 'Pearson'}) CREATE (b)-[:PublishedBy]->(p);
+#---- ok
+#
+#-STATEMENT MATCH (b:Book {title: 'Echoes of the Past'}) MATCH (p:Publisher {name: 'McGraw-Hill Ryerson'}) CREATE (b)-[:PublishedBy]->(p);
+#---- ok
+#
+#-STATEMENT MATCH (b:Book {title: 'The Dragon Call'}) MATCH (p:Publisher {name: "O'Reilly"}) CREATE (b)-[:PublishedBy]->(p);
+#---- ok
+#
+#-STATEMENT MATCH (b:Book) WITH b, create_embedding(b.title, 'voyage-ai', 'voyage-3-large') AS emb SET b.title_embedding = emb;
+#---- ok
+#
+#-STATEMENT CALL CREATE_VECTOR_INDEX('Book', 'title_vec_index', 'title_embedding');
+#---- ok
+#
+#-STATEMENT CALL QUERY_VECTOR_INDEX('Book', 'title_vec_index', create_embedding('quantum machine learning', 'voyage-ai', 'voyage-3-large'), 2) RETURN node.title ORDER BY distance;
+#-CHECK_ORDER
+#---- 2
+#Learning Machines
+#The Quantum World

--- a/extension/llm/test/test_files/voyageai.test
+++ b/extension/llm/test/test_files/voyageai.test
@@ -21,11 +21,7 @@
 ---- ok
 
 -STATEMENT return create_embedding('Hello World', 'voyage-ai', 'voyage-3-large', 512);
----- error
-Connection exception: Request failed with status 429
- Body: {"detail":"You have not yet added your payment method in the billing page and will have reduced rate limits of 3 RPM and 10K TPM. To unlock our standard rate limits, please add a payment method in the billing page for the appropriate organization in the user dashboard (https://dashboard.voyageai.com/). Even with payment methods entered, the free tokens (200M tokens for Voyage series 3) will still apply. After adding a payment method, you should see your rate limits increase after several minutes. See our pricing docs (https://docs.voyageai.com/docs/pricing) for the free tokens for your model."}
-For more information, please refer to the official Kuzu documentation: https://docs.kuzudb.com/extensions/llm/
-
+---- ok
 
 #-STATEMENT return create_embedding('Hello World', 'voyage-ai', 'voyage-3-large', 256);
 #---- ok


### PR DESCRIPTION
# Description
~~[DO NOT REVIEW NEED TO ADD LINKS]~~

1. This PR introduces one minor caveat to the llm extension. Users may now also set their OLLAMA endpoint by configuring the OLLAMA_URL env variable. Tests can be run locally and results should align with CI (when enabled). See [docs](https://github.com/kuzudb/kuzu-docs/pull/582) for how this interacts with the past way of configuring OLLAMA endpoints.
Provided below is an example of how this works (I set `OLLAMA_URL=randomEndpoint`)
```
kuzu> load llm;
┌─────────────────────────────────┐
│ result                          │
│ STRING                          │
├─────────────────────────────────┤
│ Extension: llm has been loaded. │
└─────────────────────────────────┘
(1 tuple)
(1 column)
Time: 10.18ms (compiling), 5.16ms (executing)
kuzu> return create_embedding('hello', 'ollama', 'nomic-text-embed');
Error: Connection exception: Request failed: Could not connect to server <randomEndpoint>
For more information, please refer to the official Kuzu documentation: https://docs.kuzudb.com/extensions/llm/

kuzu> return create_embedding('hello', 'ollama', 'nomic-embed-text', 'http://localhost:11434');
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ CREATE_EMBEDDING(hello,ollama,nomic-embed-text,http://localhost:11434)                                                                                                                                                                                       │
│ FLOAT[]                                                                                                                                                                                                                                                      │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ [0.421442,-0.137750,-4.120384,-0.323344,0.800035,1.050830,0.291154,-0.060479,-0.348226,-0.922697,-0.216479,1.215160,1.356523,1.343890,1.057613,-1.259035,0.676630,-1.109079,-0.917537,0.632752,0.219958,-1.568445,0.116259,-0.138144,4.047388,-0.103464,0... │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
(1 tuple)
(1 column)
Time: 31.44ms (compiling), 4.07ms (executing)
kuzu>
```


All other changes are test suite related

2. Hat tip to @sdht0. The vector case across the llm test suite needlessly introduced a `publisher` node table and `publishedby` rel table. The test has been made much simpler. 
3. badKeys has been updated. I was testing it using rewritemode and git diff, but the test rewriter needs some work on handling error (regex) tdlr how it handles regex is not reasonable. See [here](https://github.com/kuzudb/kuzu/issues/5739).
4. Comment out (majority of) voyage and gemini tests until we have a paid key that can run them completely. 


After running `E2E_TEST_FILES_DIRECTORY='.' ./build/debug/test/runner/e2e_test extension/llm/test/test_files --gtest_also_run_disabled_tests` the only tests that fail are badKeys.

<img width="893" height="206" alt="image" src="https://github.com/user-attachments/assets/e7cd6c95-7a39-4b67-a54e-bbab75cc736a" />

Rerunning badKeys (with keys disabled) this now passes.

<img width="913" height="126" alt="image" src="https://github.com/user-attachments/assets/f9023322-5155-48e6-9a64-11e7e0a23991" />


Associated docs (https://github.com/kuzudb/kuzu-docs/pull/582):

# Contributor agreement

- [X] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
