### PR TITLE
Add scripts to build from source for uv-managed Python

### DIFF
--- a/scripts/README_uv_python.md
+++ b/scripts/README_uv_python.md
@@ -1,0 +1,142 @@
+# Kuzu uv Python Integration
+
+This directory contains scripts for users who wish to use `uv`-managed Python installations for building Kuzu with Python bindings.
+
+## Quick Start
+
+Choose your preferred approach:
+
+1. **Simple script**: `./scripts/uv-make build`
+2. **Shell functions**: Use `source scripts/kuzu_uv_functions.sh` and then `kuzu_build_uv <>`
+3. **Manual**: Set environment variables and run cmake directly
+
+## Problem
+
+By default, pybind11 looks for Python in system locations or pyenv shims, which may not work correctly with `uv`-managed Python installations. This integration automatically detects your current `uv` Python installation and configures cmake accordingly.
+
+## Solutions
+
+### 1. uv-make script (recommended for most users)
+
+```bash
+# Configure and build everything with uv Python
+./scripts/uv-make build
+
+# Build only Python API
+./scripts/uv-make python
+
+# Build and run tests
+./scripts/uv-make pytest
+
+# Configure only (no build)
+./scripts/uv-make configure
+
+# Clean build directory
+./scripts/uv-make clean
+
+# Show help
+./scripts/uv-make help
+
+# Parallel builds (much faster!)
+NUM_THREADS=20 ./scripts/uv-make build
+NUM_THREADS=8 ./scripts/uv-make python
+```
+
+### 2. Shell functions (recommended for regular development)
+
+Add to your `~/.zshrc`:
+```bash
+source /path/to/kuzu/scripts/kuzu_uv_functions.sh
+```
+
+Then use the functions:
+```bash
+# Setup uv Python environment
+kuzu_uv_setup
+
+# Configure cmake with uv Python
+kuzu_cmake_uv build
+
+# Build with uv Python
+kuzu_build_uv build
+
+# Quick Python API build
+kuzu_python_uv build
+```
+
+### 3. Manual environment variables
+
+```bash
+# Get your uv Python path
+UV_PYTHON_PATH=$(uv run which python)
+UV_PYTHON_ROOT=$(dirname "$(dirname "$UV_PYTHON_PATH")")
+
+# Set environment variables
+export PYTHON_EXECUTABLE="$UV_PYTHON_PATH"
+export Python_ROOT_DIR="$UV_PYTHON_ROOT"
+
+# Run cmake
+cmake -B build -S . \
+    -DBUILD_PYTHON=ON \
+    -DPYBIND11_FINDPYTHON=ON \
+    -DPython_ROOT_DIR="$UV_PYTHON_ROOT"
+```
+
+## How it works
+
+1. **Auto-detection**: Scripts use `uv run which python` to find the current uv Python installation
+2. **Path extraction**: Extracts the Python root directory from the executable path
+3. **Environment setup**: Sets `PYTHON_EXECUTABLE` and `Python_ROOT_DIR` environment variables
+4. **Modern pybind11**: Uses `-DPYBIND11_FINDPYTHON=ON` to enable the new FindPython mode
+5. **CMake configuration**: Passes the correct paths to cmake
+
+## Files
+
+- `scripts/uv-make` - Self-contained build script with all common targets
+- `scripts/kuzu_uv_functions.sh` - Shell functions for integration into your shell profile
+
+## Summary
+
+The solution has been consolidated into these two files:
+
+1. `scripts/uv-make` - A comprehensive, self-contained script that handles:
+   - Auto-detection of uv Python installation
+   - CMake configuration with correct paths
+   - Building all targets or just Python API
+   - Running tests
+   - Cleaning build directories
+
+2. `scripts/kuzu_uv_functions.sh` - Shell functions for users who prefer to integrate into their shell profile for persistent availability.
+
+Both approaches automatically detect your current uv Python installation and work with any Python version managed by uv, making them future-proof and requiring no manual updates when you upgrade Python versions.
+
+## Parallel Builds
+
+To speed up builds significantly, you can specify the number of parallel threads:
+
+```bash
+# Use 20 threads for faster builds
+NUM_THREADS=20 ./scripts/uv-make build
+
+# Use 8 threads for Python API build
+NUM_THREADS=8 ./scripts/uv-make python
+
+# With shell functions
+NUM_THREADS=16 kuzu_build_uv build
+```
+
+If `NUM_THREADS` is not set, the scripts will auto-detect the number of CPU cores available on your system.
+
+## Troubleshooting
+
+### "Could not find uv Python installation"
+- Make sure `uv` is installed and in your PATH
+- Ensure you have a Python environment active: `uv python install 3.13`
+
+### "Python config failure"
+- The uv Python installation might be corrupted
+- Try: `uv python install 3.13 --force`
+
+### Build errors
+- Make sure you're using the same Python version for building and running
+- Check that all required Python packages are installed in your uv environment 

