### PR TITLE
Rework UpdateInfo for concurrent updates

### DIFF
--- a/src/include/main/query_result.h
+++ b/src/include/main/query_result.h
@@ -37,11 +37,7 @@ public:
      */
     KUZU_API virtual ~QueryResult() = 0;
     /**
-<<<<<<< Updated upstream
-     * @return the query is executed successfully or not.
-=======
      * @return if the query is executed successfully or not.
->>>>>>> Stashed changes
      */
     KUZU_API bool isSuccess() const;
     /**

--- a/src/include/main/query_result.h
+++ b/src/include/main/query_result.h
@@ -37,7 +37,7 @@ public:
      */
     KUZU_API virtual ~QueryResult() = 0;
     /**
-     * @return query is executed successfully or not.
+     * @return the query is executed successfully or not.
      */
     KUZU_API bool isSuccess() const;
     /**
@@ -49,11 +49,11 @@ public:
      */
     KUZU_API size_t getNumColumns() const;
     /**
-     * @return name of each column in query result.
+     * @return name of each column in the query result.
      */
     KUZU_API std::vector<std::string> getColumnNames() const;
     /**
-     * @return dataType of each column in query result.
+     * @return dataType of each column in the query result.
      */
     KUZU_API std::vector<common::LogicalType> getColumnDataTypes() const;
     /**
@@ -67,7 +67,7 @@ public:
      */
     KUZU_API bool hasNextQueryResult() const;
     /**
-     * @return get next query result to read (for multiple query statements).
+     * @return get the next query result to read (for multiple query statements).
      */
     KUZU_API QueryResult* getNextQueryResult();
     /**

--- a/src/include/main/query_result.h
+++ b/src/include/main/query_result.h
@@ -37,7 +37,11 @@ public:
      */
     KUZU_API virtual ~QueryResult() = 0;
     /**
+<<<<<<< Updated upstream
      * @return the query is executed successfully or not.
+=======
+     * @return if the query is executed successfully or not.
+>>>>>>> Stashed changes
      */
     KUZU_API bool isSuccess() const;
     /**

--- a/src/include/storage/file_handle.h
+++ b/src/include/storage/file_handle.h
@@ -148,7 +148,7 @@ private:
     std::unique_ptr<common::FileInfo> fileInfo;
     common::file_idx_t fileIndex;
     // Actually allocated/used number of pages in the file.
-    uint32_t numPages;
+    std::atomic<uint32_t> numPages;
     // This is the maximum number of pages the filehandle can currently support.
     uint32_t pageCapacity;
 

--- a/src/include/storage/table/chunked_node_group.h
+++ b/src/include/storage/table/chunked_node_group.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <atomic>
-#include <cstdint>
 #include <mutex>
 
 #include "common/enums/rel_multiplicity.h"
@@ -75,8 +74,8 @@ public:
     void resetNumRowsFromChunks();
     void setNumRows(common::offset_t numRows_);
     void resizeChunks(uint64_t newSize);
-    void setVersionInfo(std::unique_ptr<VersionInfo> versionInfo) {
-        this->versionInfo = std::move(versionInfo);
+    void setVersionInfo(std::unique_ptr<VersionInfo> versionInfo_) {
+        this->versionInfo = std::move(versionInfo_);
     }
     void resetVersionAndUpdateInfo();
 
@@ -109,9 +108,6 @@ public:
     common::row_idx_t getNumUpdatedRows(const transaction::Transaction* transaction,
         common::column_id_t columnID);
 
-    std::pair<std::unique_ptr<ColumnChunk>, std::unique_ptr<ColumnChunk>> scanUpdates(
-        const transaction::Transaction* transaction, common::column_id_t columnID);
-
     bool lookup(const transaction::Transaction* transaction, const TableScanState& state,
         const NodeGroupScanState& nodeGroupScanState, common::offset_t rowIdxInChunk,
         common::sel_t posInOutput) const;
@@ -143,8 +139,7 @@ public:
     }
 
     virtual std::unique_ptr<ChunkedNodeGroup> flushAsNewChunkedNodeGroup(
-        transaction::Transaction* transaction, MemoryManager& mm,
-        PageAllocator& pageAllocator) const;
+        transaction::Transaction* transaction, PageAllocator& pageAllocator) const;
     virtual void flush(PageAllocator& pageAllocator);
 
     void commitInsert(common::row_idx_t startRow, common::row_idx_t numRowsToCommit,

--- a/src/include/storage/table/csr_chunked_node_group.h
+++ b/src/include/storage/table/csr_chunked_node_group.h
@@ -127,8 +127,7 @@ public:
     void scanCSRHeader(MemoryManager& memoryManager, CSRNodeGroupCheckpointState& csrState) const;
 
     std::unique_ptr<ChunkedNodeGroup> flushAsNewChunkedNodeGroup(
-        transaction::Transaction* transaction, MemoryManager& mm,
-        PageAllocator& pageAllocator) const override;
+        transaction::Transaction* transaction, PageAllocator& pageAllocator) const override;
 
     void flush(PageAllocator& pageAllocator) override;
     void reclaimStorage(PageAllocator& pageAllocator) const override;

--- a/src/include/storage/table/node_group_collection.h
+++ b/src/include/storage/table/node_group_collection.h
@@ -30,9 +30,8 @@ public:
     // The returned values are the startOffset and numValuesAppended.
     // NOTE: This is specially coded to only be used by NodeBatchInsert for now.
     std::pair<common::offset_t, common::offset_t> appendToLastNodeGroupAndFlushWhenFull(
-        MemoryManager& mm, transaction::Transaction* transaction,
-        const std::vector<common::column_id_t>& columnIDs, ChunkedNodeGroup& chunkedGroup,
-        PageAllocator& pageAllocator);
+        transaction::Transaction* transaction, const std::vector<common::column_id_t>& columnIDs,
+        ChunkedNodeGroup& chunkedGroup, PageAllocator& pageAllocator);
 
     common::row_idx_t getNumTotalRows() const;
     common::node_group_idx_t getNumNodeGroups() const {

--- a/src/include/storage/table/node_table.h
+++ b/src/include/storage/table/node_table.h
@@ -41,7 +41,7 @@ struct KUZU_API NodeTableScanState : TableScanState {
 
 // There is a vtable bug related to the Apple clang v15.0.0+. Adding the `FINAL` specifier to
 // derived class causes casting failures in Apple platform.
-struct KUZU_API NodeTableInsertState : public TableInsertState {
+struct KUZU_API NodeTableInsertState : TableInsertState {
     common::ValueVector& nodeIDVector;
     const common::ValueVector& pkVector;
     std::vector<std::unique_ptr<Index::InsertState>> indexInsertStates;
@@ -74,7 +74,7 @@ struct KUZU_API NodeTableDeleteState : TableDeleteState {
     common::ValueVector& pkVector;
 
     explicit NodeTableDeleteState(common::ValueVector& nodeIDVector, common::ValueVector& pkVector)
-        : TableDeleteState{}, nodeIDVector{nodeIDVector}, pkVector{pkVector} {}
+        : nodeIDVector{nodeIDVector}, pkVector{pkVector} {}
 };
 
 class NodeTable;
@@ -132,7 +132,7 @@ public:
 
     void initInsertState(main::ClientContext* context, TableInsertState& insertState) override;
     void insert(transaction::Transaction* transaction, TableInsertState& insertState) override;
-    void initUpdateState(main::ClientContext* context, TableUpdateState& updateState);
+    void initUpdateState(main::ClientContext* context, TableUpdateState& updateState) const;
     void update(transaction::Transaction* transaction, TableUpdateState& updateState) override;
     bool delete_(transaction::Transaction* transaction, TableDeleteState& deleteState) override;
 
@@ -168,7 +168,7 @@ public:
         return *columns[columnID];
     }
 
-    std::pair<common::offset_t, common::offset_t> appendToLastNodeGroup(MemoryManager& mm,
+    std::pair<common::offset_t, common::offset_t> appendToLastNodeGroup(
         transaction::Transaction* transaction, const std::vector<common::column_id_t>& columnIDs,
         ChunkedNodeGroup& chunkedGroup, PageAllocator& pageAllocator);
 

--- a/src/include/storage/table/update_info.h
+++ b/src/include/storage/table/update_info.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <shared_mutex>
 
 #include "column_chunk_data.h"
 #include "common/types/types.h"
@@ -29,49 +30,101 @@ struct VectorUpdateInfo {
 
     std::unique_ptr<ColumnChunkData> data;
 
-    explicit VectorUpdateInfo(MemoryManager& memoryManager,
-        const common::transaction_t transactionID, common::LogicalType dataType)
+    VectorUpdateInfo()
+        : version{common::INVALID_TRANSACTION}, rowsInVector{}, numRowsUpdated(0), prev(nullptr),
+          next{nullptr}, data{nullptr} {}
+    VectorUpdateInfo(MemoryManager& memoryManager, const common::transaction_t transactionID,
+        common::LogicalType dataType)
         : version{transactionID}, rowsInVector{}, numRowsUpdated{0}, prev{nullptr}, next{nullptr} {
         data = ColumnChunkFactory::createColumnChunkData(memoryManager, std::move(dataType), false,
             common::DEFAULT_VECTOR_CAPACITY, ResidencyState::IN_MEMORY);
     }
 
     std::unique_ptr<VectorUpdateInfo> movePrev() { return std::move(prev); }
-    void setPrev(std::unique_ptr<VectorUpdateInfo> prev) { this->prev = std::move(prev); }
+    std::unique_ptr<VectorUpdateInfo> movePrevNoLock() { return std::move(prev); }
+    void setPrev(std::unique_ptr<VectorUpdateInfo> prev_) { this->prev = std::move(prev_); }
     VectorUpdateInfo* getPrev() const { return prev.get(); }
-    void setNext(VectorUpdateInfo* next) { this->next = next; }
+    void setNext(VectorUpdateInfo* next_) { this->next = next_; }
     VectorUpdateInfo* getNext() const { return next; }
+    VectorUpdateInfo* getNextNoLock() const { return next; }
+};
+
+struct UpdateNode {
+    mutable std::shared_mutex mtx;
+    std::unique_ptr<VectorUpdateInfo> info;
+
+    UpdateNode() : info{nullptr} {}
+    UpdateNode(UpdateNode&& other) noexcept : info{std::move(other.info)} {}
+
+    bool isSet() const {
+        std::shared_lock lock{mtx};
+        return info != nullptr;
+    }
+    void clear() {
+        std::unique_lock lock{mtx};
+        info = nullptr;
+    }
 };
 
 class UpdateInfo {
 public:
     UpdateInfo() {}
 
-    VectorUpdateInfo* update(MemoryManager& memoryManager,
+    VectorUpdateInfo& update(MemoryManager& memoryManager,
         const transaction::Transaction* transaction, common::idx_t vectorIdx,
         common::sel_t rowIdxInVector, const common::ValueVector& values);
 
-    void setVectorInfo(common::idx_t vectorIdx, std::unique_ptr<VectorUpdateInfo> vectorInfo) {
-        vectorsInfo[vectorIdx] = std::move(vectorInfo);
+    void clearVectorInfo(common::idx_t vectorIdx) {
+        std::unique_lock lock{mtx};
+        updates[vectorIdx].clear();
     }
-    void clearVectorInfo(common::idx_t vectorIdx) { vectorsInfo[vectorIdx] = nullptr; }
 
-    common::idx_t getNumVectors() const { return vectorsInfo.size(); }
-    VectorUpdateInfo* getVectorInfo(const transaction::Transaction* transaction,
-        common::idx_t idx) const;
+    common::idx_t getNumVectors() const {
+        std::shared_lock lock{mtx};
+        return updates.size();
+    }
+
+    void scan(const transaction::Transaction* transaction, common::ValueVector& output,
+        common::offset_t offsetInChunk, common::length_t length) const;
+    void lookup(const transaction::Transaction* transaction, common::offset_t rowInChunk,
+        common::ValueVector& output, common::sel_t posInOutputVector) const;
+
+    void scanCommitted(const transaction::Transaction* transaction, ColumnChunkData& output,
+        common::offset_t startOffsetInOutput, common::row_idx_t startRowScanned,
+        common::row_idx_t numRows) const;
+
+    void iterateVectorInfo(const transaction::Transaction* transaction, common::idx_t idx,
+        const std::function<void(const VectorUpdateInfo&)>& func) const;
+
+    void commit(common::idx_t vectorIdx, VectorUpdateInfo* info, common::transaction_t commitTS);
+    void rollback(common::idx_t vectorIdx, VectorUpdateInfo* info);
 
     common::row_idx_t getNumUpdatedRows(const transaction::Transaction* transaction) const;
 
     bool hasUpdates(const transaction::Transaction* transaction, common::row_idx_t startRow,
         common::length_t numRows) const;
 
-private:
-    VectorUpdateInfo& getOrCreateVectorInfo(MemoryManager& memoryManager,
-        const transaction::Transaction* transaction, common::idx_t vectorIdx,
-        common::sel_t rowIdxInVector, const common::LogicalType& dataType);
+    bool isSet() const {
+        std::shared_lock lock{mtx};
+        return !updates.empty();
+    }
+    void reset() {
+        std::unique_lock lock{mtx};
+        updates.clear();
+    }
 
 private:
-    std::vector<std::unique_ptr<VectorUpdateInfo>> vectorsInfo;
+    UpdateNode& getUpdateNode(common::idx_t vectorIdx);
+    UpdateNode& getOrCreateUpdateNode(common::idx_t vectorIdx);
+
+    void iterateScan(const transaction::Transaction* transaction, uint64_t startOffsetToScan,
+        uint64_t numRowsToScan, uint64_t startPosInOutput,
+        const std::function<void(const VectorUpdateInfo&, uint64_t, uint64_t)>& readFromRowFunc)
+        const;
+
+private:
+    mutable std::shared_mutex mtx;
+    std::vector<UpdateNode> updates;
 };
 
 } // namespace storage

--- a/src/include/storage/undo_buffer.h
+++ b/src/include/storage/undo_buffer.h
@@ -117,8 +117,7 @@ private:
         const uint8_t* record);
 
     static void commitVectorUpdateInfo(const uint8_t* record, common::transaction_t commitTS);
-    static void rollbackVectorUpdateInfo(const transaction::Transaction* transaction,
-        const uint8_t* record);
+    static void rollbackVectorUpdateInfo(const uint8_t* record);
 
 private:
     std::mutex mtx;

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -212,7 +212,7 @@ void NodeBatchInsert::writeAndResetNodeGroup(transaction::Transaction* transacti
         ChunkedNodeGroup sliceToWriteToDisk{*nodeGroup, info->outputDataColumns};
         FinallyWrapper sliceRestorer{
             [&]() { nodeGroup->merge(sliceToWriteToDisk, info->outputDataColumns); }};
-        std::tie(nodeOffset, numRowsWritten) = nodeTable->appendToLastNodeGroup(*mm, transaction,
+        std::tie(nodeOffset, numRowsWritten) = nodeTable->appendToLastNodeGroup(transaction,
             info->insertColumnIDs, sliceToWriteToDisk, pageAllocator);
     }
 

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -135,7 +135,7 @@ static void appendNewChunkedGroup(MemoryManager& mm, transaction::Transaction* t
     relTable.pushInsertInfo(transaction, direction, nodeGroup, chunkedGroup.getNumRows(), source);
     if (isNewNodeGroup) {
         auto flushedChunkedGroup =
-            chunkedGroup.flushAsNewChunkedNodeGroup(transaction, mm, pageAllocator);
+            chunkedGroup.flushAsNewChunkedNodeGroup(transaction, pageAllocator);
 
         // If there are deleted columns that haven't been vacuumed yet
         // we need to add extra columns to the chunked group

--- a/src/storage/file_handle.cpp
+++ b/src/storage/file_handle.cpp
@@ -62,7 +62,7 @@ page_idx_t FileHandle::addNewPage() {
 page_idx_t FileHandle::addNewPages(page_idx_t numNewPages) {
     std::unique_lock lck{fhSharedMutex, std::defer_lock_t{}};
     while (!lck.try_lock()) {}
-    const auto numPagesBeforeChange = numPages;
+    const auto numPagesBeforeChange = numPages.load();
     for (auto i = 0u; i < numNewPages; i++) {
         addNewPageWithoutLock();
     }
@@ -161,8 +161,7 @@ void FileHandle::flushPageIfDirtyWithoutLock(page_idx_t pageIdx) {
     }
 }
 
-void FileHandle::writePagesToFile(const uint8_t* buffer, uint64_t size,
-    common::page_idx_t startPageIdx) {
+void FileHandle::writePagesToFile(const uint8_t* buffer, uint64_t size, page_idx_t startPageIdx) {
     if (isInMemoryMode()) {
         auto pageSize = getPageSize();
         for (uint64_t i = 0; i < size; i += pageSize) {

--- a/src/storage/table/column_chunk.cpp
+++ b/src/storage/table/column_chunk.cpp
@@ -1,11 +1,8 @@
 #include "storage/table/column_chunk.h"
 
-#include <algorithm>
-
 #include "common/serializer/deserializer.h"
 #include "common/serializer/serializer.h"
 #include "common/vector/value_vector.h"
-#include "storage/storage_utils.h"
 #include "storage/table/column.h"
 #include "transaction/transaction.h"
 
@@ -17,7 +14,7 @@ namespace storage {
 
 ColumnChunk::ColumnChunk(MemoryManager& mm, LogicalType&& dataType, uint64_t capacity,
     bool enableCompression, ResidencyState residencyState, bool initializeToZero)
-    : mm{mm}, enableCompression{enableCompression} {
+    : enableCompression{enableCompression} {
     data = ColumnChunkFactory::createColumnChunkData(mm, std::move(dataType), enableCompression,
         capacity, residencyState, true, initializeToZero);
     KU_ASSERT(residencyState != ResidencyState::ON_DISK);
@@ -25,14 +22,13 @@ ColumnChunk::ColumnChunk(MemoryManager& mm, LogicalType&& dataType, uint64_t cap
 
 ColumnChunk::ColumnChunk(MemoryManager& mm, LogicalType&& dataType, bool enableCompression,
     ColumnChunkMetadata metadata)
-    : mm{mm}, enableCompression{enableCompression} {
+    : enableCompression{enableCompression} {
     data = ColumnChunkFactory::createColumnChunkData(mm, std::move(dataType), enableCompression,
         metadata, true, true);
 }
 
-ColumnChunk::ColumnChunk(MemoryManager& mm, bool enableCompression,
-    std::unique_ptr<ColumnChunkData> data)
-    : mm{mm}, enableCompression{enableCompression}, data{std::move(data)} {}
+ColumnChunk::ColumnChunk(bool enableCompression, std::unique_ptr<ColumnChunkData> data)
+    : enableCompression{enableCompression}, data{std::move(data)} {}
 
 void ColumnChunk::initializeScanState(ChunkState& state, const Column* column) const {
     data->initializeScanState(state, column);
@@ -52,34 +48,7 @@ void ColumnChunk::scan(const Transaction* transaction, const ChunkState& state, 
         KU_UNREACHABLE;
     }
     }
-    if (!updateInfo) {
-        return;
-    }
-    auto [startVectorIdx, startOffsetInVector] =
-        StorageUtils::getQuotientRemainder(offsetInChunk, DEFAULT_VECTOR_CAPACITY);
-    auto [endVectorIdx, endOffsetInVector] =
-        StorageUtils::getQuotientRemainder(offsetInChunk + length, DEFAULT_VECTOR_CAPACITY);
-    idx_t idx = startVectorIdx;
-    sel_t posInVector = 0u;
-    while (idx <= endVectorIdx) {
-        const auto startOffset = idx == startVectorIdx ? startOffsetInVector : 0;
-        const auto endOffset = idx == endVectorIdx ? endOffsetInVector : DEFAULT_VECTOR_CAPACITY;
-        const auto numRowsInVector = endOffset - startOffset;
-        if (const auto vectorInfo = updateInfo->getVectorInfo(transaction, idx);
-            vectorInfo && vectorInfo->numRowsUpdated > 0) {
-            for (auto i = 0u; i < numRowsInVector; i++) {
-                if (const auto itr = std::find_if(vectorInfo->rowsInVector.begin(),
-                        vectorInfo->rowsInVector.begin() + vectorInfo->numRowsUpdated,
-                        [i, startOffset](auto row) { return row == i + startOffset; });
-                    itr != vectorInfo->rowsInVector.begin() + vectorInfo->numRowsUpdated) {
-                    vectorInfo->data->lookup(itr - vectorInfo->rowsInVector.begin(), output,
-                        posInVector + i);
-                }
-            }
-        }
-        posInVector += numRowsInVector;
-        idx++;
-    }
+    updateInfo.scan(transaction, output, offsetInChunk, length);
 }
 
 template<ResidencyState SCAN_RESIDENCY_STATE>
@@ -93,14 +62,14 @@ void ColumnChunk::scanCommitted(const Transaction* transaction, ChunkState& chun
     case ResidencyState::ON_DISK: {
         if (SCAN_RESIDENCY_STATE == residencyState) {
             chunkState.column->scan(chunkState, &output.getData(), startRow, startRow + numRows);
-            scanCommittedUpdates(transaction, output.getData(), numValuesBeforeScan, startRow,
+            updateInfo.scanCommitted(transaction, output.getData(), numValuesBeforeScan, startRow,
                 numRows);
         }
     } break;
     case ResidencyState::IN_MEMORY: {
         if (SCAN_RESIDENCY_STATE == residencyState) {
             output.getData().append(data.get(), startRow, numRows);
-            scanCommittedUpdates(transaction, output.getData(), numValuesBeforeScan, startRow,
+            updateInfo.scanCommitted(transaction, output.getData(), numValuesBeforeScan, startRow,
                 numRows);
         }
     } break;
@@ -117,46 +86,7 @@ template void ColumnChunk::scanCommitted<ResidencyState::IN_MEMORY>(const Transa
 
 bool ColumnChunk::hasUpdates(const Transaction* transaction, row_idx_t startRow,
     length_t numRows) const {
-    return updateInfo && updateInfo->hasUpdates(transaction, startRow, numRows);
-}
-
-void ColumnChunk::scanCommittedUpdates(const Transaction* transaction, ColumnChunkData& output,
-    offset_t startOffsetInOutput, row_idx_t startRowScanned, row_idx_t numRows) const {
-    if (!updateInfo) {
-        return;
-    }
-    auto [startVectorIdx, startRowInVector] =
-        StorageUtils::getQuotientRemainder(startRowScanned, DEFAULT_VECTOR_CAPACITY);
-    auto [endVectorIdx, endRowInVector] =
-        StorageUtils::getQuotientRemainder(startRowScanned + numRows, DEFAULT_VECTOR_CAPACITY);
-    idx_t vectorIdx = startVectorIdx;
-    while (vectorIdx <= endVectorIdx) {
-        const auto startRow = vectorIdx == startVectorIdx ? startRowInVector : 0;
-        const auto endRow = vectorIdx == endVectorIdx ? endRowInVector : DEFAULT_VECTOR_CAPACITY;
-        // const auto numRowsInVector = endRow - startRow;
-        const auto vectorInfo = updateInfo->getVectorInfo(transaction, vectorIdx);
-        if (vectorInfo && vectorInfo->numRowsUpdated > 0) {
-            if (vectorIdx != startVectorIdx && vectorIdx != endVectorIdx) {
-                for (auto i = 0u; i < vectorInfo->numRowsUpdated; i++) {
-                    output.write(vectorInfo->data.get(), i,
-                        startOffsetInOutput + vectorIdx * DEFAULT_VECTOR_CAPACITY +
-                            vectorInfo->rowsInVector[i] - startRowScanned,
-                        1);
-                }
-            } else {
-                for (auto i = 0u; i < vectorInfo->numRowsUpdated; i++) {
-                    const auto rowInVecUpdated = vectorInfo->rowsInVector[i];
-                    if (rowInVecUpdated >= startRow && rowInVecUpdated < endRow) {
-                        output.write(vectorInfo->data.get(), i,
-                            startOffsetInOutput + vectorIdx * DEFAULT_VECTOR_CAPACITY +
-                                rowInVecUpdated - startRowScanned,
-                            1);
-                    }
-                }
-            }
-        }
-        vectorIdx++;
-    }
+    return updateInfo.hasUpdates(transaction, startRow, numRows);
 }
 
 void ColumnChunk::lookup(const Transaction* transaction, const ChunkState& state,
@@ -169,18 +99,7 @@ void ColumnChunk::lookup(const Transaction* transaction, const ChunkState& state
         state.column->lookupValue(state, rowInChunk, &output, posInOutputVector);
     } break;
     }
-    if (updateInfo) {
-        auto [vectorIdx, rowInVector] =
-            StorageUtils::getQuotientRemainder(rowInChunk, DEFAULT_VECTOR_CAPACITY);
-        if (const auto vectorInfo = updateInfo->getVectorInfo(transaction, vectorIdx)) {
-            for (auto i = 0u; i < vectorInfo->numRowsUpdated; i++) {
-                if (vectorInfo->rowsInVector[i] == rowInVector) {
-                    vectorInfo->data->lookup(i, output, posInOutputVector);
-                    return;
-                }
-            }
-        }
-    }
+    updateInfo.lookup(transaction, rowInChunk, output, posInOutputVector);
 }
 
 void ColumnChunk::update(const Transaction* transaction, offset_t offsetInChunk,
@@ -190,28 +109,16 @@ void ColumnChunk::update(const Transaction* transaction, offset_t offsetInChunk,
         return;
     }
     data->updateStats(&values, values.state->getSelVector());
-    if (!updateInfo) {
-        updateInfo = std::make_unique<UpdateInfo>();
-    }
     const auto vectorIdx = offsetInChunk / DEFAULT_VECTOR_CAPACITY;
     const auto rowIdxInVector = offsetInChunk % DEFAULT_VECTOR_CAPACITY;
-    const auto vectorUpdateInfo = updateInfo->update(data->getMemoryManager(), transaction,
-        vectorIdx, rowIdxInVector, values);
-    transaction->pushVectorUpdateInfo(*updateInfo, vectorIdx, *vectorUpdateInfo);
+    auto& vectorUpdateInfo =
+        updateInfo.update(data->getMemoryManager(), transaction, vectorIdx, rowIdxInVector, values);
+    transaction->pushVectorUpdateInfo(updateInfo, vectorIdx, vectorUpdateInfo);
 }
 
-MergedColumnChunkStats ColumnChunk::getMergedColumnChunkStats(
-    const Transaction* transaction) const {
+MergedColumnChunkStats ColumnChunk::getMergedColumnChunkStats() const {
+    KU_ASSERT(!updateInfo.isSet());
     auto baseStats = data->getMergedColumnChunkStats();
-    if (updateInfo) {
-        for (idx_t i = 0; i < updateInfo->getNumVectors(); ++i) {
-            const auto* vectorInfo = updateInfo->getVectorInfo(transaction, i);
-            if (vectorInfo) {
-                baseStats.merge(vectorInfo->data->getMergedColumnChunkStats(),
-                    getDataType().getPhysicalType());
-            }
-        }
-    }
     return baseStats;
 }
 
@@ -227,37 +134,11 @@ std::unique_ptr<ColumnChunk> ColumnChunk::deserialize(MemoryManager& mm, Deseria
     deSer.validateDebuggingInfo(key, "enable_compression");
     deSer.deserializeValue<bool>(enableCompression);
     auto data = ColumnChunkData::deserialize(mm, deSer);
-    return std::make_unique<ColumnChunk>(mm, enableCompression, std::move(data));
+    return std::make_unique<ColumnChunk>(enableCompression, std::move(data));
 }
 
 row_idx_t ColumnChunk::getNumUpdatedRows(const Transaction* transaction) const {
-    return updateInfo ? updateInfo->getNumUpdatedRows(transaction) : 0;
-}
-
-std::pair<std::unique_ptr<ColumnChunk>, std::unique_ptr<ColumnChunk>> ColumnChunk::scanUpdates(
-    const Transaction* transaction) const {
-    auto numUpdatedRows = getNumUpdatedRows(transaction);
-    // TODO(Guodong): Actually for row idx in a column chunk, UINT32 should be enough.
-    auto updatedRows = std::make_unique<ColumnChunk>(mm, LogicalType::UINT64(), numUpdatedRows,
-        false, ResidencyState::IN_MEMORY);
-    auto updatedData = std::make_unique<ColumnChunk>(mm, getDataType().copy(), numUpdatedRows,
-        false, ResidencyState::IN_MEMORY);
-    const auto numUpdateVectors = updateInfo->getNumVectors();
-    row_idx_t numAppendedRows = 0;
-    for (auto vectorIdx = 0u; vectorIdx < numUpdateVectors; vectorIdx++) {
-        const auto vectorInfo = updateInfo->getVectorInfo(transaction, vectorIdx);
-        if (!vectorInfo) {
-            continue;
-        }
-        const row_idx_t startRowIdx = vectorIdx * DEFAULT_VECTOR_CAPACITY;
-        for (auto rowIdx = 0u; rowIdx < vectorInfo->numRowsUpdated; rowIdx++) {
-            updatedRows->getData().setValue<row_idx_t>(
-                vectorInfo->rowsInVector[rowIdx] + startRowIdx, numAppendedRows++);
-        }
-        updatedData->getData().append(vectorInfo->data.get(), 0, vectorInfo->numRowsUpdated);
-        KU_ASSERT(updatedData->getData().getNumValues() == updatedRows->getData().getNumValues());
-    }
-    return {std::move(updatedRows), std::move(updatedData)};
+    return updateInfo.getNumUpdatedRows(transaction);
 }
 
 void ColumnChunk::reclaimStorage(PageAllocator& pageAllocator) const {

--- a/src/storage/table/csr_chunked_node_group.cpp
+++ b/src/storage/table/csr_chunked_node_group.cpp
@@ -233,16 +233,15 @@ length_t ChunkedCSRHeader::computeGapFromLength(length_t length) {
 }
 
 std::unique_ptr<ChunkedNodeGroup> ChunkedCSRNodeGroup::flushAsNewChunkedNodeGroup(
-    transaction::Transaction* transaction, MemoryManager& mm, PageAllocator& pageAllocator) const {
-    auto csrOffset = std::make_unique<ColumnChunk>(mm, csrHeader.offset->isCompressionEnabled(),
+    transaction::Transaction* transaction, PageAllocator& pageAllocator) const {
+    auto csrOffset = std::make_unique<ColumnChunk>(csrHeader.offset->isCompressionEnabled(),
         Column::flushChunkData(csrHeader.offset->getData(), pageAllocator));
-    auto csrLength = std::make_unique<ColumnChunk>(mm, csrHeader.length->isCompressionEnabled(),
+    auto csrLength = std::make_unique<ColumnChunk>(csrHeader.length->isCompressionEnabled(),
         Column::flushChunkData(csrHeader.length->getData(), pageAllocator));
     std::vector<std::unique_ptr<ColumnChunk>> flushedChunks(getNumColumns());
     for (auto i = 0u; i < getNumColumns(); i++) {
-        flushedChunks[i] =
-            std::make_unique<ColumnChunk>(mm, getColumnChunk(i).isCompressionEnabled(),
-                Column::flushChunkData(getColumnChunk(i).getData(), pageAllocator));
+        flushedChunks[i] = std::make_unique<ColumnChunk>(getColumnChunk(i).isCompressionEnabled(),
+            Column::flushChunkData(getColumnChunk(i).getData(), pageAllocator));
     }
     ChunkedCSRHeader newCSRHeader{std::move(csrOffset), std::move(csrLength)};
     auto flushedChunkedGroup = std::make_unique<ChunkedCSRNodeGroup>(std::move(newCSRHeader),

--- a/src/storage/table/dictionary_chunk.cpp
+++ b/src/storage/table/dictionary_chunk.cpp
@@ -3,7 +3,6 @@
 #include "common/constants.h"
 #include "common/serializer/deserializer.h"
 #include "common/serializer/serializer.h"
-#include "storage/buffer_manager/memory_manager.h"
 #include "storage/enums/residency_state.h"
 #include <bit>
 

--- a/src/storage/table/node_group_collection.cpp
+++ b/src/storage/table/node_group_collection.cpp
@@ -103,7 +103,7 @@ void NodeGroupCollection::append(const Transaction* transaction,
 }
 
 std::pair<offset_t, offset_t> NodeGroupCollection::appendToLastNodeGroupAndFlushWhenFull(
-    MemoryManager& mm, Transaction* transaction, const std::vector<column_id_t>& columnIDs,
+    Transaction* transaction, const std::vector<column_id_t>& columnIDs,
     ChunkedNodeGroup& chunkedGroup, PageAllocator& pageAllocator) {
     NodeGroup* lastNodeGroup = nullptr;
     offset_t startOffset = 0;
@@ -141,7 +141,7 @@ std::pair<offset_t, offset_t> NodeGroupCollection::appendToLastNodeGroupAndFlush
     }
     if (directFlushWhenAppend) {
         chunkedGroup.finalize();
-        auto flushedGroup = chunkedGroup.flushAsNewChunkedNodeGroup(transaction, mm, pageAllocator);
+        auto flushedGroup = chunkedGroup.flushAsNewChunkedNodeGroup(transaction, pageAllocator);
 
         // If there are deleted columns that haven't been vacuumed yet,
         // we need to add extra columns to the chunked group

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -236,7 +236,6 @@ NodeTable::NodeTable(const StorageManager* storageManager,
             dataFH, mm, shadowFile, enableCompression);
     }
     auto& pkDefinition = nodeTableEntry->getPrimaryKeyDefinition();
-    auto pkColumnID = nodeTableEntry->getColumnID(pkDefinition.getName());
     KU_ASSERT(pkColumnID != INVALID_COLUMN_ID);
     auto hashIndexType = PrimaryKeyIndex::getIndexType();
     IndexInfo indexInfo{PrimaryKeyIndex::DEFAULT_NAME, hashIndexType.typeName, tableID,
@@ -447,7 +446,7 @@ void NodeTable::insert(Transaction* transaction, TableInsertState& insertState) 
     hasChanges = true;
 }
 
-void NodeTable::initUpdateState(main::ClientContext* context, TableUpdateState& updateState) {
+void NodeTable::initUpdateState(main::ClientContext* context, TableUpdateState& updateState) const {
     auto& nodeUpdateState = updateState.cast<NodeTableUpdateState>();
     nodeUpdateState.indexUpdateState.resize(indexes.size());
     for (auto i = 0u; i < indexes.size(); i++) {
@@ -562,12 +561,12 @@ void NodeTable::addColumn(Transaction* transaction, TableAddColumnState& addColu
     hasChanges = true;
 }
 
-std::pair<offset_t, offset_t> NodeTable::appendToLastNodeGroup(MemoryManager& mm,
-    Transaction* transaction, const std::vector<column_id_t>& columnIDs,
-    ChunkedNodeGroup& chunkedGroup, PageAllocator& pageAllocator) {
+std::pair<offset_t, offset_t> NodeTable::appendToLastNodeGroup(Transaction* transaction,
+    const std::vector<column_id_t>& columnIDs, ChunkedNodeGroup& chunkedGroup,
+    PageAllocator& pageAllocator) {
     hasChanges = true;
-    return nodeGroups->appendToLastNodeGroupAndFlushWhenFull(mm, transaction, columnIDs,
-        chunkedGroup, pageAllocator);
+    return nodeGroups->appendToLastNodeGroupAndFlushWhenFull(transaction, columnIDs, chunkedGroup,
+        pageAllocator);
 }
 
 DataChunk NodeTable::constructDataChunkForColumns(const std::vector<column_id_t>& columnIDs) const {

--- a/src/storage/table/update_info.cpp
+++ b/src/storage/table/update_info.cpp
@@ -14,102 +14,21 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace storage {
 
-VectorUpdateInfo* UpdateInfo::update(MemoryManager& memoryManager, const Transaction* transaction,
+VectorUpdateInfo& UpdateInfo::update(MemoryManager& memoryManager, const Transaction* transaction,
     const idx_t vectorIdx, const sel_t rowIdxInVector, const ValueVector& values) {
-    auto& vectorUpdateInfo = getOrCreateVectorInfo(memoryManager, transaction, vectorIdx,
-        rowIdxInVector, values.dataType);
-    // Check if the row is already updated in this transaction. Overwrite if so.
-    idx_t idxInUpdateData = INVALID_IDX;
-    for (auto i = 0u; i < vectorUpdateInfo.numRowsUpdated; i++) {
-        if (vectorUpdateInfo.rowsInVector[i] == rowIdxInVector) {
-            idxInUpdateData = i;
-            break;
-        }
-    }
-    if (idxInUpdateData != INVALID_IDX) {
-        // Overwrite existing update value.
-        vectorUpdateInfo.data->write(&values, values.state->getSelVector()[0], idxInUpdateData);
-    } else {
-        // Append new value and update `rowsInVector`.
-        vectorUpdateInfo.rowsInVector[vectorUpdateInfo.numRowsUpdated] = rowIdxInVector;
-        vectorUpdateInfo.data->write(&values, values.state->getSelVector()[0],
-            vectorUpdateInfo.numRowsUpdated++);
-    }
-    return &vectorUpdateInfo;
-}
-
-VectorUpdateInfo* UpdateInfo::getVectorInfo(const Transaction* transaction, idx_t idx) const {
-    if (idx >= vectorsInfo.size() || !vectorsInfo[idx]) {
-        return nullptr;
-    }
-    auto current = vectorsInfo[idx].get();
+    UpdateNode& header = getOrCreateUpdateNode(vectorIdx);
+    // We always lock the head of the chain of vectorUpdateInfo to ensure that we can safely
+    // read/write to any part of the chain.
+    std::unique_lock chainLock{header.mtx};
+    // Traverse the chain of vectorUpdateInfo to find the one that matches the transaction. Also
+    // detect if there is any write-write conflicts.
+    auto current = header.info.get();
+    VectorUpdateInfo* vecUpdateInfo = nullptr;
     while (current) {
         if (current->version == transaction->getID()) {
+            // Same transaction, we can update the existing vector info.
             KU_ASSERT(current->version >= Transaction::START_TRANSACTION_ID);
-            return current;
-        }
-        if (current->version <= transaction->getStartTS()) {
-            KU_ASSERT(current->version < Transaction::START_TRANSACTION_ID);
-            return current;
-        }
-        current = current->getPrev();
-    }
-    return nullptr;
-}
-
-row_idx_t UpdateInfo::getNumUpdatedRows(const Transaction* transaction) const {
-    row_idx_t numUpdatedRows = 0u;
-    for (auto i = 0u; i < vectorsInfo.size(); i++) {
-        if (const auto vectorInfo = getVectorInfo(transaction, i)) {
-            numUpdatedRows += vectorInfo->numRowsUpdated;
-        }
-    }
-    return numUpdatedRows;
-}
-
-bool UpdateInfo::hasUpdates(const Transaction* transaction, row_idx_t startRow,
-    length_t numRows) const {
-    auto [startVector, rowInStartVector] =
-        StorageUtils::getQuotientRemainder(startRow, DEFAULT_VECTOR_CAPACITY);
-    auto [endVectorIdx, rowInEndVector] =
-        StorageUtils::getQuotientRemainder(startRow + numRows, DEFAULT_VECTOR_CAPACITY);
-    for (idx_t vectorIdx = startVector; vectorIdx <= endVectorIdx; ++vectorIdx) {
-        const auto updateVector = getVectorInfo(transaction, vectorIdx);
-        if (!updateVector || updateVector->numRowsUpdated == 0) {
-            continue;
-        }
-        const auto startRowInVector = (vectorIdx == startVector) ? rowInStartVector : 0;
-        const auto endRowInVector =
-            (vectorIdx == endVectorIdx) ? rowInEndVector : DEFAULT_VECTOR_CAPACITY;
-        for (auto row = startRowInVector; row <= endRowInVector; row++) {
-            if (std::any_of(updateVector->rowsInVector.begin(),
-                    updateVector->rowsInVector.begin() + updateVector->numRowsUpdated,
-                    [&](row_idx_t updatedRow) { return row == updatedRow; })) {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
-VectorUpdateInfo& UpdateInfo::getOrCreateVectorInfo(MemoryManager& memoryManager,
-    const Transaction* transaction, idx_t vectorIdx, sel_t rowIdxInVector,
-    const LogicalType& dataType) {
-    if (vectorIdx >= vectorsInfo.size()) {
-        vectorsInfo.resize(vectorIdx + 1);
-    }
-    if (!vectorsInfo[vectorIdx]) {
-        vectorsInfo[vectorIdx] = std::make_unique<VectorUpdateInfo>(memoryManager,
-            transaction->getID(), dataType.copy());
-        return *vectorsInfo[vectorIdx];
-    }
-    auto* current = vectorsInfo[vectorIdx].get();
-    VectorUpdateInfo* info = nullptr;
-    while (current) {
-        if (current->version == transaction->getID()) {
-            // Same transaction.
-            KU_ASSERT(current->version >= Transaction::START_TRANSACTION_ID);
-            info = current;
+            vecUpdateInfo = current;
         } else if (current->version > transaction->getStartTS()) {
             // Potentially there can be conflicts. `current` can be uncommitted transaction (version
             // is transaction ID) or committed transaction started after this transaction.
@@ -119,26 +38,265 @@ VectorUpdateInfo& UpdateInfo::getOrCreateVectorInfo(MemoryManager& memoryManager
                 }
             }
         }
-        current = current->next;
+        current = current->prev.get();
     }
-    if (!info) {
-        // Create a new version here.
+    if (!vecUpdateInfo) {
+        // Create a new version here if not found in the chain.
         auto newInfo = std::make_unique<VectorUpdateInfo>(memoryManager, transaction->getID(),
-            dataType.copy());
-        vectorsInfo[vectorIdx]->next = newInfo.get();
-        newInfo->prev = std::move(vectorsInfo[vectorIdx]);
-        vectorsInfo[vectorIdx] = std::move(newInfo);
-        info = vectorsInfo[vectorIdx].get();
-        if (info->prev) {
-            // Copy the data from the previous version.
-            for (auto i = 0u; i < info->prev->numRowsUpdated; i++) {
-                info->rowsInVector[i] = info->prev->rowsInVector[i];
-            }
-            info->data->append(info->prev->data.get(), 0, info->prev->numRowsUpdated);
-            info->numRowsUpdated = info->prev->numRowsUpdated;
+            values.dataType.copy());
+        vecUpdateInfo = newInfo.get();
+        auto currentInfo = std::move(header.info);
+        if (currentInfo) {
+            currentInfo->next = newInfo.get();
+        }
+        newInfo->prev = std::move(currentInfo);
+        header.info = std::move(newInfo);
+    }
+    KU_ASSERT(vecUpdateInfo);
+    // Check if the row is already updated in this transaction.
+    idx_t idxInUpdateData = INVALID_IDX;
+    for (auto i = 0u; i < vecUpdateInfo->numRowsUpdated; i++) {
+        if (vecUpdateInfo->rowsInVector[i] == rowIdxInVector) {
+            idxInUpdateData = i;
+            break;
         }
     }
-    return *info;
+    if (idxInUpdateData != INVALID_IDX) {
+        // Overwrite existing update value.
+        vecUpdateInfo->data->write(&values, values.state->getSelVector()[0], idxInUpdateData);
+    } else {
+        // Append new value and update `rowsInVector`.
+        vecUpdateInfo->rowsInVector[vecUpdateInfo->numRowsUpdated] = rowIdxInVector;
+        vecUpdateInfo->data->write(&values, values.state->getSelVector()[0],
+            vecUpdateInfo->numRowsUpdated++);
+    }
+    return *vecUpdateInfo;
+}
+
+void UpdateInfo::scan(const Transaction* transaction, ValueVector& output, offset_t offsetInChunk,
+    length_t length) const {
+    iterateScan(transaction, offsetInChunk, length, 0 /* startPosInOutput */,
+        [&](const VectorUpdateInfo& vecUpdateInfo, uint64_t i, uint64_t posInOutput) -> void {
+            vecUpdateInfo.data->lookup(i, output, posInOutput);
+        });
+}
+
+void UpdateInfo::lookup(const Transaction* transaction, offset_t rowInChunk, ValueVector& output,
+    sel_t posInOutputVector) const {
+    if (!isSet()) {
+        return;
+    }
+    auto [vectorIdx, rowInVector] =
+        StorageUtils::getQuotientRemainder(rowInChunk, DEFAULT_VECTOR_CAPACITY);
+    bool updated = false;
+    iterateVectorInfo(transaction, vectorIdx, [&](const VectorUpdateInfo& vectorInfo) {
+        if (updated) {
+            return;
+        }
+        for (auto i = 0u; i < vectorInfo.numRowsUpdated; i++) {
+            if (vectorInfo.rowsInVector[i] == rowInVector) {
+                vectorInfo.data->lookup(i, output, posInOutputVector);
+                updated = true;
+                return;
+            }
+        }
+    });
+}
+
+void UpdateInfo::scanCommitted(const Transaction* transaction, ColumnChunkData& output,
+    offset_t startOffsetInOutput, row_idx_t startRowScanned, row_idx_t numRows) const {
+    iterateScan(transaction, startRowScanned, numRows, startOffsetInOutput,
+        [&](const VectorUpdateInfo& vecUpdateInfo, uint64_t i, uint64_t posInOutput) -> void {
+            output.write(vecUpdateInfo.data.get(), i, posInOutput, 1);
+        });
+}
+
+void UpdateInfo::iterateVectorInfo(const Transaction* transaction, idx_t idx,
+    const std::function<void(const VectorUpdateInfo&)>& func) const {
+    const UpdateNode* head = nullptr;
+    {
+        std::shared_lock lock{mtx};
+        if (idx >= updates.size() || !updates[idx].isSet()) {
+            return;
+        }
+        head = &updates[idx];
+    }
+    // We lock the head of the chain to ensure that we can safely read from any part of the
+    // chain.
+    KU_ASSERT(head);
+    std::shared_lock chainLock{head->mtx};
+    auto current = head->info.get();
+    KU_ASSERT(current);
+    while (current) {
+        if (current->version == transaction->getID() ||
+            current->version <= transaction->getStartTS()) {
+            KU_ASSERT((current->version == transaction->getID() &&
+                          current->version >= Transaction::START_TRANSACTION_ID) ||
+                      (current->version <= transaction->getStartTS() &&
+                          current->version < Transaction::START_TRANSACTION_ID));
+            func(*current);
+        }
+        current = current->getPrev();
+    }
+}
+
+void UpdateInfo::commit(idx_t vectorIdx, VectorUpdateInfo* info, transaction_t commitTS) {
+    auto& updateNode = getUpdateNode(vectorIdx);
+    std::unique_lock chainLock{updateNode.mtx};
+    info->version = commitTS;
+}
+
+void UpdateInfo::rollback(idx_t vectorIdx, VectorUpdateInfo* info) {
+    UpdateNode* header = nullptr;
+    // Note that we lock the entire UpdateInfo structure here because we might modify the
+    // head of the version chain. This is just a simplification and should be optimized later.
+    {
+        std::unique_lock lock{mtx};
+        KU_ASSERT(updates.size() > vectorIdx);
+        header = &updates[vectorIdx];
+    }
+    KU_ASSERT(header);
+    std::unique_lock chainLock{header->mtx};
+    // First check if this version is still in the chain. It might have been removed by
+    // a previous rollback entry of the same transaction.
+    // TODO(Guodong): This will be optimized by moving VectorUpdateInfo into UndoBuffer.
+    auto current = header->info.get();
+    while (current) {
+        if (current != info) {
+            current = current->getPrev();
+            continue;
+        }
+        if (info->next) {
+            // Has newer version. Remove this from the version chain.
+            const auto newerVersion = info->next;
+            auto prevVersion = info->movePrevNoLock();
+            if (prevVersion) {
+                prevVersion->next = newerVersion;
+            }
+            newerVersion->setPrev(std::move(prevVersion));
+        } else {
+            KU_ASSERT(header->info.get() == info);
+            // This is the beginning of the version chain.
+            header->info = std::move(info->prev);
+        }
+        break;
+    }
+}
+
+row_idx_t UpdateInfo::getNumUpdatedRows(const Transaction* transaction) const {
+    std::unordered_set<row_idx_t> updatedRows;
+    for (auto vectorIdx = 0u; vectorIdx < updates.size(); vectorIdx++) {
+        iterateVectorInfo(transaction, vectorIdx, [&](const VectorUpdateInfo& info) {
+            for (auto i = 0u; i < info.numRowsUpdated; i++) {
+                updatedRows.insert(info.rowsInVector[i]);
+            }
+        });
+    }
+    return updatedRows.size();
+}
+
+bool UpdateInfo::hasUpdates(const Transaction* transaction, row_idx_t startRow,
+    length_t numRows) const {
+    auto [startVector, rowInStartVector] =
+        StorageUtils::getQuotientRemainder(startRow, DEFAULT_VECTOR_CAPACITY);
+    auto [endVectorIdx, rowInEndVector] =
+        StorageUtils::getQuotientRemainder(startRow + numRows, DEFAULT_VECTOR_CAPACITY);
+    if (!isSet()) {
+        return false;
+    }
+    bool hasUpdates = false;
+    for (idx_t vectorIdx = startVector; vectorIdx <= endVectorIdx; ++vectorIdx) {
+        if (hasUpdates) {
+            break;
+        }
+        iterateVectorInfo(transaction, vectorIdx, [&](const VectorUpdateInfo& info) {
+            if (info.numRowsUpdated == 0) {
+                return;
+            }
+            const auto startRowInVector = (vectorIdx == startVector) ? rowInStartVector : 0;
+            const auto endRowInVector =
+                (vectorIdx == endVectorIdx) ? rowInEndVector : DEFAULT_VECTOR_CAPACITY;
+            for (auto row = startRowInVector; row <= endRowInVector; row++) {
+                if (std::any_of(info.rowsInVector.begin(),
+                        info.rowsInVector.begin() + info.numRowsUpdated,
+                        [&](row_idx_t updatedRow) { return row == updatedRow; })) {
+                    hasUpdates = true;
+                    return;
+                }
+            }
+        });
+    }
+    return hasUpdates;
+}
+
+UpdateNode& UpdateInfo::getUpdateNode(idx_t vectorIdx) {
+    std::shared_lock lock{mtx};
+    if (vectorIdx >= updates.size()) {
+        throw RuntimeException(
+            "UpdateInfo does not have update node for vector index: " + std::to_string(vectorIdx));
+    }
+    return updates[vectorIdx];
+}
+
+UpdateNode& UpdateInfo::getOrCreateUpdateNode(idx_t vectorIdx) {
+    std::unique_lock lock{mtx};
+    if (vectorIdx >= updates.size()) {
+        updates.resize(vectorIdx + 1);
+    }
+    return updates[vectorIdx];
+}
+
+void UpdateInfo::iterateScan(const Transaction* transaction, uint64_t startOffsetToScan,
+    uint64_t numRowsToScan, uint64_t startPosInOutput,
+    const std::function<void(const VectorUpdateInfo&, uint64_t, uint64_t)>& readFromRowFunc) const {
+    if (!isSet()) {
+        return;
+    }
+    auto [startVectorIdx, startOffsetInVector] =
+        StorageUtils::getQuotientRemainder(startOffsetToScan, DEFAULT_VECTOR_CAPACITY);
+    auto [endVectorIdx, endOffsetInVector] = StorageUtils::getQuotientRemainder(
+        startOffsetToScan + numRowsToScan, DEFAULT_VECTOR_CAPACITY);
+    idx_t idx = startVectorIdx;
+    sel_t posInVector = startPosInOutput;
+    while (idx <= endVectorIdx) {
+        const auto startOffsetInclusively = idx == startVectorIdx ? startOffsetInVector : 0;
+        const auto endOffsetExclusively =
+            idx == endVectorIdx ? endOffsetInVector : DEFAULT_VECTOR_CAPACITY;
+        const auto numRowsInVector = endOffsetExclusively - startOffsetInclusively;
+        // We keep track of the rows that have been applied with updates from updateInfo. The update
+        // version chain is maintained with the newest version at the head and the oldest version at
+        // the tail. For each tuple, we iterate through the chain to merge the updates from latest
+        // visible version. If a row has been updated in the current vectorInfo, we should skip it
+        // in older versions.
+        std::vector rowsUpdated(numRowsInVector, false);
+        iterateVectorInfo(transaction, idx, [&](const VectorUpdateInfo& vecUpdateInfo) -> void {
+            if (vecUpdateInfo.numRowsUpdated == 0) {
+                return;
+            }
+            if (std::ranges::none_of(rowsUpdated, [](auto val) { return !val; })) {
+                // All rows in this vector have been updated with a newer visible version already.
+                return;
+            }
+            // TODO(Guodong): Ideally we should make sure vecUpdateInfo.rowsInVector is sorted to
+            // simplify the checks here.
+            for (auto i = 0u; i < vecUpdateInfo.numRowsUpdated; i++) {
+                if (vecUpdateInfo.rowsInVector[i] < startOffsetInclusively ||
+                    vecUpdateInfo.rowsInVector[i] >= endOffsetExclusively) {
+                    // Continue if the row is out of the current scan range.
+                    continue;
+                }
+                auto updatedRowIdx = vecUpdateInfo.rowsInVector[i] - startOffsetInclusively;
+                if (rowsUpdated[updatedRowIdx]) {
+                    // Skip the rows that have been updated with a newer visible version already.
+                    continue;
+                }
+                readFromRowFunc(vecUpdateInfo, i, posInVector + updatedRowIdx);
+                rowsUpdated[updatedRowIdx] = true;
+            }
+        });
+        posInVector += numRowsInVector;
+        idx++;
+    }
 }
 
 } // namespace storage

