### PR TITLE
Clean up unused function

### DIFF
--- a/src/include/storage/disk_array.h
+++ b/src/include/storage/disk_array.h
@@ -359,8 +359,6 @@ public:
     // memory and not on disk (nor on the wal).
     uint8_t* operator[](uint64_t idx) const;
 
-    uint64_t getMemUsage() const { return inMemArrayPages.size() * common::KUZU_PAGE_SIZE; }
-
 private:
     inline uint64_t getNumArrayPagesNeededForElements(uint64_t numElements) const {
         return (numElements + this->storageInfo.numElementsPerPage - 1) /
@@ -404,8 +402,6 @@ public:
     static constexpr uint32_t getAlignedElementSize() {
         return DiskArray<U>::getAlignedElementSize();
     }
-
-    uint64_t getMemUsage() const { return vector.getMemUsage(); }
 
 private:
     BlockVectorInternal vector;

--- a/src/include/storage/index/in_mem_hash_index.h
+++ b/src/include/storage/index/in_mem_hash_index.h
@@ -159,7 +159,6 @@ public:
 
     uint64_t numPrimarySlots() const { return pSlots->size(); }
     uint64_t numOverflowSlots() const { return oSlots->size(); }
-    uint64_t getEstimatedMemUsage() const { return pSlots->getMemUsage() + oSlots->getMemUsage(); }
 
     const HashIndexHeader& getIndexHeader() const { return indexHeader; }
 

--- a/src/include/storage/local_storage/local_hash_index.h
+++ b/src/include/storage/local_storage/local_hash_index.h
@@ -12,7 +12,6 @@ namespace storage {
 class BaseHashIndexLocalStorage {
 public:
     virtual ~BaseHashIndexLocalStorage() = default;
-    virtual uint64_t getEstimatedMemUsage() = 0;
 };
 
 enum class HashIndexLocalLookupState : uint8_t { KEY_FOUND, KEY_DELETED, KEY_NOT_EXIST };
@@ -90,10 +89,6 @@ public:
     void reserveInserts(uint64_t newEntries) { localInsertions.reserve(newEntries); }
 
     const InMemHashIndex<T>& getInsertions() { return localInsertions; }
-
-    uint64_t getEstimatedMemUsage() override {
-        return localInsertions.getEstimatedMemUsage() + localDeletions.size() * sizeof(OwnedType);
-    }
 
 private:
     // When the storage type is string, allow the key type to be string_view with a custom hash
@@ -194,8 +189,6 @@ public:
         common::ku_dynamic_cast<HashIndexLocalStorage<HashIndexType<T>>*>(localIndex.get())
             ->deleteKey(key);
     }
-
-    uint64_t getEstimatedMemUsage() { return localIndex->getEstimatedMemUsage(); }
 
 private:
     common::PhysicalTypeID keyDataTypeID;

--- a/src/include/storage/local_storage/local_node_table.h
+++ b/src/include/storage/local_storage/local_node_table.h
@@ -20,7 +20,6 @@ public:
     bool update(transaction::Transaction* transaction, TableUpdateState& updateState) override;
     bool delete_(transaction::Transaction* transaction, TableDeleteState& deleteState) override;
     bool addColumn(TableAddColumnState& addColumnState) override;
-    uint64_t getEstimatedMemUsage() override;
 
     common::offset_t validateUniquenessConstraint(const transaction::Transaction* transaction,
         const common::ValueVector& pkVector) const;

--- a/src/include/storage/local_storage/local_rel_table.h
+++ b/src/include/storage/local_storage/local_rel_table.h
@@ -40,7 +40,6 @@ public:
     bool update(transaction::Transaction* transaction, TableUpdateState& state) override;
     bool delete_(transaction::Transaction* transaction, TableDeleteState& state) override;
     bool addColumn(TableAddColumnState& addColumnState) override;
-    uint64_t getEstimatedMemUsage() override;
 
     bool checkIfNodeHasRels(common::ValueVector* srcNodeIDVector,
         common::RelDataDirection direction) const;

--- a/src/include/storage/local_storage/local_storage.h
+++ b/src/include/storage/local_storage/local_storage.h
@@ -30,8 +30,6 @@ public:
     void commit();
     void rollback();
 
-    uint64_t getEstimatedMemUsage() const;
-
 private:
     main::ClientContext& clientContext;
     std::unordered_map<common::table_id_t, std::unique_ptr<LocalTable>> tables;

--- a/src/include/storage/local_storage/local_table.h
+++ b/src/include/storage/local_storage/local_table.h
@@ -25,7 +25,6 @@ public:
     virtual bool addColumn(TableAddColumnState& addColumnState) = 0;
     virtual void clear(MemoryManager& mm) = 0;
     virtual common::TableType getTableType() const = 0;
-    virtual uint64_t getEstimatedMemUsage() = 0;
     virtual common::row_idx_t getNumTotalRows() = 0;
 
     template<class TARGET>

--- a/src/include/storage/undo_buffer.h
+++ b/src/include/storage/undo_buffer.h
@@ -93,8 +93,6 @@ public:
     void commit(common::transaction_t commitTS) const;
     void rollback(main::ClientContext* context) const;
 
-    uint64_t getMemUsage() const;
-
 private:
     uint8_t* createUndoRecord(uint64_t size);
 

--- a/src/include/transaction/transaction.h
+++ b/src/include/transaction/transaction.h
@@ -118,7 +118,6 @@ public:
     void commit(storage::WAL* wal);
     void rollback(storage::WAL* wal);
 
-    uint64_t getEstimatedMemUsage() const;
     storage::LocalStorage* getLocalStorage() const { return localStorage.get(); }
     LocalCacheManager& getLocalCacheManager() { return localCacheManager; }
     bool isUnCommitted(common::table_id_t tableID, common::offset_t nodeOffset) const;

--- a/src/storage/local_storage/local_node_table.cpp
+++ b/src/storage/local_storage/local_node_table.cpp
@@ -109,10 +109,6 @@ bool LocalNodeTable::addColumn(TableAddColumnState& addColumnState) {
     return true;
 }
 
-uint64_t LocalNodeTable::getEstimatedMemUsage() {
-    return nodeGroups.getEstimatedMemoryUsage() + hashIndex->getEstimatedMemUsage();
-}
-
 void LocalNodeTable::clear(MemoryManager& mm) {
     auto& nodeTable = ku_dynamic_cast<const NodeTable&>(table);
     hashIndex = std::make_unique<LocalHashIndex>(mm,

--- a/src/storage/local_storage/local_rel_table.cpp
+++ b/src/storage/local_storage/local_rel_table.cpp
@@ -144,18 +144,6 @@ bool LocalRelTable::addColumn(TableAddColumnState& addColumnState) {
     return true;
 }
 
-uint64_t LocalRelTable::getEstimatedMemUsage() {
-    // Estimation of fwdIndex and bwdIndex is rough.
-    if (!localNodeGroup) {
-        return 0;
-    }
-    auto estimatedMemUsage = localNodeGroup->getEstimatedMemoryUsage();
-    for (const auto& directedIndex : directedIndices) {
-        estimatedMemUsage += directedIndex.index.size() * sizeof(offset_t);
-    }
-    return estimatedMemUsage;
-}
-
 bool LocalRelTable::checkIfNodeHasRels(ValueVector* srcNodeIDVector,
     RelDataDirection direction) const {
     KU_ASSERT(srcNodeIDVector->state->isFlat());

--- a/src/storage/local_storage/local_storage.cpp
+++ b/src/storage/local_storage/local_storage.cpp
@@ -93,13 +93,5 @@ void LocalStorage::rollback() {
         bufferManager);
 }
 
-uint64_t LocalStorage::getEstimatedMemUsage() const {
-    uint64_t totalMemUsage = 0;
-    for (const auto& [_, localTable] : tables) {
-        totalMemUsage += localTable->getEstimatedMemUsage();
-    }
-    return totalMemUsage;
-}
-
 } // namespace storage
 } // namespace kuzu

--- a/src/storage/undo_buffer.cpp
+++ b/src/storage/undo_buffer.cpp
@@ -175,14 +175,6 @@ void UndoBuffer::rollback(ClientContext* context) const {
     });
 }
 
-uint64_t UndoBuffer::getMemUsage() const {
-    uint64_t totalMemUsage = 0;
-    for (const auto& buffer : memoryBuffers) {
-        totalMemUsage += buffer.getSize();
-    }
-    return totalMemUsage;
-}
-
 void UndoBuffer::commitRecord(UndoRecordType recordType, const uint8_t* record,
     transaction_t commitTS) {
     switch (recordType) {

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -79,10 +79,6 @@ void Transaction::rollback(storage::WAL*) {
     hasCatalogChanges = false;
 }
 
-uint64_t Transaction::getEstimatedMemUsage() const {
-    return localStorage->getEstimatedMemUsage() + undoBuffer->getMemUsage();
-}
-
 bool Transaction::isUnCommitted(common::table_id_t tableID, common::offset_t nodeOffset) const {
     return localStorage && localStorage->getLocalTable(tableID) &&
            nodeOffset >= getMinUncommittedNodeOffset(tableID);


### PR DESCRIPTION
# Description

Realized that the interface `getEstimatedMemUsage()` is now no longer used after some previous refactoring. This PR removes these functions.