### PR TITLE
Fix `FlatTuple::toString` truncating with UTF-8

### DIFF
--- a/src/processor/result/flat_tuple.cpp
+++ b/src/processor/result/flat_tuple.cpp
@@ -46,11 +46,11 @@ std::string FlatTuple::toString(const std::vector<uint32_t>& colsWidth,
     const std::string& delimiter, const uint32_t maxWidth) {
     std::ostringstream result;
     for (auto i = 0ul; i < values.size(); i++) {
-        std::string value = values[i]->toString();
-        uint32_t fieldLen = 0;
-        uint32_t cutoff = 0, cutoffLen = 0;
-        for (uint32_t iter = 0; iter < value.length();) {
-            uint32_t width = Utf8Proc::renderWidth(value.c_str(), iter);
+        auto value = values[i]->toString();
+        auto fieldLen = 0u;
+        auto cutoff = 0u, cutoffLen = 0u;
+        for (auto iter = 0u; iter < value.length();) {
+            auto width = Utf8Proc::renderWidth(value.c_str(), iter);
             if (fieldLen + 3 > maxWidth && cutoff == 0) {
                 cutoff = iter;
                 cutoffLen = fieldLen;

--- a/src/processor/result/flat_tuple.cpp
+++ b/src/processor/result/flat_tuple.cpp
@@ -49,7 +49,7 @@ std::string FlatTuple::toString(const std::vector<uint32_t>& colsWidth,
         std::string value = values[i]->toString();
         uint32_t fieldLen = 0;
         uint32_t cutoff = 0, cutoffLen = 0;
-        for (uint32_t iter = 0; iter < value.length(); ) {
+        for (uint32_t iter = 0; iter < value.length();) {
             uint32_t width = Utf8Proc::renderWidth(value.c_str(), iter);
             if (fieldLen + 3 > maxWidth && cutoff == 0) {
                 cutoff = iter;

--- a/src/processor/result/flat_tuple.cpp
+++ b/src/processor/result/flat_tuple.cpp
@@ -8,8 +8,6 @@
 #include "utf8proc.h"
 #include "utf8proc_wrapper.h"
 
-#include <iostream>
-
 using namespace kuzu::utf8proc;
 using namespace kuzu::common;
 


### PR DESCRIPTION
We now calculate the length of the string and determine the cut-off position while accounting for multi-byte characters.

Resolves https://github.com/kuzudb/kuzu/issues/5674
