### PR TITLE
Clean up `minUncommittedNodeOffsets` in Transaction and keep startOffset inside each LocalNodeTable

### DIFF
--- a/src/include/storage/local_storage/local_node_table.h
+++ b/src/include/storage/local_storage/local_node_table.h
@@ -13,8 +13,7 @@ class MemoryManager;
 
 class LocalNodeTable final : public LocalTable {
 public:
-    LocalNodeTable(const catalog::TableCatalogEntry* tableEntry, const Table& table,
-        MemoryManager& mm);
+    LocalNodeTable(const catalog::TableCatalogEntry* tableEntry, Table& table, MemoryManager& mm);
     DELETE_COPY_AND_MOVE(LocalNodeTable);
 
     bool insert(transaction::Transaction* transaction, TableInsertState& insertState) override;
@@ -43,6 +42,7 @@ public:
         common::sel_t pos, common::offset_t& result) const;
 
     TableStats getStats() const { return nodeGroups.getStats(); }
+    common::offset_t getStartOffset() const { return startOffset; }
 
     static std::vector<common::LogicalType> getNodeTableColumnTypes(
         const catalog::TableCatalogEntry& table);
@@ -52,6 +52,8 @@ private:
     bool isVisible(const transaction::Transaction* transaction, common::offset_t offset) const;
 
 private:
+    // This is equivalent to the num of committed nodes in the table.
+    common::offset_t startOffset;
     PageCursor overflowCursor;
     std::unique_ptr<OverflowFile> overflowFile;
     OverflowFileHandle* overflowFileHandle;

--- a/src/include/storage/local_storage/local_node_table.h
+++ b/src/include/storage/local_storage/local_node_table.h
@@ -13,7 +13,8 @@ class MemoryManager;
 
 class LocalNodeTable final : public LocalTable {
 public:
-    LocalNodeTable(const catalog::TableCatalogEntry* tableEntry, const Table& table);
+    LocalNodeTable(const catalog::TableCatalogEntry* tableEntry, const Table& table,
+        MemoryManager& mm);
     DELETE_COPY_AND_MOVE(LocalNodeTable);
 
     bool insert(transaction::Transaction* transaction, TableInsertState& insertState) override;
@@ -28,7 +29,7 @@ public:
 
     common::TableType getTableType() const override { return common::TableType::NODE; }
 
-    void clear() override;
+    void clear(MemoryManager& mm) override;
 
     common::row_idx_t getNumTotalRows() override { return nodeGroups.getNumTotalRows(); }
     common::node_group_idx_t getNumNodeGroups() const { return nodeGroups.getNumNodeGroups(); }
@@ -47,7 +48,7 @@ public:
         const catalog::TableCatalogEntry& table);
 
 private:
-    void initLocalHashIndex();
+    void initLocalHashIndex(MemoryManager& mm);
     bool isVisible(const transaction::Transaction* transaction, common::offset_t offset) const;
 
 private:

