### PR TITLE
gds: update logical plan

### DIFF
--- a/extension/algo/src/function/k_core_decomposition.cpp
+++ b/extension/algo/src/function/k_core_decomposition.cpp
@@ -232,7 +232,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     expression_vector columns;
     columns.push_back(nodeOutput->constCast<NodeExpression>().getInternalID());
     columns.push_back(input->binder->createVariable(GROUP_ID_COLUMN_NAME, LogicalType::INT64()));
-    return std::make_unique<GDSBindData>(std::move(columns), std::move(graphEntry), nodeOutput);
+    return std::make_unique<GDSBindData>(std::move(columns), std::move(graphEntry), expression_vector{nodeOutput});
 }
 
 function_set KCoreDecompositionFunction::getFunctionSet() {

--- a/extension/algo/src/function/k_core_decomposition.cpp
+++ b/extension/algo/src/function/k_core_decomposition.cpp
@@ -232,7 +232,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     expression_vector columns;
     columns.push_back(nodeOutput->constCast<NodeExpression>().getInternalID());
     columns.push_back(input->binder->createVariable(GROUP_ID_COLUMN_NAME, LogicalType::INT64()));
-    return std::make_unique<GDSBindData>(std::move(columns), std::move(graphEntry), expression_vector{nodeOutput});
+    return std::make_unique<GDSBindData>(std::move(columns), std::move(graphEntry),
+        expression_vector{nodeOutput});
 }
 
 function_set KCoreDecompositionFunction::getFunctionSet() {

--- a/extension/algo/src/function/louvain.cpp
+++ b/extension/algo/src/function/louvain.cpp
@@ -76,7 +76,7 @@ struct LouvainBindData final : public GDSBindData {
     LouvainBindData(expression_vector columns, graph::NativeGraphEntry graphEntry,
         std::shared_ptr<Expression> nodeOutput,
         std::unique_ptr<LouvainOptionalParams> optionalParams)
-        : GDSBindData{std::move(columns), std::move(graphEntry), std::move(nodeOutput)} {
+        : GDSBindData{std::move(columns), std::move(graphEntry), expression_vector{nodeOutput}} {
         this->optionalParams = std::move(optionalParams);
     }
 

--- a/extension/algo/src/function/page_rank.cpp
+++ b/extension/algo/src/function/page_rank.cpp
@@ -69,7 +69,7 @@ struct PageRankBindData final : public GDSBindData {
     PageRankBindData(expression_vector columns, graph::NativeGraphEntry graphEntry,
         std::shared_ptr<Expression> nodeOutput,
         std::unique_ptr<PageRankOptionalParams> optionalParams)
-        : GDSBindData{std::move(columns), std::move(graphEntry), std::move(nodeOutput)} {
+        : GDSBindData{std::move(columns), std::move(graphEntry), expression_vector{nodeOutput}} {
         this->optionalParams = std::move(optionalParams);
     }
 

--- a/extension/algo/src/function/spanning_forest.cpp
+++ b/extension/algo/src/function/spanning_forest.cpp
@@ -400,19 +400,20 @@ static void getLogicalPlan(Planner* planner, const BoundReadingClause& readingCl
     auto boundNode = relOutput->getSrcNode();
     auto nbrNode = relOutput->getDstNode();
     const auto extendDir = ExtendDirection::FWD;
-    planner->appendScanNodeTable(boundNode->getInternalID(), boundNode->getTableIDs(), {}, scanPlan);
+    planner->appendScanNodeTable(boundNode->getInternalID(), boundNode->getTableIDs(), {},
+        scanPlan);
 
     auto relProperties = planner->getProperties(*relOutput);
 
     // If the query is of the form return... rel.someProperty...
     // then the internal id of the rel will not be added by getProperties and
-    // it must be added. 
-    
+    // it must be added.
+
     // Alternatively, if the query is of the form return... rel...
     // The internal id of the rel will be added by getProperties. We may
     // not add duplicate internal ids to the properties relProperties container.
     bool foundInternalId = false;
-    for(const auto& property : relProperties) {
+    for (const auto& property : relProperties) {
         if (property->getDataType().getLogicalTypeID() == LogicalTypeID::INTERNAL_ID) {
             foundInternalId = true;
             break;
@@ -422,7 +423,9 @@ static void getLogicalPlan(Planner* planner, const BoundReadingClause& readingCl
         relProperties.push_back(relOutput->getInternalID());
     }
 
-    planner->appendExtend(boundNode, nbrNode, std::dynamic_pointer_cast<RelExpression>(bindData->output[2]), extendDir, relProperties, scanPlan);
+    planner->appendExtend(boundNode, nbrNode,
+        std::dynamic_pointer_cast<RelExpression>(bindData->output[2]), extendDir, relProperties,
+        scanPlan);
     planner->appendProjection(relProperties, scanPlan);
     expression_vector joinConditions;
     joinConditions.push_back(relOutput->getInternalID());

--- a/extension/algo/src/function/spanning_forest.cpp
+++ b/extension/algo/src/function/spanning_forest.cpp
@@ -1,4 +1,7 @@
+#include <memory>
 #include "binder/binder.h"
+#include "binder/expression/expression.h"
+#include "binder/query/reading_clause/bound_table_function_call.h"
 #include "common/assert.h"
 #include "common/exception/binder.h"
 #include "common/exception/runtime.h"
@@ -12,15 +15,17 @@
 #include "function/gds/gds.h"
 #include "function/gds/gds_object_manager.h"
 #include "function/table/bind_input.h"
+#include "planner/operator/logical_table_function_call.h"
+#include "planner/planner.h"
 #include "processor/execution_context.h"
 
-using namespace std;
 using namespace kuzu::binder;
 using namespace kuzu::common;
 using namespace kuzu::processor;
 using namespace kuzu::storage;
 using namespace kuzu::graph;
 using namespace kuzu::function;
+using namespace kuzu::planner;
 
 namespace kuzu {
 namespace algo_extension {
@@ -100,8 +105,8 @@ SFOptionalParams::SFOptionalParams(const expression_vector& optionalParams)
 
 struct SFBindData final : public GDSBindData {
     SFBindData(expression_vector columns, graph::NativeGraphEntry graphEntry,
-        std::shared_ptr<Expression> nodeOutput, std::unique_ptr<SFOptionalParams> optionalParams)
-        : GDSBindData{std::move(columns), std::move(graphEntry), std::move(nodeOutput)} {
+        expression_vector output, std::unique_ptr<SFOptionalParams> optionalParams)
+        : GDSBindData{std::move(columns), std::move(graphEntry), output} {
         this->optionalParams = std::move(optionalParams);
     }
 
@@ -341,13 +346,66 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
             std::string(SpanningForest::name) + " only supports operations on one rel table.");
     }
     expression_vector columns;
-    auto nodeOutput = GDSFunction::bindNodeOutput(*input, graphEntry.getNodeEntries(), "SRC");
-    columns.push_back(nodeOutput->constCast<NodeExpression>().getInternalID());
-    columns.push_back(input->binder->createVariable("DST", LogicalType::INTERNAL_ID()));
-    columns.push_back(input->binder->createVariable("REL", LogicalType::INTERNAL_ID()));
+    auto srcOutput = GDSFunction::bindNodeOutput(*input, graphEntry.getNodeEntries(), "SRC", 0);
+    auto dstOutput = GDSFunction::bindNodeOutput(*input, graphEntry.getNodeEntries(), "DST", 1);
+    auto relOutput = GDSFunction::bindRelOutput(*input, graphEntry.getRelEntries(), std::dynamic_pointer_cast<NodeExpression>(srcOutput), std::dynamic_pointer_cast<NodeExpression>(dstOutput), "REL", 2);
+    columns.push_back(srcOutput->constCast<NodeExpression>().getInternalID());
+    columns.push_back(dstOutput->constCast<NodeExpression>().getInternalID());
+    columns.push_back(relOutput->constCast<RelExpression>().getInternalID());
     columns.push_back(input->binder->createVariable("FOREST_ID", LogicalType::UINT64()));
-    return std::make_unique<SFBindData>(std::move(columns), std::move(graphEntry), nodeOutput,
+    return std::make_unique<SFBindData>(std::move(columns), std::move(graphEntry), expression_vector{srcOutput, dstOutput, relOutput},
         std::make_unique<SFOptionalParams>(input->optionalParamsLegacy));
+}
+
+static void getLogicalPlan(Planner* planner, const BoundReadingClause& readingClause,
+    expression_vector predicates, LogicalPlan& plan) {
+    auto& call = readingClause.constCast<BoundTableFunctionCall>();
+    auto bindData = call.getBindData()->constPtrCast<GDSBindData>();
+    auto op = std::make_shared<LogicalTableFunctionCall>(call.getTableFunc(), bindData->copy());
+    
+    std::vector<std::shared_ptr<LogicalOperator>> nodeMaskPlanRoots;
+    for (auto& nodeInfo : bindData->graphEntry.nodeInfos) {
+        if (nodeInfo.predicate == nullptr) {
+            continue;
+        }
+        auto& node = nodeInfo.nodeOrRel->constCast<NodeExpression>();
+        planner->getCardinliatyEstimatorUnsafe().init(node);
+        auto p = planner->getNodeSemiMaskPlan(SemiMaskTargetType::GDS_GRAPH_NODE, node,
+            nodeInfo.predicate);
+        nodeMaskPlanRoots.push_back(p.getLastOperator());
+    }
+
+    for (auto root : nodeMaskPlanRoots) {
+        op->addChild(root);
+    }
+    op->computeFactorizedSchema();
+    planner->planReadOp(std::move(op), predicates, plan);
+
+    for(auto i = 0u; i < 2; ++i) {
+        auto nodeOutput  = bindData->output[i]->ptrCast<NodeExpression>();
+        KU_ASSERT(nodeOutput != nullptr);
+        planner->getCardinliatyEstimatorUnsafe().init(*nodeOutput);
+        auto scanPlan = planner->getNodePropertyScanPlan(*nodeOutput);
+        if (!scanPlan.isEmpty()) {
+            expression_vector joinConditions;
+            joinConditions.push_back(nodeOutput->getInternalID());
+            planner->appendHashJoin(joinConditions, JoinType::INNER, plan, scanPlan, plan);
+        }
+    }
+    auto relOutput = bindData->output[2]->ptrCast<RelExpression>();
+    KU_ASSERT(relOutput != nullptr);
+    auto scanPlan = LogicalPlan();
+    auto boundNode = relOutput->getSrcNode();
+     auto nbrNode = relOutput->getDstNode();
+    const auto extendDir = ExtendDirection::FWD;
+    planner->appendScanNodeTable(boundNode->getInternalID(), boundNode->getTableIDs(), {}, scanPlan);
+    auto relProperties = planner->getProperties(*relOutput);
+    planner->appendExtend(boundNode, nbrNode, std::dynamic_pointer_cast<RelExpression>(bindData->output[2]), extendDir, relProperties, scanPlan);
+    relProperties.push_back(relOutput->getInternalID());
+    planner->appendProjection(relProperties, scanPlan);
+    expression_vector joinConditions;
+    joinConditions.push_back(relOutput->getInternalID());
+    planner->appendHashJoin(joinConditions, JoinType::INNER, plan, scanPlan, plan);
 }
 
 function_set SpanningForest::getFunctionSet() {
@@ -358,7 +416,7 @@ function_set SpanningForest::getFunctionSet() {
     func->initSharedStateFunc = GDSFunction::initSharedState;
     func->initLocalStateFunc = TableFunction::initEmptyLocalState;
     func->canParallelFunc = [] { return false; };
-    func->getLogicalPlanFunc = GDSFunction::getLogicalPlan;
+    func->getLogicalPlanFunc = getLogicalPlan;
     func->getPhysicalPlanFunc = GDSFunction::getPhysicalPlan;
     result.push_back(std::move(func));
     return result;

--- a/extension/algo/src/function/spanning_forest.cpp
+++ b/extension/algo/src/function/spanning_forest.cpp
@@ -405,8 +405,9 @@ static void getLogicalPlan(Planner* planner, const BoundReadingClause& readingCl
 
     auto relProperties = planner->getProperties(*relOutput);
 
-    // If the query returns a specific relationship property (e.g., RETURN ... rel.someProperty ...),
-    // getProperties() will not include the relationship's internal ID, so we need to add it manually.
+    // If the query returns a specific relationship property (e.g., RETURN ... rel.someProperty
+    // ...), getProperties() will not include the relationship's internal ID, so we need to add it
+    // manually.
     //
     // If the query returns the whole relationship (e.g., RETURN ... rel ...),
     // getProperties() will include the internal ID automatically.

--- a/extension/algo/src/function/spanning_forest.cpp
+++ b/extension/algo/src/function/spanning_forest.cpp
@@ -405,13 +405,12 @@ static void getLogicalPlan(Planner* planner, const BoundReadingClause& readingCl
 
     auto relProperties = planner->getProperties(*relOutput);
 
-    // If the query is of the form return... rel.someProperty...
-    // then the internal id of the rel will not be added by getProperties and
-    // it must be added.
-
-    // Alternatively, if the query is of the form return... rel...
-    // The internal id of the rel will be added by getProperties. We may
-    // not add duplicate internal ids to the properties relProperties container.
+    // If the query returns a specific relationship property (e.g., RETURN ... rel.someProperty ...),
+    // getProperties() will not include the relationship's internal ID, so we need to add it manually.
+    //
+    // If the query returns the whole relationship (e.g., RETURN ... rel ...),
+    // getProperties() will include the internal ID automatically.
+    // In that case, we must avoid adding it again to relProperties.
     bool foundInternalId = false;
     for (const auto& property : relProperties) {
         if (property->getDataType().getLogicalTypeID() == LogicalTypeID::INTERNAL_ID) {

--- a/extension/algo/src/function/strongly_connected_components.cpp
+++ b/extension/algo/src/function/strongly_connected_components.cpp
@@ -289,8 +289,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     expression_vector columns;
     columns.push_back(nodeOutput->constCast<NodeExpression>().getInternalID());
     columns.push_back(input->binder->createVariable(GROUP_ID_COLUMN_NAME, LogicalType::INT64()));
-    auto bindData =
-        std::make_unique<GDSBindData>(std::move(columns), std::move(graphEntry), expression_vector{nodeOutput});
+    auto bindData = std::make_unique<GDSBindData>(std::move(columns), std::move(graphEntry),
+        expression_vector{nodeOutput});
     bindData->optionalParams =
         std::make_unique<MaxIterationOptionalParams>(input->optionalParamsLegacy);
     return bindData;

--- a/extension/algo/src/function/strongly_connected_components.cpp
+++ b/extension/algo/src/function/strongly_connected_components.cpp
@@ -1,4 +1,5 @@
 #include "binder/binder.h"
+#include "binder/expression/expression.h"
 #include "common/task_system/progress_bar.h"
 #include "function/algo_function.h"
 #include "function/component_ids.h"
@@ -289,7 +290,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     columns.push_back(nodeOutput->constCast<NodeExpression>().getInternalID());
     columns.push_back(input->binder->createVariable(GROUP_ID_COLUMN_NAME, LogicalType::INT64()));
     auto bindData =
-        std::make_unique<GDSBindData>(std::move(columns), std::move(graphEntry), nodeOutput);
+        std::make_unique<GDSBindData>(std::move(columns), std::move(graphEntry), expression_vector{nodeOutput});
     bindData->optionalParams =
         std::make_unique<MaxIterationOptionalParams>(input->optionalParamsLegacy);
     return bindData;

--- a/extension/algo/src/function/strongly_connected_components_kosaraju.cpp
+++ b/extension/algo/src/function/strongly_connected_components_kosaraju.cpp
@@ -256,7 +256,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     auto nodeOutput = GDSFunction::bindNodeOutput(*input, graphEntry.getNodeEntries());
     columns.push_back(nodeOutput->constPtrCast<NodeExpression>()->getInternalID());
     columns.push_back(input->binder->createVariable(GROUP_ID_COLUMN_NAME, LogicalType::INT64()));
-    return std::make_unique<GDSBindData>(std::move(columns), std::move(graphEntry), expression_vector{nodeOutput});
+    return std::make_unique<GDSBindData>(std::move(columns), std::move(graphEntry),
+        expression_vector{nodeOutput});
 }
 
 function_set SCCKosarajuFunction::getFunctionSet() {

--- a/extension/algo/src/function/strongly_connected_components_kosaraju.cpp
+++ b/extension/algo/src/function/strongly_connected_components_kosaraju.cpp
@@ -1,4 +1,5 @@
 #include "binder/binder.h"
+#include "binder/expression/expression.h"
 #include "common/exception/interrupt.h"
 #include "common/exception/runtime.h"
 #include "common/task_system/progress_bar.h"
@@ -255,7 +256,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     auto nodeOutput = GDSFunction::bindNodeOutput(*input, graphEntry.getNodeEntries());
     columns.push_back(nodeOutput->constPtrCast<NodeExpression>()->getInternalID());
     columns.push_back(input->binder->createVariable(GROUP_ID_COLUMN_NAME, LogicalType::INT64()));
-    return std::make_unique<GDSBindData>(std::move(columns), std::move(graphEntry), nodeOutput);
+    return std::make_unique<GDSBindData>(std::move(columns), std::move(graphEntry), expression_vector{nodeOutput});
 }
 
 function_set SCCKosarajuFunction::getFunctionSet() {

--- a/extension/algo/src/function/weakly_connected_components.cpp
+++ b/extension/algo/src/function/weakly_connected_components.cpp
@@ -95,8 +95,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     expression_vector columns;
     columns.push_back(nodeOutput->constCast<NodeExpression>().getInternalID());
     columns.push_back(input->binder->createVariable(GROUP_ID_COLUMN_NAME, LogicalType::INT64()));
-    auto bindData =
-        std::make_unique<GDSBindData>(std::move(columns), std::move(graphEntry), expression_vector{nodeOutput});
+    auto bindData = std::make_unique<GDSBindData>(std::move(columns), std::move(graphEntry),
+        expression_vector{nodeOutput});
     bindData->optionalParams =
         std::make_unique<MaxIterationOptionalParams>(input->optionalParamsLegacy);
     return bindData;

--- a/extension/algo/src/function/weakly_connected_components.cpp
+++ b/extension/algo/src/function/weakly_connected_components.cpp
@@ -96,7 +96,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     columns.push_back(nodeOutput->constCast<NodeExpression>().getInternalID());
     columns.push_back(input->binder->createVariable(GROUP_ID_COLUMN_NAME, LogicalType::INT64()));
     auto bindData =
-        std::make_unique<GDSBindData>(std::move(columns), std::move(graphEntry), nodeOutput);
+        std::make_unique<GDSBindData>(std::move(columns), std::move(graphEntry), expression_vector{nodeOutput});
     bindData->optionalParams =
         std::make_unique<MaxIterationOptionalParams>(input->optionalParamsLegacy);
     return bindData;

--- a/extension/algo/test/test_files/spanning_forest.test
+++ b/extension/algo/test/test_files/spanning_forest.test
@@ -35,10 +35,7 @@
 ---- ok
 
 -STATEMENT CALL SPANNING_FOREST('Graph')
-    YIELD src, dst, rel, forest_id MATCH (n) WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 9
 0|2|6|0
@@ -52,10 +49,7 @@
 8|9|3|0
 
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='weight', variant:='min')
-    YIELD src, dst, rel, forest_id MATCH (n) WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 9
 0|1|5|0
@@ -69,10 +63,7 @@
 8|9|3|0
 
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='weight', variant:='max')
-    YIELD src, dst, rel, forest_id MATCH (n) WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 9
 0|2|6|2
@@ -118,11 +109,7 @@
 ---- ok
 
 -STATEMENT CALL SF('Graph', weight_property:='weight')
-    YIELD src, dst, rel, forest_id
-    MATCH (n) WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 9
 0|1|5|0
@@ -167,12 +154,7 @@
 ---- ok
 
 -STATEMENT CALL SPANNING_FOREST('Graph')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 8
 0|2|6|0
@@ -185,12 +167,7 @@
 8|9|3|5
 
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='weight')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 8
 0|1|5|0
@@ -203,12 +180,7 @@
 8|9|3|5
 
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='weight', variant:='max')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 8
 0|2|6|2
@@ -242,32 +214,17 @@
 ---- ok
 
 -STATEMENT CALL SPANNING_FOREST('Graph')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 0
 
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='weight', variant:='min')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 0
 
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='weight', variant:='max')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 0
 
@@ -311,12 +268,7 @@
 ---- ok
 
 -STATEMENT CALL SPANNING_FOREST('Graph')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 9
 0|2|8|0
@@ -330,12 +282,7 @@
 8|9|3|0
 
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='weight', variant:='min')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 9
 0|1|5|0
@@ -349,12 +296,7 @@
 8|9|3|0
 
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='weight', variant:='max')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 9
 0|2|8|3
@@ -411,12 +353,7 @@
 ---- ok
 
 -STATEMENT CALL SPANNING_FOREST('Graph')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 9
 0|2|8|0
@@ -430,12 +367,7 @@
 8|9|3|0
 
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='weight', variant:='min')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 9
 0|1|5|0
@@ -449,12 +381,7 @@
 8|9|3|0
 
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='weight', variant:='max')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 9
 0|2|8|3
@@ -477,12 +404,7 @@
 -STATEMENT CALL PROJECT_GRAPH('Graph', ['Node'], ['Edge']);
 ---- ok
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='weight')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- error
 Runtime exception: Provided weight property is not numerical: weight
@@ -497,12 +419,7 @@ Runtime exception: Provided weight property is not numerical: weight
 -STATEMENT CALL PROJECT_GRAPH('Graph', ['Node'], ['Edge']);
 ---- ok
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='height')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- error
 Runtime exception: Cannot find property: height
@@ -519,12 +436,7 @@ Runtime exception: Cannot find property: height
 -STATEMENT CALL PROJECT_GRAPH('Graph', ['Node', 'Node2'], ['Edge']);
 ---- ok
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='height')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- error
 Binder exception: SPANNING_FOREST only supports operations on one node table.
@@ -541,12 +453,7 @@ Binder exception: SPANNING_FOREST only supports operations on one node table.
 -STATEMENT CALL PROJECT_GRAPH('Graph', ['Node'], ['Edge', 'Edge2']);
 ---- ok
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='height')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- error
 Binder exception: SPANNING_FOREST only supports operations on one rel table.
@@ -561,12 +468,7 @@ Binder exception: SPANNING_FOREST only supports operations on one rel table.
 -STATEMENT CALL PROJECT_GRAPH('Graph', ['Node'], ['Edge']);
 ---- ok
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='height', variant:='medium')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- error
 Binder exception: Variant argument expects max or min. Got: medium
@@ -584,12 +486,7 @@ Binder exception: Variant argument expects max or min. Got: medium
 ---- ok
 
 -STATEMENT CALL SPANNING_FOREST('Graph')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 0
 
@@ -608,12 +505,7 @@ Binder exception: Variant argument expects max or min. Got: medium
 ---- ok
 
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='weight')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 1
 0|1|5|0
