### PR TITLE
test-tools: update rewriter behaviour for error (regex)

### DIFF
--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -247,8 +247,14 @@ private:
             // ---- error(regex)
             // ^Error: Binder exception: Variable .* is not in scope\.$
             case ResultType::ERROR_REGEX: {
-                newFile += statement->newOutput;
-                skipExistingOutput(file);
+                auto lines = skipExistingOutput(file);
+                // See ERROR_MSG
+                if (lines.find("${") != std::string::npos) {
+                    newFile += currLine + '\n' + lines;
+                } else {
+                    newFile += statement->newOutput;
+                }
+
             } break;
             }
         }

--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -248,12 +248,7 @@ private:
             // ^Error: Binder exception: Variable .* is not in scope\.$
             case ResultType::ERROR_REGEX: {
                 newFile += statement->newOutput;
-                // Get the nextline which specifies the regex pattern the error should match
-                getline(file, currLine);
-                // If the actual output is an error, put the existing regex expression back.
-                if (statement->newOutput != "---- ok\n") {
-                    newFile += currLine + '\n';
-                }
+                skipExistingOutput(file);
             } break;
             }
         }

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -252,23 +252,21 @@ void TestRunner::generateOutput(QueryResult* result, TestStatement* statement, s
         statement->newOutput += StringUtils::rtrim(result->getErrorMessage()) + '\n';
     } break;
     case ResultType::ERROR_REGEX: {
-            statement->newOutput += "---- ";
-            if (result->isSuccess())
-            {
-                statement->newOutput += "ok\n";
-                break;
-            }
-            auto actualError = StringUtils::rtrim(result->getErrorMessage());
-            if (std::regex_match(actualError, std::regex(testAnswer.expectedResult[0])))
-            {
-                statement->newOutput += "error(regex)\n";
-                statement->newOutput += testAnswer.expectedResult[0];
-                statement->newOutput += '\n';
-                break;
-            }
-            statement->newOutput += "error\n";
-            statement->newOutput += actualError;
+        statement->newOutput += "---- ";
+        if (result->isSuccess()) {
+            statement->newOutput += "ok\n";
+            break;
+        }
+        auto actualError = StringUtils::rtrim(result->getErrorMessage());
+        if (std::regex_match(actualError, std::regex(testAnswer.expectedResult[0]))) {
+            statement->newOutput += "error(regex)\n";
+            statement->newOutput += testAnswer.expectedResult[0];
             statement->newOutput += '\n';
+            break;
+        }
+        statement->newOutput += "error\n";
+        statement->newOutput += actualError;
+        statement->newOutput += '\n';
     } break;
     }
 }

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -252,9 +252,23 @@ void TestRunner::generateOutput(QueryResult* result, TestStatement* statement, s
         statement->newOutput += StringUtils::rtrim(result->getErrorMessage()) + '\n';
     } break;
     case ResultType::ERROR_REGEX: {
-        statement->newOutput +=
-            "---- " + (result->isSuccess() ? std::string("ok") : std::string("error(regex)")) +
-            '\n';
+            statement->newOutput += "---- ";
+            if (result->isSuccess())
+            {
+                statement->newOutput += "ok\n";
+                break;
+            }
+            auto actualError = StringUtils::rtrim(result->getErrorMessage());
+            if (std::regex_match(actualError, std::regex(testAnswer.expectedResult[0])))
+            {
+                statement->newOutput += "error(regex)\n";
+                statement->newOutput += testAnswer.expectedResult[0];
+                statement->newOutput += '\n';
+                break;
+            }
+            statement->newOutput += "error\n";
+            statement->newOutput += actualError;
+            statement->newOutput += '\n';
     } break;
     }
 }


### PR DESCRIPTION
# Description
[Do not review; in test]
Update the rewriter to do the following for error(regex)

1. If the query succeeds (no error). Replace the output with 
`---- ok`

2. If the query fails and matches the regex.
Leave the output as is (i.e write the same expected error back).
`---- error(regex)`
`{old error regex}`

3. If the query fails and does not match the regex
Overwrite the output with 
`---- error`
`{query error msg}`

Closes #5739 

# Contributor agreement

- [X] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
