### PR TITLE
query profiler: segfault trying to profile export database

### DIFF
--- a/src/include/planner/operator/logical_operator.h
+++ b/src/include/planner/operator/logical_operator.h
@@ -135,7 +135,14 @@ public:
 
 protected:
     void createEmptySchema() { schema = std::make_unique<Schema>(); }
-    void copyChildSchema(uint32_t idx) { schema = children[idx]->getSchema()->copy(); }
+    void copyChildSchema(uint32_t idx) { 
+    if (auto childSchema = children[idx]->getSchema()) {
+        schema = childSchema->copy(); 
+    }
+    else {
+        createEmptySchema();
+    }
+}
 
 protected:
     LogicalOperatorType operatorType;

--- a/src/include/planner/operator/logical_operator.h
+++ b/src/include/planner/operator/logical_operator.h
@@ -135,14 +135,7 @@ public:
 
 protected:
     void createEmptySchema() { schema = std::make_unique<Schema>(); }
-    void copyChildSchema(uint32_t idx) { 
-    if (auto childSchema = children[idx]->getSchema()) {
-        schema = childSchema->copy(); 
-    }
-    else {
-        createEmptySchema();
-    }
-}
+    void copyChildSchema(uint32_t idx) { schema = children[idx]->getSchema()->copy(); }
 
 protected:
     LogicalOperatorType operatorType;

--- a/src/planner/operator/logical_explain.cpp
+++ b/src/planner/operator/logical_explain.cpp
@@ -8,7 +8,12 @@ namespace planner {
 void LogicalExplain::computeSchema() {
     switch (explainType) {
     case ExplainType::PROFILE:
-        copyChildSchema(0);
+        if (children[0]->getSchema()) {
+            copyChildSchema(0);
+        }
+        else {
+            createEmptySchema();
+        }
         break;
     case ExplainType::PHYSICAL_PLAN:
     case ExplainType::LOGICAL_PLAN:

--- a/src/planner/operator/logical_explain.cpp
+++ b/src/planner/operator/logical_explain.cpp
@@ -10,8 +10,7 @@ void LogicalExplain::computeSchema() {
     case ExplainType::PROFILE:
         if (children[0]->getSchema()) {
             copyChildSchema(0);
-        }
-        else {
+        } else {
             createEmptySchema();
         }
         break;

--- a/test/test_files/explain/export_explain.test
+++ b/test/test_files/explain/export_explain.test
@@ -1,0 +1,41 @@
+-DATASET CSV EMPTY
+
+--
+
+# Note that the import is used to clean up the exported db
+
+-CASE ExplainEmptyExportSchemaOnly
+-SKIP_WASM
+-SKIP_IN_MEM
+-STATEMENT EXPLAIN EXPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_empty_export_schema_only" (SCHEMA_ONLY=true);
+---- ok
+-IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_empty_export_schema_only"
+
+-CASE ExplainEmptyExport
+-SKIP_WASM
+-SKIP_IN_MEM
+-STATEMENT EXPLAIN EXPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_empty_export"
+---- ok
+-IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_empty_export"
+
+-CASE ExplainExportSchemaOnly
+-SKIP_WASM
+-SKIP_IN_MEM
+-STATEMENT CREATE NODE TABLE `mixed-newlines`(A STRING, B STRING, PRIMARY KEY(A));
+---- ok
+-STATEMENT COPY `mixed-newlines` FROM "${KUZU_ROOT_DIRECTORY}/dataset/csv-multiline-quote-tests/mixed-newlines.csv" (PARALLEL=FALSE);
+---- ok
+-STATEMENT EXPLAIN EXPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_export_schema_only"(SCHEMA_ONLY=true);
+---- ok
+-IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_export_schema_only"
+
+-CASE ExplainExport
+-SKIP_WASM
+-SKIP_IN_MEM
+-STATEMENT CREATE NODE TABLE `mixed-newlines`(A STRING, B STRING, PRIMARY KEY(A));
+---- ok
+-STATEMENT COPY `mixed-newlines` FROM "${KUZU_ROOT_DIRECTORY}/dataset/csv-multiline-quote-tests/mixed-newlines.csv" (PARALLEL=FALSE);
+---- ok
+-STATEMENT EXPLAIN EXPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_export";
+---- ok
+-IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_export";

--- a/test/test_files/explain/export_explain.test
+++ b/test/test_files/explain/export_explain.test
@@ -7,14 +7,14 @@
 -CASE ExplainEmptyExportSchemaOnly
 -SKIP_WASM
 -SKIP_IN_MEM
--STATEMENT EXPLAIN EXPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_empty_export_schema_only" (SCHEMA_ONLY=true);
+-STATEMENT PROFILE EXPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_empty_export_schema_only" (SCHEMA_ONLY=true);
 ---- ok
 -IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_empty_export_schema_only"
 
 -CASE ExplainEmptyExport
 -SKIP_WASM
 -SKIP_IN_MEM
--STATEMENT EXPLAIN EXPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_empty_export"
+-STATEMENT PROFILE EXPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_empty_export"
 ---- ok
 -IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_empty_export"
 
@@ -25,7 +25,7 @@
 ---- ok
 -STATEMENT COPY `mixed-newlines` FROM "${KUZU_ROOT_DIRECTORY}/dataset/csv-multiline-quote-tests/mixed-newlines.csv" (PARALLEL=FALSE);
 ---- ok
--STATEMENT EXPLAIN EXPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_export_schema_only"(SCHEMA_ONLY=true);
+-STATEMENT PROFILE EXPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_export_schema_only"(SCHEMA_ONLY=true);
 ---- ok
 -IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_export_schema_only"
 
@@ -36,6 +36,6 @@
 ---- ok
 -STATEMENT COPY `mixed-newlines` FROM "${KUZU_ROOT_DIRECTORY}/dataset/csv-multiline-quote-tests/mixed-newlines.csv" (PARALLEL=FALSE);
 ---- ok
--STATEMENT EXPLAIN EXPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_export";
+-STATEMENT PROFILE EXPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_export";
 ---- ok
 -IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_special/explain_export";


### PR DESCRIPTION
# Description

There is no nullptr check on the function `copyChildSchema` which is called by `LogicalExplain::computeSchema`.
The segfault in the issue was caused by a nullptr dereference on the `schema` member. This PR creates an empty schema if the child schema is nullptr. This may not be the right fix; we may want to check how this was ever nullptr. Pinging @andyfengHKU to validate. 



Fixes #5802 

- [X] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
