### PR TITLE
extension(llm): update test suite with proper provider names

### DIFF
--- a/extension/llm/src/function/create_embedding.cpp
+++ b/extension/llm/src/function/create_embedding.cpp
@@ -34,6 +34,7 @@ public:
                 // Accepted for backward compatibility.
                 {"open-ai", &OpenAIEmbedding::getInstance},
                 {"voyageai", &VoyageAIEmbedding::getInstance},
+                // Accepted for backward compatibility.
                 {"voyage-ai", &VoyageAIEmbedding::getInstance},
                 {"google-vertex", &GoogleVertexEmbedding::getInstance},
                 {"google-gemini", &GoogleGeminiEmbedding::getInstance},

--- a/extension/llm/test/.env.example
+++ b/extension/llm/test/.env.example
@@ -1,8 +1,8 @@
-# Usage for tests
+# Env template file for tests.
 # cp ./extension/llm/test/.env.example ./extension/llm/test/.env
-# (fill out needed keys)
+# Fill out keys for providers.
 # vi ./extension/llm/test/.env 
-# (source the filled out file)
+# Source the filled env file before running tests.
 # . ./extension/llm/test/.env 
 
 export AWS_ACCESS_KEY=

--- a/extension/llm/test/.env.example
+++ b/extension/llm/test/.env.example
@@ -1,0 +1,18 @@
+# Usage for tests
+# cp ./extension/llm/test/.env.example ./extension/llm/test/.env
+# vi ./extension/llm/test/.env
+# . ./extension/llm/test/.env
+
+export AWS_ACCESS_KEY=
+export AWS_SECRET_ACCESS_KEY=
+
+export GOOGLE_GEMINI_API_KEY=
+
+export GOOGLE_CLOUD_PROJECT_ID=
+export GOOGLE_VERTEX_ACCESS_KEY=
+
+export OLLAMA_URL=http://localhost:11434
+
+export OPENAI_API_KEY=
+
+export VOYAGE_API_KEY=

--- a/extension/llm/test/.env.example
+++ b/extension/llm/test/.env.example
@@ -1,7 +1,9 @@
 # Usage for tests
 # cp ./extension/llm/test/.env.example ./extension/llm/test/.env
-# vi ./extension/llm/test/.env
-# . ./extension/llm/test/.env
+# (fill out needed keys)
+# vi ./extension/llm/test/.env 
+# (source the filled out file)
+# . ./extension/llm/test/.env 
 
 export AWS_ACCESS_KEY=
 export AWS_SECRET_ACCESS_KEY=

--- a/extension/llm/test/test_files/openai.test
+++ b/extension/llm/test/test_files/openai.test
@@ -8,6 +8,20 @@
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
 ---- ok
 
+-STATEMENT MATCH (e:embedding) RETURN array_cosine_similarity(e.embedding, create_embedding(e.text, 'openai', 'text-embedding-3-small')) >= 0.9 AS similarity;
+---- 6
+True
+True
+True
+True
+True
+True
+
+-CASE BackwardsCompatibilityTest
+
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
+---- ok
+
 -STATEMENT MATCH (e:embedding) RETURN array_cosine_similarity(e.embedding, create_embedding(e.text, 'open-ai', 'text-embedding-3-small')) >= 0.9 AS similarity;
 ---- 6
 True
@@ -22,19 +36,19 @@ True
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
 ---- ok
 
--STATEMENT return create_embedding('Hello World', 'open-ai', 'text-embedding-3-small', 10);
+-STATEMENT return create_embedding('Hello World', 'openai', 'text-embedding-3-small', 10);
 ---- ok
 
--STATEMENT return create_embedding('Hello World', 'open-ai', 'text-embedding-3-small', 35);
+-STATEMENT return create_embedding('Hello World', 'openai', 'text-embedding-3-small', 35);
 ---- ok
 
--STATEMENT return create_embedding('Hello World', 'open-ai', 'text-embedding-3-small', 969);
+-STATEMENT return create_embedding('Hello World', 'openai', 'text-embedding-3-small', 969);
 ---- ok
 
--STATEMENT RETURN CREATE_EMBEDDING("Hello world", "open-ai", "text-embedding-3-small");
+-STATEMENT RETURN CREATE_EMBEDDING("Hello world", "openai", "text-embedding-3-small");
 ---- ok
 