--- a/scripts/kuzu_uv_functions.sh
+++ b/scripts/kuzu_uv_functions.sh
@@ -1,0 +1,59 @@
+# Kuzu uv Python integration functions
+# Add this to your ~/.zshrc: source /path/to/kuzu/scripts/kuzu_uv_functions.sh
+
+# Auto-detect and setup uv Python for Kuzu builds
+kuzu_uv_setup() {
+    local uv_python_path=$(uv run which python 2>/dev/null)
+    
+    if [ -z "$uv_python_path" ]; then
+        echo "Error: Could not find uv Python installation"
+        echo "Make sure you have uv installed and a Python environment active"
+        return 1
+    fi
+    
+    local uv_python_root=$(dirname "$(dirname "$uv_python_path")")
+    
+    export PYTHON_EXECUTABLE="$uv_python_path"
+    export Python_ROOT_DIR="$uv_python_root"
+    
+    echo "uv Python environment set up:"
+    echo "  PYTHON_EXECUTABLE=$uv_python_path"
+    echo "  Python_ROOT_DIR=$uv_python_root"
+}
+
+# Configure cmake with uv Python
+kuzu_cmake_uv() {
+    local build_dir="${1:-build}"
+    local extra_flags="${@:2}"
+    
+    # Auto-setup if not already done
+    if [ -z "$PYTHON_EXECUTABLE" ]; then
+        kuzu_uv_setup
+    fi
+    
+    cmake -B "$build_dir" -S . \
+        -DBUILD_PYTHON=ON \
+        -DPYBIND11_FINDPYTHON=ON \
+        -DPython_ROOT_DIR="$Python_ROOT_DIR" \
+        $extra_flags
+    
+    echo "CMake configuration complete. Build directory: $build_dir"
+}
+
+# Build with uv Python
+kuzu_build_uv() {
+    local build_dir="${1:-build}"
+    local num_threads="${NUM_THREADS:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)}"
+    kuzu_cmake_uv "$build_dir"
+    echo "Building with uv Python using $num_threads threads..."
+    make -C "$build_dir" -j "$num_threads"
+}
+
+# Quick Python API build with uv
+kuzu_python_uv() {
+    local build_dir="${1:-build}"
+    local num_threads="${NUM_THREADS:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)}"
+    kuzu_cmake_uv "$build_dir" -DBUILD_SHELL=FALSE
+    echo "Building Python API with uv Python using $num_threads threads..."
+    make -C "$build_dir" _kuzu -j "$num_threads"
+} 