@@ -639,12 +531,7 @@ Binder exception: Variant argument expects max or min. Got: medium
 ---- ok
 
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='weight')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 4
 0|1|1|3
@@ -673,12 +560,7 @@ Binder exception: Variant argument expects max or min. Got: medium
 ---- ok
 
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='weight')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 4
 0|1|1|0
@@ -708,12 +590,7 @@ Binder exception: Variant argument expects max or min. Got: medium
 ---- ok
 
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='weight')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 3
 0|1|1|2
@@ -745,12 +622,7 @@ Binder exception: Variant argument expects max or min. Got: medium
 ---- ok
 
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='weight')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 6
 0|1|10|3
@@ -789,12 +661,7 @@ Binder exception: Variant argument expects max or min. Got: medium
 ---- ok
 
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='weight')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 7
 0|1|1|6
@@ -825,12 +692,7 @@ Binder exception: Variant argument expects max or min. Got: medium
 ---- ok
 
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='weight')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 3
 1|3|1|0
@@ -838,12 +700,7 @@ Binder exception: Variant argument expects max or min. Got: medium
 2|3|1|0
 
 -STATEMENT CALL SPANNING_FOREST('Graph', weight_property:='weight', variant:='max')
-    YIELD src, dst, rel, forest_id
-    MATCH (n)
-    WHERE ID(n) = dst
-    MATCH ()-[r]->()
-    WHERE ID(r) = rel
-    RETURN src.id AS src, n.id AS dst, r.weight as weight, forest_id
+    RETURN src.id AS src, dst.id AS dst, rel.weight as weight, forest_id
     ORDER BY forest_id;
 ---- 3
 0|1|1|2

