### PR TITLE
fix(python): add support for bytes parameters in BLOB fields

### DIFF
--- a/tools/python_api/src_cpp/include/py_conversion.h
+++ b/tools/python_api/src_cpp/include/py_conversion.h
@@ -18,6 +18,7 @@ enum class PythonObjectType : uint8_t {
     Datetime,
     Date,
     String,
+    Bytes,
     List,
     UUID,
     Dict,

--- a/tools/python_api/src_cpp/py_conversion.cpp
+++ b/tools/python_api/src_cpp/py_conversion.cpp
@@ -32,6 +32,8 @@ PythonObjectType getPythonObjectType(py::handle& ele) {
         return PythonObjectType::Date;
     } else if (py::isinstance<py::str>(ele)) {
         return PythonObjectType::String;
+    } else if (py::isinstance<py::bytes>(ele)) {
+        return PythonObjectType::Bytes;
     } else if (py::isinstance<py::list>(ele)) {
         return PythonObjectType::List;
     } else if (py::isinstance(ele, uuid)) {
@@ -172,6 +174,14 @@ void transformPythonValue(common::ValueVector* outputVector, uint64_t pos, py::h
     case PythonObjectType::String: {
         outputVector->setNull(pos, false /* isNull */);
         common::StringVector::addString(outputVector, pos, ele.cast<std::string>());
+    } break;
+    case PythonObjectType::Bytes: {
+        outputVector->setNull(pos, false /* isNull */);
+        auto bytes = py::cast<py::bytes>(ele);
+        const char* data = PyBytes_AsString(bytes.ptr());
+        Py_ssize_t size = PyBytes_Size(bytes.ptr());
+        std::string blobStr(data, size);
+        outputVector->setValue(pos, blobStr);
     } break;
     case PythonObjectType::List: {
         transformListValue(outputVector, pos, ele);

--- a/tools/python_api/src_cpp/py_udf.cpp
+++ b/tools/python_api/src_cpp/py_udf.cpp
@@ -101,6 +101,8 @@ static LogicalType getLogicalTypeNonNested(const py::handle& ele) {
         return LogicalType::DOUBLE();
     } else if (ele.is(py::type::of(py::str()))) {
         return LogicalType::STRING();
+    } else if (ele.is(py::type::of(py::bytes()))) {
+        return LogicalType::BLOB();
     } else if (ele.is(py::type::of(datetime_val))) {
         return LogicalType::TIMESTAMP();
     } else if (ele.is(py::type::of(date_val))) {

--- a/tools/python_api/test/test_blob_parameter.py
+++ b/tools/python_api/test/test_blob_parameter.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+from type_aliases import ConnDB
+
+
+def test_bytes_param(conn_db_empty: ConnDB) -> None:
+    conn, _ = conn_db_empty
+    conn.execute("CREATE NODE TABLE tab(id SERIAL PRIMARY KEY, data BLOB)")
+
+    data_0 = b"\x00\x01\x02\x03\xff"
+    data_1 = b"testing"
+    data_2 = b"A" * 4096  # 4KB "max"
+    data_3 = b""  # empty
+    data_4 = None  # null
+    data_5 = "Hello 🌍"  # str
+
+    cases = [
+        data_0,
+        data_1,
+        data_2,
+        data_3,
+        data_4,
+        data_5.encode("utf-8"),  # to bytes
+    ]
+    for data in cases:
+        conn.execute("CREATE (t:tab {data: $data})", {"data": data})
+
+    result = conn.execute("MATCH (t:tab) RETURN t.data ORDER BY t.id")
+    assert result.get_next() == [data_0]
+    assert result.get_next() == [data_1]
+    assert result.get_next() == [data_2]
+    assert result.get_next() == [data_3]
+    assert result.get_next() == [data_4]
+    assert result.get_next()[0].decode("utf-8") == data_5
+    result.close()
+
+
+def test_bytes_param_backwards_compatibility(conn_db_empty: ConnDB) -> None:
+    conn, _ = conn_db_empty
+    conn.execute("CREATE NODE TABLE tab(id SERIAL PRIMARY KEY, data BLOB)")
+
+    binary = b"backwards_compatibility"
+    string = "".join(f"\\x{b:02x}" for b in binary)  # to \xHH format
+
+    assert isinstance(string, str)
+    assert re.match(r"^(\\x[0-9a-f]{2})+$", string)
+
+    conn.execute("CREATE (t:tab {data: BLOB($string)})", {"string": string})
+
+    result = conn.execute("MATCH (t:tab) RETURN t.data")
+    assert result.get_next() == [binary]
+    result.close()
+
+
+def test_bytes_param_where_clause(conn_db_empty: ConnDB) -> None:
+    conn, _ = conn_db_empty
+    conn.execute("CREATE NODE TABLE tab(id INT64 PRIMARY KEY, data BLOB)")
+
+    data = b"where_clause"
+
+    conn.execute("CREATE (t:tab {id: 0, data: $data})", {"data": b"some data"})
+    conn.execute("CREATE (t:tab {id: 1, data: $data})", {"data": data})
+    conn.execute("CREATE (t:tab {id: 2, data: $data})", {"data": b"some other data"})
+
+    result = conn.execute("MATCH (t:tab) WHERE t.data = $search RETURN t.id", {"search": data})
+    assert result.get_next() == [1]
+    assert not result.has_next()
+    result.close()
+
+
+def test_bytes_param_update(conn_db_empty: ConnDB) -> None:
+    conn, _ = conn_db_empty
+    conn.execute("CREATE NODE TABLE tab(id SERIAL PRIMARY KEY, data BLOB)")
+
+    initial = b"initial"
+    updated = b"updated"
+
+    conn.execute("CREATE (t:tab {data: $data})", {"data": initial})
+    conn.execute("MATCH (t:tab) SET t.data = $new_data", {"new_data": updated})
+
+    result = conn.execute("MATCH (t:tab) RETURN t.data")
+    assert result.get_next() == [updated]
+    result.close()
+
+
+def test_bytes_param_mixed_types(conn_db_empty: ConnDB) -> None:
+    conn, _ = conn_db_empty
+    conn.execute("CREATE NODE TABLE tab(id SERIAL PRIMARY KEY, data BLOB, name STRING, value DOUBLE)")
+
+    data = b"data"
+    name = "name"
+    value = 3.14
+
+    params = {"data": data, "name": name, "value": value}
+    conn.execute("CREATE (t:tab {data: $data, name: $name, value: $value})", params)
+
+    result = conn.execute("MATCH (t:tab) RETURN t.data, t.name, t.value")
+    assert result.get_next() == [data, name, value]
+    result.close()
+
+
+def test_bytes_param_relationship(conn_db_empty: ConnDB) -> None:
+    conn, _ = conn_db_empty
+    conn.execute("CREATE NODE TABLE person(name STRING PRIMARY KEY)")
+    conn.execute("CREATE REL TABLE rel(FROM person TO person, data BLOB)")
+
+    conn.execute("CREATE (p:person {name: 'Alice'})")
+    conn.execute("CREATE (p:person {name: 'Bob'})")
+
+    data = b"relationship"
+
+    conn.execute(
+        """
+            MATCH (p1:person {name: 'Alice'}), (p2:person {name: 'Bob'})
+            CREATE (p1)-[r:rel {data: $data}]->(p2)
+        """,
+        {"data": data},
+    )
+
+    result = conn.execute("MATCH ()-[r:rel]->() RETURN r.data")
+    assert result.get_next() == [data]
+    result.close()
+
+
+def test_bytes_param_invalid_types(conn_db_empty: ConnDB) -> None:
+    conn, _ = conn_db_empty
+    conn.execute("CREATE NODE TABLE tab(id SERIAL PRIMARY KEY, data BLOB)")
+
+    cases = [
+        ("test", "STRING"),
+        ("", "STRING"),
+        (1, "INT8"),
+        (256, "INT16"),
+        ([1, 2], "INT8[]"),
+        (True, "BOOL"),
+    ]
+
+    for data, real in cases:
+        msg = f"Binder exception: Expression $data has data type {real} but expected BLOB. Implicit cast is not supported."
+        with pytest.raises(RuntimeError, match=re.escape(msg)):
+            conn.execute("CREATE (t:tab {data: $data})", {"data": data})
+
+
+def test_bytes_param_udf(conn_db_empty: ConnDB) -> None:
+    conn, _ = conn_db_empty
+
+    def reverse_bytes(data: bytes) -> bytes:
+        return data[::-1]
+
+    conn.create_function("reverse_bytes", reverse_bytes, ["BLOB"], "BLOB")
+
+    data = b"hello"
+    expected = b"olleh"
+
+    result = conn.execute("RETURN reverse_bytes($data)", {"data": data})
+    assert result.get_next() == [expected]
+
+    result = conn.execute("RETURN reverse_bytes(NULL)")
+    assert result.get_next() == [None]
+
+    result.close()

--- a/tools/python_api/test/test_blob_parameter.py
+++ b/tools/python_api/test/test_blob_parameter.py
@@ -12,7 +12,7 @@ def test_bytes_param(conn_db_empty: ConnDB) -> None:
 
     data_0 = b"\x00\x01\x02\x03\xff"
     data_1 = b"testing"
-    data_2 = b"A" * 4096  # 4KB "max"
+    data_2 = b"A" * 4096  # max size: 4KB, see https://docs.kuzudb.com/cypher/data-types/#blob
     data_3 = b""  # empty
     data_4 = None  # null
     data_5 = "Hello 🌍"  # str


### PR DESCRIPTION
## Problem

The Python API was failing with `AttributeError: module 'importlib' has no attribute 'util'` when passing Python `bytes` objects directly as parameters for BLOB fields.

**Expected behavior:** Python `bytes` should be accepted directly for BLOB parameters since BLOB stands for Binary Large Object.

**Previously:** Users had to manually convert bytes to hex strings and use the `BLOB()` function.

## Solution

This PR adds support for Python `bytes` objects in BLOB contexts across the Python API.

### Changes Made

- **Type detection**: Add recognition for Python `bytes` objects as BLOB type
- **Parameter handling**: Convert `bytes` to BLOB when used as query parameters
- **Data ingestion**: Support `bytes` objects when loading data from Python
- **UDF support**: Allow `bytes` as input/output types in user-defined functions

### Implementation Details

- Fixes the `Python bytes → Kuzu BLOB` conversion using Python C API (`PyBytes_AsString`, `PyBytes_Size`) 
- The reverse direction `Kuzu BLOB → Python bytes` (query results) was already working correctly
- Maintains full round-trip consistency: `Python bytes → Kuzu BLOB → Python bytes`
- Preserves backward compatibility with existing `BLOB("\\xHH")` syntax

### Test Coverage

Test suite (`test_blob_parameter.py`) covers:
- ✅ Basic bytes parameters (raw binary, text, large data, empty, null)
- ✅ UTF-8 end-to-end conversion
- ✅ Backward compatibility with string + `BLOB()`
- ✅ CRUD operations (CREATE, UPDATE, WHERE clauses)
- ✅ Mixed parameter types
- ✅ Relationship properties with BLOB
- ✅ User-defined functions with bytes
- ✅ Error handling for invalid types

Fixes #5859

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).