--STATEMENT RETURN CREATE_EMBEDDING("Hello world", "open-ai", "text-embedding-3-small", 512);
+-STATEMENT RETURN CREATE_EMBEDDING("Hello world", "openai", "text-embedding-3-small", 512);
 ---- ok
 
 -CASE SemanticDistanceCheck
@@ -43,22 +57,22 @@ True
 ---- ok
 
 -LOG Similar Text 1
--STATEMENT WITH create_embedding('Who is the author of 1984?', 'open-ai', 'text-embedding-3-small') AS t1, create_embedding('Who wrote the novel 1984?', 'open-ai', 'text-embedding-3-small') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8
+-STATEMENT WITH create_embedding('Who is the author of 1984?', 'openai', 'text-embedding-3-small') AS t1, create_embedding('Who wrote the novel 1984?', 'openai', 'text-embedding-3-small') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8
 ---- 1
 True
 
 -LOG Similar Text 2
--STATEMENT WITH create_embedding('What is the capital of France?', 'open-ai', 'text-embedding-3-small') AS t1, create_embedding('Which city is the capital of France?', 'open-ai', 'text-embedding-3-small') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
+-STATEMENT WITH create_embedding('What is the capital of France?', 'openai', 'text-embedding-3-small') AS t1, create_embedding('Which city is the capital of France?', 'openai', 'text-embedding-3-small') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
 ---- 1
 True
 
 -LOG Dissimilar Text 1
--STATEMENT WITH create_embedding('How to train a dog', 'open-ai', 'text-embedding-3-small') AS t1, create_embedding('What is the capital of France', 'open-ai', 'text-embedding-3-small') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
+-STATEMENT WITH create_embedding('How to train a dog', 'openai', 'text-embedding-3-small') AS t1, create_embedding('What is the capital of France', 'openai', 'text-embedding-3-small') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
 ---- 1
 False
 
 -LOG Dissimilar Text 2
--STATEMENT WITH create_embedding('How do Unix file permissions work?', 'open-ai', 'text-embedding-3-small') AS t1, create_embedding('History of the Roman Empire', 'open-ai', 'text-embedding-3-small') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
+-STATEMENT WITH create_embedding('How do Unix file permissions work?', 'openai', 'text-embedding-3-small') AS t1, create_embedding('History of the Roman Empire', 'openai', 'text-embedding-3-small') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
 ---- 1
 False
 
@@ -78,7 +92,7 @@ False
     (:Book {title: 'Echoes of the Past', published_year: 2010}),
     (:Book {title: 'The Dragon Call', published_year: 2015});
 ---- ok
--STATEMENT MATCH (b:Book) WITH b, create_embedding(b.title, 'open-ai', 'text-embedding-3-small') AS emb SET b.title_embedding = emb;
+-STATEMENT MATCH (b:Book) WITH b, create_embedding(b.title, 'openai', 'text-embedding-3-small') AS emb SET b.title_embedding = emb;
 ---- ok
 -STATEMENT CALL CREATE_VECTOR_INDEX('Book', 'title_vec_index', 'title_embedding');
 ---- ok
@@ -86,7 +100,7 @@ False
 -STATEMENT CALL QUERY_VECTOR_INDEX(
         'Book',
         'title_vec_index',
-        create_embedding('quantum machine learning', 'open-ai', 'text-embedding-3-small'),
+        create_embedding('quantum machine learning', 'openai', 'text-embedding-3-small'),
         2
     )
     RETURN node.title

--- a/extension/llm/test/test_files/voyageai.test
+++ b/extension/llm/test/test_files/voyageai.test
@@ -8,25 +8,38 @@
 #-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
 #---- ok
 #
+#-STATEMENT MATCH (e:embedding) RETURN array_cosine_similarity(e.embedding, create_embedding(e.text, 'voyageai', 'voyage-3-large')) >= 0.9 AS similarity;
+#---- 4
+#True
+#True
+#True
+#True
+
+#-CASE BackwardsCompatibilityTest
+#
+#-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
+#---- ok
+#
 #-STATEMENT MATCH (e:embedding) RETURN array_cosine_similarity(e.embedding, create_embedding(e.text, 'voyage-ai', 'voyage-3-large')) >= 0.9 AS similarity;
 #---- 4
 #True
 #True
 #True
 #True
-#
+
+
 -CASE TryConfiguration
 
 -STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/llm/build/libllm.kuzu_extension"
 ---- ok
 
--STATEMENT RETURN CREATE_EMBEDDING("Hello world", "voyage-ai", "voyage-3-large");
+-STATEMENT RETURN CREATE_EMBEDDING("Hello world", "voyageai", "voyage-3-large");
 ---- ok
 