--- a/src/storage/table/update_info.cpp
+++ b/src/storage/table/update_info.cpp
@@ -1,6 +1,5 @@
 #include "storage/table/update_info.h"
 
-#include <algorithm>
 #include <bitset>
 
 #include "common/exception/runtime.h"

--- a/src/storage/table/version_info.cpp
+++ b/src/storage/table/version_info.cpp
@@ -255,7 +255,7 @@ row_idx_t VectorVersionInfo::getNumDeletions(transaction_t startTS, transaction_
 void VectorVersionInfo::rollbackInsertions(row_idx_t startRowInVector, row_idx_t numRows) {
     if (isSameInsertionVersion()) {
         // This implicitly assumes that all rows are inserted in the same transaction, so regardless
-        // which rows to be roll backed, we just reset the sameInsertionVersion.
+        // which rows to be rolled back, we just reset the sameInsertionVersion.
         sameInsertionVersion = INVALID_TRANSACTION;
     } else {
         if (insertedVersions) {

--- a/src/storage/table/version_info.cpp
+++ b/src/storage/table/version_info.cpp
@@ -24,7 +24,7 @@ struct VectorVersionInfo {
     std::unique_ptr<std::array<transaction_t, DEFAULT_VECTOR_CAPACITY>> insertedVersions;
     std::unique_ptr<std::array<transaction_t, DEFAULT_VECTOR_CAPACITY>> deletedVersions;
     // If all values in the Vector are inserted/deleted in the same transaction, we can use this to
-    // aovid the allocation of `array`.
+    // avoid the allocation of `array`.
     transaction_t sameInsertionVersion;
     transaction_t sameDeletionVersion;
     InsertionStatus insertionStatus;
@@ -255,7 +255,7 @@ row_idx_t VectorVersionInfo::getNumDeletions(transaction_t startTS, transaction_
 void VectorVersionInfo::rollbackInsertions(row_idx_t startRowInVector, row_idx_t numRows) {
     if (isSameInsertionVersion()) {
         // This implicitly assumes that all rows are inserted in the same transaction, so regardless
-        // which rows to be rollbacked, we just reset the sameInsertionVersion.
+        // which rows to be roll backed, we just reset the sameInsertionVersion.
         sameInsertionVersion = INVALID_TRANSACTION;
     } else {
         if (insertedVersions) {

--- a/src/storage/undo_buffer.cpp
+++ b/src/storage/undo_buffer.cpp
@@ -222,7 +222,9 @@ void UndoBuffer::commitVersionInfo(UndoRecordType recordType, const uint8_t* rec
 
 void UndoBuffer::commitVectorUpdateInfo(const uint8_t* record, transaction_t commitTS) {
     auto& undoRecord = *reinterpret_cast<VectorUpdateRecord const*>(record);
-    undoRecord.vectorUpdateInfo->version = commitTS;
+    KU_ASSERT(undoRecord.updateInfo);
+    KU_ASSERT(undoRecord.vectorUpdateInfo);
+    undoRecord.updateInfo->commit(undoRecord.vectorIdx, undoRecord.vectorUpdateInfo, commitTS);
 }
 
 void UndoBuffer::rollbackRecord(ClientContext* context, const UndoRecordType recordType,
@@ -239,7 +241,7 @@ void UndoBuffer::rollbackRecord(ClientContext* context, const UndoRecordType rec
         rollbackVersionInfo(context, recordType, record);
     } break;
     case UndoRecordType::UPDATE_INFO: {
-        rollbackVectorUpdateInfo(transaction::Transaction::Get(*context), record);
+        rollbackVectorUpdateInfo(record);
     } break;
     default: {
         KU_UNREACHABLE;
@@ -257,7 +259,7 @@ void UndoBuffer::rollbackCatalogEntryRecord(const uint8_t* record) {
         const auto newerEntry = entryToRollback->getNext();
         newerEntry->setPrev(entryToRollback->movePrev());
     } else {
-        // This is the begin of the version chain.
+        // This is the beginning of the version chain.
         auto olderEntry = entryToRollback->movePrev();
         catalogSet->eraseNoLock(catalogEntry->getName());
         if (olderEntry) {
@@ -296,29 +298,10 @@ void UndoBuffer::rollbackVersionInfo(ClientContext* context, UndoRecordType reco
     }
 }
 
-void UndoBuffer::rollbackVectorUpdateInfo(const transaction::Transaction* transaction,
-    const uint8_t* record) {
+void UndoBuffer::rollbackVectorUpdateInfo(const uint8_t* record) {
     auto& undoRecord = *reinterpret_cast<VectorUpdateRecord const*>(record);
     KU_ASSERT(undoRecord.updateInfo);
-    if (undoRecord.updateInfo->getVectorInfo(transaction, undoRecord.vectorIdx) !=
-        undoRecord.vectorUpdateInfo) {
-        // The version chain has been updated. No need to rollback.
-        return;
-    }
-    if (undoRecord.vectorUpdateInfo->getNext()) {
-        // Has newer versions. Simply remove the current one from the version chain.
-        const auto newerVersion = undoRecord.vectorUpdateInfo->getNext();
-        auto prevVersion = undoRecord.vectorUpdateInfo->movePrev();
-        prevVersion->next = newerVersion;
-        newerVersion->setPrev(std::move(prevVersion));
-    } else {
-        // This is the begin of the version chain.
-        if (auto prevVersion = undoRecord.vectorUpdateInfo->movePrev()) {
-            undoRecord.updateInfo->setVectorInfo(undoRecord.vectorIdx, std::move(prevVersion));
-        } else {
-            undoRecord.updateInfo->clearVectorInfo(undoRecord.vectorIdx);
-        }
-    }
+    undoRecord.updateInfo->rollback(undoRecord.vectorIdx, undoRecord.vectorUpdateInfo);
 }
 
 } // namespace storage

--- a/test/graph_test/private_graph_test.cpp
+++ b/test/graph_test/private_graph_test.cpp
@@ -75,6 +75,7 @@ void DBTest::runTest(std::vector<TestStatement>& statements, uint64_t checkpoint
         if (statement.reloadDBFlag) {
             // For in-mem mode, we skip reload.
             if (!inMemMode) {
+                spdlog::info("QUERY: RELOAD DB");
                 for (auto& name : connNames) {
                     if (connMap.contains(name)) {
                         connMap.erase(name);

--- a/test/include/graph_test/private_graph_test.h
+++ b/test/include/graph_test/private_graph_test.h
@@ -45,7 +45,7 @@ class EmptyDBTest : public PrivateGraphTest {
 // ConcurrentTestExecutor is not thread safe
 class ConcurrentTestExecutor {
 public:
-    ConcurrentTestExecutor(bool& connectionsPaused, main::Connection& connection,
+    ConcurrentTestExecutor(std::atomic<bool>& connectionsPaused, main::Connection& connection,
         std::string databasePath)
         : connectionPaused{connectionsPaused}, connection{connection},
           databasePath{std::move(databasePath)} {}
@@ -62,7 +62,7 @@ public:
 private:
     void runStatements() const;
 
-    bool& connectionPaused;
+    std::atomic<bool>& connectionPaused;
     main::Connection& connection;
     std::string databasePath;
     std::thread connThread;
@@ -86,7 +86,7 @@ public:
 
 protected:
     bool isConcurrent = false;
-    bool connectionsPaused = false;
+    std::atomic<bool> connectionsPaused = false;
     std::unordered_map<std::string, ConcurrentTestExecutor> concurrentTests;
 };
 

--- a/test/include/test_runner/csv_converter.h
+++ b/test/include/test_runner/csv_converter.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "main/kuzu.h"
@@ -15,8 +16,9 @@ class CSVConverter {
 public:
     explicit CSVConverter(std::string csvDatasetPath, std::string outputDatasetPath,
         std::optional<uint64_t> bufferPoolSize, std::string outputFileExtension)
-        : csvDatasetPath{csvDatasetPath}, outputDatasetPath{outputDatasetPath},
-          bufferPoolSize{bufferPoolSize}, fileExtension{outputFileExtension} {}
+        : csvDatasetPath{std::move(csvDatasetPath)},
+          outputDatasetPath{std::move(outputDatasetPath)}, bufferPoolSize{bufferPoolSize},
+          fileExtension{std::move(outputFileExtension)} {}
 
     void convertCSVDataset();
 
@@ -34,15 +36,16 @@ private:
         std::string outputFilePath;
         // get cypher query to convert csv file to output file
         virtual std::string getConverterQuery(main::ClientContext* context) const = 0;
+        virtual ~TableInfo() = default;
     };
 
-    struct NodeTableInfo final : public TableInfo {
+    struct NodeTableInfo final : TableInfo {
         std::string primaryKey;
         // get converter query for node table
         std::string getConverterQuery(main::ClientContext* context) const override;
     };
 
-    struct RelTableInfo final : public TableInfo {
+    struct RelTableInfo final : TableInfo {
         std::shared_ptr<NodeTableInfo> fromTable;
         std::shared_ptr<NodeTableInfo> toTable;
         // get converter query for rel table

--- a/test/storage/buffer_manager_test.cpp
+++ b/test/storage/buffer_manager_test.cpp
@@ -75,7 +75,7 @@ TEST_F(EmptyBufferManagerTest, TestSpillToDiskMemoryUsage) {
 
     {
         std::vector<std::unique_ptr<ColumnChunk>> chunks;
-        chunks.push_back(std::make_unique<ColumnChunk>(*mm, false,
+        chunks.push_back(std::make_unique<ColumnChunk>(false,
             std::make_unique<ColumnChunkData>(*mm, LogicalType(LogicalTypeID::INT64), 1024, false,
                 ResidencyState::IN_MEMORY, false)));
         auto chunkedNodeGroup = ChunkedNodeGroup(std::move(chunks), 0);
@@ -99,7 +99,7 @@ TEST_F(EmptyBufferManagerTest, TestSpillToDiskMemoryUsage) {
     {
         // The memory manager uses the buffer manager for allocations of size TEMP_PAGE_SIZE
         std::vector<std::unique_ptr<ColumnChunk>> chunks;
-        chunks.push_back(std::make_unique<ColumnChunk>(*mm, false,
+        chunks.push_back(std::make_unique<ColumnChunk>(false,
             std::make_unique<ColumnChunkData>(*mm, LogicalType(LogicalTypeID::INT64),
                 TEMP_PAGE_SIZE / sizeof(int64_t), false, ResidencyState::IN_MEMORY, false)));
         auto chunkedNodeGroup = ChunkedNodeGroup(std::move(chunks), 0);

--- a/test/storage/node_update_test.cpp
+++ b/test/storage/node_update_test.cpp
@@ -27,7 +27,7 @@ TEST_F(NodeUpdateTest, UpdateSameRow) {
     ASSERT_EQ(res->getNext()->getValue(0)->val.int64Val, 300);
 }
 
-TEST_F(NodeUpdateTest, UpdateSameRowRedundtanly) {
+TEST_F(NodeUpdateTest, UpdateSameRowRedundantly) {
     if (inMemMode || systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }

--- a/test/test_files/dml_node/set/set_empty.test
+++ b/test/test_files/dml_node/set/set_empty.test
@@ -142,3 +142,20 @@ Charlienew
 -STATEMENT MATCH (p:person) WHERE p.id % 2 = 0 AND p.prop>=1000000 RETURN COUNT(*)
 ---- 1
 100000
+
+-CASE RandUpdateInt
+-STATEMENT CREATE NODE TABLE test(id INT64, prop INT64, PRIMARY KEY(id));
+---- ok
+-STATEMENT UNWIND range(0, 200000) AS i CREATE (:test {id: i, prop: i})
+---- ok
+-SET seed current_timestamp()
+-LOG seed: ${seed}
+-SET _ random.set_seed(${seed})
+-LOOP i 1 1000
+-SET val random.randInt32(200000)
+-STATEMENT MATCH (t:test) WHERE t.id=${val} SET t.prop = t.prop + 200001
+---- ok
+-ENDLOOP
+-STATEMENT MATCH (t:test) WHERE t.prop<200000 RETURN COUNT(*);
+---- 1
+199000

--- a/test/test_files/transaction/concurrency/dml_empty_serial_execution.test
+++ b/test/test_files/transaction/concurrency/dml_empty_serial_execution.test
@@ -34,26 +34,35 @@
 ---- error
 Runtime exception: Write-write conflict of updating the same row.
 
--CASE NodeUpdateSameRow
+-CASE NodeUpdateOverlappedRows
 -STATEMENT CALL debug_enable_multi_writes=true;
 ---- ok
--INSERT_STATEMENT_BLOCK COPY_TINYSNB_PERSON
--LOOP i 1 100
--STATEMENT MATCH (p:person) WHERE p.ID = 0 SET p.fName = 'Apple' RETURN p.*;
----- ok
--ENDLOOP
 -CREATE_CONNECTION conn2
+-STATEMENT CREATE NODE TABLE test(id INT64, val INT64, PRIMARY KEY(id));
+---- ok
+-STATEMENT COPY test FROM (UNWIND RANGE(0, 1000) AS id RETURN id, id + 1 AS val);
+---- ok
 -LOOP i 1 100
--STATEMENT [conn2] MATCH (p:person) WHERE p.ID = 0 SET p.fName = 'Alphabet' RETURN p.*;
+-STATEMENT MATCH (p:test) WHERE p.ID=${i} SET p.val=p.val+1000;
 ---- ok
 -ENDLOOP
--LOOP i 1 100
--STATEMENT MATCH (p:person) WHERE p.ID = 0 SET p.fName = 'Alphabet100' RETURN p.*;
+-LOOP i 50 100
+-STATEMENT [conn2] MATCH (p:test) WHERE p.ID=${i} SET p.val=p.val+2000;
 ---- ok
 -ENDLOOP
--STATEMENT MATCH (p:person) WHERE p.ID = 0 RETURN p.fName;
+-LOOP i 80 100
+-STATEMENT MATCH (p:test) WHERE p.ID=${i} SET p.val=p.val+4000;
+---- ok
+-ENDLOOP
+-STATEMENT MATCH (p:test) WHERE p.val>1000 RETURN COUNT(*);
 ---- 1
-Alphabet100
+101
+-STATEMENT MATCH (p:test) WHERE p.val>2000 RETURN COUNT(*);
+---- 1
+51
+-STATEMENT MATCH (p:test) WHERE p.val>4000 RETURN COUNT(*);
+---- 1
+21
 
 -CASE WWConflictNodeCopyDelete
 -STATEMENT CALL debug_enable_multi_writes=true;

--- a/test/test_files/transaction/concurrency/dml_empty_serial_execution.test
+++ b/test/test_files/transaction/concurrency/dml_empty_serial_execution.test
@@ -34,6 +34,27 @@
 ---- error
 Runtime exception: Write-write conflict of updating the same row.
 
+-CASE NodeUpdateSameRow
+-STATEMENT CALL debug_enable_multi_writes=true;
+---- ok
+-INSERT_STATEMENT_BLOCK COPY_TINYSNB_PERSON
+-LOOP i 1 100
+-STATEMENT MATCH (p:person) WHERE p.ID = 0 SET p.fName = 'Apple' RETURN p.*;
+---- ok
+-ENDLOOP
+-CREATE_CONNECTION conn2
+-LOOP i 1 100
+-STATEMENT [conn2] MATCH (p:person) WHERE p.ID = 0 SET p.fName = 'Alphabet' RETURN p.*;
+---- ok
+-ENDLOOP
+-LOOP i 1 100
+-STATEMENT MATCH (p:person) WHERE p.ID = 0 SET p.fName = 'Alphabet100' RETURN p.*;
+---- ok
+-ENDLOOP
+-STATEMENT MATCH (p:person) WHERE p.ID = 0 RETURN p.fName;
+---- 1
+Alphabet100
+
 -CASE WWConflictNodeCopyDelete
 -STATEMENT CALL debug_enable_multi_writes=true;
 ---- ok
@@ -158,7 +179,7 @@ Runtime exception: Write-write conflict: deleting a row that is already deleted 
 -STATEMENT [conn2] BEGIN TRANSACTION;
 ---- ok
 -STATEMENT LOAD WITH HEADERS (ID INt64, fName StRING, gender INT64, isStudent BoOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration interval, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID)
-            FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv" 
+            FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv"
             CREATE (:person{ID:ID, fName:fName, gender:gender, isStudent:isStudent, isWorker:isWorker, age:age, eyeSight:eyeSight, birthdate:birthdate, registerTime:registerTime, lastJobDuration:lastJobDuration, workedHours:workedHours, usedNames:usedNames, courseScoresPerTerm:courseScoresPerTerm, grades:grades, height:height, u:u});
 ---- ok
 -STATEMENT [conn2] LOAD WITH HEADERS (ID INt64, fName StRING, gender INT64, isStudent BoOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration interval, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, u UUID)

--- a/test/test_files/transaction/concurrency/dml_tinysnb_serial_execution.test
+++ b/test/test_files/transaction/concurrency/dml_tinysnb_serial_execution.test
@@ -1,8 +1,8 @@
 -DATASET CSV tinysnb
--SKIP
 --
 
 -CASE ConcurrentSingleWriteCreate
+-SKIP
 -CREATE_CONNECTION conn2
 -BEGIN_CONCURRENT_EXECUTION
 -STATEMENT CREATE (:person {ID: 11, fName: 'Ivan'});
@@ -23,6 +23,8 @@
 11|Ivan
 
 -CASE ConcurrentSingleWriteUpdate
+-STATEMENT CALL debug_enable_multi_writes=true;
+---- ok
 -CREATE_CONNECTION conn2
 -BEGIN_CONCURRENT_EXECUTION
 -STATEMENT MATCH (p:person) WHERE p.ID=0 SET p.fName='Apple';
@@ -42,6 +44,7 @@
 10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
 
 -CASE ConcurrentSingleWriteDelete
+-SKIP
 -STATEMENT CREATE (:person {ID: 11, fName: 'Ivan'});
 ---- ok
 -CREATE_CONNECTION conn2

--- a/test/test_files/transaction/concurrency/dml_tinysnb_serial_execution.test
+++ b/test/test_files/transaction/concurrency/dml_tinysnb_serial_execution.test
@@ -23,6 +23,7 @@
 11|Ivan
 
 -CASE ConcurrentSingleWriteUpdate
+-SKIP_WASM
 -STATEMENT CALL debug_enable_multi_writes=true;
 ---- ok
 -CREATE_CONNECTION conn2

--- a/test/test_runner/csv_converter.cpp
+++ b/test/test_runner/csv_converter.cpp
@@ -196,6 +196,8 @@ void CSVConverter::convertCSVDataset() {
     tempConn = std::make_unique<main::Connection>(tempDb.get());
 
     convertCSVFiles();
+    tempConn.reset();
+    tempDb.reset();
     removeParentDirectoryOfDBPath(tempDatabasePath);
 }
 

--- a/test/test_runner/test_parser.cpp
+++ b/test/test_runner/test_parser.cpp
@@ -368,15 +368,16 @@ TestStatement TestParser::parseStatement(const std::string& testCaseName) {
             variableMap.insert_or_assign(varName, std::move(value));
             return statement;
         }
+        case TokenType::CREATE_CONNECTION: {
+            checkMinimumParams(1);
+            testGroup->testCasesConnNames[testCaseName].insert(currentToken.params[1]);
+            return statement;
+        }
 
             // Following token types are not terminal for a statement, so we continue parsing.
         case TokenType::CHECKPOINT_WAIT_TIMEOUT: {
             checkMinimumParams(1);
             testGroup->checkpointWaitTimeout = stoi(currentToken.params[1]);
-        } break;
-        case TokenType::CREATE_CONNECTION: {
-            checkMinimumParams(1);
-            testGroup->testCasesConnNames[testCaseName].insert(currentToken.params[1]);
         } break;
         case TokenType::STATEMENT: {
             std::string query = paramsToString(1);

--- a/test/transaction/transaction_test.cpp
+++ b/test/transaction/transaction_test.cpp
@@ -556,9 +556,11 @@ static void updateNodesWithMixedTransactions(uint64_t startID, uint64_t num, boo
             << "Failed to update test" << id << ": " << res->getErrorMessage();
     }
     if (shouldCommit) {
-        conn->query("COMMIT;");
+        auto res = conn->query("COMMIT;");
+        ASSERT_TRUE(res->isSuccess()) << "Failed to update commit:" << res->getErrorMessage();
     } else {
-        conn->query("ROLLBACK;");
+        auto res = conn->query("ROLLBACK;");
+        ASSERT_TRUE(res->isSuccess()) << "Failed to update rollback:" << res->getErrorMessage();
     }
 }
 

--- a/test/transaction/transaction_test.cpp
+++ b/test/transaction/transaction_test.cpp
@@ -341,4 +341,357 @@ TEST_F(EmptyDBTransactionTest, ConcurrentComplexRelationshipInsertions) {
     auto verifiedCount = res->getNext()->getValue(0)->getValue<int64_t>();
     ASSERT_EQ(verifiedCount, numTotalInsertions / 3);
 }
+
+static void updateNodes(uint64_t startID, uint64_t num, kuzu::main::Database& database) {
+    auto conn = std::make_unique<kuzu::main::Connection>(&database);
+    for (uint64_t i = 0; i < num; ++i) {
+        auto id = startID + i;
+        auto newName = stringFormat("UPerson{}", id);
+        auto res = conn->query(
+            stringFormat("MATCH (n:test) WHERE n.id = {} SET n.name = '{}';", id, newName));
+        ASSERT_TRUE(res->isSuccess())
+            << "Failed to update test" << id << ": " << res->getErrorMessage();
+    }
+}
+
+TEST_F(EmptyDBTransactionTest, ConcurrentNodeUpdates) {
+    if (systemConfig->checkpointThreshold == 0) {
+        GTEST_SKIP();
+    }
+    conn->query("CALL debug_enable_multi_writes=true;");
+    auto numThreads = 4;
+    auto numUpdatesPerThread = 3000;
+    auto numTotalNodes = numThreads * numUpdatesPerThread;
+
+    conn->query("CREATE NODE TABLE test(id INT64 PRIMARY KEY, name STRING);");
+
+    // First insert all nodes
+    for (auto i = 0; i < numTotalNodes; ++i) {
+        auto res = conn->query(stringFormat("CREATE (:test {id: {}, name: 'Person{}'});", i, i));
+        ASSERT_TRUE(res->isSuccess());
+    }
+
+    // Verify initial state
+    auto res = conn->query("MATCH (a:test) RETURN COUNT(a) AS COUNT;");
+    ASSERT_TRUE(res->isSuccess());
+    ASSERT_EQ(res->getNumTuples(), 1);
+    auto initialCount = res->getNext()->getValue(0)->getValue<int64_t>();
+    ASSERT_EQ(initialCount, numTotalNodes);
+
+    // Update concurrently
+    std::vector<std::thread> threads;
+    for (auto i = 0; i < numThreads; ++i) {
+        threads.emplace_back(updateNodes, i * numUpdatesPerThread, numUpdatesPerThread,
+            std::ref(*database));
+    }
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    // Verify all nodes were updated
+    res =
+        conn->query("MATCH (a:test) WHERE a.name STARTS WITH 'UPerson' RETURN COUNT(a) AS COUNT;");
+    ASSERT_TRUE(res->isSuccess());
+    ASSERT_EQ(res->getNumTuples(), 1);
+    auto updatedCount = res->getNext()->getValue(0)->getValue<int64_t>();
+    ASSERT_EQ(updatedCount, numTotalNodes);
+}
+
+static void updateMixedTypeNodes(uint64_t startID, uint64_t num, kuzu::main::Database& database) {
+    auto conn = std::make_unique<kuzu::main::Connection>(&database);
+    for (auto i = 0u; i < num; ++i) {
+        auto id = startID + i;
+        auto newScore = 100.0 + (id % 20);
+        auto newActive = (id % 3 == 0) ? "false" : "true";
+        auto newName = stringFormat("UpdatedUser{}", id);
+        auto res = conn->query(stringFormat(
+            "MATCH (n:mixed_test) WHERE n.id = {} SET n.score = {}, n.active = {}, n.name = '{}';",
+            id, newScore, newActive, newName));
+        ASSERT_TRUE(res->isSuccess())
+            << "Failed to update mixed_test" << id << ": " << res->getErrorMessage();
+    }
+}
+
+TEST_F(EmptyDBTransactionTest, ConcurrentMixedTypeUpdates) {
+    if (systemConfig->checkpointThreshold == 0) {
+        GTEST_SKIP();
+    }
+    conn->query("CALL debug_enable_multi_writes=true;");
+    auto numThreads = 4;
+    auto numUpdatesPerThread = 2500;
+    auto numTotalNodes = numThreads * numUpdatesPerThread;
+
+    conn->query("CREATE NODE TABLE mixed_test(id INT64 PRIMARY KEY, score DOUBLE, active BOOLEAN, "
+                "name STRING);");
+
+    // First insert all nodes with initial values
+    for (auto i = 0; i < numTotalNodes; ++i) {
+        auto score = 95.5 + (i % 10);
+        auto isActive = (i % 2 == 0) ? "true" : "false";
+        auto res = conn->query(
+            stringFormat("CREATE (:mixed_test {id: {}, score: {}, active: {}, name: 'User{}'});", i,
+                score, isActive, i));
+        ASSERT_TRUE(res->isSuccess());
+    }
+
+    // Verify initial state
+    auto res = conn->query("MATCH (a:mixed_test) RETURN COUNT(a) AS COUNT;");
+    ASSERT_TRUE(res->isSuccess());
+    ASSERT_EQ(res->getNumTuples(), 1);
+    auto initialCount = res->getNext()->getValue(0)->getValue<int64_t>();
+    ASSERT_EQ(initialCount, numTotalNodes);
+
+    // Update concurrently
+    std::vector<std::thread> threads;
+    for (auto i = 0; i < numThreads; ++i) {
+        threads.emplace_back(updateMixedTypeNodes, i * numUpdatesPerThread, numUpdatesPerThread,
+            std::ref(*database));
+    }
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    // Verify all nodes were updated
+    res = conn->query(
+        "MATCH (a:mixed_test) WHERE a.name STARTS WITH 'UpdatedUser' RETURN COUNT(a) AS COUNT;");
+    ASSERT_TRUE(res->isSuccess());
+    ASSERT_EQ(res->getNumTuples(), 1);
+    auto updatedCount = res->getNext()->getValue(0)->getValue<int64_t>();
+    ASSERT_EQ(updatedCount, numTotalNodes);
+
+    // Verify score updates (all should be >= 100.0)
+    res = conn->query("MATCH (a:mixed_test) WHERE a.score >= 100.0 RETURN COUNT(a) AS COUNT;");
+    ASSERT_TRUE(res->isSuccess());
+    ASSERT_EQ(res->getNumTuples(), 1);
+    auto scoreUpdatedCount = res->getNext()->getValue(0)->getValue<int64_t>();
+    ASSERT_EQ(scoreUpdatedCount, numTotalNodes);
+
+    // Verify boolean updates (distribution should be different from initial)
+    res =
+        conn->query("MATCH (a:mixed_test) WHERE a.active = false RETURN COUNT(a) AS FALSE_COUNT;");
+    ASSERT_TRUE(res->isSuccess());
+    ASSERT_EQ(res->getNumTuples(), 1);
+    auto falseCount = res->getNext()->getValue(0)->getValue<int64_t>();
+    ASSERT_EQ(falseCount, 3334);
+}
+
+static void updateRelationships(uint64_t startID, uint64_t num, kuzu::main::Database& database) {
+    auto conn = std::make_unique<kuzu::main::Connection>(&database);
+    for (auto i = 0u; i < num; ++i) {
+        auto fromID = startID + i;
+        auto toID = (startID + i + 1) % (num * 4);
+        auto newWeight = 10.0 + (i % 5) * 2.0;
+        auto res = conn->query(stringFormat("MATCH (a:person)-[r:knows]->(b:person) WHERE a.id = "
+                                            "{} AND b.id = {} SET r.weight = {};",
+            fromID, toID, newWeight));
+        ASSERT_TRUE(res->isSuccess()) << "Failed to update relationship from " << fromID << " to "
+                                      << toID << ": " << res->getErrorMessage();
+    }
+}
+
+TEST_F(EmptyDBTransactionTest, ConcurrentRelationshipUpdates) {
+    if (systemConfig->checkpointThreshold == 0) {
+        GTEST_SKIP();
+    }
+    conn->query("CALL debug_enable_multi_writes=true;");
+    auto numThreads = 4;
+    auto numUpdatesPerThread = 1500;
+    auto numTotalUpdates = numThreads * numUpdatesPerThread;
+
+    conn->query("CREATE NODE TABLE person(id INT64 PRIMARY KEY, name STRING);");
+    conn->query("CREATE REL TABLE knows(FROM person TO person, weight DOUBLE);");
+
+    // Create nodes
+    for (auto i = 0; i < numTotalUpdates; ++i) {
+        auto res = conn->query(stringFormat("CREATE (:person {id: {}, name: 'Person{}'});", i, i));
+        ASSERT_TRUE(res->isSuccess());
+    }
+
+    // Create relationships
+    for (auto i = 0; i < numTotalUpdates; ++i) {
+        auto fromID = i;
+        auto toID = (i + 1) % numTotalUpdates;
+        auto weight = 1.0 + (i % 10) * 0.1;
+        auto res = conn->query(stringFormat("MATCH (a:person), (b:person) WHERE a.id = {} AND b.id "
+                                            "= {} CREATE (a)-[:knows {weight: {}}]->(b);",
+            fromID, toID, weight));
+        ASSERT_TRUE(res->isSuccess());
+    }
+
+    // Verify initial relationships
+    auto res = conn->query("MATCH ()-[r:knows]->() RETURN COUNT(r) AS COUNT;");
+    ASSERT_TRUE(res->isSuccess());
+    ASSERT_EQ(res->getNumTuples(), 1);
+    auto initialCount = res->getNext()->getValue(0)->getValue<int64_t>();
+    ASSERT_EQ(initialCount, numTotalUpdates);
+
+    // Update relationships concurrently
+    std::vector<std::thread> threads;
+    for (auto i = 0; i < numThreads; ++i) {
+        threads.emplace_back(updateRelationships, i * numUpdatesPerThread, numUpdatesPerThread,
+            std::ref(*database));
+    }
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    // Verify all relationships were updated (all weights should be >= 10.0)
+    res = conn->query("MATCH ()-[r:knows]->() WHERE r.weight >= 10.0 RETURN COUNT(r) AS COUNT;");
+    ASSERT_TRUE(res->isSuccess());
+    ASSERT_EQ(res->getNumTuples(), 1);
+    auto updatedCount = res->getNext()->getValue(0)->getValue<int64_t>();
+    ASSERT_EQ(updatedCount, numTotalUpdates);
+}
+
+static void updateNodesWithMixedTransactions(uint64_t startID, uint64_t num, bool shouldCommit,
+    kuzu::main::Database& database) {
+    auto conn = std::make_unique<kuzu::main::Connection>(&database);
+    conn->query("BEGIN TRANSACTION;");
+    for (uint64_t i = 0; i < num; ++i) {
+        auto id = startID + i;
+        auto newName = stringFormat("TxPerson{}", id);
+        auto res = conn->query(
+            stringFormat("MATCH (n:test) WHERE n.id = {} SET n.name = '{}';", id, newName));
+        ASSERT_TRUE(res->isSuccess())
+            << "Failed to update test" << id << ": " << res->getErrorMessage();
+    }
+    if (shouldCommit) {
+        conn->query("COMMIT;");
+    } else {
+        conn->query("ROLLBACK;");
+    }
+}
+
+TEST_F(EmptyDBTransactionTest, ConcurrentNodeUpdatesWithMixedTransactions) {
+    if (systemConfig->checkpointThreshold == 0) {
+        GTEST_SKIP();
+    }
+    conn->query("CALL debug_enable_multi_writes=true;");
+    auto numThreads = 3;
+    auto numUpdatesPerThread = 10;
+    auto numTotalNodes = numThreads * numUpdatesPerThread;
+
+    conn->query("CREATE NODE TABLE test(id INT64 PRIMARY KEY, name STRING);");
+
+    // Insert initial nodes
+    for (auto i = 0; i < numTotalNodes; ++i) {
+        auto res = conn->query(stringFormat("CREATE (:test {id: {}, name: 'Person{}'});", i, i));
+        ASSERT_TRUE(res->isSuccess());
+    }
+
+    // Verify initial state
+    auto res = conn->query("MATCH (a:test) RETURN COUNT(a) AS COUNT;");
+    ASSERT_TRUE(res->isSuccess());
+    ASSERT_EQ(res->getNumTuples(), 1);
+    auto initialCount = res->getNext()->getValue(0)->getValue<int64_t>();
+    ASSERT_EQ(initialCount, numTotalNodes);
+
+    // Update concurrently with mixed transactions (half commit, half rollback)
+    std::vector<std::thread> threads;
+    for (auto i = 0; i < numThreads; ++i) {
+        bool shouldCommit = (i % 2 == 0); // Even threads commit, odd threads rollback
+        threads.emplace_back(updateNodesWithMixedTransactions, i * numUpdatesPerThread,
+            numUpdatesPerThread, shouldCommit, std::ref(*database));
+    }
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    // Verify only committed transactions persisted (half of the updates)
+    res =
+        conn->query("MATCH (a:test) WHERE a.name STARTS WITH 'TxPerson' RETURN COUNT(a) AS COUNT;");
+    ASSERT_TRUE(res->isSuccess());
+    ASSERT_EQ(res->getNumTuples(), 1);
+    auto committedCount = res->getNext()->getValue(0)->getValue<int64_t>();
+    ASSERT_EQ(committedCount, 20);
+
+    // Verify rollback transactions didn't persist
+    res = conn->query("MATCH (a:test) WHERE a.name STARTS WITH 'Person' RETURN COUNT(a) AS COUNT;");
+    ASSERT_TRUE(res->isSuccess());
+    ASSERT_EQ(res->getNumTuples(), 1);
+    auto originalCount = res->getNext()->getValue(0)->getValue<int64_t>();
+    ASSERT_EQ(originalCount, 10);
+}
+
+static void updateRelationshipsWithMixedTransactions(uint64_t startID, uint64_t num,
+    bool shouldCommit, kuzu::main::Database& database) {
+    auto conn = std::make_unique<kuzu::main::Connection>(&database);
+    conn->query("BEGIN TRANSACTION;");
+    for (auto i = 0u; i < num; ++i) {
+        auto fromID = startID + i;
+        auto toID = startID + i;
+        auto newWeight = 200.0;
+        auto res = conn->query(stringFormat("MATCH (a:person)-[r:knows]->(b:person) WHERE a.id = "
+                                            "{} AND b.id = {} SET r.weight = {};",
+            fromID, toID, newWeight));
+        ASSERT_TRUE(res->isSuccess()) << "Failed to update relationship from " << fromID << " to "
+                                      << toID << ": " << res->getErrorMessage();
+    }
+    if (shouldCommit) {
+        conn->query("COMMIT;");
+    } else {
+        conn->query("ROLLBACK;");
+    }
+}
+
+TEST_F(EmptyDBTransactionTest, ConcurrentRelationshipUpdatesWithMixedTransactions) {
+    if (systemConfig->checkpointThreshold == 0) {
+        GTEST_SKIP();
+    }
+    conn->query("CALL debug_enable_multi_writes=true;");
+    auto numThreads = 4;
+    auto numUpdatesPerThread = 1000;
+    auto numTotalUpdates = numThreads * numUpdatesPerThread;
+
+    conn->query("CREATE NODE TABLE person(id INT64 PRIMARY KEY, name STRING);");
+    conn->query("CREATE REL TABLE knows(FROM person TO person, weight DOUBLE);");
+
+    // Create nodes
+    for (auto i = 0; i < numTotalUpdates; ++i) {
+        auto res = conn->query(stringFormat("CREATE (:person {id: {}, name: 'Person{}'});", i, i));
+        ASSERT_TRUE(res->isSuccess());
+    }
+
+    // Create relationships with initial weights
+    for (auto i = 0; i < numTotalUpdates; ++i) {
+        auto fromID = i;
+        auto toID = i;
+        auto weight = 20.0;
+        auto res = conn->query(stringFormat("MATCH (a:person), (b:person) WHERE a.id = {} AND b.id "
+                                            "= {} CREATE (a)-[:knows {weight: {}}]->(b);",
+            fromID, toID, weight));
+        ASSERT_TRUE(res->isSuccess());
+    }
+
+    // Verify initial relationships
+    auto res = conn->query("MATCH ()-[r:knows]->() RETURN COUNT(r) AS COUNT;");
+    ASSERT_TRUE(res->isSuccess());
+    ASSERT_EQ(res->getNumTuples(), 1);
+    auto initialCount = res->getNext()->getValue(0)->getValue<int64_t>();
+    ASSERT_EQ(initialCount, numTotalUpdates);
+
+    // Update relationships with mixed transactions
+    std::vector<std::thread> threads;
+    for (auto i = 0; i < numThreads; ++i) {
+        bool shouldCommit = (i % 3 != 0);
+        threads.emplace_back(updateRelationshipsWithMixedTransactions, i * numUpdatesPerThread,
+            numUpdatesPerThread, shouldCommit, std::ref(*database));
+    }
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    res = conn->query("MATCH ()-[r:knows]->() WHERE r.weight = 200.0 RETURN COUNT(r) AS COUNT;");
+    ASSERT_TRUE(res->isSuccess());
+    ASSERT_EQ(res->getNumTuples(), 1);
+    auto committedCount = res->getNext()->getValue(0)->getValue<int64_t>();
+    auto expectedCommitted = numTotalUpdates / 2;
+    ASSERT_EQ(committedCount, expectedCommitted);
+
+    res = conn->query("MATCH ()-[r:knows]->() WHERE r.weight = 20.0 RETURN COUNT(r) AS COUNT;");
+    ASSERT_TRUE(res->isSuccess());
+    ASSERT_EQ(res->getNumTuples(), 1);
+    auto originalCount = res->getNext()->getValue(0)->getValue<int64_t>();
+    ASSERT_EQ(originalCount, numTotalUpdates / 2);
+}
 #endif

--- a/test/transaction/transaction_test.cpp
+++ b/test/transaction/transaction_test.cpp
@@ -567,8 +567,8 @@ TEST_F(EmptyDBTransactionTest, ConcurrentNodeUpdatesWithMixedTransactions) {
         GTEST_SKIP();
     }
     conn->query("CALL debug_enable_multi_writes=true;");
-    auto numThreads = 3;
-    auto numUpdatesPerThread = 10;
+    auto numThreads = 4;
+    auto numUpdatesPerThread = 100;
     auto numTotalNodes = numThreads * numUpdatesPerThread;
 
     conn->query("CREATE NODE TABLE test(id INT64 PRIMARY KEY, name STRING);");
@@ -603,14 +603,14 @@ TEST_F(EmptyDBTransactionTest, ConcurrentNodeUpdatesWithMixedTransactions) {
     ASSERT_TRUE(res->isSuccess());
     ASSERT_EQ(res->getNumTuples(), 1);
     auto committedCount = res->getNext()->getValue(0)->getValue<int64_t>();
-    ASSERT_EQ(committedCount, 20);
+    ASSERT_EQ(committedCount, 200);
 
     // Verify rollback transactions didn't persist
     res = conn->query("MATCH (a:test) WHERE a.name STARTS WITH 'Person' RETURN COUNT(a) AS COUNT;");
     ASSERT_TRUE(res->isSuccess());
     ASSERT_EQ(res->getNumTuples(), 1);
     auto originalCount = res->getNext()->getValue(0)->getValue<int64_t>();
-    ASSERT_EQ(originalCount, 10);
+    ASSERT_EQ(originalCount, 200);
 }
 
 static void updateRelationshipsWithMixedTransactions(uint64_t startID, uint64_t num,


### PR DESCRIPTION
# Description

We use `UpdateInfo` to track multiple versions of data if any were updated. 

Previously, the `UpdateInfo` wasn't designed for concurrent accesses, this PR adds proper locks within UpdateInfo for concurrent accesses. For each vector of data, a `UpdateNode` is kept as the head of the version list.
The locks are placed at two levels, one for the whole `UpdateInfo` structure, and one for each version list, i.e., `UpdateNode`.

The scan of update data is reworked as well, as there can be multiple transactions ongoing concurrently now. Previously we assume that only one writer exists, and the version chain should contain committed updates only (roll backed ones gets removed from the chain immediately). The scan now performs first by scanning the base data, then traversing the version chain and find the latest available update for each row and overwrite the scanned base data accordingly.

Note that the garbage collection is not done within this PR, which will come in a later one, as some further rework is needed separately.

A simple benchmark was performed locally on Mac mini with M4 pro chip. The benchmark is to update each tuple of a node table with 1M tuples with 1/2/4/8 threads under *in-memory mode*. Each update itself is a transaction. Each thread simply updates a sequential range of nodes to set an int64 property value to a new one.

The benchmark result:
| # threads | branch | time (ms) |
| --------- | ------- | ---------- |
| 1 | master | 106825 |
| 1 | new | 105715 |
| 2 | new | 64242 | 
| 4 | new | 44582 | 
| 8 | new | 33626 |
