### PR TITLE
export-import: fix quotes not preserved on multiline strings

### DIFF
--- a/src/function/export/export_csv_function.cpp
+++ b/src/function/export/export_csv_function.cpp
@@ -54,10 +54,8 @@ static bool requireQuotes(const ExportCSVBindData& exportCSVBindData, const uint
     }
     static constexpr const char* NEWLINE = "\n\r";
     for (auto i = 0u; i < len; i++) {
-        if (str[i] == exportCSVBindData.exportOption.quoteChar ||
-            str[i] == NEWLINE[0] ||
-            str[i] == NEWLINE[1] ||
-            str[i] == exportCSVBindData.exportOption.delimiter) {
+        if (str[i] == exportCSVBindData.exportOption.quoteChar || str[i] == NEWLINE[0] ||
+            str[i] == NEWLINE[1] || str[i] == exportCSVBindData.exportOption.delimiter) {
             return true;
         }
     }


### PR DESCRIPTION
# Description

Implements comment in issue. 

Fixes #5761 

# Contributor agreement

- [X] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