--STATEMENT return create_embedding('Hello World', 'voyage-ai', 'voyage-3-large', 512);
+-STATEMENT return create_embedding('Hello World', 'voyageai', 'voyage-3-large', 512);
 ---- ok
 
-#-STATEMENT return create_embedding('Hello World', 'voyage-ai', 'voyage-3-large', 256);
+#-STATEMENT return create_embedding('Hello World', 'voyageai', 'voyage-3-large', 256);
 #---- ok
 #
 #-CASE SemanticDistanceCheck
@@ -35,25 +48,25 @@
 #---- ok
 #
 #-LOG Similar Text 1
-#-STATEMENT WITH create_embedding('Who is the author of 1984?', 'voyage-ai', 'voyage-3-large') AS t1, create_embedding('Who wrote the novel 1984?', 'voyage-ai', 'voyage-3-large') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
+#-STATEMENT WITH create_embedding('Who is the author of 1984?', 'voyageai', 'voyage-3-large') AS t1, create_embedding('Who wrote the novel 1984?', 'voyageai', 'voyage-3-large') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
 #---- 1
 #True
 
 #
 #-LOG Similar Text 2
-#-STATEMENT WITH create_embedding('What is the capital of France?', 'voyage-ai', 'voyage-3-large') AS t1, create_embedding('Which city is the capital of France?', 'voyage-ai', 'voyage-3-large') AS t2 RETURN array_cosine_similarity(t1, t2) >- 0.8;
+#-STATEMENT WITH create_embedding('What is the capital of France?', 'voyageai', 'voyage-3-large') AS t1, create_embedding('Which city is the capital of France?', 'voyageai', 'voyage-3-large') AS t2 RETURN array_cosine_similarity(t1, t2) >- 0.8;
 #---- 1
 #True
 #
 #
 #-LOG Dissimilar Text 1
-#-STATEMENT WITH create_embedding('How to train a dog', 'voyage-ai', 'voyage-3-large') AS t1, create_embedding('What is the capital of France', 'voyage-ai', 'voyage-3-large') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
+#-STATEMENT WITH create_embedding('How to train a dog', 'voyageai', 'voyage-3-large') AS t1, create_embedding('What is the capital of France', 'voyageai', 'voyage-3-large') AS t2 RETURN array_cosine_similarity(t1, t2) >= 0.8;
 #---- 1
 #False
 #
 #
 #-LOG Dissimilar Text 2
-#-STATEMENT WITH create_embedding('How do Unix file permissions work?', 'voyage-ai', 'voyage-3-large') AS t1, create_embedding('History of the Roman Empire', 'voyage-ai', 'voyage-3-large') AS t2 RETURN array_cosine_similarity(t1, t2) >- 0.8;
+#-STATEMENT WITH create_embedding('How do Unix file permissions work?', 'voyageai', 'voyage-3-large') AS t1, create_embedding('History of the Roman Empire', 'voyageai', 'voyage-3-large') AS t2 RETURN array_cosine_similarity(t1, t2) >- 0.8;
 #---- 1
 #False
 #
@@ -76,7 +89,7 @@
 #    (:Book {title: 'Echoes of the Past', published_year: 2010}),
 #    (:Book {title: 'The Dragon Call', published_year: 2015});
 #---- ok
-#-STATEMENT MATCH (b:Book) WITH b, create_embedding(b.title, 'voyage-ai', 'voyage-3-large') AS emb SET b.title_embedding = emb;
+#-STATEMENT MATCH (b:Book) WITH b, create_embedding(b.title, 'voyageai', 'voyage-3-large') AS emb SET b.title_embedding = emb;
 #---- ok
 #-STATEMENT CALL CREATE_VECTOR_INDEX('Book', 'title_vec_index', 'title_embedding');
 #---- ok
@@ -84,7 +97,7 @@
 #-STATEMENT CALL QUERY_VECTOR_INDEX(
 #        'Book',
 #        'title_vec_index',
-#        create_embedding('quantum machine learning', 'voyage-ai', 'voyage-3-large'),
+#        create_embedding('quantum machine learning', 'voyageai', 'voyage-3-large'),
 #        2
 #    )
 #    RETURN node.title


### PR DESCRIPTION
# Description
Add env example file 
Add comment on `voyage-ai` alias
Update `openai` and `voyageai` test suite to use updated names. Keep a backwards compatibility check for aliases.



# Contributor agreement

- [X] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
