### PR TITLE
Avoid OnDiskGraphNbrScanState#getChunk() create new propertyVectors

### DIFF
--- a/src/graph/graph.cpp
+++ b/src/graph/graph.cpp
@@ -4,8 +4,9 @@
 
 namespace kuzu::graph {
 NbrScanState::Chunk::Chunk(std::span<const common::nodeID_t> nbrNodes,
-    common::SelectionVector& selVector, std::vector<common::ValueVector*> propertyVectors)
-    : nbrNodes{nbrNodes}, selVector{selVector}, propertyVectors{std::move(propertyVectors)} {
+    common::SelectionVector& selVector,
+    std::span<const std::shared_ptr<common::ValueVector>> propertyVectors)
+    : nbrNodes{nbrNodes}, selVector{selVector}, propertyVectors{propertyVectors} {
     KU_ASSERT(nbrNodes.size() == common::DEFAULT_VECTOR_CAPACITY);
 }
 

--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -98,7 +98,7 @@ OnDiskGraphNbrScanState::OnDiskGraphNbrScanState(ClientContext* context,
     srcNodeIDVector = getValueVector(LogicalType::INTERNAL_ID(), mm, state);
     srcNodeIDVector->state = DataChunkState::getSingleValueDataChunkState();
     dstNodeIDVector = getValueVector(LogicalType::INTERNAL_ID(), mm, state);
-    propertyVectors.resize(relProperties.size());
+    propertyVectors.valueVectors.resize(relProperties.size());
     // TODO(bmwinger): If there are both a predicate and a custom edgePropertyIndex, they will
     // currently be scanned twice. The propertyVector could simply be one of the vectors used
     // for the predicate.
@@ -109,7 +109,7 @@ OnDiskGraphNbrScanState::OnDiskGraphNbrScanState(ClientContext* context,
         auto& property = entry.getProperty(propertyName);
         relPropertyColumnIDs[i] = entry.getColumnID(propertyName);
         KU_ASSERT(relPropertyColumnIDs[i] != INVALID_COLUMN_ID);
-        propertyVectors[i] = getValueVector(property.getType(), mm, state);
+        propertyVectors.valueVectors[i] = getValueVector(property.getType(), mm, state);
     }
     if (predicate != nullptr) {
         auto mapper = ExpressionMapper(&schema);
@@ -120,8 +120,8 @@ OnDiskGraphNbrScanState::OnDiskGraphNbrScanState(ClientContext* context,
     for (auto dataDirection : entry.constCast<RelGroupCatalogEntry>().getRelDataDirections()) {
         auto columnIDs = getColumnIDs(predicateProps, entry, relPropertyColumnIDs);
         std::vector outVectors{dstNodeIDVector.get()};
-        for (auto& propertyVector : propertyVectors) {
-            outVectors.push_back(propertyVector.get());
+        for (auto i = 0u; i < propertyVectors.getNumValueVectors(); i++) {
+            outVectors.push_back(&propertyVectors.getValueVectorMutable(i));
         }
         for (auto& property : predicateProps) {
             auto pos = DataPos(schema.getExpressionPos(*property));

--- a/src/include/graph/graph.h
+++ b/src/include/graph/graph.h
@@ -54,7 +54,7 @@ public:
 
     private:
         Chunk(std::span<const common::nodeID_t> nbrNodes, common::SelectionVector& selVector,
-            std::vector<common::ValueVector*> propertyVectors);
+            std::span<const std::shared_ptr<common::ValueVector>> propertyVectors);
 
         Chunk(const Chunk& other) noexcept
             : nbrNodes{other.nbrNodes}, selVector{other.selVector},
@@ -65,7 +65,7 @@ public:
         // this reference can be modified, but the underlying data will be reset the next time next
         // is called
         common::SelectionVector& selVector;
-        std::vector<common::ValueVector*> propertyVectors;
+        std::span<const std::shared_ptr<common::ValueVector>> propertyVectors;
     };
 
     virtual ~NbrScanState() = default;
@@ -76,8 +76,9 @@ public:
 
 protected:
     static Chunk createChunk(std::span<const common::nodeID_t> nbrNodes,
-        common::SelectionVector& selVector, std::vector<common::ValueVector*> propertyVectors) {
-        return Chunk{nbrNodes, selVector, std::move(propertyVectors)};
+        common::SelectionVector& selVector,
+        std::span<const std::shared_ptr<common::ValueVector>> propertyVectors) {
+        return Chunk{nbrNodes, selVector, propertyVectors};
     }
 };
 

--- a/src/include/graph/on_disk_graph.h
+++ b/src/include/graph/on_disk_graph.h
@@ -34,11 +34,8 @@ public:
         std::vector<std::string> relProperties, bool randomLookup = false);
 
     Chunk getChunk() override {
-        std::vector<common::ValueVector*> vectors;
-        for (auto& propertyVector : propertyVectors) {
-            vectors.push_back(propertyVector.get());
-        }
-        return createChunk(currentIter->getNbrNodes(), currentIter->getSelVectorUnsafe(), vectors);
+        return createChunk(currentIter->getNbrNodes(), currentIter->getSelVectorUnsafe(),
+            std::span(propertyVectors.valueVectors));
     }
     bool next() override;
 
@@ -84,7 +81,7 @@ public:
 private:
     std::unique_ptr<common::ValueVector> srcNodeIDVector;
     std::unique_ptr<common::ValueVector> dstNodeIDVector;
-    std::vector<std::unique_ptr<common::ValueVector>> propertyVectors;
+    common::DataChunk propertyVectors;
 
     std::unique_ptr<evaluator::ExpressionEvaluator> relPredicateEvaluator;
     common::SemiMask* nbrNodeMask = nullptr;


### PR DESCRIPTION
# Description

Optimize gds framework performance.In my gds algorithm , the time taken was reduced from 1703ms to 1563ms.

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