--- a/src/include/storage/local_storage/local_rel_table.h
+++ b/src/include/storage/local_storage/local_rel_table.h
@@ -58,7 +58,8 @@ public:
     }
     bool isEmpty() const {
         KU_ASSERT(directedIndices.size() >= 1);
-        RUNTIME_CHECK(for (const auto& index : directedIndices) {
+        RUNTIME_CHECK(for (const auto& index
+                           : directedIndices) {
             KU_ASSERT(index.index.empty() == directedIndices[0].index.empty());
         });
         return directedIndices[0].isEmpty();

--- a/src/include/storage/local_storage/local_rel_table.h
+++ b/src/include/storage/local_storage/local_rel_table.h
@@ -50,7 +50,7 @@ public:
     static void initializeScan(TableScanState& state);
     bool scan(const transaction::Transaction* transaction, TableScanState& state) const;
 
-    void clear() override {
+    void clear(MemoryManager&) override {
         localNodeGroup.reset();
         for (auto& index : directedIndices) {
             index.clear();
@@ -58,8 +58,7 @@ public:
     }
     bool isEmpty() const {
         KU_ASSERT(directedIndices.size() >= 1);
-        RUNTIME_CHECK(for (const auto& index
-                           : directedIndices) {
+        RUNTIME_CHECK(for (const auto& index : directedIndices) {
             KU_ASSERT(index.index.empty() == directedIndices[0].index.empty());
         });
         return directedIndices[0].isEmpty();

--- a/src/include/storage/local_storage/local_rel_table.h
+++ b/src/include/storage/local_storage/local_rel_table.h
@@ -58,8 +58,7 @@ public:
     }
     bool isEmpty() const {
         KU_ASSERT(directedIndices.size() >= 1);
-        RUNTIME_CHECK(for (const auto& index
-                           : directedIndices) {
+        RUNTIME_CHECK(for (const auto& index : directedIndices) {
             KU_ASSERT(index.index.empty() == directedIndices[0].index.empty());
         });
         return directedIndices[0].isEmpty();

--- a/src/include/storage/local_storage/local_storage.h
+++ b/src/include/storage/local_storage/local_storage.h
@@ -21,7 +21,7 @@ public:
     DELETE_COPY_AND_MOVE(LocalStorage);
 
     // Do nothing if the table already exists, otherwise create a new local table.
-    LocalTable* getOrCreateLocalTable(const Table& table);
+    LocalTable* getOrCreateLocalTable(Table& table);
     // Return nullptr if no local table exists.
     LocalTable* getLocalTable(common::table_id_t tableID) const;
 

--- a/src/include/storage/local_storage/local_table.h
+++ b/src/include/storage/local_storage/local_table.h
@@ -24,7 +24,7 @@ public:
     virtual bool delete_(transaction::Transaction* transaction, TableDeleteState& deleteState) = 0;
     virtual bool addColumn(transaction::Transaction* transaction,
         TableAddColumnState& addColumnState) = 0;
-    virtual void clear() = 0;
+    virtual void clear(MemoryManager& mm) = 0;
     virtual common::TableType getTableType() const = 0;
     virtual uint64_t getEstimatedMemUsage() = 0;
     virtual common::row_idx_t getNumTotalRows() = 0;

--- a/src/include/storage/table/node_group.h
+++ b/src/include/storage/table/node_group.h
@@ -43,7 +43,6 @@ struct NodeGroupScanState {
     }
 };
 
-class MemoryManager;
 struct NodeGroupCheckpointState {
     std::vector<common::column_id_t> columnIDs;
     std::vector<Column*> columns;

--- a/src/include/storage/table/table.h
+++ b/src/include/storage/table/table.h
@@ -176,7 +176,7 @@ public:
     virtual void commit(main::ClientContext* context, catalog::TableCatalogEntry* tableEntry,
         LocalTable* localTable) = 0;
     virtual bool checkpoint(main::ClientContext* context, catalog::TableCatalogEntry* tableEntry,
-        storage::PageAllocator& pageAllocator) = 0;
+        PageAllocator& pageAllocator) = 0;
     virtual void rollbackCheckpoint() = 0;
     virtual void reclaimStorage(PageAllocator& pageAllocator) const = 0;
 
@@ -196,8 +196,6 @@ public:
     TARGET* ptrCast() {
         return common::ku_dynamic_cast<TARGET*>(this);
     }
-
-    MemoryManager& getMemoryManager() const { return *memoryManager; }
 
     static common::DataChunk constructDataChunk(MemoryManager* mm,
         std::vector<common::LogicalType> types);

--- a/src/include/transaction/transaction.h
+++ b/src/include/transaction/transaction.h
@@ -131,13 +131,7 @@ public:
         common::row_idx_t localRowIdx) const {
         return getMinUncommittedNodeOffset(tableID) + localRowIdx;
     }
-    common::offset_t getMinUncommittedNodeOffset(common::table_id_t tableID) const {
-        // The only case that minUncommittedNodeOffsets doesn't track the given tableID is when the
-        // table is newly created within the same transaction, thus the minUncommittedNodeOffsets
-        // should be 0.
-        return minUncommittedNodeOffsets.contains(tableID) ? minUncommittedNodeOffsets.at(tableID) :
-                                                             0;
-    }
+
     void pushCreateDropCatalogEntry(catalog::CatalogSet& catalogSet,
         catalog::CatalogEntry& catalogEntry, bool isInternal, bool skipLoggingToWAL = false);
     void pushAlterCatalogEntry(catalog::CatalogSet& catalogSet, catalog::CatalogEntry& catalogEntry,
@@ -151,12 +145,8 @@ public:
     void pushVectorUpdateInfo(storage::UpdateInfo& updateInfo, common::idx_t vectorIdx,
         storage::VectorUpdateInfo& vectorUpdateInfo) const;
 
-    static Transaction getDummyTransactionFromExistingOne(const Transaction& other);
-
 private:
-    Transaction(TransactionType transactionType, common::transaction_t ID,
-        common::transaction_t startTS,
-        std::unordered_map<common::table_id_t, common::offset_t> minUncommittedNodeOffsets);
+    common::offset_t getMinUncommittedNodeOffset(common::table_id_t tableID) const;
 
 private:
     TransactionType type;
@@ -171,11 +161,6 @@ private:
     LocalCacheManager localCacheManager;
     bool forceCheckpoint;
     std::atomic<bool> hasCatalogChanges;
-
-    // For each node table, we keep track of the minimum uncommitted node offset when the
-    // transaction starts. This is mainly used to assign offsets to local nodes and determine if a
-    // given node is transaction local or not.
-    std::unordered_map<common::table_id_t, common::offset_t> minUncommittedNodeOffsets;
 };
 
 // TODO(bmwinger): These shouldn't need to be exported

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -97,7 +97,6 @@ void NodeBatchInsert::executeInternal(ExecutionContext* context) {
     const auto clientContext = context->clientContext;
     std::optional<ProducerToken> token;
     auto nodeLocalState = localState->ptrCast<NodeBatchInsertLocalState>();
-    const auto nodeInfo = info->ptrCast<NodeBatchInsertInfo>();
     if (nodeLocalState->localIndexBuilder) {
         token = nodeLocalState->localIndexBuilder->getProducerToken();
     }
@@ -123,6 +122,7 @@ void NodeBatchInsert::executeInternal(ExecutionContext* context) {
         nodeLocalState->localIndexBuilder->finishedProducing(nodeLocalState->errorHandler.value());
         nodeLocalState->errorHandler->flushStoredErrors();
     }
+    const auto nodeInfo = info->ptrCast<NodeBatchInsertInfo>();
     sharedState->table->cast<NodeTable>().mergeStats(nodeInfo->insertColumnIDs,
         nodeLocalState->stats);
 }

--- a/src/storage/local_storage/local_rel_table.cpp
+++ b/src/storage/local_storage/local_rel_table.cpp
@@ -276,8 +276,7 @@ row_idx_t LocalRelTable::findMatchingRow(const Transaction* transaction,
             intersectRows.begin() + endRowToScan};
         const auto scanState = setupLocalTableScanState(scanChunk, currentRowsToCheck);
 
-        [[maybe_unused]] auto lookupRes =
-            localNodeGroup->lookupMultiple(&DUMMY_TRANSACTION, *scanState);
+        [[maybe_unused]] auto lookupRes = localNodeGroup->lookupMultiple(transaction, *scanState);
         const auto scannedRelIDVector = scanState->outputVectors[0];
         KU_ASSERT(
             scannedRelIDVector->state->getSelVector().getSelSize() == currentRowsToCheck.size());

--- a/src/storage/local_storage/local_rel_table.cpp
+++ b/src/storage/local_storage/local_rel_table.cpp
@@ -276,8 +276,8 @@ row_idx_t LocalRelTable::findMatchingRow(const Transaction* transaction,
             intersectRows.begin() + endRowToScan};
         const auto scanState = setupLocalTableScanState(scanChunk, currentRowsToCheck);
 
-        auto dummyTrx = Transaction::getDummyTransactionFromExistingOne(*transaction);
-        [[maybe_unused]] auto lookupRes = localNodeGroup->lookupMultiple(&dummyTrx, *scanState);
+        [[maybe_unused]] auto lookupRes =
+            localNodeGroup->lookupMultiple(&DUMMY_TRANSACTION, *scanState);
         const auto scannedRelIDVector = scanState->outputVectors[0];
         KU_ASSERT(
             scannedRelIDVector->state->getSelVector().getSelSize() == currentRowsToCheck.size());

--- a/src/storage/local_storage/local_storage.cpp
+++ b/src/storage/local_storage/local_storage.cpp
@@ -14,7 +14,7 @@ using namespace kuzu::transaction;
 namespace kuzu {
 namespace storage {
 
-LocalTable* LocalStorage::getOrCreateLocalTable(const Table& table) {
+LocalTable* LocalStorage::getOrCreateLocalTable(Table& table) {
     const auto tableID = table.getTableID();
     auto catalog = clientContext.getCatalog();
     auto transaction = clientContext.getTransaction();

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -619,7 +619,7 @@ void NodeTable::commit(main::ClientContext* context, TableCatalogEntry* tableEnt
     }
 
     // 4. Clear local table.
-    localTable->clear();
+    localTable->clear(*context->getMemoryManager());
 }
 
 visible_func NodeTable::getVisibleFunc(const Transaction* transaction) const {

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -575,7 +575,7 @@ void NodeTable::commit(main::ClientContext* context, TableCatalogEntry* tableEnt
     // 2. Set deleted flag for tuples that are deleted in local storage.
     row_idx_t numLocalRows = 0u;
     for (auto localNodeGroupIdx = 0u; localNodeGroupIdx < localNodeTable.getNumNodeGroups();
-        localNodeGroupIdx++) {
+         localNodeGroupIdx++) {
         const auto localNodeGroup = localNodeTable.getNodeGroup(localNodeGroupIdx);
         if (localNodeGroup->hasDeletions(transaction)) {
             // TODO(Guodong): Assume local storage is small here. Should optimize the loop away by
@@ -725,7 +725,7 @@ void NodeTable::scanIndexColumns(main::ClientContext* context, IndexScanHelper& 
 
     const auto numNodeGroups = nodeGroups_.getNumNodeGroups();
     for (node_group_idx_t nodeGroupToScan = 0u; nodeGroupToScan < numNodeGroups;
-        ++nodeGroupToScan) {
+         ++nodeGroupToScan) {
         scanState->nodeGroup = nodeGroups_.getNodeGroupNoLock(nodeGroupToScan);
 
         // It is possible for the node group to have no chunked groups if we are rolling back due to

--- a/src/storage/table/rel_table.cpp
+++ b/src/storage/table/rel_table.cpp
@@ -401,7 +401,7 @@ void RelTable::commit(main::ClientContext* context, TableCatalogEntry* tableEntr
     LocalTable* localTable) {
     auto& localRelTable = localTable->cast<LocalRelTable>();
     if (localRelTable.isEmpty()) {
-        localTable->clear();
+        localTable->clear(*context->getMemoryManager());
         return;
     }
     // Update relID in local storage.
@@ -439,7 +439,7 @@ void RelTable::commit(main::ClientContext* context, TableCatalogEntry* tableEntr
         }
     }
 
-    localRelTable.clear();
+    localRelTable.clear(*context->getMemoryManager());
 }
 
 void RelTable::reclaimStorage(PageAllocator& pageAllocator) const {

--- a/src/storage/table/rel_table.cpp
+++ b/src/storage/table/rel_table.cpp
@@ -219,8 +219,7 @@ void RelTable::update(Transaction* transaction, TableUpdateState& updateState) {
         relOffset >= StorageConstants::MAX_NUM_ROWS_IN_TABLE) {
         const auto localTable = transaction->getLocalStorage()->getLocalTable(tableID);
         KU_ASSERT(localTable);
-        auto dummyTrx = Transaction::getDummyTransactionFromExistingOne(*transaction);
-        localTable->update(&dummyTrx, updateState);
+        localTable->update(&DUMMY_TRANSACTION, updateState);
     } else {
         for (auto& relData : directedRelData) {
             relData->update(transaction,


### PR DESCRIPTION
# Description

This PR reworks the design of keeping min uncommitted node offsets from Transaction to each LocalNodeTable as needed.
It simplifies the design and also ease the overheads of keeping track of min uncommitted node offsets when there are lots of node tables in the database.

Also, cleaned up the  interface `getMemoryManager()` from `Table`, which was added for convenience but doesn't make much sense.