### PR TITLE
Remove `Transaction::getClientContext` interface

### DIFF
--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -339,7 +339,7 @@ bool OnDiskGraphVertexScanState::next() {
     numNodesToScan = std::min(endOffset - currentOffset, DEFAULT_VECTOR_CAPACITY);
     auto result = tableScanState->scanNext(context.getTransaction(), currentOffset, numNodesToScan);
     currentOffset += result.numRows;
-    return result != NODE_GROUP_SCAN_EMMPTY_RESULT;
+    return result != NODE_GROUP_SCAN_EMPTY_RESULT;
 }
 
 } // namespace graph

--- a/src/include/storage/local_storage/local_node_table.h
+++ b/src/include/storage/local_storage/local_node_table.h
@@ -19,8 +19,7 @@ public:
     bool insert(transaction::Transaction* transaction, TableInsertState& insertState) override;
     bool update(transaction::Transaction* transaction, TableUpdateState& updateState) override;
     bool delete_(transaction::Transaction* transaction, TableDeleteState& deleteState) override;
-    bool addColumn(transaction::Transaction* transaction,
-        TableAddColumnState& addColumnState) override;
+    bool addColumn(TableAddColumnState& addColumnState) override;
     uint64_t getEstimatedMemUsage() override;
 
     common::offset_t validateUniquenessConstraint(const transaction::Transaction* transaction,

--- a/src/include/storage/local_storage/local_rel_table.h
+++ b/src/include/storage/local_storage/local_rel_table.h
@@ -32,14 +32,14 @@ struct DirectedCSRIndex {
 
 class LocalRelTable final : public LocalTable {
 public:
-    LocalRelTable(const catalog::TableCatalogEntry* tableEntry, const Table& table);
+    LocalRelTable(const catalog::TableCatalogEntry* tableEntry, const Table& table,
+        MemoryManager& mm);
     DELETE_COPY_AND_MOVE(LocalRelTable);
 
     bool insert(transaction::Transaction* transaction, TableInsertState& state) override;
     bool update(transaction::Transaction* transaction, TableUpdateState& state) override;
     bool delete_(transaction::Transaction* transaction, TableDeleteState& state) override;
-    bool addColumn(transaction::Transaction* transaction,
-        TableAddColumnState& addColumnState) override;
+    bool addColumn(TableAddColumnState& addColumnState) override;
     uint64_t getEstimatedMemUsage() override;
 
     bool checkIfNodeHasRels(common::ValueVector* srcNodeIDVector,
@@ -58,8 +58,7 @@ public:
     }
     bool isEmpty() const {
         KU_ASSERT(directedIndices.size() >= 1);
-        RUNTIME_CHECK(for (const auto& index
-                           : directedIndices) {
+        RUNTIME_CHECK(for (const auto& index : directedIndices) {
             KU_ASSERT(index.index.empty() == directedIndices[0].index.empty());
         });
         return directedIndices[0].isEmpty();

--- a/src/include/storage/local_storage/local_rel_table.h
+++ b/src/include/storage/local_storage/local_rel_table.h
@@ -58,7 +58,8 @@ public:
     }
     bool isEmpty() const {
         KU_ASSERT(directedIndices.size() >= 1);
-        RUNTIME_CHECK(for (const auto& index : directedIndices) {
+        RUNTIME_CHECK(for (const auto& index
+                           : directedIndices) {
             KU_ASSERT(index.index.empty() == directedIndices[0].index.empty());
         });
         return directedIndices[0].isEmpty();

--- a/src/include/storage/local_storage/local_table.h
+++ b/src/include/storage/local_storage/local_table.h
@@ -22,8 +22,7 @@ public:
     virtual bool insert(transaction::Transaction* transaction, TableInsertState& insertState) = 0;
     virtual bool update(transaction::Transaction* transaction, TableUpdateState& updateState) = 0;
     virtual bool delete_(transaction::Transaction* transaction, TableDeleteState& deleteState) = 0;
-    virtual bool addColumn(transaction::Transaction* transaction,
-        TableAddColumnState& addColumnState) = 0;
+    virtual bool addColumn(TableAddColumnState& addColumnState) = 0;
     virtual void clear(MemoryManager& mm) = 0;
     virtual common::TableType getTableType() const = 0;
     virtual uint64_t getEstimatedMemUsage() = 0;

--- a/src/include/storage/table/chunked_node_group.h
+++ b/src/include/storage/table/chunked_node_group.h
@@ -121,9 +121,8 @@ public:
 
     bool delete_(const transaction::Transaction* transaction, common::row_idx_t rowIdxInChunk);
 
-    void addColumn(const transaction::Transaction* transaction,
-        const TableAddColumnState& addColumnState, bool enableCompression,
-        PageAllocator* pageAllocator, ColumnStats* newColumnStats);
+    void addColumn(MemoryManager& mm, const TableAddColumnState& addColumnState,
+        bool enableCompression, PageAllocator* pageAllocator, ColumnStats* newColumnStats);
 
     bool isDeleted(const transaction::Transaction* transaction, common::row_idx_t rowInChunk) const;
     bool isInserted(const transaction::Transaction* transaction,
@@ -144,7 +143,8 @@ public:
     }
 
     virtual std::unique_ptr<ChunkedNodeGroup> flushAsNewChunkedNodeGroup(
-        transaction::Transaction* transaction, PageAllocator& pageAllocator) const;
+        transaction::Transaction* transaction, MemoryManager& mm,
+        PageAllocator& pageAllocator) const;
     virtual void flush(PageAllocator& pageAllocator);
 
     void commitInsert(common::row_idx_t startRow, common::row_idx_t numRowsToCommit,

--- a/src/include/storage/table/column_chunk.h
+++ b/src/include/storage/table/column_chunk.h
@@ -38,11 +38,11 @@ struct ColumnCheckpointState {
 
 class ColumnChunk {
 public:
-    ColumnChunk(MemoryManager& memoryManager, common::LogicalType&& dataType, uint64_t capacity,
+    ColumnChunk(MemoryManager& mm, common::LogicalType&& dataType, uint64_t capacity,
         bool enableCompression, ResidencyState residencyState, bool initializeToZero = true);
-    ColumnChunk(MemoryManager& memoryManager, common::LogicalType&& dataType,
-        bool enableCompression, ColumnChunkMetadata metadata);
-    ColumnChunk(bool enableCompression, std::unique_ptr<ColumnChunkData> data);
+    ColumnChunk(MemoryManager& mm, common::LogicalType&& dataType, bool enableCompression,
+        ColumnChunkMetadata metadata);
+    ColumnChunk(MemoryManager& mm, bool enableCompression, std::unique_ptr<ColumnChunkData> data);
 
     void initializeScanState(ChunkState& state, const Column* column) const;
     void scan(const transaction::Transaction* transaction, const ChunkState& state,
@@ -61,8 +61,7 @@ public:
         return getResidencyState() == ResidencyState::ON_DISK ? 0 : data->getEstimatedMemoryUsage();
     }
     void serialize(common::Serializer& serializer) const;
-    static std::unique_ptr<ColumnChunk> deserialize(MemoryManager& memoryManager,
-        common::Deserializer& deSer);
+    static std::unique_ptr<ColumnChunk> deserialize(MemoryManager& mm, common::Deserializer& deSer);
 
     uint64_t getNumValues() const { return data->getNumValues(); }
     void setNumValues(const uint64_t numValues) const { data->setNumValues(numValues); }
@@ -110,6 +109,7 @@ private:
         common::row_idx_t numRows) const;
 
 private:
+    MemoryManager& mm;
     // TODO(Guodong): This field should be removed. Ideally it shouldn't be cached anywhere in
     // storage structures, instead should be fed into functions needed from ClientContext dbConfig.
     bool enableCompression;

--- a/src/include/storage/table/csr_chunked_node_group.h
+++ b/src/include/storage/table/csr_chunked_node_group.h
@@ -66,7 +66,7 @@ struct KUZU_API ChunkedCSRHeader {
     common::offset_t getStartCSROffset(common::offset_t nodeOffset) const;
     common::offset_t getEndCSROffset(common::offset_t nodeOffset) const;
     common::length_t getCSRLength(common::offset_t nodeOffset) const;
-    common::length_t getGapSize(common::length_t length) const;
+    common::length_t getGapSize(common::length_t nodeOffset) const;
 
     bool sanityCheck() const;
     void copyFrom(const ChunkedCSRHeader& other) const;
@@ -127,7 +127,8 @@ public:
     void scanCSRHeader(MemoryManager& memoryManager, CSRNodeGroupCheckpointState& csrState) const;
 
     std::unique_ptr<ChunkedNodeGroup> flushAsNewChunkedNodeGroup(
-        transaction::Transaction* transaction, PageAllocator& pageAllocator) const override;
+        transaction::Transaction* transaction, MemoryManager& mm,
+        PageAllocator& pageAllocator) const override;
 
     void flush(PageAllocator& pageAllocator) override;
     void reclaimStorage(PageAllocator& pageAllocator) const override;

--- a/src/include/storage/table/node_group_collection.h
+++ b/src/include/storage/table/node_group_collection.h
@@ -13,8 +13,8 @@ class MemoryManager;
 
 class NodeGroupCollection {
 public:
-    NodeGroupCollection(const std::vector<common::LogicalType>& types, bool enableCompression,
-        ResidencyState residency = ResidencyState::IN_MEMORY,
+    NodeGroupCollection(MemoryManager& mm, const std::vector<common::LogicalType>& types,
+        bool enableCompression, ResidencyState residency = ResidencyState::IN_MEMORY,
         const VersionRecordHandler* versionRecordHandler = nullptr);
 
     void append(const transaction::Transaction* transaction,
@@ -73,8 +73,7 @@ public:
 
     common::column_id_t getNumColumns() const { return types.size(); }
 
-    void addColumn(transaction::Transaction* transaction, TableAddColumnState& addColumnState,
-        PageAllocator* pageAllocator = nullptr);
+    void addColumn(TableAddColumnState& addColumnState, PageAllocator* pageAllocator = nullptr);
 
     uint64_t getEstimatedMemoryUsage() const;
 
@@ -111,6 +110,8 @@ private:
     void pushInsertInfo(const transaction::Transaction* transaction, const NodeGroup* nodeGroup,
         common::row_idx_t numRows);
 
+private:
+    MemoryManager& mm;
     bool enableCompression;
     // Num rows in the collection regardless of deletions.
     std::atomic<common::row_idx_t> numTotalRows;

--- a/src/include/storage/table/node_table.h
+++ b/src/include/storage/table/node_table.h
@@ -103,7 +103,7 @@ class StorageManager;
 class KUZU_API NodeTable final : public Table {
 public:
     NodeTable(const StorageManager* storageManager,
-        const catalog::NodeTableCatalogEntry* nodeTableEntry, MemoryManager* memoryManager);
+        const catalog::NodeTableCatalogEntry* nodeTableEntry, MemoryManager* mm);
 
     common::row_idx_t getNumTotalRows(const transaction::Transaction* transaction) override;
 

--- a/src/include/storage/table/rel_table_data.h
+++ b/src/include/storage/table/rel_table_data.h
@@ -16,6 +16,7 @@ namespace transaction {
 class Transaction;
 }
 namespace storage {
+class Table;
 class MemoryManager;
 class RelTableData;
 
@@ -55,7 +56,7 @@ private:
 class RelTableData {
 public:
     RelTableData(FileHandle* dataFH, MemoryManager* mm, ShadowFile* shadowFile,
-        const catalog::RelGroupCatalogEntry& relGroupEntry, common::table_id_t tableID,
+        const catalog::RelGroupCatalogEntry& relGroupEntry, Table& table,
         common::RelDataDirection direction, common::table_id_t nbrTableID, bool enableCompression);
 
     bool update(transaction::Transaction* transaction, common::ValueVector& boundNodeIDVector,
@@ -63,8 +64,7 @@ public:
         const common::ValueVector& dataVector) const;
     bool delete_(transaction::Transaction* transaction, common::ValueVector& boundNodeIDVector,
         const common::ValueVector& relIDVector);
-    void addColumn(transaction::Transaction* transaction, TableAddColumnState& addColumnState,
-        PageAllocator& pageAllocator);
+    void addColumn(TableAddColumnState& addColumnState, PageAllocator& pageAllocator);
 
     bool checkIfNodeHasRels(transaction::Transaction* transaction,
         common::ValueVector* srcNodeIDVector) const;
@@ -146,9 +146,8 @@ private:
     const VersionRecordHandler* getVersionRecordHandler(CSRNodeGroupScanSource source) const;
 
 private:
-    common::table_id_t tableID;
-    std::string tableName;
-    MemoryManager* memoryManager;
+    Table& table;
+    MemoryManager* mm;
     ShadowFile* shadowFile;
     bool enableCompression;
     PackedCSRInfo packedCSRInfo;

--- a/src/include/transaction/transaction.h
+++ b/src/include/transaction/transaction.h
@@ -101,7 +101,6 @@ public:
     common::transaction_t getStartTS() const { return startTS; }
     common::transaction_t getCommitTS() const { return commitTS; }
     int64_t getCurrentTS() const { return currentTS; }
-    main::ClientContext* getClientContext() const { return clientContext; }
 
     void setForceCheckpoint() { forceCheckpoint = true; }
     bool shouldAppendToUndoBuffer() const {

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -135,7 +135,7 @@ static void appendNewChunkedGroup(MemoryManager& mm, transaction::Transaction* t
     relTable.pushInsertInfo(transaction, direction, nodeGroup, chunkedGroup.getNumRows(), source);
     if (isNewNodeGroup) {
         auto flushedChunkedGroup =
-            chunkedGroup.flushAsNewChunkedNodeGroup(transaction, pageAllocator);
+            chunkedGroup.flushAsNewChunkedNodeGroup(transaction, mm, pageAllocator);
 
         // If there are deleted columns that haven't been vacuumed yet
         // we need to add extra columns to the chunked group

--- a/src/storage/local_storage/local_node_table.cpp
+++ b/src/storage/local_storage/local_node_table.cpp
@@ -26,7 +26,7 @@ std::vector<LogicalType> LocalNodeTable::getNodeTableColumnTypes(
 LocalNodeTable::LocalNodeTable(const catalog::TableCatalogEntry* tableEntry, Table& table,
     MemoryManager& mm)
     : LocalTable{table}, overflowFileHandle(nullptr),
-      nodeGroups{getNodeTableColumnTypes(*tableEntry), false /*enableCompression*/} {
+      nodeGroups{mm, getNodeTableColumnTypes(*tableEntry), false /*enableCompression*/} {
     initLocalHashIndex(mm);
     startOffset = table.getNumTotalRows(nullptr /* transaction */);
 }
@@ -70,7 +70,7 @@ bool LocalNodeTable::insert(Transaction* transaction, TableInsertState& insertSt
     const auto nodeIDPos =
         nodeInsertState.nodeIDVector.state->getSelVector().getSelectedPositions()[0];
     nodeInsertState.nodeIDVector.setValue(nodeIDPos, internalID_t{nodeOffset, table.getTableID()});
-    nodeGroups.append(transaction, insertState.propertyVectors);
+    nodeGroups.append(&DUMMY_TRANSACTION, insertState.propertyVectors);
     return true;
 }
 
@@ -104,8 +104,8 @@ bool LocalNodeTable::delete_(Transaction* transaction, TableDeleteState& deleteS
     return nodeGroup->delete_(transaction, rowIdxInGroup);
 }
 
-bool LocalNodeTable::addColumn(Transaction* transaction, TableAddColumnState& addColumnState) {
-    nodeGroups.addColumn(transaction, addColumnState);
+bool LocalNodeTable::addColumn(TableAddColumnState& addColumnState) {
+    nodeGroups.addColumn(addColumnState);
     return true;
 }
 

--- a/src/storage/local_storage/local_storage.cpp
+++ b/src/storage/local_storage/local_storage.cpp
@@ -18,18 +18,18 @@ LocalTable* LocalStorage::getOrCreateLocalTable(Table& table) {
     const auto tableID = table.getTableID();
     auto catalog = clientContext.getCatalog();
     auto transaction = clientContext.getTransaction();
+    auto& mm = *clientContext.getMemoryManager();
     if (!tables.contains(tableID)) {
         switch (table.getTableType()) {
         case TableType::NODE: {
             auto tableEntry = catalog->getTableCatalogEntry(transaction, table.getTableID());
-            tables[tableID] = std::make_unique<LocalNodeTable>(tableEntry, table,
-                *clientContext.getMemoryManager());
+            tables[tableID] = std::make_unique<LocalNodeTable>(tableEntry, table, mm);
         } break;
         case TableType::REL: {
             // We have to fetch the rel group entry from the catalog to based on the relGroupID.
             auto tableEntry =
                 catalog->getTableCatalogEntry(transaction, table.cast<RelTable>().getRelGroupID());
-            tables[tableID] = std::make_unique<LocalRelTable>(tableEntry, table);
+            tables[tableID] = std::make_unique<LocalRelTable>(tableEntry, table, mm);
         } break;
         default:
             KU_UNREACHABLE;

--- a/src/storage/table/chunked_node_group.cpp
+++ b/src/storage/table/chunked_node_group.cpp
@@ -2,7 +2,6 @@
 
 #include "common/assert.h"
 #include "common/types/types.h"
-#include "main/client_context.h"
 #include "storage/buffer_manager/buffer_manager.h"
 #include "storage/buffer_manager/memory_manager.h"
 #include "storage/buffer_manager/spiller.h"

--- a/src/storage/table/chunked_node_group.cpp
+++ b/src/storage/table/chunked_node_group.cpp
@@ -368,13 +368,11 @@ bool ChunkedNodeGroup::delete_(const Transaction* transaction, row_idx_t rowIdxI
     return versionInfo->delete_(transaction->getID(), rowIdxInChunk);
 }
 
-void ChunkedNodeGroup::addColumn(const Transaction* transaction,
-    const TableAddColumnState& addColumnState, bool enableCompression, PageAllocator* pageAllocator,
-    ColumnStats* newColumnStats) {
+void ChunkedNodeGroup::addColumn(MemoryManager& mm, const TableAddColumnState& addColumnState,
+    bool enableCompression, PageAllocator* pageAllocator, ColumnStats* newColumnStats) {
     auto& dataType = addColumnState.propertyDefinition.getType();
-    chunks.push_back(
-        std::make_unique<ColumnChunk>(*transaction->getClientContext()->getMemoryManager(),
-            dataType.copy(), capacity, enableCompression, ResidencyState::IN_MEMORY));
+    chunks.push_back(std::make_unique<ColumnChunk>(mm, dataType.copy(), capacity, enableCompression,
+        ResidencyState::IN_MEMORY));
     auto& chunkData = chunks.back()->getData();
     auto numExistingRows = getNumRows();
     chunkData.populateWithDefaultVal(addColumnState.defaultEvaluator, numExistingRows,
@@ -419,11 +417,12 @@ void ChunkedNodeGroup::finalize() const {
 }
 
 std::unique_ptr<ChunkedNodeGroup> ChunkedNodeGroup::flushAsNewChunkedNodeGroup(
-    Transaction* transaction, PageAllocator& pageAllocator) const {
+    Transaction* transaction, MemoryManager& mm, PageAllocator& pageAllocator) const {
     std::vector<std::unique_ptr<ColumnChunk>> flushedChunks(getNumColumns());
     for (auto i = 0u; i < getNumColumns(); i++) {
-        flushedChunks[i] = std::make_unique<ColumnChunk>(getColumnChunk(i).isCompressionEnabled(),
-            Column::flushChunkData(getColumnChunk(i).getData(), pageAllocator));
+        flushedChunks[i] =
+            std::make_unique<ColumnChunk>(mm, getColumnChunk(i).isCompressionEnabled(),
+                Column::flushChunkData(getColumnChunk(i).getData(), pageAllocator));
     }
     auto flushedChunkedGroup =
         std::make_unique<ChunkedNodeGroup>(std::move(flushedChunks), 0 /*startRowIdx*/);

--- a/src/storage/table/column_chunk.cpp
+++ b/src/storage/table/column_chunk.cpp
@@ -5,7 +5,6 @@
 #include "common/serializer/deserializer.h"
 #include "common/serializer/serializer.h"
 #include "common/vector/value_vector.h"
-#include "main/client_context.h"
 #include "storage/storage_utils.h"
 #include "storage/table/column.h"
 #include "transaction/transaction.h"

--- a/src/storage/table/csr_chunked_node_group.cpp
+++ b/src/storage/table/csr_chunked_node_group.cpp
@@ -41,13 +41,13 @@ CSRRegion CSRRegion::upgradeLevel(const std::vector<CSRRegion>& leafRegions,
     const idx_t leftLeafRegionIdx = newRegion.getLeftLeafRegionIdx();
     const idx_t rightLeafRegionIdx = newRegion.getRightLeafRegionIdx();
     for (auto leafRegionIdx = leftLeafRegionIdx; leafRegionIdx <= rightLeafRegionIdx;
-        leafRegionIdx++) {
+         leafRegionIdx++) {
         KU_ASSERT(leafRegionIdx < leafRegions.size());
         newRegion.sizeChange += leafRegions[leafRegionIdx].sizeChange;
         newRegion.hasPersistentDeletions |= leafRegions[leafRegionIdx].hasPersistentDeletions;
         newRegion.hasInsertions |= leafRegions[leafRegionIdx].hasInsertions;
         for (auto columnID = 0u; columnID < leafRegions[leafRegionIdx].hasUpdates.size();
-            columnID++) {
+             columnID++) {
             newRegion.hasUpdates[columnID] =
                 static_cast<bool>(newRegion.hasUpdates[columnID]) ||
                 static_cast<bool>(leafRegions[leafRegionIdx].hasUpdates[columnID]);

--- a/src/storage/table/csr_node_group.cpp
+++ b/src/storage/table/csr_node_group.cpp
@@ -620,7 +620,7 @@ ChunkCheckpointState CSRNodeGroup::checkpointColumnInRegion(const UniqLock& lock
     dummyChunkForNulls->getData().resetToAllNull();
     // Copy per csr list from old chunk and merge with new insertions into the newChunkData.
     for (auto nodeOffset = region.leftNodeOffset; nodeOffset <= region.rightNodeOffset;
-        nodeOffset++) {
+         nodeOffset++) {
         const auto oldCSRLength = csrState.oldHeader->getCSRLength(nodeOffset);
         KU_ASSERT(csrState.oldHeader->getStartCSROffset(nodeOffset) >= leftCSROffset);
         const auto oldStartRow = csrState.oldHeader->getStartCSROffset(nodeOffset) - leftCSROffset;
@@ -707,7 +707,7 @@ void CSRNodeGroup::collectInMemRegionChangesAndUpdateHeaderLength(const UniqLock
     row_idx_t numInsertionsInRegion = 0u;
     if (csrIndex) {
         for (auto nodeOffset = region.leftNodeOffset; nodeOffset <= region.rightNodeOffset;
-            nodeOffset++) {
+             nodeOffset++) {
             auto rows = csrIndex->indices[nodeOffset].getRows();
             row_idx_t numInsertedRows = rows.size();
             row_idx_t numInMemDeletionsInCSR = 0;
@@ -740,7 +740,7 @@ void CSRNodeGroup::collectOnDiskRegionChangesAndUpdateHeaderLength(const UniqLoc
     int64_t numDeletionsInRegion = 0u;
     if (persistentChunkGroup) {
         for (auto nodeOffset = region.leftNodeOffset; nodeOffset <= region.rightNodeOffset;
-            nodeOffset++) {
+             nodeOffset++) {
             const auto numDeletedRows =
                 getNumDeletionsForNodeInPersistentData(nodeOffset, csrState);
             if (numDeletedRows == 0) {

--- a/src/storage/table/csr_node_group.cpp
+++ b/src/storage/table/csr_node_group.cpp
@@ -138,7 +138,7 @@ NodeGroupScanResult CSRNodeGroup::scan(const Transaction* transaction,
         switch (nodeGroupScanState.source) {
         case CSRNodeGroupScanSource::COMMITTED_PERSISTENT: {
             auto result = scanCommittedPersistent(transaction, relScanState, nodeGroupScanState);
-            if (result == NODE_GROUP_SCAN_EMMPTY_RESULT && csrIndex) {
+            if (result == NODE_GROUP_SCAN_EMPTY_RESULT && csrIndex) {
                 initScanForCommittedInMem(relScanState, nodeGroupScanState);
                 continue;
             }
@@ -147,15 +147,15 @@ NodeGroupScanResult CSRNodeGroup::scan(const Transaction* transaction,
         case CSRNodeGroupScanSource::COMMITTED_IN_MEMORY: {
             relScanState.resetOutVectors();
             const auto result = scanCommittedInMem(transaction, relScanState, nodeGroupScanState);
-            if (result == NODE_GROUP_SCAN_EMMPTY_RESULT) {
+            if (result == NODE_GROUP_SCAN_EMPTY_RESULT) {
                 relScanState.outState->getSelVectorUnsafe().setSelSize(0);
-                return NODE_GROUP_SCAN_EMMPTY_RESULT;
+                return NODE_GROUP_SCAN_EMPTY_RESULT;
             }
             return result;
         }
         case CSRNodeGroupScanSource::NONE: {
             relScanState.outState->getSelVectorUnsafe().setSelSize(0);
-            return NODE_GROUP_SCAN_EMMPTY_RESULT;
+            return NODE_GROUP_SCAN_EMPTY_RESULT;
         }
         default: {
             KU_UNREACHABLE;
@@ -185,7 +185,7 @@ NodeGroupScanResult CSRNodeGroup::scanCommittedPersistentWithCache(const Transac
         }
         if (nodeGroupScanState.nextRowToScan == nodeGroupScanState.numTotalRows ||
             tableState.currBoundNodeIdx >= tableState.cachedBoundNodeSelVector.getSelSize()) {
-            return NODE_GROUP_SCAN_EMMPTY_RESULT;
+            return NODE_GROUP_SCAN_EMPTY_RESULT;
         }
         const auto currNodeOffset = tableState.nodeIDVector->readNodeOffset(
             tableState.cachedBoundNodeSelVector[tableState.currBoundNodeIdx]);
@@ -223,7 +223,7 @@ NodeGroupScanResult CSRNodeGroup::scanCommittedPersistentWithoutCache(
     const auto offsetInGroup = currNodeOffset % StorageConfig::NODE_GROUP_SIZE;
     const auto csrListLength = nodeGroupScanState.header->getCSRLength(offsetInGroup);
     if (nodeGroupScanState.nextRowToScan == csrListLength) {
-        return NODE_GROUP_SCAN_EMMPTY_RESULT;
+        return NODE_GROUP_SCAN_EMPTY_RESULT;
     }
     const auto startRow = nodeGroupScanState.header->getStartCSROffset(offsetInGroup) +
                           nodeGroupScanState.nextRowToScan;
@@ -240,7 +240,7 @@ NodeGroupScanResult CSRNodeGroup::scanCommittedInMem(const Transaction* transact
     RelTableScanState& tableState, CSRNodeGroupScanState& nodeGroupScanState) const {
     while (true) {
         if (tableState.currBoundNodeIdx >= tableState.cachedBoundNodeSelVector.getSelSize()) {
-            return NODE_GROUP_SCAN_EMMPTY_RESULT;
+            return NODE_GROUP_SCAN_EMPTY_RESULT;
         }
         if (nodeGroupScanState.inMemCSRList.rowIndices.empty()) {
             const auto boundNodePos =
@@ -257,7 +257,7 @@ NodeGroupScanResult CSRNodeGroup::scanCommittedInMem(const Transaction* transact
             nodeGroupScanState.inMemCSRList.isSequential ?
                 scanCommittedInMemSequential(transaction, tableState, nodeGroupScanState) :
                 scanCommittedInMemRandom(transaction, tableState, nodeGroupScanState);
-        if (scanResult == NODE_GROUP_SCAN_EMMPTY_RESULT) {
+        if (scanResult == NODE_GROUP_SCAN_EMPTY_RESULT) {
             tableState.currBoundNodeIdx++;
             nodeGroupScanState.nextRowToScan = 0;
             nodeGroupScanState.inMemCSRList.clear();
@@ -280,7 +280,7 @@ NodeGroupScanResult CSRNodeGroup::scanCommittedInMemSequential(const Transaction
         StorageUtils::getQuotientRemainder(startRow, StorageConfig::CHUNKED_NODE_GROUP_CAPACITY);
     numRows = std::min(numRows, StorageConfig::CHUNKED_NODE_GROUP_CAPACITY - startRowInChunk);
     if (numRows == 0) {
-        return NODE_GROUP_SCAN_EMMPTY_RESULT;
+        return NODE_GROUP_SCAN_EMPTY_RESULT;
     }
     const ChunkedNodeGroup* chunkedGroup = nullptr;
     {
@@ -298,7 +298,7 @@ NodeGroupScanResult CSRNodeGroup::scanCommittedInMemRandom(const Transaction* tr
                                       nodeGroupScanState.nextRowToScan,
         DEFAULT_VECTOR_CAPACITY);
     if (numRows == 0) {
-        return NODE_GROUP_SCAN_EMMPTY_RESULT;
+        return NODE_GROUP_SCAN_EMPTY_RESULT;
     }
     row_idx_t nextRow = 0;
     ChunkedNodeGroup* chunkedGroup = nullptr;
@@ -435,13 +435,13 @@ bool CSRNodeGroup::delete_(const Transaction* transaction, CSRNodeGroupScanSourc
     }
 }
 
-void CSRNodeGroup::addColumn(Transaction* transaction, TableAddColumnState& addColumnState,
-    PageAllocator* pageAllocator, ColumnStats* newColumnStats) {
+void CSRNodeGroup::addColumn(TableAddColumnState& addColumnState, PageAllocator* pageAllocator,
+    ColumnStats* newColumnStats) {
     if (persistentChunkGroup) {
-        persistentChunkGroup->addColumn(transaction, addColumnState, enableCompression,
-            pageAllocator, newColumnStats);
+        persistentChunkGroup->addColumn(mm, addColumnState, enableCompression, pageAllocator,
+            newColumnStats);
     }
-    NodeGroup::addColumn(transaction, addColumnState, pageAllocator, newColumnStats);
+    NodeGroup::addColumn(addColumnState, pageAllocator, newColumnStats);
 }
 
 void CSRNodeGroup::serialize(Serializer& serializer) {
@@ -620,7 +620,7 @@ ChunkCheckpointState CSRNodeGroup::checkpointColumnInRegion(const UniqLock& lock
     dummyChunkForNulls->getData().resetToAllNull();
     // Copy per csr list from old chunk and merge with new insertions into the newChunkData.
     for (auto nodeOffset = region.leftNodeOffset; nodeOffset <= region.rightNodeOffset;
-         nodeOffset++) {
+        nodeOffset++) {
         const auto oldCSRLength = csrState.oldHeader->getCSRLength(nodeOffset);
         KU_ASSERT(csrState.oldHeader->getStartCSROffset(nodeOffset) >= leftCSROffset);
         const auto oldStartRow = csrState.oldHeader->getStartCSROffset(nodeOffset) - leftCSROffset;
@@ -707,7 +707,7 @@ void CSRNodeGroup::collectInMemRegionChangesAndUpdateHeaderLength(const UniqLock
     row_idx_t numInsertionsInRegion = 0u;
     if (csrIndex) {
         for (auto nodeOffset = region.leftNodeOffset; nodeOffset <= region.rightNodeOffset;
-             nodeOffset++) {
+            nodeOffset++) {
             auto rows = csrIndex->indices[nodeOffset].getRows();
             row_idx_t numInsertedRows = rows.size();
             row_idx_t numInMemDeletionsInCSR = 0;
@@ -740,7 +740,7 @@ void CSRNodeGroup::collectOnDiskRegionChangesAndUpdateHeaderLength(const UniqLoc
     int64_t numDeletionsInRegion = 0u;
     if (persistentChunkGroup) {
         for (auto nodeOffset = region.leftNodeOffset; nodeOffset <= region.rightNodeOffset;
-             nodeOffset++) {
+            nodeOffset++) {
             const auto numDeletedRows =
                 getNumDeletionsForNodeInPersistentData(nodeOffset, csrState);
             if (numDeletedRows == 0) {

--- a/src/storage/table/node_group.cpp
+++ b/src/storage/table/node_group.cpp
@@ -3,7 +3,6 @@
 #include "common/assert.h"
 #include "common/types/types.h"
 #include "common/uniq_lock.h"
-#include "main/client_context.h"
 #include "storage/buffer_manager/memory_manager.h"
 #include "storage/enums/residency_state.h"
 #include "storage/storage_utils.h"

--- a/src/storage/table/node_group.cpp
+++ b/src/storage/table/node_group.cpp
@@ -36,7 +36,6 @@ row_idx_t NodeGroup::append(const Transaction* transaction,
     row_idx_t startRowIdx, row_idx_t numRowsToAppend) {
     const auto lock = chunkedGroups.lock();
     const auto numRowsBeforeAppend = getNumRows();
-    auto& mm = *transaction->getClientContext()->getMemoryManager();
     if (chunkedGroups.isEmpty(lock)) {
         chunkedGroups.appendGroup(lock,
             std::make_unique<ChunkedNodeGroup>(mm, dataTypes, enableCompression,
@@ -69,7 +68,6 @@ void NodeGroup::append(const Transaction* transaction, const std::vector<ValueVe
     const row_idx_t startRowIdx, const row_idx_t numRowsToAppend) {
     const auto lock = chunkedGroups.lock();
     const auto numRowsBeforeAppend = getNumRows();
-    auto& mm = *transaction->getClientContext()->getMemoryManager();
     if (chunkedGroups.isEmpty(lock)) {
         chunkedGroups.appendGroup(lock,
             std::make_unique<ChunkedNodeGroup>(mm, dataTypes, enableCompression,
@@ -88,7 +86,7 @@ void NodeGroup::append(const Transaction* transaction, const std::vector<ValueVe
         lastChunkedGroup = chunkedGroups.getLastGroup(lock);
         const auto numRowsToAppendInGroup = std::min(numRowsToAppend - numRowsAppended,
             StorageConfig::CHUNKED_NODE_GROUP_CAPACITY - lastChunkedGroup->getNumRows());
-        lastChunkedGroup->append(&DUMMY_TRANSACTION, vectors, startRowIdx + numRowsAppended,
+        lastChunkedGroup->append(transaction, vectors, startRowIdx + numRowsAppended,
             numRowsToAppendInGroup);
         numRowsAppended += numRowsToAppendInGroup;
     }
@@ -179,7 +177,7 @@ NodeGroupScanResult NodeGroup::scan(const Transaction* transaction, TableScanSta
         chunkedGroup->getNumRows() + chunkedGroup->getStartRowIdx()) {
         nodeGroupScanState.chunkedGroupIdx++;
         if (nodeGroupScanState.chunkedGroupIdx >= chunkedGroups.getNumGroups(lock)) {
-            return NODE_GROUP_SCAN_EMMPTY_RESULT;
+            return NODE_GROUP_SCAN_EMPTY_RESULT;
         }
         ChunkedNodeGroup* currentChunkedGroup =
             chunkedGroups.getGroup(lock, nodeGroupScanState.chunkedGroupIdx);
@@ -351,12 +349,12 @@ bool NodeGroup::hasDeletions(const Transaction* transaction) const {
     return false;
 }
 
-void NodeGroup::addColumn(Transaction* transaction, TableAddColumnState& addColumnState,
-    PageAllocator* pageAllocator, ColumnStats* newColumnStats) {
+void NodeGroup::addColumn(TableAddColumnState& addColumnState, PageAllocator* pageAllocator,
+    ColumnStats* newColumnStats) {
     dataTypes.push_back(addColumnState.propertyDefinition.getType().copy());
     const auto lock = chunkedGroups.lock();
     for (auto& chunkedGroup : chunkedGroups.getAllGroups(lock)) {
-        chunkedGroup->addColumn(transaction, addColumnState, enableCompression, pageAllocator,
+        chunkedGroup->addColumn(mm, addColumnState, enableCompression, pageAllocator,
             newColumnStats);
     }
 }
@@ -527,7 +525,7 @@ void NodeGroup::serialize(Serializer& serializer) {
     }
 }
 
-std::unique_ptr<NodeGroup> NodeGroup::deserialize(MemoryManager& memoryManager, Deserializer& deSer,
+std::unique_ptr<NodeGroup> NodeGroup::deserialize(MemoryManager& mm, Deserializer& deSer,
     const std::vector<LogicalType>& columnTypes) {
     std::string key;
     node_group_idx_t nodeGroupIdx = INVALID_NODE_GROUP_IDX;
@@ -549,21 +547,21 @@ std::unique_ptr<NodeGroup> NodeGroup::deserialize(MemoryManager& memoryManager, 
     switch (format) {
     case NodeGroupDataFormat::REGULAR: {
         if (hasCheckpointedData) {
-            chunkedNodeGroup = ChunkedNodeGroup::deserialize(memoryManager, deSer);
+            chunkedNodeGroup = ChunkedNodeGroup::deserialize(mm, deSer);
         } else {
-            chunkedNodeGroup = std::make_unique<ChunkedNodeGroup>(memoryManager, columnTypes,
+            chunkedNodeGroup = std::make_unique<ChunkedNodeGroup>(mm, columnTypes,
                 enableCompression, 0, 0, ResidencyState::IN_MEMORY);
         }
-        return std::make_unique<NodeGroup>(nodeGroupIdx, enableCompression,
+        return std::make_unique<NodeGroup>(mm, nodeGroupIdx, enableCompression,
             std::move(chunkedNodeGroup));
     }
     case NodeGroupDataFormat::CSR: {
         if (hasCheckpointedData) {
-            chunkedNodeGroup = ChunkedCSRNodeGroup::deserialize(memoryManager, deSer);
-            return std::make_unique<CSRNodeGroup>(nodeGroupIdx, enableCompression,
+            chunkedNodeGroup = ChunkedCSRNodeGroup::deserialize(mm, deSer);
+            return std::make_unique<CSRNodeGroup>(mm, nodeGroupIdx, enableCompression,
                 std::move(chunkedNodeGroup));
         } else {
-            return std::make_unique<CSRNodeGroup>(nodeGroupIdx, enableCompression,
+            return std::make_unique<CSRNodeGroup>(mm, nodeGroupIdx, enableCompression,
                 copyVector(columnTypes));
         }
     }

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -572,7 +572,7 @@ void NodeTable::commit(main::ClientContext* context, TableCatalogEntry* tableEnt
     // 2. Set deleted flag for tuples that are deleted in local storage.
     row_idx_t numLocalRows = 0u;
     for (auto localNodeGroupIdx = 0u; localNodeGroupIdx < localNodeTable.getNumNodeGroups();
-        localNodeGroupIdx++) {
+         localNodeGroupIdx++) {
         const auto localNodeGroup = localNodeTable.getNodeGroup(localNodeGroupIdx);
         if (localNodeGroup->hasDeletions(transaction)) {
             // TODO(Guodong): Assume local storage is small here. Should optimize the loop away by
@@ -722,7 +722,7 @@ void NodeTable::scanIndexColumns(main::ClientContext* context, IndexScanHelper& 
 
     const auto numNodeGroups = nodeGroups_.getNumNodeGroups();
     for (node_group_idx_t nodeGroupToScan = 0u; nodeGroupToScan < numNodeGroups;
-        ++nodeGroupToScan) {
+         ++nodeGroupToScan) {
         scanState->nodeGroup = nodeGroups_.getNodeGroupNoLock(nodeGroupToScan);
 
         // It is possible for the node group to have no chunked groups if we are rolling back due to

--- a/test/storage/buffer_manager_test.cpp
+++ b/test/storage/buffer_manager_test.cpp
@@ -75,10 +75,10 @@ TEST_F(EmptyBufferManagerTest, TestSpillToDiskMemoryUsage) {
 
     {
         std::vector<std::unique_ptr<ColumnChunk>> chunks;
-        chunks.push_back(std::make_unique<storage::ColumnChunk>(false,
+        chunks.push_back(std::make_unique<ColumnChunk>(*mm, false,
             std::make_unique<ColumnChunkData>(*mm, LogicalType(LogicalTypeID::INT64), 1024, false,
                 ResidencyState::IN_MEMORY, false)));
-        auto chunkedNodeGroup = storage::ChunkedNodeGroup(std::move(chunks), 0);
+        auto chunkedNodeGroup = ChunkedNodeGroup(std::move(chunks), 0);
         chunkedNodeGroup.setUnused(*mm);
         auto memoryWithChunks = bm->getUsedMemory();
         SpillResult memorySpilled{};
@@ -99,10 +99,10 @@ TEST_F(EmptyBufferManagerTest, TestSpillToDiskMemoryUsage) {
     {
         // The memory manager uses the buffer manager for allocations of size TEMP_PAGE_SIZE
         std::vector<std::unique_ptr<ColumnChunk>> chunks;
-        chunks.push_back(std::make_unique<storage::ColumnChunk>(false,
+        chunks.push_back(std::make_unique<ColumnChunk>(*mm, false,
             std::make_unique<ColumnChunkData>(*mm, LogicalType(LogicalTypeID::INT64),
                 TEMP_PAGE_SIZE / sizeof(int64_t), false, ResidencyState::IN_MEMORY, false)));
-        auto chunkedNodeGroup = storage::ChunkedNodeGroup(std::move(chunks), 0);
+        auto chunkedNodeGroup = ChunkedNodeGroup(std::move(chunks), 0);
         chunkedNodeGroup.setUnused(*mm);
         SpillResult memorySpilled{};
         bm->getSpillerOrSkip([&](auto& spiller) {


### PR DESCRIPTION
# Description

We were grabbing clientContext through Transaction for convenience previously, which in the first place is not a good interface design for `Transaction` as the usage of the interface is mainly to grab MemoryManager, and the client context can be nullptr for dummy transactions, which can lead to some potential unsafe function calls.