### PR TITLE
extension(llm): use proper provider names

### DIFF
--- a/extension/llm/CMakeLists.txt
+++ b/extension/llm/CMakeLists.txt
@@ -29,8 +29,7 @@ build_extension_lib(${BUILD_STATIC_EXTENSION} "llm")
 
 target_link_libraries(kuzu_${EXTENSION_LIB_NAME}_extension
         PRIVATE
-        simsimd
-        OpenSSL::SSL
+        ${OPENSSL_LIBRARIES}
         mbedtls
         $<TARGET_OBJECTS:httpfs_crypto>
 )

--- a/extension/llm/src/function/create_embedding.cpp
+++ b/extension/llm/src/function/create_embedding.cpp
@@ -30,7 +30,10 @@ public:
         StringUtils::toLower(provider);
         static const std::unordered_map<std::string,
             std::function<std::shared_ptr<EmbeddingProvider>()>>
-            providerInstanceMap = {{"open-ai", &OpenAIEmbedding::getInstance},
+            providerInstanceMap = {
+                {"openai", &OpenAIEmbedding::getInstance},
+                {"open-ai", &OpenAIEmbedding::getInstance},
+                {"voyageai", &VoyageAIEmbedding::getInstance},
                 {"voyage-ai", &VoyageAIEmbedding::getInstance},
                 {"google-vertex", &GoogleVertexEmbedding::getInstance},
                 {"google-gemini", &GoogleGeminiEmbedding::getInstance},

--- a/extension/llm/src/function/create_embedding.cpp
+++ b/extension/llm/src/function/create_embedding.cpp
@@ -30,8 +30,7 @@ public:
         StringUtils::toLower(provider);
         static const std::unordered_map<std::string,
             std::function<std::shared_ptr<EmbeddingProvider>()>>
-            providerInstanceMap = {
-                {"openai", &OpenAIEmbedding::getInstance},
+            providerInstanceMap = {{"openai", &OpenAIEmbedding::getInstance},
                 {"open-ai", &OpenAIEmbedding::getInstance},
                 {"voyageai", &VoyageAIEmbedding::getInstance},
                 {"voyage-ai", &VoyageAIEmbedding::getInstance},

--- a/extension/llm/src/function/create_embedding.cpp
+++ b/extension/llm/src/function/create_embedding.cpp
@@ -31,6 +31,7 @@ public:
         static const std::unordered_map<std::string,
             std::function<std::shared_ptr<EmbeddingProvider>()>>
             providerInstanceMap = {{"openai", &OpenAIEmbedding::getInstance},
+                // Accepted for backward compatibility.
                 {"open-ai", &OpenAIEmbedding::getInstance},
                 {"voyageai", &VoyageAIEmbedding::getInstance},
                 {"voyage-ai", &VoyageAIEmbedding::getInstance},


### PR DESCRIPTION
# Description

Accept both "open-ai" and "openai".
Accept both "voyage-ai" and "voyageai".
`target_link_libraries` included simsimd needlessly (this was never needed for this extension, not sure why it ever sticked around).
`OpenSSL::SSL` -> `${OPENSSL_LIBRARIES}` like `httpfs`


Associated docs (https://github.com/kuzudb/kuzu-docs/pull/589):

# Contributor agreement

- [X] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