--- a/scripts/uv-make
+++ b/scripts/uv-make
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# UV Python integration for Kuzu builds
+# Auto-detects uv Python installation and configures cmake accordingly
+# Usage: ./scripts/uv-make <target>
+
+set -e
+
+# Auto-detect uv Python installation
+UV_PYTHON_PATH=$(uv run which python 2>/dev/null)
+
+if [ -z "$UV_PYTHON_PATH" ]; then
+    echo "Error: Could not find uv Python installation"
+    echo "Make sure you have uv installed and a Python environment active"
+    echo "Try: uv python install 3.13"
+    exit 1
+fi
+
+# Extract the root directory (remove /bin/python from the path)
+UV_PYTHON_ROOT=$(dirname "$(dirname "$UV_PYTHON_PATH")")
+
+# Function to run cmake with uv Python
+run_cmake() {
+    local build_dir="${1:-build}"
+    local extra_flags="${@:2}"
+    
+    echo "Found uv Python at: $UV_PYTHON_PATH"
+    echo "Python root directory: $UV_PYTHON_ROOT"
+    
+    PYTHON_EXECUTABLE="$UV_PYTHON_PATH" \
+    Python_ROOT_DIR="$UV_PYTHON_ROOT" \
+    cmake -B "$build_dir" -S . \
+        -DBUILD_PYTHON=ON \
+        -DPYBIND11_FINDPYTHON=ON \
+        -DPython_ROOT_DIR="$UV_PYTHON_ROOT" \
+        $extra_flags
+    
+    echo "CMake configuration complete. Build directory: $build_dir"
+}
+
+# Function to build
+run_build() {
+    local build_dir="${1:-build}"
+    local num_threads="${NUM_THREADS:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)}"
+    echo "Building with uv Python using $num_threads threads..."
+    make -C "$build_dir" -j "$num_threads"
+}
+
+case "${1:-help}" in
+    configure)
+        run_cmake "${2:-build}"
+        ;;
+    build)
+        run_cmake "${2:-build}"
+        run_build "${2:-build}"
+        ;;
+    python)
+        run_cmake "${2:-build}" -DBUILD_SHELL=FALSE
+        local num_threads="${NUM_THREADS:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)}"
+        echo "Building Python API with uv Python using $num_threads threads..."
+        make -C "${2:-build}" _kuzu -j "$num_threads"
+        ;;
+    pytest)
+        run_cmake "${2:-build}" -DBUILD_SHELL=FALSE
+        local num_threads="${NUM_THREADS:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)}"
+        echo "Building Python API with uv Python using $num_threads threads..."
+        make -C "${2:-build}" _kuzu -j "$num_threads"
+        echo "Running tests with uv Python..."
+        PYTHONPATH=tools/python_api/build uv run python -m pytest -vv tools/python_api/test
+        ;;
+    clean)
+        rm -rf "${2:-build}"
+        echo "Cleaned build directory: ${2:-build}"
+        ;;
+    help|--help|-h|"")
+        echo "UV Python integration for Kuzu builds"
+        echo "Usage: $0 <target> [build_dir]"
+        echo ""
+        echo "Targets:"
+        echo "  configure    - Configure cmake with auto-detected uv Python"
+        echo "  build        - Configure and build everything with uv Python"
+        echo "  python       - Configure and build only Python API with uv Python"
+        echo "  pytest       - Configure, build Python API, and run tests with uv Python"
+        echo "  clean        - Clean build directory"
+        echo "  help         - Show this help"
+        echo ""
+        echo "Examples:"
+        echo "  $0 build              # Build in 'build' directory"
+        echo "  $0 python build-debug # Build Python API in 'build-debug' directory"
+        echo "  $0 pytest             # Build and test Python API"
+        echo ""
+        echo "Environment variables:"
+        echo "  NUM_THREADS           # Number of parallel build threads (default: auto-detect)"
+        echo ""
+        echo "Examples with parallel builds:"
+        echo "  NUM_THREADS=20 $0 build    # Build with 20 threads"
+        echo "  NUM_THREADS=8 $0 python    # Build Python API with 8 threads"
+        ;;
+    *)
+        echo "Unknown target: $1"
+        echo "Run '$0 help' for usage information"
+        exit 1
+        ;;
+esac 


### PR DESCRIPTION
# Description

This PR adds scripts to allow users to build from source using uv-managed Python rather than system, brew, or pyenv-managed Python. **It's non-intrusive** and does not force users to use uv (it's totally opt-in).

uv has become the defacto standard to manage Python installations and virtual environment for many users, and its most recent release 0.8.0 is a landmark one, because it can [now manage Python installs globally](https://pydevtools.com/blog/uv-0-8-release-automatic-python-installation-to-path/) without conflicting with system Python in any way. It's also orders of magnitude faster to install things in uv than with any other method in Python, for both installing new Python versions, and for downloading packages from PyPI.

The shell scripts provided allow users who choose to use uv to build Python from source (includes a `README.md` to help). Users who prefer doing things the old way don't need to use these scripts.

## How did I test?

I completely uninstalled `pyenv` which I used before to manage global Python (which pybind11 and cmake relied upon). The build process broke, as expected. The system Python installation I have on my mac is far too old to be usable by Kuzu, so the build didn't happen. Then, I ran the scripts included in this PR, and cmake and pybind11 now locate the global uv installation correctly, and the entire build process for Kuzu and Python works seamlessly, end-to-end.

Example commands (includes option for parallel builds):
```bash
# Configure and build everything with uv Python
./scripts/uv-make build

# Build only Python API
./scripts/uv-make python

# Build and run tests
./scripts/uv-make pytest

# Configure only (no build)
./scripts/uv-make configure

# Clean build directory
./scripts/uv-make clean

# Show help
./scripts/uv-make help

# Parallel builds (much faster!)
NUM_THREADS=20 ./scripts/uv-make build
NUM_THREADS=8 ./scripts/uv-make python
```

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
