### PR TITLE
Fix LSQB benchmark runs

### DIFF
--- a/benchmark/lsqb/benchmark_runner.py
+++ b/benchmark/lsqb/benchmark_runner.py
@@ -126,7 +126,7 @@ def run_query(conn, query_spec):
 
 
 def run_kuzu(sf, serialized_graph_path, num_threads):
-    db = kuzu.Database(os.path.join(serialized_graph_path, "kuzu.db"))
+    db = kuzu.Database(os.path.join(serialized_graph_path, "db.kuzu"))
     conn = kuzu.Connection(db, num_threads=num_threads)
     if timeout is not None:
         conn.set_query_timeout(timeout)

--- a/benchmark/lsqb/benchmark_runner.py
+++ b/benchmark/lsqb/benchmark_runner.py
@@ -126,7 +126,7 @@ def run_query(conn, query_spec):
 
 
 def run_kuzu(sf, serialized_graph_path, num_threads):
-    db = kuzu.Database(serialized_graph_path)
+    db = kuzu.Database(os.path.join(serialized_graph_path, "kuzu.db"))
     conn = kuzu.Connection(db, num_threads=num_threads)
     if timeout is not None:
         conn.set_query_timeout(timeout)

--- a/benchmark/lsqb/serializer.py
+++ b/benchmark/lsqb/serializer.py
@@ -144,7 +144,7 @@ def serialize(dataset_name, dataset_path, serialized_graph_path):
     shutil.rmtree(serialized_graph_path, ignore_errors=True)
     os.mkdir(serialized_graph_path)
 
-    db = kuzu.Database(os.path.join(serialized_graph_path, "kuzu.db"))
+    db = kuzu.Database(os.path.join(serialized_graph_path, "db.kuzu"))
     conn = kuzu.Connection(db)
     logging.info("Successfully connected")
 

--- a/benchmark/lsqb/serializer.py
+++ b/benchmark/lsqb/serializer.py
@@ -144,7 +144,7 @@ def serialize(dataset_name, dataset_path, serialized_graph_path):
     shutil.rmtree(serialized_graph_path, ignore_errors=True)
     os.mkdir(serialized_graph_path)
 
-    db = kuzu.Database(serialized_graph_path)
+    db = kuzu.Database(os.path.join(serialized_graph_path, "kuzu.db"))
     conn = kuzu.Connection(db)
     logging.info("Successfully connected")
 


### PR DESCRIPTION
# Description

The LSQB benchmark failed due to the change of single file database. Not we need to pass in a file path instead of a directory to construct a Kuzu Database.