### PR TITLE
fsync() the WAL on open

### DIFF
--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -70,6 +70,9 @@ void WAL::initWriter(main::ClientContext* context) {
     fileInfo = vfs->openFile(walPath,
         FileOpenFlags(FileFlags::CREATE_IF_NOT_EXISTS | FileFlags::READ_ONLY | FileFlags::WRITE),
         context);
+    // A previous unclean exit may have left non-durable contents in the WAL, so make our best
+    // effort at ensuring that we're recovering durable WAL entries.
+    fileInfo->syncFile();
     writer = std::make_shared<BufferedFileWriter>(*fileInfo);
     // WAL should always be APPEND only. We don't want to overwrite the file as it may still
     // contain records not replayed. This can happen if checkpoint is not triggered before the

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -70,9 +70,6 @@ void WAL::initWriter(main::ClientContext* context) {
     fileInfo = vfs->openFile(walPath,
         FileOpenFlags(FileFlags::CREATE_IF_NOT_EXISTS | FileFlags::READ_ONLY | FileFlags::WRITE),
         context);
-    // A previous unclean exit may have left non-durable contents in the WAL, so make our best
-    // effort at ensuring that we're recovering durable WAL entries.
-    fileInfo->syncFile();
     writer = std::make_shared<BufferedFileWriter>(*fileInfo);
     // WAL should always be APPEND only. We don't want to overwrite the file as it may still
     // contain records not replayed. This can happen if checkpoint is not triggered before the

--- a/src/storage/wal/wal_replayer.cpp
+++ b/src/storage/wal/wal_replayer.cpp
@@ -53,6 +53,9 @@ void WALReplayer::replay() const {
         checkpointer.readCheckpoint();
         return;
     }
+    // A previous unclean exit may have left non-durable contents in the WAL, so before we start
+    // replaying the WAL records, make a best-effort attempt at ensuring the WAL is fully durable.
+    fileInfo->syncFile();
     // Start replaying the WAL records.
     try {
         // First, we dry run the replay to find out the offset of the last record that was


### PR DESCRIPTION
# Description

It's generally wise to ensure that whatever set of changes are being recovered from the WAL are actually durable before they're processed. By a strict interpretation of the UNIX spec, the fsync() on open doesn't _have_ to actually do anything, but in practice on Linux and the common ext4/xfs it does, and thus avoids weird crash->recover->power loss, and now storage is now ahead of the WAL sorts of weirdness.

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).

---

I'm mostly just using this as the tiny change to work through the build/test/submit PR process.  I see hints of linter or lcov usage, is there something in the makefile I missed for that?  Is there anything else I should be double checking before submitting PRs? 