--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -491,7 +491,7 @@ static void getLogicalPlan(Planner* planner, const BoundReadingClause& readingCl
     op->computeFactorizedSchema();
     planner->planReadOp(std::move(op), predicates, plan);
 
-    auto nodeOutput = bindData->nodeOutput->ptrCast<NodeExpression>();
+    auto nodeOutput = bindData->output[0]->ptrCast<NodeExpression>();
     KU_ASSERT(nodeOutput != nullptr);
     planner->getCardinliatyEstimatorUnsafe().init(*nodeOutput);
     auto scanPlan = planner->getNodePropertyScanPlan(*nodeOutput);

--- a/extension/fts/src/include/function/query_fts_bind_data.h
+++ b/extension/fts/src/include/function/query_fts_bind_data.h
@@ -41,11 +41,11 @@ struct QueryFTSBindData final : public function::GDSBindData {
         const catalog::IndexCatalogEntry& entry,
         std::unique_ptr<QueryFTSOptionalParams> optionalParams, common::idx_t numDocs,
         double avgDocLen)
-        : GDSBindData{std::move(columns), std::move(graphEntry), std::move(docs)},
+        : GDSBindData{std::move(columns), std::move(graphEntry), binder::expression_vector{docs}},
           query{std::move(query)}, entry{entry},
-          outputTableID{nodeOutput->constCast<binder::NodeExpression>().getTableIDs()[0]},
+          outputTableID{output[0]->constCast<binder::NodeExpression>().getTableIDs()[0]},
           numDocs{numDocs}, avgDocLen{avgDocLen} {
-        auto& nodeExpr = nodeOutput->constCast<binder::NodeExpression>();
+        auto& nodeExpr = output[0]->constCast<binder::NodeExpression>();
         KU_ASSERT(nodeExpr.getNumEntries() == 1);
         outputTableID = nodeExpr.getEntry(0)->getTableID();
         this->optionalParams = std::move(optionalParams);

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -1,6 +1,7 @@
 #include "function/gds/gds.h"
 
 #include "binder/binder.h"
+#include "binder/expression/rel_expression.h"
 #include "binder/query/reading_clause/bound_table_function_call.h"
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
@@ -140,12 +141,25 @@ NativeGraphEntry GDSFunction::bindGraphEntry(ClientContext& context,
     return result;
 }
 
+std::shared_ptr<binder::Expression> GDSFunction::bindRelOutput(const TableFuncBindInput& bindInput,
+    const std::vector<catalog::TableCatalogEntry*>& relEntries, std::shared_ptr<NodeExpression> srcNode,
+    std::shared_ptr<NodeExpression> dstNode, const std::optional<std::string>& name, const std::optional<uint64_t>& yieldVariableIdx) {
+    std::string relColumnName = name.value_or(REL_COLUMN_NAME);
+    StringUtils::toLower(relColumnName);
+    if (!bindInput.yieldVariables.empty()) {
+        relColumnName = bindColumnName(bindInput.yieldVariables[yieldVariableIdx.value_or(0)], relColumnName);
+    }
+    auto rel = bindInput.binder->createNonRecursiveQueryRel(relColumnName, relEntries, srcNode, dstNode, RelDirectionType::SINGLE);
+    bindInput.binder->addToScope(REL_COLUMN_NAME, rel);
+    return rel;
+}
+
 std::shared_ptr<Expression> GDSFunction::bindNodeOutput(const TableFuncBindInput& bindInput,
-    const std::vector<TableCatalogEntry*>& nodeEntries, const std::optional<std::string>& name) {
+    const std::vector<TableCatalogEntry*>& nodeEntries, const std::optional<std::string>& name, const std::optional<uint64_t>& yieldVariableIdx) {
     std::string nodeColumnName = name.value_or(NODE_COLUMN_NAME);
     StringUtils::toLower(nodeColumnName);
     if (!bindInput.yieldVariables.empty()) {
-        nodeColumnName = bindColumnName(bindInput.yieldVariables[0], nodeColumnName);
+        nodeColumnName = bindColumnName(bindInput.yieldVariables[yieldVariableIdx.value_or(0)], nodeColumnName);
     }
     auto node = bindInput.binder->createQueryNode(nodeColumnName, nodeEntries);
     bindInput.binder->addToScope(nodeColumnName, node);
@@ -199,7 +213,7 @@ void GDSFunction::getLogicalPlan(Planner* planner, const BoundReadingClause& rea
     op->computeFactorizedSchema();
     planner->planReadOp(std::move(op), predicates, plan);
 
-    auto nodeOutput = bindData->nodeOutput->ptrCast<NodeExpression>();
+    auto nodeOutput = bindData->output[0]->ptrCast<NodeExpression>();
     KU_ASSERT(nodeOutput != nullptr);
     planner->getCardinliatyEstimatorUnsafe().init(*nodeOutput);
     auto scanPlan = planner->getNodePropertyScanPlan(*nodeOutput);

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -142,24 +142,29 @@ NativeGraphEntry GDSFunction::bindGraphEntry(ClientContext& context,
 }
 
 std::shared_ptr<binder::Expression> GDSFunction::bindRelOutput(const TableFuncBindInput& bindInput,
-    const std::vector<catalog::TableCatalogEntry*>& relEntries, std::shared_ptr<NodeExpression> srcNode,
-    std::shared_ptr<NodeExpression> dstNode, const std::optional<std::string>& name, const std::optional<uint64_t>& yieldVariableIdx) {
+    const std::vector<catalog::TableCatalogEntry*>& relEntries,
+    std::shared_ptr<NodeExpression> srcNode, std::shared_ptr<NodeExpression> dstNode,
+    const std::optional<std::string>& name, const std::optional<uint64_t>& yieldVariableIdx) {
     std::string relColumnName = name.value_or(REL_COLUMN_NAME);
     StringUtils::toLower(relColumnName);
     if (!bindInput.yieldVariables.empty()) {
-        relColumnName = bindColumnName(bindInput.yieldVariables[yieldVariableIdx.value_or(0)], relColumnName);
+        relColumnName =
+            bindColumnName(bindInput.yieldVariables[yieldVariableIdx.value_or(0)], relColumnName);
     }
-    auto rel = bindInput.binder->createNonRecursiveQueryRel(relColumnName, relEntries, srcNode, dstNode, RelDirectionType::SINGLE);
+    auto rel = bindInput.binder->createNonRecursiveQueryRel(relColumnName, relEntries, srcNode,
+        dstNode, RelDirectionType::SINGLE);
     bindInput.binder->addToScope(REL_COLUMN_NAME, rel);
     return rel;
 }
 
 std::shared_ptr<Expression> GDSFunction::bindNodeOutput(const TableFuncBindInput& bindInput,
-    const std::vector<TableCatalogEntry*>& nodeEntries, const std::optional<std::string>& name, const std::optional<uint64_t>& yieldVariableIdx) {
+    const std::vector<TableCatalogEntry*>& nodeEntries, const std::optional<std::string>& name,
+    const std::optional<uint64_t>& yieldVariableIdx) {
     std::string nodeColumnName = name.value_or(NODE_COLUMN_NAME);
     StringUtils::toLower(nodeColumnName);
     if (!bindInput.yieldVariables.empty()) {
-        nodeColumnName = bindColumnName(bindInput.yieldVariables[yieldVariableIdx.value_or(0)], nodeColumnName);
+        nodeColumnName =
+            bindColumnName(bindInput.yieldVariables[yieldVariableIdx.value_or(0)], nodeColumnName);
     }
     auto node = bindInput.binder->createQueryNode(nodeColumnName, nodeEntries);
     bindInput.binder->addToScope(nodeColumnName, node);

--- a/src/graph/graph_entry.cpp
+++ b/src/graph/graph_entry.cpp
@@ -28,6 +28,14 @@ std::vector<table_id_t> NativeGraphEntry::getNodeTableIDs() const {
     return result;
 }
 
+std::vector<TableCatalogEntry*> NativeGraphEntry::getRelEntries() const {
+    std::vector<TableCatalogEntry*> result;
+    for (auto& info : relInfos) {
+        result.push_back(info.entry);
+    }
+    return result;
+}
+
 std::vector<TableCatalogEntry*> NativeGraphEntry::getNodeEntries() const {
     std::vector<TableCatalogEntry*> result;
     for (auto& info : nodeInfos) {

--- a/src/include/binder/expression/rel_expression.h
+++ b/src/include/binder/expression/rel_expression.h
@@ -41,7 +41,7 @@ struct RecursiveInfo {
     std::unique_ptr<function::RJBindData> bindData;
 };
 
-class RelExpression final : public NodeOrRelExpression {
+class KUZU_API RelExpression final : public NodeOrRelExpression {
 public:
     RelExpression(common::LogicalType dataType, std::string uniqueName, std::string variableName,
         std::vector<catalog::TableCatalogEntry*> entries, std::shared_ptr<NodeExpression> srcNode,

--- a/src/include/binder/expression/rel_expression.h
+++ b/src/include/binder/expression/rel_expression.h
@@ -56,7 +56,7 @@ public:
         return dataType.getLogicalTypeID() == common::LogicalTypeID::RECURSIVE_REL;
     }
 
-    KUZU_API bool isMultiLabeled() const override;
+    bool isMultiLabeled() const override;
     bool isBoundByMultiLabeledNode() const {
         return srcNode->isMultiLabeled() || dstNode->isMultiLabeled();
     }

--- a/src/include/function/gds/gds.h
+++ b/src/include/function/gds/gds.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "binder/expression/node_expression.h"
 #include "common/mask.h"
 #include "function/table/bind_data.h"
 #include "graph/graph.h"
@@ -26,16 +27,16 @@ struct KUZU_API GDSConfig {
 
 struct KUZU_API GDSBindData : public TableFuncBindData {
     graph::NativeGraphEntry graphEntry;
-    std::shared_ptr<binder::Expression> nodeOutput;
+    binder::expression_vector output;
 
     GDSBindData(binder::expression_vector columns, graph::NativeGraphEntry graphEntry,
-        std::shared_ptr<binder::Expression> nodeOutput)
+        binder::expression_vector output)
         : TableFuncBindData{std::move(columns)}, graphEntry{graphEntry.copy()},
-          nodeOutput{std::move(nodeOutput)} {}
+          output{std::move(output)} {}
 
     GDSBindData(const GDSBindData& other)
         : TableFuncBindData{other}, graphEntry{other.graphEntry.copy()},
-          nodeOutput{other.nodeOutput}, resultTable{other.resultTable} {}
+          output{other.output}, resultTable{other.resultTable} {}
 
     void setResultFTable(std::shared_ptr<processor::FactorizedTable> table) {
         resultTable = std::move(table);
@@ -70,15 +71,19 @@ private:
 // Base class for every graph data science algorithm.
 class KUZU_API GDSFunction {
     static constexpr char NODE_COLUMN_NAME[] = "node";
+    static constexpr char REL_COLUMN_NAME[] = "rel";
 
 public:
     static graph::NativeGraphEntry bindGraphEntry(main::ClientContext& context,
         const std::string& name);
     static graph::NativeGraphEntry bindGraphEntry(main::ClientContext& context,
         const graph::ParsedNativeGraphEntry& parsedGraphEntry);
+    static std::shared_ptr<binder::Expression> bindRelOutput(const TableFuncBindInput& bindInput,
+    const std::vector<catalog::TableCatalogEntry*>& relEntries, std::shared_ptr<binder::NodeExpression> srcNode,
+    std::shared_ptr<binder::NodeExpression> dstNode, const std::optional<std::string>& name = std::nullopt, const std::optional<uint64_t>& yieldVariableIdx = std::nullopt);
     static std::shared_ptr<binder::Expression> bindNodeOutput(const TableFuncBindInput& bindInput,
         const std::vector<catalog::TableCatalogEntry*>& nodeEntries,
-        const std::optional<std::string>& name = std::nullopt);
+        const std::optional<std::string>& name = std::nullopt, const std::optional<uint64_t>& yieldVariableIdx = std::nullopt);
     static std::string bindColumnName(const parser::YieldVariable& yieldVariable,
         std::string expressionName);
 

--- a/src/include/function/gds/gds.h
+++ b/src/include/function/gds/gds.h
@@ -35,8 +35,8 @@ struct KUZU_API GDSBindData : public TableFuncBindData {
           output{std::move(output)} {}
 
     GDSBindData(const GDSBindData& other)
-        : TableFuncBindData{other}, graphEntry{other.graphEntry.copy()},
-          output{other.output}, resultTable{other.resultTable} {}
+        : TableFuncBindData{other}, graphEntry{other.graphEntry.copy()}, output{other.output},
+          resultTable{other.resultTable} {}
 
     void setResultFTable(std::shared_ptr<processor::FactorizedTable> table) {
         resultTable = std::move(table);
@@ -79,11 +79,15 @@ public:
     static graph::NativeGraphEntry bindGraphEntry(main::ClientContext& context,
         const graph::ParsedNativeGraphEntry& parsedGraphEntry);
     static std::shared_ptr<binder::Expression> bindRelOutput(const TableFuncBindInput& bindInput,
-    const std::vector<catalog::TableCatalogEntry*>& relEntries, std::shared_ptr<binder::NodeExpression> srcNode,
-    std::shared_ptr<binder::NodeExpression> dstNode, const std::optional<std::string>& name = std::nullopt, const std::optional<uint64_t>& yieldVariableIdx = std::nullopt);
+        const std::vector<catalog::TableCatalogEntry*>& relEntries,
+        std::shared_ptr<binder::NodeExpression> srcNode,
+        std::shared_ptr<binder::NodeExpression> dstNode,
+        const std::optional<std::string>& name = std::nullopt,
+        const std::optional<uint64_t>& yieldVariableIdx = std::nullopt);
     static std::shared_ptr<binder::Expression> bindNodeOutput(const TableFuncBindInput& bindInput,
         const std::vector<catalog::TableCatalogEntry*>& nodeEntries,
-        const std::optional<std::string>& name = std::nullopt, const std::optional<uint64_t>& yieldVariableIdx = std::nullopt);
+        const std::optional<std::string>& name = std::nullopt,
+        const std::optional<uint64_t>& yieldVariableIdx = std::nullopt);
     static std::string bindColumnName(const parser::YieldVariable& yieldVariable,
         std::string expressionName);
 

--- a/src/include/graph/graph_entry.h
+++ b/src/include/graph/graph_entry.h
@@ -34,6 +34,7 @@ struct KUZU_API NativeGraphEntry {
     bool isEmpty() const { return nodeInfos.empty() && relInfos.empty(); }
 
     std::vector<common::table_id_t> getNodeTableIDs() const;
+    std::vector<catalog::TableCatalogEntry*> getRelEntries() const;
     std::vector<catalog::TableCatalogEntry*> getNodeEntries() const;
 
     const NativeGraphEntryTableInfo& getRelInfo(common::table_id_t tableID) const;


### PR DESCRIPTION
# Description

Update logical plans for GDS. 

Populates dst and rel columns of MSF with the fields of associated internal id. 

i.e MSF returns
```
┌─────────────────────────────────┬─────────────────────────────────┬────────────────────────────────────────────────────┬───────────┐
│ src                             │ dst                             │ rel                                                │ FOREST_ID │
│ NODE                            │ NODE                            │ REL                                                │ UINT64    │
├─────────────────────────────────┼─────────────────────────────────┼────────────────────────────────────────────────────┼───────────┤
│ {_ID: 0:0, _LABEL: Node, id: 4} │ {_ID: 0:1, _LABEL: Node, id: 9} │ (0:0)-{_LABEL: Edge, _ID: 1:0, weight: 2}->(0:1)   │ 0         │
│ {_ID: 0:2, _LABEL: Node, id: 2} │ {_ID: 0:4, _LABEL: Node, id: 3} │ (0:2)-{_LABEL: Edge, _ID: 1:3, weight: 3}->(0:4)   │ 0         │
│ {_ID: 0:4, _LABEL: Node, id: 3} │ {_ID: 0:0, _LABEL: Node, id: 4} │ (0:4)-{_LABEL: Edge, _ID: 1:2, weight: 3}->(0:0)   │ 0         │
│ {_ID: 0:7, _LABEL: Node, id: 8} │ {_ID: 0:1, _LABEL: Node, id: 9} │ (0:7)-{_LABEL: Edge, _ID: 1:7, weight: 3}->(0:1)   │ 0         │
│ {_ID: 0:9, _LABEL: Node, id: 6} │ {_ID: 0:8, _LABEL: Node, id: 7} │ (0:9)-{_LABEL: Edge, _ID: 1:9, weight: 3}->(0:8)   │ 0         │
│ {_ID: 0:6, _LABEL: Node, id: 0} │ {_ID: 0:5, _LABEL: Node, id: 1} │ (0:6)-{_LABEL: Edge, _ID: 1:6, weight: 5}->(0:5)   │ 0         │
│ {_ID: 0:6, _LABEL: Node, id: 0} │ {_ID: 0:2, _LABEL: Node, id: 2} │ (0:6)-{_LABEL: Edge, _ID: 1:5, weight: 6}->(0:2)   │ 0         │
│ {_ID: 0:3, _LABEL: Node, id: 5} │ {_ID: 0:8, _LABEL: Node, id: 7} │ (0:3)-{_LABEL: Edge, _ID: 1:10, weight: 10}->(0:8) │ 0         │
│ {_ID: 0:8, _LABEL: Node, id: 7} │ {_ID: 0:7, _LABEL: Node, id: 8} │ (0:8)-{_LABEL: Edge, _ID: 1:8, weight: 10}->(0:7)  │ 0         │
└─────────────────────────────────┴─────────────────────────────────┴────────────────────────────────────────────────────┴───────────┘
```


Instead of

```
┌─────────────────────────────────┬─────────────┬─────────────┬───────────┐
│ src                             │ DST         │ REL         │ FOREST_ID │
│ NODE                            │ INTERNAL_ID │ INTERNAL_ID │ UINT64    │
├─────────────────────────────────┼─────────────┼─────────────┼───────────┤
│ {_ID: 0:0, _LABEL: Node, id: 4} │ 0:1         │ 1:0         │ 0         │
│ {_ID: 0:2, _LABEL: Node, id: 2} │ 0:4         │ 1:3         │ 0         │
│ {_ID: 0:4, _LABEL: Node, id: 3} │ 0:0         │ 1:2         │ 0         │
│ {_ID: 0:7, _LABEL: Node, id: 8} │ 0:1         │ 1:7         │ 0         │
│ {_ID: 0:9, _LABEL: Node, id: 6} │ 0:8         │ 1:9         │ 0         │
│ {_ID: 0:6, _LABEL: Node, id: 0} │ 0:5         │ 1:6         │ 0         │
│ {_ID: 0:6, _LABEL: Node, id: 0} │ 0:2         │ 1:5         │ 0         │
│ {_ID: 0:3, _LABEL: Node, id: 5} │ 0:8         │ 1:10        │ 0         │
│ {_ID: 0:8, _LABEL: Node, id: 7} │ 0:7         │ 1:8         │ 0         │
└─────────────────────────────────┴─────────────┴─────────────┴───────────┘
```