### PR TITLE
Fix fd leaks of shadow files

### DIFF
--- a/src/common/file_system/file_system.cpp
+++ b/src/common/file_system/file_system.cpp
@@ -59,7 +59,7 @@ void FileSystem::truncate(FileInfo& /*fileInfo*/, uint64_t /*size*/) const {
     KU_UNREACHABLE;
 }
 
-void FileSystem::reset(kuzu::common::FileInfo& fileInfo) {
+void FileSystem::reset(FileInfo& fileInfo) {
     fileInfo.seek(0, SEEK_SET);
 }
 

--- a/src/include/storage/file_handle.h
+++ b/src/include/storage/file_handle.h
@@ -102,6 +102,7 @@ public:
 
     common::page_idx_t getNumPages() const { return numPages; }
     common::FileInfo* getFileInfo() const { return fileInfo.get(); }
+    void resetFileInfo() { fileInfo.reset(); }
 
     uint64_t getPageSize() const {
         return isLargePaged() ? common::TEMP_PAGE_SIZE : common::KUZU_PAGE_SIZE;

--- a/src/storage/shadow_file.cpp
+++ b/src/storage/shadow_file.cpp
@@ -133,7 +133,7 @@ void ShadowFile::clear(BufferManager& bm) {
 }
 
 void ShadowFile::reset() {
-    shadowingFH->getFileInfo()->reset();
+    shadowingFH->fileInfo.reset();
     shadowingFH = nullptr;
     vfs->removeFileIfExists(shadowFilePath);
 }

--- a/src/storage/shadow_file.cpp
+++ b/src/storage/shadow_file.cpp
@@ -133,7 +133,7 @@ void ShadowFile::clear(BufferManager& bm) {
 }
 
 void ShadowFile::reset() {
-    shadowingFH->fileInfo.reset();
+    shadowingFH->resetFileInfo();
     shadowingFH = nullptr;
     vfs->removeFileIfExists(shadowFilePath);
 }


### PR DESCRIPTION
# Description

The shadow file descriptor is not properly closed, thus leading to leaks.

TODO: Best to add a comprehensive test suite for file descriptor leaks, so we don't run into this problem again.