### PR TITLE
Fullfsync on macOS/iOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,23 @@ message(STATUS "KUZU_NODE_GROUP_SIZE_LOG2: ${KUZU_NODE_GROUP_SIZE_LOG2}")
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/templates/system_config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/src/include/common/system_config.h @ONLY)
 
+include(CheckCXXSymbolExists)
+check_cxx_symbol_exists(F_FULLFSYNC "fcntl.h" HAS_FULLFSYNC)
+check_cxx_symbol_exists(fdatasync "unistd.h" HAS_FDATASYNC)
+if(HAS_FULLFSYNC)
+    message(STATUS "✓ F_FULLFSYNC will be used on this platform")
+    add_compile_definitions(HAS_FULLFSYNC)
+else()
+    message(STATUS "✗ F_FULLFSYNC not available")
+endif()
+
+if(HAS_FDATASYNC)
+    message(STATUS "✓ fdatasync will be used on this platform")
+    add_compile_definitions(HAS_FDATASYNC)
+else()
+    message(STATUS "✗ fdatasync not available, using fsync fallback")
+endif()
+
 if(MSVC)
     # Required for M_PI on Windows
     add_compile_definitions(_USE_MATH_DEFINES)

--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -133,7 +133,7 @@ std::unique_ptr<FileInfo> LocalFileSystem::openFile(const std::string& path, Fil
         throw IOException(stringFormat("Cannot open file {}: {}", fullPath, posixErrMessage()));
     }
     if (flags.lockType != FileLockType::NO_LOCK) {
-        struct flock fl{};
+        struct flock fl {};
         memset(&fl, 0, sizeof fl);
         fl.l_type = flags.lockType == FileLockType::READ_LOCK ? F_RDLCK : F_WRLCK;
         fl.l_whence = SEEK_SET;
@@ -537,7 +537,7 @@ uint64_t LocalFileSystem::getFileSize(const FileInfo& fileInfo) const {
     }
     return size.QuadPart;
 #else
-    struct stat s{};
+    struct stat s {};
     if (fstat(localFileInfo->fd, &s) == -1) {
         throw IOException(stringFormat("Cannot read size of file. path: {} - Error {}: {}",
             fileInfo.path, errno, posixErrMessage()));

--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -133,7 +133,7 @@ std::unique_ptr<FileInfo> LocalFileSystem::openFile(const std::string& path, Fil
         throw IOException(stringFormat("Cannot open file {}: {}", fullPath, posixErrMessage()));
     }
     if (flags.lockType != FileLockType::NO_LOCK) {
-        struct flock fl {};
+        struct flock fl{};
         memset(&fl, 0, sizeof fl);
         fl.l_type = flags.lockType == FileLockType::READ_LOCK ? F_RDLCK : F_WRLCK;
         fl.l_whence = SEEK_SET;
@@ -453,7 +453,7 @@ void LocalFileSystem::syncFile(const FileInfo& fileInfo) const {
             std::system_category().message(error)));
     }
 #else
-#if HAS_FULLFSYNC
+#if HAS_FULLFSYNC and defined(__APPLE__)
     // Try F_FULLFSYNC first on macOS/iOS, which is required to guarantee durability past power
     // failures.
     if (fcntl(localFileInfo->fd, F_FULLFSYNC) == 0) {
@@ -537,7 +537,7 @@ uint64_t LocalFileSystem::getFileSize(const FileInfo& fileInfo) const {
     }
     return size.QuadPart;
 #else
-    struct stat s {};
+    struct stat s{};
     if (fstat(localFileInfo->fd, &s) == -1) {
         throw IOException(stringFormat("Cannot read size of file. path: {} - Error {}: {}",
             fileInfo.path, errno, posixErrMessage()));

--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -453,7 +453,7 @@ void LocalFileSystem::syncFile(const FileInfo& fileInfo) const {
             std::system_category().message(error)));
     }
 #else
-#if HAVE_FULLFSYNC
+#if HAS_FULLFSYNC
     // Try F_FULLFSYNC first on macOS/iOS, which is required to guarantee durability past power
     // failures.
     if (fcntl(localFileInfo->fd, F_FULLFSYNC) == 0) {
@@ -470,7 +470,7 @@ void LocalFileSystem::syncFile(const FileInfo& fileInfo) const {
     }
 #endif
     bool syncSuccess = false;
-#if HAVE_FDATASYNC
+#if HAS_FDATASYNC
     syncSuccess = fdatasync(localFileInfo->fd) == 0; // Only sync file data + essential metadata.
 #else
     syncSuccess = fsync(localFileInfo->fd) == 0; // Sync file data + all metadata.

--- a/src/include/storage/wal/wal_replayer.h
+++ b/src/include/storage/wal/wal_replayer.h
@@ -45,6 +45,9 @@ private:
     void removeWALAndShadowFiles() const;
     void removeFileIfExists(const std::string& path) const;
 
+    std::unique_ptr<common::FileInfo> openWALFile() const;
+    void syncWALFile(const common::FileInfo& fileInfo) const;
+
 private:
     main::ClientContext& clientContext;
     std::string walPath;


### PR DESCRIPTION
# Description

`F_FULLFSYNC` is required on MacOS/iOS to guarantee that the drive flushes its cache to disk. Also I added `fdatasync` which should be slightly faster than `fsync` is available to avoid full metadata sync.

For more details, I found this [blog post](https://transactional.blog/how-to-learn/disk-io) a good read.

Also, fixed file flags for `fsync` in WALReplay, and `fsync` should only happen when the database is opened in read-write mode.