### PR TITLE
Proper error when cast invalid json

### DIFF
--- a/extension/json/test/error.test
+++ b/extension/json/test/error.test
@@ -54,18 +54,21 @@ Binder exception: Invalid primary key column type json. Primary keys must be eit
 -STATEMENT CREATE NODE TABLE PERSON (ID INT64, NAME JSON, description STRING, PRIMARY KEY(ID));
 ---- ok
 -STATEMENT CREATE (p:PERSON {ID: 52, NAME: 'KUZU', DESCRIPTION: 'good'});
----- ok
+---- error
+Conversion exception: Cannot convert KUZU to JSON.
+-STATEMENT CREATE (p:PERSON {ID: 52, NAME: '', DESCRIPTION: 'good'});
+---- error
+Conversion exception: Cannot convert  to JSON.
 -STATEMENT CREATE (p:PERSON {ID: 22, NAME: 'neo', DESCRIPTION: 'ok'});
----- ok
+---- error
+Conversion exception: Cannot convert neo to JSON.
 -STATEMENT CALL TABLE_INFO('person') RETURN *;
 ---- 3
 0|ID|INT64|NULL|True
 1|NAME|json|NULL|False
 2|description|STRING|NULL|False
 -STATEMENT MATCH (p:person) RETURN p.*;
----- 2
-22|neo|ok
-52|KUZU|good
+---- 0
 -RELOADDB
 -STATEMENT CALL TABLE_INFO('person') RETURN *;
 ---- 3
@@ -73,6 +76,4 @@ Binder exception: Invalid primary key column type json. Primary keys must be eit
 1|NAME|json|NULL|False
 2|description|STRING|NULL|False
 -STATEMENT MATCH (p:person) RETURN p.*;
----- 2
-22|neo|ok
-52|KUZU|good
+---- 0

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -110,21 +110,14 @@ static std::string unsupportedImplicitCastException(const Expression& expression
         expression.toString(), expression.dataType.toString(), targetTypeStr);
 }
 
-static bool checkUDTCast(const LogicalType& type, const LogicalType& target) {
-    if (type.isInternalType() && target.isInternalType()) {
-        return false;
-    }
-    return type.getLogicalTypeID() == target.getLogicalTypeID();
-}
-
 std::shared_ptr<Expression> ExpressionBinder::implicitCastIfNecessary(
     const std::shared_ptr<Expression>& expression, const LogicalType& targetType) {
     auto& type = expression->dataType;
-    if (checkUDTCast(type, targetType)) {
-        return expression;
-    }
     if (type == targetType || targetType.containsAny()) { // No need to cast.
         return expression;
+    }
+    if (!type.isInternalType() || !targetType.isInternalType()) {
+        return implicitCast(expression, targetType);
     }
     if (ExpressionUtil::canCastStatically(*expression, targetType)) {
         expression->cast(targetType);


### PR DESCRIPTION
Closes #5856 
We should properly error when the user tries to cast a invalid json string to json.

For example:
```
INSTALL json;
LOAD json;
CREATE NODE TABLE User(name STRING PRIMARY KEY, metadata JSON);
CREATE (:User {name: 'Joe', metadata: ''});
```
We should error since empty string is not a valid jso.