### PR TITLE
Fix types path in nodes_api package.json

### DIFF
--- a/tools/nodejs_api/package.json
+++ b/tools/nodejs_api/package.json
@@ -4,12 +4,12 @@
   "description": "An in-process property graph database management system built for query speed and scalability.",
   "main": "index.js",
   "module": "./index.mjs",
-  "types": "./index.d.ts",
+  "types": "./kuzu.d.ts",
   "exports":{
     ".":{
       "require": "./index.js",
       "import": "./index.mjs",
-      "types": "./index.d.ts"
+      "types": "./kuzu.d.ts"
     }
   },
   "type": "commonjs",


### PR DESCRIPTION
# Description

`index.d.ts` does not exist but is referenced within package.json, leading to the following error:

```
Could not find a declaration file for module 'kuzu'. '/Users/chrismcc/workspace/lexikon/node_modules/kuzu/index.mjs' implicitly has an 'any' type.
```

<img width="1882" height="298" alt="CleanShot 2025-07-19 at 12 41 43@2x" src="https://github.com/user-attachments/assets/51f90f0b-d2e5-4394-b27e-e4f32329de82" />

It looks like `index.d.ts`  was renamed to `kuzu.d.ts` in #5427 but package.json wasn't updated with the new filename. This PR aligns package.json with the rename in #5427. 

(As an alternative fix, we could just rename the file back to `index.d.ts` - let me know if that would be the preferred path)

Associated docs (issue or PR): https://github.com/kuzudb/kuzu/pull/5427

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
