### PR TITLE
Add abstract arrow query result

### DIFF
--- a/src/common/arrow/arrow_array_scan.cpp
+++ b/src/common/arrow/arrow_array_scan.cpp
@@ -1,8 +1,8 @@
 #include "common/arrow/arrow_converter.h"
 #include "common/exception/runtime.h"
+#include "common/types/int128_t.h"
 #include "common/types/interval_t.h"
 #include "common/types/types.h"
-#include "common/types/int128_t.h"
 #include "common/vector/value_vector.h"
 
 namespace kuzu {

--- a/src/common/arrow/arrow_array_scan.cpp
+++ b/src/common/arrow/arrow_array_scan.cpp
@@ -2,6 +2,7 @@
 #include "common/exception/runtime.h"
 #include "common/types/interval_t.h"
 #include "common/types/types.h"
+#include "common/types/int128_t.h"
 #include "common/vector/value_vector.h"
 
 namespace kuzu {

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -78,7 +78,7 @@ void ArrowConverter::initializeChild(ArrowSchema& child, const std::string& name
 }
 
 void ArrowConverter::setArrowFormatForStruct(ArrowSchemaHolder& rootHolder, ArrowSchema& child,
-    const LogicalType& dataType) {
+    const LogicalType& dataType, bool fallbackExtensionTypes) {
     child.format = "+s";
     // name is set by parent.
     child.n_children = (std::int64_t)StructType::getNumFields(dataType);
@@ -94,12 +94,12 @@ void ArrowConverter::setArrowFormatForStruct(ArrowSchemaHolder& rootHolder, Arro
         initializeChild(*child.children[i]);
         const auto& structField = StructType::getField(dataType, i);
         child.children[i]->name = copyName(rootHolder, structField.getName());
-        setArrowFormat(rootHolder, *child.children[i], structField.getType());
+        setArrowFormat(rootHolder, *child.children[i], structField.getType(), fallbackExtensionTypes);
     }
 }
 
 void ArrowConverter::setArrowFormatForUnion(ArrowSchemaHolder& rootHolder, ArrowSchema& child,
-    const LogicalType& dataType) {
+    const LogicalType& dataType, bool fallbackExtensionTypes) {
     std::string formatStr = "+ud";
     child.n_children = (std::int64_t)UnionType::getNumFields(dataType);
     rootHolder.nestedChildren.emplace_back();
@@ -115,14 +115,14 @@ void ArrowConverter::setArrowFormatForUnion(ArrowSchemaHolder& rootHolder, Arrow
         const auto& unionFieldType = UnionType::getFieldType(dataType, i);
         auto unionFieldName = UnionType::getFieldName(dataType, i);
         child.children[i]->name = copyName(rootHolder, unionFieldName);
-        setArrowFormat(rootHolder, *child.children[i], unionFieldType);
+        setArrowFormat(rootHolder, *child.children[i], unionFieldType, fallbackExtensionTypes);
         formatStr += (i == 0u ? ":" : ",") + std::to_string(i);
     }
     child.format = copyName(rootHolder, formatStr);
 }
 
 void ArrowConverter::setArrowFormatForInternalID(ArrowSchemaHolder& rootHolder, ArrowSchema& child,
-    const LogicalType& /*dataType*/) {
+    const LogicalType& /*dataType*/, bool fallbackExtensionTypes) {
     child.format = "+s";
     // name is set by parent.
     child.n_children = 2;
@@ -136,14 +136,14 @@ void ArrowConverter::setArrowFormatForInternalID(ArrowSchemaHolder& rootHolder, 
     child.children = &rootHolder.nestedChildrenPtr.back()[0];
     initializeChild(*child.children[0]);
     child.children[0]->name = copyName(rootHolder, "offset");
-    setArrowFormat(rootHolder, *child.children[0], LogicalType::INT64());
+    setArrowFormat(rootHolder, *child.children[0], LogicalType::INT64(), fallbackExtensionTypes);
     initializeChild(*child.children[1]);
     child.children[1]->name = copyName(rootHolder, "table");
-    setArrowFormat(rootHolder, *child.children[1], LogicalType::INT64());
+    setArrowFormat(rootHolder, *child.children[1], LogicalType::INT64(), fallbackExtensionTypes);
 }
 
 void ArrowConverter::setArrowFormat(ArrowSchemaHolder& rootHolder, ArrowSchema& child,
-    const LogicalType& dataType) {
+    const LogicalType& dataType, bool fallbackExtensionTypes) {
     switch (dataType.getLogicalTypeID()) {
     case LogicalTypeID::BOOL: {
         child.format = "b";
@@ -234,7 +234,7 @@ void ArrowConverter::setArrowFormat(ArrowSchemaHolder& rootHolder, ArrowSchema& 
         initializeChild(rootHolder.nestedChildren.back()[0]);
         child.children = &rootHolder.nestedChildrenPtr.back()[0];
         child.children[0]->name = "l";
-        setArrowFormat(rootHolder, **child.children, ListType::getChildType(dataType));
+        setArrowFormat(rootHolder, **child.children, ListType::getChildType(dataType), fallbackExtensionTypes);
     } break;
     case LogicalTypeID::ARRAY: {
         auto numValuesPerArray = "+w:" + std::to_string(ArrayType::getNumElements(dataType));
@@ -247,7 +247,7 @@ void ArrowConverter::setArrowFormat(ArrowSchemaHolder& rootHolder, ArrowSchema& 
         initializeChild(rootHolder.nestedChildren.back()[0]);
         child.children = &rootHolder.nestedChildrenPtr.back()[0];
         child.children[0]->name = "l";
-        setArrowFormat(rootHolder, **child.children, ArrayType::getChildType(dataType));
+        setArrowFormat(rootHolder, **child.children, ArrayType::getChildType(dataType), fallbackExtensionTypes);
     } break;
     case LogicalTypeID::MAP: {
         child.format = "+m";
@@ -259,19 +259,19 @@ void ArrowConverter::setArrowFormat(ArrowSchemaHolder& rootHolder, ArrowSchema& 
         initializeChild(rootHolder.nestedChildren.back()[0]);
         child.children = &rootHolder.nestedChildrenPtr.back()[0];
         child.children[0]->name = "l";
-        setArrowFormat(rootHolder, **child.children, ListType::getChildType(dataType));
+        setArrowFormat(rootHolder, **child.children, ListType::getChildType(dataType), fallbackExtensionTypes);
     } break;
     case LogicalTypeID::STRUCT:
     case LogicalTypeID::NODE:
     case LogicalTypeID::REL:
     case LogicalTypeID::RECURSIVE_REL:
-        setArrowFormatForStruct(rootHolder, child, dataType);
+        setArrowFormatForStruct(rootHolder, child, dataType, fallbackExtensionTypes);
         break;
     case LogicalTypeID::INTERNAL_ID:
-        setArrowFormatForInternalID(rootHolder, child, dataType);
+        setArrowFormatForInternalID(rootHolder, child, dataType, fallbackExtensionTypes);
         break;
     case LogicalTypeID::UNION:
-        setArrowFormatForUnion(rootHolder, child, dataType);
+        setArrowFormatForUnion(rootHolder, child, dataType, fallbackExtensionTypes);
         break;
     default:
         throw RuntimeException(
@@ -280,7 +280,7 @@ void ArrowConverter::setArrowFormat(ArrowSchemaHolder& rootHolder, ArrowSchema& 
 }
 
 std::unique_ptr<ArrowSchema> ArrowConverter::toArrowSchema(
-    const std::vector<LogicalType>& dataTypes, const std::vector<std::string>& columnNames) {
+    const std::vector<LogicalType>& dataTypes, const std::vector<std::string>& columnNames, bool fallbackExtensionTypes) {
     auto outSchema = std::make_unique<ArrowSchema>();
     auto rootHolder = std::make_unique<ArrowSchemaHolder>();
 
@@ -303,23 +303,12 @@ std::unique_ptr<ArrowSchema> ArrowConverter::toArrowSchema(
         auto& child = rootHolder->children[i];
         initializeChild(child);
         child.name = copyName(*rootHolder, columnNames[i]);
-        setArrowFormat(*rootHolder, child, dataTypes[i]);
+        setArrowFormat(*rootHolder, child, dataTypes[i], fallbackExtensionTypes);
     }
 
     outSchema->private_data = rootHolder.release();
     outSchema->release = releaseArrowSchema;
     return outSchema;
-}
-
-void ArrowConverter::toArrowArray(main::QueryResult& queryResult, ArrowArray* outArray,
-    std::int64_t chunkSize) {
-    std::vector<LogicalType> types;
-    for (const auto& type : queryResult.getColumnDataTypes()) {
-        types.push_back(type.copy());
-    }
-    ArrowRowBatch::fallbackExtensionTypes = fallbackExtensionTypes;
-    auto rowBatch = make_unique<ArrowRowBatch>(std::move(types), chunkSize);
-    *outArray = rowBatch->append(queryResult, chunkSize);
 }
 
 } // namespace common

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -94,7 +94,8 @@ void ArrowConverter::setArrowFormatForStruct(ArrowSchemaHolder& rootHolder, Arro
         initializeChild(*child.children[i]);
         const auto& structField = StructType::getField(dataType, i);
         child.children[i]->name = copyName(rootHolder, structField.getName());
-        setArrowFormat(rootHolder, *child.children[i], structField.getType(), fallbackExtensionTypes);
+        setArrowFormat(rootHolder, *child.children[i], structField.getType(),
+            fallbackExtensionTypes);
     }
 }
 
@@ -234,7 +235,8 @@ void ArrowConverter::setArrowFormat(ArrowSchemaHolder& rootHolder, ArrowSchema& 
         initializeChild(rootHolder.nestedChildren.back()[0]);
         child.children = &rootHolder.nestedChildrenPtr.back()[0];
         child.children[0]->name = "l";
-        setArrowFormat(rootHolder, **child.children, ListType::getChildType(dataType), fallbackExtensionTypes);
+        setArrowFormat(rootHolder, **child.children, ListType::getChildType(dataType),
+            fallbackExtensionTypes);
     } break;
     case LogicalTypeID::ARRAY: {
         auto numValuesPerArray = "+w:" + std::to_string(ArrayType::getNumElements(dataType));
@@ -247,7 +249,8 @@ void ArrowConverter::setArrowFormat(ArrowSchemaHolder& rootHolder, ArrowSchema& 
         initializeChild(rootHolder.nestedChildren.back()[0]);
         child.children = &rootHolder.nestedChildrenPtr.back()[0];
         child.children[0]->name = "l";
-        setArrowFormat(rootHolder, **child.children, ArrayType::getChildType(dataType), fallbackExtensionTypes);
+        setArrowFormat(rootHolder, **child.children, ArrayType::getChildType(dataType),
+            fallbackExtensionTypes);
     } break;
     case LogicalTypeID::MAP: {
         child.format = "+m";
@@ -259,7 +262,8 @@ void ArrowConverter::setArrowFormat(ArrowSchemaHolder& rootHolder, ArrowSchema& 
         initializeChild(rootHolder.nestedChildren.back()[0]);
         child.children = &rootHolder.nestedChildrenPtr.back()[0];
         child.children[0]->name = "l";
-        setArrowFormat(rootHolder, **child.children, ListType::getChildType(dataType), fallbackExtensionTypes);
+        setArrowFormat(rootHolder, **child.children, ListType::getChildType(dataType),
+            fallbackExtensionTypes);
     } break;
     case LogicalTypeID::STRUCT:
     case LogicalTypeID::NODE:
@@ -280,7 +284,8 @@ void ArrowConverter::setArrowFormat(ArrowSchemaHolder& rootHolder, ArrowSchema& 
 }
 
 std::unique_ptr<ArrowSchema> ArrowConverter::toArrowSchema(
-    const std::vector<LogicalType>& dataTypes, const std::vector<std::string>& columnNames, bool fallbackExtensionTypes) {
+    const std::vector<LogicalType>& dataTypes, const std::vector<std::string>& columnNames,
+    bool fallbackExtensionTypes) {
     auto outSchema = std::make_unique<ArrowSchema>();
     auto rootHolder = std::make_unique<ArrowSchemaHolder>();
 

--- a/src/common/arrow/arrow_row_batch.cpp
+++ b/src/common/arrow/arrow_row_batch.cpp
@@ -7,6 +7,7 @@
 #include "common/types/value/rel.h"
 #include "common/types/value/value.h"
 #include "storage/storage_utils.h"
+#include "processor/result/flat_tuple.h"
 
 namespace kuzu {
 namespace common {
@@ -14,8 +15,8 @@ namespace common {
 static void resizeVector(ArrowVector* vector, const LogicalType& type, int64_t capacity,
     bool fallbackExtensionTypes);
 
-ArrowRowBatch::ArrowRowBatch(std::vector<LogicalType> types, std::int64_t capacity)
-    : types{std::move(types)}, numTuples{0} {
+ArrowRowBatch::ArrowRowBatch(std::vector<LogicalType> types, std::int64_t capacity, bool fallbackExtensionTypes)
+    : types{std::move(types)}, numTuples{0}, fallbackExtensionTypes{fallbackExtensionTypes} {
     auto numVectors = this->types.size();
     vectors.resize(numVectors);
     for (auto i = 0u; i < numVectors; i++) {
@@ -262,42 +263,42 @@ static void setBitToOne(std::uint8_t* data, std::int64_t pos) {
     data[bytePos] |= ((std::uint64_t)1 << bitOffset);
 }
 
-void ArrowRowBatch::appendValue(ArrowVector* vector, const LogicalType& type, Value* value) {
-    if (value->isNull()) {
+void ArrowRowBatch::appendValue(ArrowVector* vector, const LogicalType& type, const Value& value, bool fallbackExtensionTypes) {
+    if (value.isNull()) {
         copyNullValue(vector, value, vector->numValues);
     } else {
-        copyNonNullValue(vector, type, value, vector->numValues);
+        copyNonNullValue(vector, type, value, vector->numValues, fallbackExtensionTypes);
     }
     vector->numValues++;
 }
 
 template<LogicalTypeID DT>
 void ArrowRowBatch::templateCopyNonNullValue(ArrowVector* vector, const LogicalType& /*type*/,
-    Value* value, std::int64_t pos) {
+    const Value& value, std::int64_t pos, bool) {
     auto valSize = storage::StorageUtils::getDataTypeSize(LogicalType{DT});
-    std::memcpy(vector->data.data() + pos * valSize, &value->val, valSize);
+    std::memcpy(vector->data.data() + pos * valSize, &value.val, valSize);
 }
 
 template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::DECIMAL>(ArrowVector* vector,
-    const LogicalType& type, Value* value, std::int64_t pos) {
+    const LogicalType& type, const Value& value, std::int64_t pos, bool) {
     auto valSize = storage::StorageUtils::getDataTypeSize(type);
-    std::memcpy(vector->data.data() + pos * 16, &value->val, valSize);
+    std::memcpy(vector->data.data() + pos * 16, &value.val, valSize);
 }
 
 template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::INTERVAL>(ArrowVector* vector,
-    const LogicalType& /*type*/, Value* value, std::int64_t pos) {
+    const LogicalType& /*type*/, const Value& value, std::int64_t pos, bool) {
     auto destAddr = (int64_t*)(vector->data.data() + pos * sizeof(std::int64_t));
-    auto intervalVal = value->val.intervalVal;
+    auto intervalVal = value.val.intervalVal;
     *destAddr = intervalVal.micros + intervalVal.days * Interval::MICROS_PER_DAY +
                 intervalVal.months * Interval::MICROS_PER_MONTH;
 }
 
 template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::BOOL>(ArrowVector* vector,
-    const LogicalType& /*type*/, Value* value, std::int64_t pos) {
-    if (value->val.booleanVal) {
+    const LogicalType& /*type*/, const Value& value, std::int64_t pos, bool) {
+    if (value.val.booleanVal) {
         setBitToOne(vector->data.data(), pos);
     } else {
         setBitToZero(vector->data.data(), pos);
@@ -306,23 +307,23 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::BOOL>(ArrowVector* v
 
 template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::STRING>(ArrowVector* vector,
-    const LogicalType& /*type*/, Value* value, std::int64_t pos) {
+    const LogicalType& /*type*/, const Value& value, std::int64_t pos, bool) {
     auto offsets = (std::uint32_t*)vector->data.data();
-    auto strLength = value->strVal.length();
+    auto strLength = value.strVal.length();
     if (pos == 0) {
         offsets[pos] = 0;
     }
     offsets[pos + 1] = offsets[pos] + strLength;
     vector->overflow.resize(offsets[pos + 1] + 1);
-    std::memcpy(vector->overflow.data() + offsets[pos], value->strVal.data(), strLength);
+    std::memcpy(vector->overflow.data() + offsets[pos], value.strVal.data(), strLength);
 }
 
 template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::UUID>(ArrowVector* vector,
-    const LogicalType& /*type*/, Value* value, std::int64_t pos) {
+    const LogicalType& /*type*/, const Value& value, std::int64_t pos, bool fallbackExtensionTypes) {
     if (!fallbackExtensionTypes) {
         auto valSize = sizeof(int128_t);
-        auto val = value->val.int128Val;
+        auto val = value.val.int128Val;
         val.high ^= (int64_t(1) << 63); // MSB is stored flipped internally
         // Convert to little-endian
         auto valPtr = reinterpret_cast<int8_t*>(&val);
@@ -332,7 +333,7 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::UUID>(ArrowVector* v
         std::memcpy(vector->data.data() + pos * valSize, &val, valSize);
     } else {
         auto offsets = (std::uint32_t*)vector->data.data();
-        auto str = UUID::toString(value->val.int128Val);
+        auto str = UUID::toString(value.val.int128Val);
         auto strLength = str.length();
         if (pos == 0) {
             offsets[pos] = 0;
@@ -345,9 +346,9 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::UUID>(ArrowVector* v
 
 template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::LIST>(ArrowVector* vector,
-    const LogicalType& type, Value* value, std::int64_t pos) {
+    const LogicalType& type, const Value& value, std::int64_t pos, bool fallbackExtensionTypes) {
     auto offsets = (std::uint32_t*)vector->data.data();
-    auto numElements = value->childrenSize;
+    auto numElements = value.childrenSize;
     if (pos == 0) {
         offsets[pos] = 0;
     }
@@ -357,46 +358,46 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::LIST>(ArrowVector* v
     resizeChildVectors(vector, typeVec, offsets[pos + 1] + 1, fallbackExtensionTypes);
     for (auto i = 0u; i < numElements; i++) {
         appendValue(vector->childData[0].get(), ListType::getChildType(type),
-            value->children[i].get());
+            *value.children[i], fallbackExtensionTypes);
     }
 }
 
 template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::ARRAY>(ArrowVector* vector,
-    const LogicalType& type, Value* value, std::int64_t /*pos*/) {
-    auto numElements = value->childrenSize;
+    const LogicalType& type, const Value& value, std::int64_t /*pos*/, bool fallbackExtensionTypes) {
+    auto numElements = value.childrenSize;
     for (auto i = 0u; i < numElements; i++) {
         appendValue(vector->childData[0].get(), ArrayType::getChildType(type),
-            value->children[i].get());
+            *value.children[i], fallbackExtensionTypes);
     }
 }
 
 template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::MAP>(ArrowVector* vector,
-    const LogicalType& type, Value* value, std::int64_t pos) {
-    return templateCopyNonNullValue<LogicalTypeID::LIST>(vector, type, value, pos);
+    const LogicalType& type, const Value& value, std::int64_t pos, bool fallbackExtensionTypes) {
+    return templateCopyNonNullValue<LogicalTypeID::LIST>(vector, type, value, pos, fallbackExtensionTypes);
 }
 
 template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::STRUCT>(ArrowVector* vector,
-    const LogicalType& type, Value* value, std::int64_t /*pos*/) {
-    for (auto i = 0u; i < value->childrenSize; i++) {
+    const LogicalType& type, const Value& value, std::int64_t /*pos*/, bool fallbackExtensionTypes) {
+    for (auto i = 0u; i < value.childrenSize; i++) {
         appendValue(vector->childData[i].get(), StructType::getFieldType(type, i),
-            value->children[i].get());
+            *value.children[i], fallbackExtensionTypes);
     }
 }
 
 template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::UNION>(ArrowVector* vector,
-    const LogicalType& type, Value* value, std::int64_t pos) {
+    const LogicalType& type, const Value& value, std::int64_t pos, bool fallbackExtensionTypes) {
     auto typeBuffer = (std::uint8_t*)vector->data.data();
     auto offsetsBuffer = (std::int32_t*)vector->overflow.data();
     for (auto i = 0u; i < UnionType::getNumFields(type); i++) {
-        if (UnionType::getFieldType(type, i) == value->children[0]->dataType) {
+        if (UnionType::getFieldType(type, i) == value.children[0]->dataType) {
             typeBuffer[pos] = i;
             offsetsBuffer[pos] = vector->childData[i]->numValues;
             return appendValue(vector->childData[i].get(), UnionType::getFieldType(type, i),
-                value->children[0].get());
+                *value.children[0], fallbackExtensionTypes);
         }
     }
     KU_UNREACHABLE; // We should always be able to find a matching type
@@ -404,145 +405,145 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::UNION>(ArrowVector* 
 
 template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::INTERNAL_ID>(ArrowVector* vector,
-    const LogicalType& /*type*/, Value* value, std::int64_t /*pos*/) {
-    auto nodeID = value->getValue<nodeID_t>();
+    const LogicalType& /*type*/, const Value& value, std::int64_t /*pos*/, bool fallbackExtensionTypes) {
+    auto nodeID = value.getValue<nodeID_t>();
     Value offsetVal((std::int64_t)nodeID.offset);
     Value tableIDVal((std::int64_t)nodeID.tableID);
-    appendValue(vector->childData[0].get(), LogicalType::INT64(), &offsetVal);
-    appendValue(vector->childData[1].get(), LogicalType::INT64(), &tableIDVal);
+    appendValue(vector->childData[0].get(), LogicalType::INT64(), offsetVal, fallbackExtensionTypes);
+    appendValue(vector->childData[1].get(), LogicalType::INT64(), tableIDVal, fallbackExtensionTypes);
 }
 
 template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::NODE>(ArrowVector* vector,
-    const LogicalType& type, Value* value, std::int64_t /*pos*/) {
+    const LogicalType& type, const Value& value, std::int64_t /*pos*/, bool fallbackExtensionTypes) {
     appendValue(vector->childData[0].get(), StructType::getFieldType(type, 0),
-        NodeVal::getNodeIDVal(value));
+        *NodeVal::getNodeIDVal(&value), fallbackExtensionTypes);
     appendValue(vector->childData[1].get(), StructType::getFieldType(type, 1),
-        NodeVal::getLabelVal(value));
+        *NodeVal::getLabelVal(&value), fallbackExtensionTypes);
     std::int64_t propertyId = 2;
-    auto numProperties = NodeVal::getNumProperties(value);
+    auto numProperties = NodeVal::getNumProperties(&value);
     for (auto i = 0u; i < numProperties; i++) {
-        auto val = NodeVal::getPropertyVal(value, i);
+        auto val = NodeVal::getPropertyVal(&value, i);
         appendValue(vector->childData[propertyId].get(), StructType::getFieldType(type, propertyId),
-            val);
+            *val, fallbackExtensionTypes);
         propertyId++;
     }
 }
 
 template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::REL>(ArrowVector* vector,
-    const LogicalType& type, Value* value, std::int64_t /*pos*/) {
+    const LogicalType& type, const Value& value, std::int64_t /*pos*/, bool fallbackExtensionTypes) {
     appendValue(vector->childData[0].get(), StructType::getFieldType(type, 0),
-        RelVal::getSrcNodeIDVal(value));
+        *RelVal::getSrcNodeIDVal(&value), fallbackExtensionTypes);
     appendValue(vector->childData[1].get(), StructType::getFieldType(type, 1),
-        RelVal::getDstNodeIDVal(value));
+        *RelVal::getDstNodeIDVal(&value), fallbackExtensionTypes);
     appendValue(vector->childData[2].get(), StructType::getFieldType(type, 2),
-        RelVal::getLabelVal(value));
+        *RelVal::getLabelVal(&value), fallbackExtensionTypes);
     appendValue(vector->childData[3].get(), StructType::getFieldType(type, 3),
-        RelVal::getIDVal(value));
+        *RelVal::getIDVal(&value), fallbackExtensionTypes);
     common::property_id_t propertyID = 4;
-    auto numProperties = RelVal::getNumProperties(value);
+    auto numProperties = RelVal::getNumProperties(&value);
     for (auto i = 0u; i < numProperties; i++) {
-        auto val = RelVal::getPropertyVal(value, i);
+        auto val = RelVal::getPropertyVal(&value, i);
         appendValue(vector->childData[propertyID].get(), StructType::getFieldType(type, propertyID),
-            val);
+            *val, fallbackExtensionTypes);
         propertyID++;
     }
 }
 
-void ArrowRowBatch::copyNonNullValue(ArrowVector* vector, const LogicalType& type, Value* value,
-    std::int64_t pos) {
+void ArrowRowBatch::copyNonNullValue(ArrowVector* vector, const LogicalType& type, const Value& value,
+    std::int64_t pos, bool fallbackExtensionTypes) {
     switch (type.getLogicalTypeID()) {
     case LogicalTypeID::BOOL: {
-        templateCopyNonNullValue<LogicalTypeID::BOOL>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::BOOL>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::DECIMAL:
     case LogicalTypeID::INT128: {
-        templateCopyNonNullValue<LogicalTypeID::INT128>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::INT128>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::UUID: {
-        templateCopyNonNullValue<LogicalTypeID::UUID>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::UUID>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::SERIAL:
     case LogicalTypeID::INT64: {
-        templateCopyNonNullValue<LogicalTypeID::INT64>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::INT64>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::INT32: {
-        templateCopyNonNullValue<LogicalTypeID::INT32>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::INT32>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::INT16: {
-        templateCopyNonNullValue<LogicalTypeID::INT16>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::INT16>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::INT8: {
-        templateCopyNonNullValue<LogicalTypeID::INT8>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::INT8>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::UINT64: {
-        templateCopyNonNullValue<LogicalTypeID::UINT64>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::UINT64>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::UINT32: {
-        templateCopyNonNullValue<LogicalTypeID::UINT32>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::UINT32>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::UINT16: {
-        templateCopyNonNullValue<LogicalTypeID::UINT16>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::UINT16>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::UINT8: {
-        templateCopyNonNullValue<LogicalTypeID::UINT8>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::UINT8>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::DOUBLE: {
-        templateCopyNonNullValue<LogicalTypeID::DOUBLE>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::DOUBLE>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::FLOAT: {
-        templateCopyNonNullValue<LogicalTypeID::FLOAT>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::FLOAT>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::DATE: {
-        templateCopyNonNullValue<LogicalTypeID::DATE>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::DATE>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::TIMESTAMP: {
-        templateCopyNonNullValue<LogicalTypeID::TIMESTAMP>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::TIMESTAMP>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::TIMESTAMP_TZ: {
-        templateCopyNonNullValue<LogicalTypeID::TIMESTAMP_TZ>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::TIMESTAMP_TZ>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::TIMESTAMP_NS: {
-        templateCopyNonNullValue<LogicalTypeID::TIMESTAMP_NS>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::TIMESTAMP_NS>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::TIMESTAMP_MS: {
-        templateCopyNonNullValue<LogicalTypeID::TIMESTAMP_MS>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::TIMESTAMP_MS>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::TIMESTAMP_SEC: {
-        templateCopyNonNullValue<LogicalTypeID::TIMESTAMP_SEC>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::TIMESTAMP_SEC>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::INTERVAL: {
-        templateCopyNonNullValue<LogicalTypeID::INTERVAL>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::INTERVAL>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::BLOB:
     case LogicalTypeID::STRING: {
-        templateCopyNonNullValue<LogicalTypeID::STRING>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::STRING>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::LIST: {
-        templateCopyNonNullValue<LogicalTypeID::LIST>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::LIST>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::ARRAY: {
-        templateCopyNonNullValue<LogicalTypeID::ARRAY>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::ARRAY>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::MAP: {
-        templateCopyNonNullValue<LogicalTypeID::MAP>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::MAP>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::RECURSIVE_REL:
     case LogicalTypeID::STRUCT: {
-        templateCopyNonNullValue<LogicalTypeID::STRUCT>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::STRUCT>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::UNION: {
-        templateCopyNonNullValue<LogicalTypeID::UNION>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::UNION>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::INTERNAL_ID: {
-        templateCopyNonNullValue<LogicalTypeID::INTERNAL_ID>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::INTERNAL_ID>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::NODE: {
-        templateCopyNonNullValue<LogicalTypeID::NODE>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::NODE>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     case LogicalTypeID::REL: {
-        templateCopyNonNullValue<LogicalTypeID::REL>(vector, type, value, pos);
+        templateCopyNonNullValue<LogicalTypeID::REL>(vector, type, value, pos, fallbackExtensionTypes);
     } break;
     default: {
         KU_UNREACHABLE;
@@ -594,12 +595,12 @@ void ArrowRowBatch::templateCopyNullValue<LogicalTypeID::STRUCT>(ArrowVector* ve
     vector->numNulls++;
 }
 
-void ArrowRowBatch::copyNullValueUnion(ArrowVector* vector, Value* value, std::int64_t pos) {
+void ArrowRowBatch::copyNullValueUnion(ArrowVector* vector, const Value& value, std::int64_t pos) {
     auto typeBuffer = (std::uint8_t*)vector->data.data();
     auto offsetsBuffer = (std::int32_t*)vector->overflow.data();
     typeBuffer[pos] = 0;
     offsetsBuffer[pos] = vector->childData[0]->numValues;
-    copyNullValue(vector->childData[0].get(), value->children[0].get(), pos);
+    copyNullValue(vector->childData[0].get(), *value.children[0], pos);
     vector->numNulls++;
 }
 
@@ -610,8 +611,8 @@ static void copyArrowArray(ArrowVector* vector, std::int64_t pos, uint64_t numEl
     child->numValues += numElements;
 }
 
-void ArrowRowBatch::copyNullValue(ArrowVector* vector, Value* value, std::int64_t pos) {
-    switch (value->dataType.getLogicalTypeID()) {
+void ArrowRowBatch::copyNullValue(ArrowVector* vector, const Value& value, std::int64_t pos) {
+    switch (value.dataType.getLogicalTypeID()) {
     case LogicalTypeID::BOOL: {
         templateCopyNullValue<LogicalTypeID::BOOL>(vector, pos);
     } break;
@@ -680,7 +681,7 @@ void ArrowRowBatch::copyNullValue(ArrowVector* vector, Value* value, std::int64_
         templateCopyNullValue<LogicalTypeID::LIST>(vector, pos);
     } break;
     case LogicalTypeID::ARRAY: {
-        copyArrowArray(vector, pos, ArrayType::getNumElements(value->dataType));
+        copyArrowArray(vector, pos, ArrayType::getNumElements(value.dataType));
     } break;
     case LogicalTypeID::MAP: {
         templateCopyNullValue<LogicalTypeID::MAP>(vector, pos);
@@ -736,7 +737,7 @@ static std::unique_ptr<ArrowArray> createArrayFromVector(ArrowVector& vector) {
 }
 
 template<LogicalTypeID DT>
-ArrowArray* ArrowRowBatch::templateCreateArray(ArrowVector& vector, const LogicalType& /*type*/) {
+ArrowArray* ArrowRowBatch::templateCreateArray(ArrowVector& vector, const LogicalType& /*type*/, bool) {
     auto result = createArrayFromVector(vector);
     vector.array = std::move(result);
     return vector.array.get();
@@ -744,7 +745,7 @@ ArrowArray* ArrowRowBatch::templateCreateArray(ArrowVector& vector, const Logica
 
 template<>
 ArrowArray* ArrowRowBatch::templateCreateArray<LogicalTypeID::STRING>(ArrowVector& vector,
-    const LogicalType& /*type*/) {
+    const LogicalType& /*type*/, bool) {
     auto result = createArrayFromVector(vector);
     result->n_buffers = 3;
     result->buffers[2] = vector.overflow.data();
@@ -754,45 +755,45 @@ ArrowArray* ArrowRowBatch::templateCreateArray<LogicalTypeID::STRING>(ArrowVecto
 
 template<>
 ArrowArray* ArrowRowBatch::templateCreateArray<LogicalTypeID::LIST>(ArrowVector& vector,
-    const LogicalType& type) {
+    const LogicalType& type, bool fallbackExtensionTypes) {
     auto result = createArrayFromVector(vector);
     vector.childPointers.resize(1);
     result->children = vector.childPointers.data();
     result->n_children = 1;
     vector.childPointers[0] =
-        convertVectorToArray(*vector.childData[0], ListType::getChildType(type));
+        convertVectorToArray(*vector.childData[0], ListType::getChildType(type), fallbackExtensionTypes);
     vector.array = std::move(result);
     return vector.array.get();
 }
 
 template<>
 ArrowArray* ArrowRowBatch::templateCreateArray<LogicalTypeID::ARRAY>(ArrowVector& vector,
-    const LogicalType& type) {
+    const LogicalType& type, bool fallbackExtensionTypes) {
     auto result = createArrayFromVector(vector);
     vector.childPointers.resize(1);
     result->n_buffers = 1;
     result->children = vector.childPointers.data();
     result->n_children = 1;
     vector.childPointers[0] =
-        convertVectorToArray(*vector.childData[0], ArrayType::getChildType(type));
+        convertVectorToArray(*vector.childData[0], ArrayType::getChildType(type), fallbackExtensionTypes);
     vector.array = std::move(result);
     return vector.array.get();
 }
 
 template<>
 ArrowArray* ArrowRowBatch::templateCreateArray<LogicalTypeID::MAP>(ArrowVector& vector,
-    const LogicalType& type) {
-    return templateCreateArray<LogicalTypeID::LIST>(vector, type);
+    const LogicalType& type, bool fallbackExtensionTypes) {
+    return templateCreateArray<LogicalTypeID::LIST>(vector, type, fallbackExtensionTypes);
 }
 
 template<>
 ArrowArray* ArrowRowBatch::templateCreateArray<LogicalTypeID::STRUCT>(ArrowVector& vector,
-    const LogicalType& type) {
-    return convertStructVectorToArray(vector, type);
+    const LogicalType& type, bool fallbackExtensionTypes) {
+    return convertStructVectorToArray(vector, type, fallbackExtensionTypes);
 }
 
 ArrowArray* ArrowRowBatch::convertStructVectorToArray(ArrowVector& vector,
-    const LogicalType& type) {
+    const LogicalType& type, bool fallbackExtensionTypes) {
     auto result = createArrayFromVector(vector);
     result->n_buffers = 1;
     vector.childPointers.resize(StructType::getNumFields(type));
@@ -800,14 +801,14 @@ ArrowArray* ArrowRowBatch::convertStructVectorToArray(ArrowVector& vector,
     result->n_children = (std::int64_t)StructType::getNumFields(type);
     for (auto i = 0u; i < StructType::getNumFields(type); i++) {
         const auto& childType = StructType::getFieldType(type, i);
-        vector.childPointers[i] = convertVectorToArray(*vector.childData[i], childType);
+        vector.childPointers[i] = convertVectorToArray(*vector.childData[i], childType, fallbackExtensionTypes);
     }
     vector.array = std::move(result);
     return vector.array.get();
 }
 
 ArrowArray* ArrowRowBatch::convertInternalIDVectorToArray(ArrowVector& vector,
-    const LogicalType& /*type*/) {
+    const LogicalType& /*type*/, bool fallbackExtensionTypes) {
     auto result = createArrayFromVector(vector);
     result->n_buffers = 1;
     vector.childPointers.resize(2);
@@ -815,7 +816,7 @@ ArrowArray* ArrowRowBatch::convertInternalIDVectorToArray(ArrowVector& vector,
     result->n_children = 2;
     for (auto i = 0; i < 2; i++) {
         auto childType = LogicalType::INT64();
-        vector.childPointers[i] = convertVectorToArray(*vector.childData[i], childType);
+        vector.childPointers[i] = convertVectorToArray(*vector.childData[i], childType, fallbackExtensionTypes);
     }
     vector.array = std::move(result);
     return vector.array.get();
@@ -823,7 +824,7 @@ ArrowArray* ArrowRowBatch::convertInternalIDVectorToArray(ArrowVector& vector,
 
 template<>
 ArrowArray* ArrowRowBatch::templateCreateArray<LogicalTypeID::UNION>(ArrowVector& vector,
-    const LogicalType& type) {
+    const LogicalType& type, bool fallbackExtensionTypes) {
     // since union is a special case, we make the ArrowArray ourselves instead of using
     // createArrayFromVector
     auto nChildren = UnionType::getNumFields(type);
@@ -843,124 +844,124 @@ ArrowArray* ArrowRowBatch::templateCreateArray<LogicalTypeID::UNION>(ArrowVector
     vector.array->buffers[1] = vector.overflow.data();
     for (auto i = 0u; i < nChildren; i++) {
         const auto& childType = UnionType::getFieldType(type, i);
-        vector.childPointers[i] = convertVectorToArray(*vector.childData[i], childType);
+        vector.childPointers[i] = convertVectorToArray(*vector.childData[i], childType, fallbackExtensionTypes);
     }
     return vector.array.get();
 }
 
 template<>
 ArrowArray* ArrowRowBatch::templateCreateArray<LogicalTypeID::INTERNAL_ID>(ArrowVector& vector,
-    const LogicalType& type) {
-    return convertInternalIDVectorToArray(vector, type);
+    const LogicalType& type, bool fallbackExtensionTypes) {
+    return convertInternalIDVectorToArray(vector, type, fallbackExtensionTypes);
 }
 
 template<>
 ArrowArray* ArrowRowBatch::templateCreateArray<LogicalTypeID::NODE>(ArrowVector& vector,
-    const LogicalType& type) {
-    return convertStructVectorToArray(vector, type);
+    const LogicalType& type, bool fallbackExtensionTypes) {
+    return convertStructVectorToArray(vector, type, fallbackExtensionTypes);
 }
 
 template<>
 ArrowArray* ArrowRowBatch::templateCreateArray<LogicalTypeID::REL>(ArrowVector& vector,
-    const LogicalType& type) {
-    return convertStructVectorToArray(vector, type);
+    const LogicalType& type, bool fallbackExtensionTypes) {
+    return convertStructVectorToArray(vector, type, fallbackExtensionTypes);
 }
 
-ArrowArray* ArrowRowBatch::convertVectorToArray(ArrowVector& vector, const LogicalType& type) {
+ArrowArray* ArrowRowBatch::convertVectorToArray(ArrowVector& vector, const LogicalType& type, bool fallbackExtensionTypes) {
     switch (type.getLogicalTypeID()) {
     case LogicalTypeID::BOOL: {
-        return templateCreateArray<LogicalTypeID::BOOL>(vector, type);
+        return templateCreateArray<LogicalTypeID::BOOL>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::DECIMAL:
     case LogicalTypeID::INT128: {
-        return templateCreateArray<LogicalTypeID::INT128>(vector, type);
+        return templateCreateArray<LogicalTypeID::INT128>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::SERIAL:
     case LogicalTypeID::INT64: {
-        return templateCreateArray<LogicalTypeID::INT64>(vector, type);
+        return templateCreateArray<LogicalTypeID::INT64>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::INT32: {
-        return templateCreateArray<LogicalTypeID::INT32>(vector, type);
+        return templateCreateArray<LogicalTypeID::INT32>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::INT16: {
-        return templateCreateArray<LogicalTypeID::INT16>(vector, type);
+        return templateCreateArray<LogicalTypeID::INT16>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::INT8: {
-        return templateCreateArray<LogicalTypeID::INT8>(vector, type);
+        return templateCreateArray<LogicalTypeID::INT8>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::UINT64: {
-        return templateCreateArray<LogicalTypeID::UINT64>(vector, type);
+        return templateCreateArray<LogicalTypeID::UINT64>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::UINT32: {
-        return templateCreateArray<LogicalTypeID::UINT32>(vector, type);
+        return templateCreateArray<LogicalTypeID::UINT32>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::UINT16: {
-        return templateCreateArray<LogicalTypeID::UINT16>(vector, type);
+        return templateCreateArray<LogicalTypeID::UINT16>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::UINT8: {
-        return templateCreateArray<LogicalTypeID::UINT8>(vector, type);
+        return templateCreateArray<LogicalTypeID::UINT8>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::DOUBLE: {
-        return templateCreateArray<LogicalTypeID::DOUBLE>(vector, type);
+        return templateCreateArray<LogicalTypeID::DOUBLE>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::FLOAT: {
-        return templateCreateArray<LogicalTypeID::FLOAT>(vector, type);
+        return templateCreateArray<LogicalTypeID::FLOAT>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::DATE: {
-        return templateCreateArray<LogicalTypeID::DATE>(vector, type);
+        return templateCreateArray<LogicalTypeID::DATE>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::TIMESTAMP_MS: {
-        return templateCreateArray<LogicalTypeID::TIMESTAMP_MS>(vector, type);
+        return templateCreateArray<LogicalTypeID::TIMESTAMP_MS>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::TIMESTAMP_NS: {
-        return templateCreateArray<LogicalTypeID::TIMESTAMP_NS>(vector, type);
+        return templateCreateArray<LogicalTypeID::TIMESTAMP_NS>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::TIMESTAMP_SEC: {
-        return templateCreateArray<LogicalTypeID::TIMESTAMP_SEC>(vector, type);
+        return templateCreateArray<LogicalTypeID::TIMESTAMP_SEC>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::TIMESTAMP_TZ: {
-        return templateCreateArray<LogicalTypeID::TIMESTAMP_TZ>(vector, type);
+        return templateCreateArray<LogicalTypeID::TIMESTAMP_TZ>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::TIMESTAMP: {
-        return templateCreateArray<LogicalTypeID::TIMESTAMP>(vector, type);
+        return templateCreateArray<LogicalTypeID::TIMESTAMP>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::INTERVAL: {
-        return templateCreateArray<LogicalTypeID::INTERVAL>(vector, type);
+        return templateCreateArray<LogicalTypeID::INTERVAL>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::UUID: {
         if (!fallbackExtensionTypes) {
-            return templateCreateArray<LogicalTypeID::UUID>(vector, type);
+            return templateCreateArray<LogicalTypeID::UUID>(vector, type, fallbackExtensionTypes);
         }
         [[fallthrough]];
     }
     case LogicalTypeID::BLOB:
     case LogicalTypeID::STRING: {
-        return templateCreateArray<LogicalTypeID::STRING>(vector, type);
+        return templateCreateArray<LogicalTypeID::STRING>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::LIST: {
-        return templateCreateArray<LogicalTypeID::LIST>(vector, type);
+        return templateCreateArray<LogicalTypeID::LIST>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::ARRAY: {
-        return templateCreateArray<LogicalTypeID::ARRAY>(vector, type);
+        return templateCreateArray<LogicalTypeID::ARRAY>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::MAP: {
-        return templateCreateArray<LogicalTypeID::MAP>(vector, type);
+        return templateCreateArray<LogicalTypeID::MAP>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::RECURSIVE_REL:
     case LogicalTypeID::STRUCT: {
-        return templateCreateArray<LogicalTypeID::STRUCT>(vector, type);
+        return templateCreateArray<LogicalTypeID::STRUCT>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::UNION: {
-        return templateCreateArray<LogicalTypeID::UNION>(vector, type);
+        return templateCreateArray<LogicalTypeID::UNION>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::INTERNAL_ID: {
-        return templateCreateArray<LogicalTypeID::INTERNAL_ID>(vector, type);
+        return templateCreateArray<LogicalTypeID::INTERNAL_ID>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::NODE: {
-        return templateCreateArray<LogicalTypeID::NODE>(vector, type);
+        return templateCreateArray<LogicalTypeID::NODE>(vector, type, fallbackExtensionTypes);
     }
     case LogicalTypeID::REL: {
-        return templateCreateArray<LogicalTypeID::REL>(vector, type);
+        return templateCreateArray<LogicalTypeID::REL>(vector, type, fallbackExtensionTypes);
     }
     default: {
         KU_UNREACHABLE;
@@ -982,28 +983,18 @@ ArrowArray ArrowRowBatch::toArray() {
     result.dictionary = nullptr;
     rootHolder->childData = std::move(vectors);
     for (auto i = 0u; i < rootHolder->childData.size(); i++) {
-        rootHolder->childPointers[i] = convertVectorToArray(*rootHolder->childData[i], types[i]);
+        rootHolder->childPointers[i] = convertVectorToArray(*rootHolder->childData[i], types[i], fallbackExtensionTypes);
     }
     result.private_data = rootHolder.release();
     result.release = releaseArrowVector;
     return result;
 }
 
-ArrowArray ArrowRowBatch::append(main::QueryResult& queryResult, std::int64_t chunkSize) {
-    std::int64_t numTuplesInBatch = 0;
-    auto numColumns = queryResult.getColumnNames().size();
-    while (numTuplesInBatch < chunkSize) {
-        if (!queryResult.hasNext()) {
-            break;
-        }
-        auto tuple = queryResult.getNext();
-        for (auto i = 0u; i < numColumns; i++) {
-            appendValue(vectors[i].get(), types[i], tuple->getValue(i));
-        }
-        numTuplesInBatch++;
+void ArrowRowBatch::append(const processor::FlatTuple& tuple) {
+    for (auto i = 0u; i < types.size(); i++) {
+        appendValue(vectors[i].get(), types[i], tuple[i], fallbackExtensionTypes);
     }
-    numTuples += numTuplesInBatch;
-    return toArray();
+    numTuples++;
 }
 
 } // namespace common

--- a/src/include/common/arrow/arrow_converter.h
+++ b/src/include/common/arrow/arrow_converter.h
@@ -5,7 +5,6 @@
 
 #include "common/arrow/arrow.h"
 #include "common/arrow/arrow_nullmask_tree.h"
-#include "main/query_result.h"
 
 struct ArrowSchema;
 
@@ -21,17 +20,12 @@ struct ArrowSchemaHolder {
     std::vector<std::unique_ptr<char[]>> ownedMetadatas;
 };
 
-struct ArrowConverter {
-public:
-    inline static bool fallbackExtensionTypes = false;
-
+class ArrowConverter {
 public:
     static std::unique_ptr<ArrowSchema> toArrowSchema(const std::vector<LogicalType>& dataTypes,
-        const std::vector<std::string>& columnNames);
-    static void toArrowArray(main::QueryResult& queryResult, ArrowArray* out_array,
-        std::int64_t chunkSize);
+        const std::vector<std::string>& columnNames, bool fallbackExtensionTypes);
 
-    static common::LogicalType fromArrowSchema(const ArrowSchema* schema);
+    static LogicalType fromArrowSchema(const ArrowSchema* schema);
     static void fromArrowArray(const ArrowSchema* schema, const ArrowArray* array,
         ValueVector& outputVector, ArrowNullMaskTree* mask, uint64_t srcOffset, uint64_t dstOffset,
         uint64_t count);
@@ -41,13 +35,13 @@ public:
 private:
     static void initializeChild(ArrowSchema& child, const std::string& name = "");
     static void setArrowFormatForStruct(ArrowSchemaHolder& rootHolder, ArrowSchema& child,
-        const LogicalType& dataType);
+        const LogicalType& dataType, bool fallbackExtensionTypes);
     static void setArrowFormatForUnion(ArrowSchemaHolder& rootHolder, ArrowSchema& child,
-        const LogicalType& dataType);
+        const LogicalType& dataType, bool fallbackExtensionTypes);
     static void setArrowFormatForInternalID(ArrowSchemaHolder& rootHolder, ArrowSchema& child,
-        const LogicalType& dataType);
+        const LogicalType& dataType, bool fallbackExtensionTypes);
     static void setArrowFormat(ArrowSchemaHolder& rootHolder, ArrowSchema& child,
-        const LogicalType& dataType);
+        const LogicalType& dataType, bool fallbackExtensionTypes);
 };
 
 } // namespace common

--- a/src/include/common/arrow/arrow_row_batch.h
+++ b/src/include/common/arrow/arrow_row_batch.h
@@ -49,30 +49,36 @@ struct ArrowVector {
 // An arrow data chunk consisting of N rows in columnar format.
 class ArrowRowBatch {
 public:
-    ArrowRowBatch(std::vector<LogicalType> types, std::int64_t capacity, bool fallbackExtensionTypes);
+    ArrowRowBatch(std::vector<LogicalType> types, std::int64_t capacity,
+        bool fallbackExtensionTypes);
 
     void append(const processor::FlatTuple& tuple);
     ArrowArray toArray();
 
 private:
-    static void appendValue(ArrowVector* vector, const LogicalType& type, const Value& value, bool fallbackExtensionTypes);
+    static void appendValue(ArrowVector* vector, const LogicalType& type, const Value& value,
+        bool fallbackExtensionTypes);
 
-    static ArrowArray* convertVectorToArray(ArrowVector& vector, const LogicalType& type, bool fallbackExtensionTypes);
-    static ArrowArray* convertStructVectorToArray(ArrowVector& vector, const LogicalType& type, bool fallbackExtensionTypes);
-    static ArrowArray* convertInternalIDVectorToArray(ArrowVector& vector, const LogicalType& type, bool fallbackExtensionTypes);
+    static ArrowArray* convertVectorToArray(ArrowVector& vector, const LogicalType& type,
+        bool fallbackExtensionTypes);
+    static ArrowArray* convertStructVectorToArray(ArrowVector& vector, const LogicalType& type,
+        bool fallbackExtensionTypes);
+    static ArrowArray* convertInternalIDVectorToArray(ArrowVector& vector, const LogicalType& type,
+        bool fallbackExtensionTypes);
 
     static void copyNonNullValue(ArrowVector* vector, const LogicalType& type, const Value& value,
         std::int64_t pos, bool fallbackExtensionTypes);
     static void copyNullValue(ArrowVector* vector, const Value& value, std::int64_t pos);
 
     template<LogicalTypeID DT>
-    static void templateCopyNonNullValue(ArrowVector* vector, const LogicalType& type, const Value& value,
-        std::int64_t pos, bool fallbackExtensionTypes);
+    static void templateCopyNonNullValue(ArrowVector* vector, const LogicalType& type,
+        const Value& value, std::int64_t pos, bool fallbackExtensionTypes);
     template<LogicalTypeID DT>
     static void templateCopyNullValue(ArrowVector* vector, std::int64_t pos);
     static void copyNullValueUnion(ArrowVector* vector, const Value& value, std::int64_t pos);
     template<LogicalTypeID DT>
-    static ArrowArray* templateCreateArray(ArrowVector& vector, const LogicalType& type, bool fallbackExtensionTypes);
+    static ArrowArray* templateCreateArray(ArrowVector& vector, const LogicalType& type,
+        bool fallbackExtensionTypes);
 
 private:
     // TODO(Xiyang): remove types

--- a/src/include/common/arrow/arrow_row_batch.h
+++ b/src/include/common/arrow/arrow_row_batch.h
@@ -6,12 +6,16 @@
 #include "common/arrow/arrow.h"
 #include "common/arrow/arrow_buffer.h"
 #include "common/types/types.h"
-#include "main/query_result.h"
 
 struct ArrowSchema;
 
 namespace kuzu {
+namespace processor {
+class FlatTuple;
+}
+
 namespace common {
+class Value;
 
 // An Arrow Vector(i.e., Array) is defined by a few pieces of metadata and data:
 //  1) a logical data type;
@@ -45,40 +49,37 @@ struct ArrowVector {
 // An arrow data chunk consisting of N rows in columnar format.
 class ArrowRowBatch {
 public:
-    inline static bool fallbackExtensionTypes = false;
+    ArrowRowBatch(std::vector<LogicalType> types, std::int64_t capacity, bool fallbackExtensionTypes);
 
-public:
-    ArrowRowBatch(std::vector<LogicalType> types, std::int64_t capacity);
-
-    //! Append a data chunk to the underlying arrow array
-    ArrowArray append(main::QueryResult& queryResult, std::int64_t chunkSize);
-
-private:
-    static void appendValue(ArrowVector* vector, const LogicalType& type, Value* value);
-
-    static ArrowArray* convertVectorToArray(ArrowVector& vector, const LogicalType& type);
-    static ArrowArray* convertStructVectorToArray(ArrowVector& vector, const LogicalType& type);
-    static ArrowArray* convertInternalIDVectorToArray(ArrowVector& vector, const LogicalType& type);
-
-    static void copyNonNullValue(ArrowVector* vector, const LogicalType& type, Value* value,
-        std::int64_t pos);
-    static void copyNullValue(ArrowVector* vector, Value* value, std::int64_t pos);
-
-    template<LogicalTypeID DT>
-    static void templateCopyNonNullValue(ArrowVector* vector, const LogicalType& type, Value* value,
-        std::int64_t pos);
-    template<LogicalTypeID DT>
-    static void templateCopyNullValue(ArrowVector* vector, std::int64_t pos);
-    static void copyNullValueUnion(ArrowVector* vector, Value* value, std::int64_t pos);
-    template<LogicalTypeID DT>
-    static ArrowArray* templateCreateArray(ArrowVector& vector, const LogicalType& type);
-
+    void append(const processor::FlatTuple& tuple);
     ArrowArray toArray();
 
 private:
+    static void appendValue(ArrowVector* vector, const LogicalType& type, const Value& value, bool fallbackExtensionTypes);
+
+    static ArrowArray* convertVectorToArray(ArrowVector& vector, const LogicalType& type, bool fallbackExtensionTypes);
+    static ArrowArray* convertStructVectorToArray(ArrowVector& vector, const LogicalType& type, bool fallbackExtensionTypes);
+    static ArrowArray* convertInternalIDVectorToArray(ArrowVector& vector, const LogicalType& type, bool fallbackExtensionTypes);
+
+    static void copyNonNullValue(ArrowVector* vector, const LogicalType& type, const Value& value,
+        std::int64_t pos, bool fallbackExtensionTypes);
+    static void copyNullValue(ArrowVector* vector, const Value& value, std::int64_t pos);
+
+    template<LogicalTypeID DT>
+    static void templateCopyNonNullValue(ArrowVector* vector, const LogicalType& type, const Value& value,
+        std::int64_t pos, bool fallbackExtensionTypes);
+    template<LogicalTypeID DT>
+    static void templateCopyNullValue(ArrowVector* vector, std::int64_t pos);
+    static void copyNullValueUnion(ArrowVector* vector, const Value& value, std::int64_t pos);
+    template<LogicalTypeID DT>
+    static ArrowArray* templateCreateArray(ArrowVector& vector, const LogicalType& type, bool fallbackExtensionTypes);
+
+private:
+    // TODO(Xiyang): remove types
     std::vector<LogicalType> types;
     std::vector<std::unique_ptr<ArrowVector>> vectors;
     std::int64_t numTuples;
+    bool fallbackExtensionTypes = false;
 };
 
 } // namespace common

--- a/src/include/common/types/ku_list.h
+++ b/src/include/common/types/ku_list.h
@@ -6,8 +6,6 @@ namespace kuzu {
 namespace common {
 
 struct ku_list_t {
-
-public:
     ku_list_t() : size{0}, overflowPtr{0} {}
     ku_list_t(uint64_t size, uint64_t overflowPtr) : size{size}, overflowPtr{overflowPtr} {}
 

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -30,7 +30,12 @@ namespace common {
 class RandomEngine;
 class TaskScheduler;
 class ProgressBar;
+class VirtualFileSystem;
 } // namespace common
+
+namespace catalog {
+class Catalog;
+}
 
 namespace extension {
 class ExtensionManager;
@@ -43,6 +48,10 @@ class TableFunctionCall;
 
 namespace graph {
 class GraphEntrySet;
+}
+
+namespace storage {
+class StorageManager;
 }
 
 namespace main {
@@ -166,13 +175,18 @@ public:
 
     void cleanUp();
 
-    // Query.
+    struct ArrowInfo {
+        bool asArrow = false;
+        int64_t chunkSize = 1000;
+
+        ArrowInfo(bool asArrow, int64_t chunkSize) : asArrow(asArrow), chunkSize(chunkSize) {}
+    };
+    std::unique_ptr<QueryResult> query(std::string_view queryStatement,
+        std::optional<uint64_t> queryID = std::nullopt, ArrowInfo arrowInfo = {false, 1000});
     std::unique_ptr<PreparedStatement> prepareWithParams(std::string_view query,
         std::unordered_map<std::string, std::unique_ptr<common::Value>> inputParams = {});
     std::unique_ptr<QueryResult> executeWithParams(PreparedStatement* preparedStatement,
         std::unordered_map<std::string, std::unique_ptr<common::Value>> inputParams,
-        std::optional<uint64_t> queryID = std::nullopt);
-    std::unique_ptr<QueryResult> query(std::string_view queryStatement,
         std::optional<uint64_t> queryID = std::nullopt);
 
 private:
@@ -222,10 +236,9 @@ private:
 
     std::unique_ptr<QueryResult> executeNoLock(PreparedStatement* preparedStatement,
         CachedPreparedStatement* cachedPreparedStatement,
-        std::optional<uint64_t> queryID = std::nullopt);
-
+        std::optional<uint64_t> queryID = std::nullopt, ArrowInfo arrowInfo = {false, 1000});
     std::unique_ptr<QueryResult> queryNoLock(std::string_view query,
-        std::optional<uint64_t> queryID = std::nullopt);
+        std::optional<uint64_t> queryID = std::nullopt, ArrowInfo arrowInfo = {false, 1000});
 
     bool canExecuteWriteQuery() const;
 

--- a/src/include/main/connection.h
+++ b/src/include/main/connection.h
@@ -47,6 +47,8 @@ public:
      */
     KUZU_API std::unique_ptr<QueryResult> query(std::string_view query);
 
+    KUZU_API std::unique_ptr<QueryResult> queryAsArrow(std::string_view query, int64_t chunkSize);
+
     /**
      * @brief Prepares the given query and returns the prepared statement.
      * @param query The query to prepare.

--- a/src/include/main/database.h
+++ b/src/include/main/database.h
@@ -12,6 +12,7 @@
 #include "common/database_lifecycle_manager.h"
 #include "kuzu_fwd.h"
 #include "main/db_config.h"
+
 namespace kuzu {
 namespace common {
 class FileSystem;

--- a/src/include/main/prepared_statement.h
+++ b/src/include/main/prepared_statement.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "common/api.h"
+#include "common/types/value/value.h"
 #include "query_summary.h"
 
 namespace kuzu {
@@ -14,6 +15,12 @@ class LogicalType;
 }
 namespace parser {
 class Statement;
+}
+namespace binder {
+class Expression;
+}
+namespace planner {
+class LogicalPlan;
 }
 
 namespace main {
@@ -39,8 +46,6 @@ struct CachedPreparedStatement {
 class PreparedStatement {
     friend class Connection;
     friend class ClientContext;
-    friend class testing::TestHelper;
-    friend class testing::TestRunner;
 
 public:
     KUZU_API ~PreparedStatement();

--- a/src/include/main/query_result.h
+++ b/src/include/main/query_result.h
@@ -94,12 +94,12 @@ public:
      */
     KUZU_API virtual std::string toString() const = 0;
     /**
-      * @brief Returns the arrow schema of the query result.
-      * @return datatypes of the columns as an arrow schema
-      *
-      * It is the caller's responsibility to call the release function to release the underlying data
-      * If converting to another arrow type, this is usually handled automatically.
-      */
+     * @brief Returns the arrow schema of the query result.
+     * @return datatypes of the columns as an arrow schema
+     *
+     * It is the caller's responsibility to call the release function to release the underlying data
+     * If converting to another arrow type, this is usually handled automatically.
+     */
     KUZU_API std::unique_ptr<ArrowSchema> getArrowSchema() const;
     /**
      * @return whether there are more arrow chunk to read.
@@ -125,7 +125,8 @@ public:
 
     void setQuerySummary(std::unique_ptr<QuerySummary> summary);
 
-    void setDBLifeCycleManager(std::shared_ptr<common::DatabaseLifeCycleManager> dbLifeCycleManager);
+    void setDBLifeCycleManager(
+        std::shared_ptr<common::DatabaseLifeCycleManager> dbLifeCycleManager);
 
     static std::unique_ptr<QueryResult> getQueryResultWithError(const std::string& errorMessage);
 

--- a/src/include/main/query_result.h
+++ b/src/include/main/query_result.h
@@ -6,51 +6,36 @@
 #include "common/arrow/arrow.h"
 #include "common/database_lifecycle_manager.h"
 #include "common/types/types.h"
-#include "kuzu_fwd.h"
-#include "processor/result/flat_tuple.h"
 #include "query_summary.h"
+
 namespace kuzu {
+namespace processor {
+class FlatTuple;
+}
 namespace main {
+
+enum class QueryResultType {
+    FTABLE = 0,
+    ARROW = 1,
+};
 
 /**
  * @brief QueryResult stores the result of a query execution.
  */
 class QueryResult {
-    friend class Connection;
-    friend class ClientContext;
-    class QueryResultIterator {
-    private:
-        QueryResult* currentResult;
-
-    public:
-        QueryResultIterator() = default;
-
-        explicit QueryResultIterator(QueryResult* startResult) : currentResult(startResult) {}
-
-        void operator++() {
-            if (currentResult) {
-                currentResult = currentResult->nextQueryResult.get();
-            }
-        }
-
-        bool isEnd() const { return currentResult == nullptr; }
-
-        bool hasNextQueryResult() const { return currentResult->nextQueryResult != nullptr; }
-
-        QueryResult* getCurrentResult() const { return currentResult; }
-    };
-
 public:
     /**
      * @brief Used to create a QueryResult object for the failing query.
      */
     KUZU_API QueryResult();
 
-    explicit QueryResult(const PreparedSummary& preparedSummary);
+    QueryResult(QueryResultType type, std::vector<std::string> columnNames,
+        std::vector<common::LogicalType> columnTypes);
+
     /**
      * @brief Deconstructs the QueryResult object.
      */
-    KUZU_API ~QueryResult();
+    KUZU_API virtual ~QueryResult() = 0;
     /**
      * @return query is executed successfully or not.
      */
@@ -72,18 +57,11 @@ public:
      */
     KUZU_API std::vector<common::LogicalType> getColumnDataTypes() const;
     /**
-     * @return num of tuples in query result.
-     */
-    KUZU_API uint64_t getNumTuples() const;
-    /**
      * @return query summary which stores the execution time, compiling time, plan and query
      * options.
      */
     KUZU_API QuerySummary* getQuerySummary() const;
-    /**
-     * @return whether there are more tuples to read.
-     */
-    KUZU_API bool hasNext() const;
+    QuerySummary* getQuerySummaryUnsafe();
     /**
      * @return whether there are more query results to read.
      */
@@ -92,34 +70,41 @@ public:
      * @return get next query result to read (for multiple query statements).
      */
     KUZU_API QueryResult* getNextQueryResult();
-
-    std::unique_ptr<QueryResult> nextQueryResult;
+    /**
+     * @return num of tuples in query result.
+     */
+    KUZU_API virtual uint64_t getNumTuples() const = 0;
+    /**
+     * @return whether there are more tuples to read.
+     */
+    KUZU_API virtual bool hasNext() const = 0;
     /**
      * @return next flat tuple in the query result. Note that to reduce resource allocation, all
      * calls to getNext() reuse the same FlatTuple object. Since its contents will be overwritten,
      * please complete processing a FlatTuple or make a copy of its data before calling getNext()
      * again.
      */
-    KUZU_API std::shared_ptr<processor::FlatTuple> getNext();
-    /**
-     * @return string of first query result.
-     */
-    KUZU_API std::string toString() const;
-
+    KUZU_API virtual std::shared_ptr<processor::FlatTuple> getNext() = 0;
     /**
      * @brief Resets the result tuple iterator.
      */
-    KUZU_API void resetIterator();
-
+    KUZU_API virtual void resetIterator() = 0;
     /**
-     * @brief Returns the arrow schema of the query result.
-     * @return datatypes of the columns as an arrow schema
-     *
-     * It is the caller's responsibility to call the release function to release the underlying data
-     * If converting to another arrow type, this this is usually handled automatically.
+     * @return string of first query result.
      */
+    KUZU_API virtual std::string toString() const = 0;
+    /**
+      * @brief Returns the arrow schema of the query result.
+      * @return datatypes of the columns as an arrow schema
+      *
+      * It is the caller's responsibility to call the release function to release the underlying data
+      * If converting to another arrow type, this is usually handled automatically.
+      */
     KUZU_API std::unique_ptr<ArrowSchema> getArrowSchema() const;
-
+    /**
+     * @return whether there are more arrow chunk to read.
+     */
+    KUZU_API virtual bool hasNextArrowChunk() = 0;
     /**
      * @brief Returns the next chunk of the query result as an arrow array.
      * @param chunkSize number of tuples to return in the chunk.
@@ -129,43 +114,75 @@ public:
      * This can be converted to a RecordBatch with arrow's ImportRecordBatch function
      *
      * It is the caller's responsibility to call the release function to release the underlying data
-     * If converting to another arrow type, this this is usually handled automatically.
+     * If converting to another arrow type, this is usually handled automatically.
      */
-    KUZU_API std::unique_ptr<ArrowArray> getNextArrowChunk(int64_t chunkSize);
+    KUZU_API virtual std::unique_ptr<ArrowArray> getNextArrowChunk(int64_t chunkSize) = 0;
 
-    processor::FactorizedTable* getTable() { return factorizedTable.get(); }
+    QueryResultType getType() const { return type; }
+
+    void addNextResult(std::unique_ptr<QueryResult> next_);
+    std::unique_ptr<QueryResult> moveNextResult();
+
+    void setQuerySummary(std::unique_ptr<QuerySummary> summary);
+
+    void setDBLifeCycleManager(std::shared_ptr<common::DatabaseLifeCycleManager> dbLifeCycleManager);
 
     static std::unique_ptr<QueryResult> getQueryResultWithError(const std::string& errorMessage);
 
-private:
-    void setColumnHeader(std::vector<std::string> columnNames,
-        std::vector<common::LogicalType> columnTypes);
-    void initResultTableAndIterator(std::shared_ptr<processor::FactorizedTable> factorizedTable_);
+    template<class TARGET>
+    TARGET& cast() {
+        return common::ku_dynamic_cast<TARGET&>(*this);
+    }
+    template<class TARGET>
+    const TARGET& constCast() const {
+        return common::ku_dynamic_cast<const TARGET&>(*this);
+    }
+
+protected:
     void validateQuerySucceed() const;
-    std::pair<std::unique_ptr<processor::FlatTuple>, std::unique_ptr<processor::FlatTupleIterator>>
-    getIterator() const;
     void checkDatabaseClosedOrThrow() const;
 
-private:
-    // execution status
+protected:
+    class QueryResultIterator {
+    public:
+        QueryResultIterator() = default;
+
+        explicit QueryResultIterator(QueryResult* startResult) : current(startResult) {}
+
+        void operator++() {
+            if (current) {
+                current = current->nextQueryResult.get();
+            }
+        }
+
+        bool isEnd() const { return current == nullptr; }
+
+        bool hasNextQueryResult() const { return current->nextQueryResult != nullptr; }
+
+        QueryResult* getCurrentResult() const { return current; }
+
+    private:
+        QueryResult* current;
+    };
+
+    QueryResultType type;
+
     bool success = true;
+
     std::string errMsg;
 
-    // header information
     std::vector<std::string> columnNames;
-    std::vector<common::LogicalType> columnDataTypes;
-    // data
-    std::shared_ptr<processor::FactorizedTable> factorizedTable;
-    std::unique_ptr<processor::FlatTupleIterator> iterator;
+
+    std::vector<common::LogicalType> columnTypes;
+
     std::shared_ptr<processor::FlatTuple> tuple;
 
-    // execution statistics
     std::unique_ptr<QuerySummary> querySummary;
 
-    // query iterator
+    std::unique_ptr<QueryResult> nextQueryResult;
+
     QueryResultIterator queryResultIterator;
 
-    // database life cycle manager
     std::shared_ptr<common::DatabaseLifeCycleManager> dbLifeCycleManager;
 };
 

--- a/src/include/main/query_result/arrow_query_result.h
+++ b/src/include/main/query_result/arrow_query_result.h
@@ -11,7 +11,8 @@ class ArrowQueryResult : public QueryResult {
 
 public:
     ArrowQueryResult(std::vector<std::string> columnNames,
-        std::vector<common::LogicalType> columnTypes, processor::FactorizedTable& table, int64_t chunkSize);
+        std::vector<common::LogicalType> columnTypes, processor::FactorizedTable& table,
+        int64_t chunkSize);
 
     uint64_t getNumTuples() const override;
 
@@ -37,5 +38,5 @@ private:
     uint64_t cursor = 0;
 };
 
-}
-}
+} // namespace main
+} // namespace kuzu

--- a/src/include/main/query_result/arrow_query_result.h
+++ b/src/include/main/query_result/arrow_query_result.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "main/query_result.h"
+#include "materialized_query_result.h"
+
+namespace kuzu {
+namespace main {
+
+class ArrowQueryResult : public QueryResult {
+    static constexpr QueryResultType type_ = QueryResultType::ARROW;
+
+public:
+    ArrowQueryResult(std::vector<std::string> columnNames,
+        std::vector<common::LogicalType> columnTypes, processor::FactorizedTable& table, int64_t chunkSize);
+
+    uint64_t getNumTuples() const override;
+
+    bool hasNext() const override;
+
+    std::shared_ptr<processor::FlatTuple> getNext() override;
+
+    void resetIterator() override;
+
+    std::string toString() const override;
+
+    bool hasNextArrowChunk() override;
+
+    std::unique_ptr<ArrowArray> getNextArrowChunk(int64_t chunkSize) override;
+
+private:
+    ArrowArray getArray(processor::FactorizedTableIterator& iterator, int64_t chunkSize);
+
+private:
+    std::vector<ArrowArray> arrays;
+    int64_t chunkSize_;
+    uint64_t numTuples = 0;
+    uint64_t cursor = 0;
+};
+
+}
+}

--- a/src/include/main/query_result/materialized_query_result.h
+++ b/src/include/main/query_result/materialized_query_result.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "main/query_result.h"
+
+namespace kuzu {
+namespace processor {
+class FactorizedTable;
+class FactorizedTableIterator;
+}
+
+namespace main {
+
+class MaterializedQueryResult : public QueryResult {
+    static constexpr QueryResultType type_ = QueryResultType::FTABLE;
+
+public:
+    MaterializedQueryResult();
+    MaterializedQueryResult(std::vector<std::string> columnNames,
+        std::vector<common::LogicalType> columnTypes, std::shared_ptr<processor::FactorizedTable> table);
+    ~MaterializedQueryResult() override;
+
+    uint64_t getNumTuples() const override;
+
+    bool hasNext() const override;
+
+    std::shared_ptr<processor::FlatTuple> getNext() override;
+
+    void resetIterator() override;
+
+    std::string toString() const override;
+
+    bool hasNextArrowChunk() override;
+
+    std::unique_ptr<ArrowArray> getNextArrowChunk(int64_t chunkSize) override;
+
+    const processor::FactorizedTable& getFactorizedTable() const { return *table; }
+
+private:
+    std::shared_ptr<processor::FactorizedTable> table;
+    std::unique_ptr<processor::FactorizedTableIterator> iterator;
+};
+
+}
+}

--- a/src/include/main/query_result/materialized_query_result.h
+++ b/src/include/main/query_result/materialized_query_result.h
@@ -6,7 +6,7 @@ namespace kuzu {
 namespace processor {
 class FactorizedTable;
 class FactorizedTableIterator;
-}
+} // namespace processor
 
 namespace main {
 
@@ -16,7 +16,8 @@ class MaterializedQueryResult : public QueryResult {
 public:
     MaterializedQueryResult();
     MaterializedQueryResult(std::vector<std::string> columnNames,
-        std::vector<common::LogicalType> columnTypes, std::shared_ptr<processor::FactorizedTable> table);
+        std::vector<common::LogicalType> columnTypes,
+        std::shared_ptr<processor::FactorizedTable> table);
     ~MaterializedQueryResult() override;
 
     uint64_t getNumTuples() const override;
@@ -40,5 +41,5 @@ private:
     std::unique_ptr<processor::FactorizedTableIterator> iterator;
 };
 
-}
-}
+} // namespace main
+} // namespace kuzu

--- a/src/include/main/query_summary.h
+++ b/src/include/main/query_summary.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "common/api.h"
 #include <cstdint>
+
+#include "common/api.h"
 
 namespace kuzu {
 namespace common {
@@ -25,7 +26,8 @@ class QuerySummary {
 
 public:
     QuerySummary() = default;
-    explicit QuerySummary(const PreparedSummary& preparedSummary) : preparedSummary{preparedSummary} {}
+    explicit QuerySummary(const PreparedSummary& preparedSummary)
+        : preparedSummary{preparedSummary} {}
     /**
      * @return query compiling time in milliseconds.
      */

--- a/src/include/main/query_summary.h
+++ b/src/include/main/query_summary.h
@@ -1,9 +1,13 @@
 #pragma once
 
 #include "common/api.h"
-#include "kuzu_fwd.h"
+#include <cstdint>
 
 namespace kuzu {
+namespace common {
+enum class StatementType : uint8_t;
+}
+
 namespace main {
 
 /**
@@ -18,10 +22,10 @@ struct PreparedSummary { // NOLINT(*-pro-type-member-init)
  * @brief QuerySummary stores the execution time, plan, compiling time and query options of a query.
  */
 class QuerySummary {
-    friend class ClientContext;
-    friend class benchmark::Benchmark;
 
 public:
+    QuerySummary() = default;
+    explicit QuerySummary(const PreparedSummary& preparedSummary) : preparedSummary{preparedSummary} {}
     /**
      * @return query compiling time in milliseconds.
      */
@@ -31,10 +35,11 @@ public:
      */
     KUZU_API double getExecutionTime() const;
 
-    void incrementCompilingTime(double increment);
-    void incrementExecutionTime(double increment);
+    void setExecutionTime(double time);
 
-    void setPreparedSummary(PreparedSummary preparedSummary_);
+    void incrementCompilingTime(double increment);
+
+    void incrementExecutionTime(double increment);
 
     /**
      * @return true if the query is executed with EXPLAIN.

--- a/src/include/processor/processor.h
+++ b/src/include/processor/processor.h
@@ -1,12 +1,11 @@
 #pragma once
 
 #include "common/task_system/task_scheduler.h"
-#include "processor/physical_plan.h"
-#include "processor/result/factorized_table.h"
 
 namespace kuzu {
 namespace processor {
 
+class PhysicalPlan;
 class QueryProcessor {
 
 public:
@@ -16,8 +15,9 @@ public:
     explicit QueryProcessor(uint64_t numThreads);
 #endif
 
-    inline common::TaskScheduler* getTaskScheduler() { return taskScheduler.get(); }
+    common::TaskScheduler* getTaskScheduler() { return taskScheduler.get(); }
 
+    // TODO(Xiyang): we should change this to directly return a query result.
     std::shared_ptr<FactorizedTable> execute(PhysicalPlan* physicalPlan, ExecutionContext* context);
 
 private:

--- a/src/include/processor/result/flat_tuple.h
+++ b/src/include/processor/result/flat_tuple.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -16,20 +15,40 @@ namespace processor {
  */
 class FlatTuple {
 public:
-    void addValue(std::unique_ptr<common::Value> value);
+    explicit FlatTuple(const std::vector<common::LogicalType>& types);
+
+    DELETE_COPY_AND_MOVE(FlatTuple);
 
     /**
      * @return number of values in the FlatTuple.
      */
-    KUZU_API uint32_t len() const;
+    KUZU_API common::idx_t len() const;
+    /**
+     * @brief Get a pointer to the value at the specified index.
+     * @param idx The index of the value to retrieve.
+     * @return A pointer to the Value at the specified index.
+     */
+    KUZU_API common::Value* getValue(common::idx_t idx);
 
     /**
-     * @param idx value index to get.
-     * @return the value stored at idx.
+     * @brief Access the value at the specified index by reference.
+     * @param idx The index of the value to access.
+     * @return A reference to the Value at the specified index.
      */
-    KUZU_API common::Value* getValue(uint32_t idx) const;
+    KUZU_API common::Value& operator[](common::idx_t idx);
 
-    KUZU_API std::string toString();
+    /**
+     * @brief Access the value at the specified index by const reference.
+     * @param idx The index of the value to access.
+     * @return A const reference to the Value at the specified index.
+     */
+    KUZU_API const common::Value& operator[](common::idx_t idx) const;
+
+    /**
+     * @brief Convert the FlatTuple to a string representation.
+     * @return A string representation of all values in the FlatTuple.
+     */
+    KUZU_API std::string toString() const;
 
     /**
      * @param colsWidth The length of each column
@@ -42,7 +61,7 @@ public:
         const std::string& delimiter = "|", uint32_t maxWidth = -1);
 
 private:
-    std::vector<std::unique_ptr<common::Value>> values;
+    std::vector<common::Value> values;
 };
 
 } // namespace processor

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(query_result)
+
 add_library(kuzu_main
         OBJECT
         attached_database.cpp

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -26,6 +26,7 @@
 #include "storage/buffer_manager/spiller.h"
 #include "storage/storage_manager.h"
 #include "transaction/transaction_context.h"
+#include "main/query_result/arrow_query_result.h"
 
 #if defined(_WIN32)
 #include "common/windows_utils.h"
@@ -408,13 +409,13 @@ std::unique_ptr<QueryResult> ClientContext::executeWithParams(PreparedStatement*
 }
 
 std::unique_ptr<QueryResult> ClientContext::query(std::string_view query,
-    std::optional<uint64_t> queryID) {
+    std::optional<uint64_t> queryID, ArrowInfo arrowInfo) {
     lock_t lck{mtx};
-    return queryNoLock(query, queryID);
+    return queryNoLock(query, queryID, arrowInfo);
 }
 
 std::unique_ptr<QueryResult> ClientContext::queryNoLock(std::string_view query,
-    std::optional<uint64_t> queryID) {
+    std::optional<uint64_t> queryID, ArrowInfo arrowInfo) {
     auto parsedStatements = std::vector<std::shared_ptr<Statement>>();
     try {
         parsedStatements = parseQuery(query);
@@ -428,12 +429,12 @@ std::unique_ptr<QueryResult> ClientContext::queryNoLock(std::string_view query,
         auto [preparedStatement, cachedStatement] =
             prepareNoLock(statement, false /*shouldCommitNewTransaction*/);
         auto currentQueryResult =
-            executeNoLock(preparedStatement.get(), cachedStatement.get(), queryID);
+            executeNoLock(preparedStatement.get(), cachedStatement.get(), queryID, arrowInfo);
         if (!currentQueryResult->isSuccess()) {
             if (!lastResult) {
                 queryResult = std::move(currentQueryResult);
             } else {
-                queryResult->nextQueryResult = std::move(currentQueryResult);
+                queryResult->addNextResult(std::move(currentQueryResult));
             }
             break;
         }
@@ -452,8 +453,9 @@ std::unique_ptr<QueryResult> ClientContext::queryNoLock(std::string_view query,
             queryResult = std::move(currentQueryResult);
             lastResult = queryResult.get();
         } else {
-            lastResult->nextQueryResult = std::move(currentQueryResult);
-            lastResult = lastResult->nextQueryResult.get();
+            auto current = currentQueryResult.get();
+            lastResult->addNextResult(std::move(currentQueryResult));
+            lastResult = current;
         }
     }
     useInternalCatalogEntry_ = false;
@@ -556,7 +558,7 @@ ClientContext::PrepareResult ClientContext::prepareNoLock(
 }
 
 std::unique_ptr<QueryResult> ClientContext::executeNoLock(PreparedStatement* preparedStatement,
-    CachedPreparedStatement* cachedStatement, std::optional<uint64_t> queryID) {
+    CachedPreparedStatement* cachedStatement, std::optional<uint64_t> queryID, ArrowInfo arrowInfo) {
     if (!preparedStatement->isSuccess()) {
         return QueryResult::getQueryResultWithError(preparedStatement->errMsg);
     }
@@ -566,7 +568,6 @@ std::unique_ptr<QueryResult> ClientContext::executeNoLock(PreparedStatement* pre
     auto executingTimer = TimeMetric(true /* enable */);
     executingTimer.start();
     std::shared_ptr<FactorizedTable> resultFT;
-    std::unique_ptr<QueryResult> queryResult;
     try {
         bool isTransactionStatement =
             preparedStatement->getStatementType() == StatementType::TRANSACTION;
@@ -583,7 +584,6 @@ std::unique_ptr<QueryResult> ClientContext::executeNoLock(PreparedStatement* pre
                 auto mapper = PlanMapper(executionContext.get());
                 const auto physicalPlan = mapper.mapLogicalPlanToPhysical(
                     cachedStatement->logicalPlan.get(), cachedStatement->columns);
-                queryResult = std::make_unique<QueryResult>(preparedStatement->preparedSummary);
                 if (isTransactionStatement) {
                     resultFT = localDatabase->queryProcessor->execute(physicalPlan.get(),
                         executionContext.get());
@@ -606,11 +606,18 @@ std::unique_ptr<QueryResult> ClientContext::executeNoLock(PreparedStatement* pre
     getMemoryManager()->getBufferManager()->getSpillerOrSkip(
         [](auto& spiller) { spiller.clearFile(); });
     executingTimer.stop();
-    queryResult->querySummary->executionTime = executingTimer.getElapsedTimeMS();
-    queryResult->setColumnHeader(cachedStatement->getColumnNames(),
-        cachedStatement->getColumnTypes());
-    queryResult->initResultTableAndIterator(std::move(resultFT));
-    return queryResult;
+    auto columnNames = cachedStatement->getColumnNames();
+    auto columnTypes = cachedStatement->getColumnTypes();
+    std::unique_ptr<QueryResult> result;
+    if (arrowInfo.asArrow) {
+        result = std::make_unique<ArrowQueryResult>(std::move(columnNames), std::move(columnTypes), *resultFT, arrowInfo.chunkSize);
+    } else {
+        result = std::make_unique<MaterializedQueryResult>(std::move(columnNames), std::move(columnTypes), resultFT);
+    }
+    auto summary = std::make_unique<QuerySummary>(preparedStatement->preparedSummary);
+    summary->setExecutionTime(executingTimer.getElapsedTimeMS());
+    result->setQuerySummary(std::move(summary));
+    return result;
 }
 
 std::unique_ptr<QueryResult> ClientContext::handleFailedExecution(std::optional<uint64_t> queryID,

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -49,7 +49,14 @@ std::unique_ptr<PreparedStatement> Connection::prepareWithParams(std::string_vie
 std::unique_ptr<QueryResult> Connection::query(std::string_view queryStatement) {
     dbLifeCycleManager->checkDatabaseClosedOrThrow();
     auto queryResult = clientContext->query(queryStatement);
-    queryResult->dbLifeCycleManager = dbLifeCycleManager;
+    queryResult->setDBLifeCycleManager(dbLifeCycleManager);
+    return queryResult;
+}
+
+std::unique_ptr<QueryResult> Connection::queryAsArrow(std::string_view query, int64_t chunkSize) {
+    dbLifeCycleManager->checkDatabaseClosedOrThrow();
+    auto queryResult = clientContext->query(query, std::nullopt, {true, chunkSize});
+    queryResult->setDBLifeCycleManager(dbLifeCycleManager);
     return queryResult;
 }
 
@@ -57,7 +64,7 @@ std::unique_ptr<QueryResult> Connection::queryWithID(std::string_view queryState
     uint64_t queryID) {
     dbLifeCycleManager->checkDatabaseClosedOrThrow();
     auto queryResult = clientContext->query(queryStatement, queryID);
-    queryResult->dbLifeCycleManager = dbLifeCycleManager;
+    queryResult->setDBLifeCycleManager(dbLifeCycleManager);
     return queryResult;
 }
 
@@ -75,7 +82,7 @@ std::unique_ptr<QueryResult> Connection::executeWithParams(PreparedStatement* pr
     std::unordered_map<std::string, std::unique_ptr<Value>> inputParams) {
     dbLifeCycleManager->checkDatabaseClosedOrThrow();
     auto queryResult = clientContext->executeWithParams(preparedStatement, std::move(inputParams));
-    queryResult->dbLifeCycleManager = dbLifeCycleManager;
+    queryResult->setDBLifeCycleManager(dbLifeCycleManager);
     return queryResult;
 }
 
@@ -85,7 +92,7 @@ std::unique_ptr<QueryResult> Connection::executeWithParamsWithID(
     dbLifeCycleManager->checkDatabaseClosedOrThrow();
     auto queryResult =
         clientContext->executeWithParams(preparedStatement, std::move(inputParams), queryID);
-    queryResult->dbLifeCycleManager = dbLifeCycleManager;
+    queryResult->setDBLifeCycleManager(dbLifeCycleManager);
     return queryResult;
 }
 

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -1,7 +1,8 @@
 #include "main/query_result.h"
-#include "processor/result/flat_tuple.h"
+
 #include "common/arrow/arrow_converter.h"
 #include "main/query_result/materialized_query_result.h"
+#include "processor/result/flat_tuple.h"
 
 using namespace kuzu::common;
 using namespace kuzu::processor;
@@ -10,8 +11,8 @@ namespace kuzu {
 namespace main {
 
 QueryResult::QueryResult()
-    : type{QueryResultType::FTABLE}, nextQueryResult{nullptr},
-      queryResultIterator{this}, dbLifeCycleManager{nullptr} {}
+    : type{QueryResultType::FTABLE}, nextQueryResult{nullptr}, queryResultIterator{this},
+      dbLifeCycleManager{nullptr} {}
 
 QueryResult::QueryResult(QueryResultType type, std::vector<std::string> columnNames,
     std::vector<LogicalType> columnTypes)
@@ -73,7 +74,8 @@ QueryResult* QueryResult::getNextQueryResult() {
 
 std::unique_ptr<ArrowSchema> QueryResult::getArrowSchema() const {
     checkDatabaseClosedOrThrow();
-    return ArrowConverter::toArrowSchema(getColumnDataTypes(), getColumnNames(), false /* fallbackExtensionTypes */);
+    return ArrowConverter::toArrowSchema(getColumnDataTypes(), getColumnNames(),
+        false /* fallbackExtensionTypes */);
 }
 
 void QueryResult::validateQuerySucceed() const {

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -1,11 +1,7 @@
 #include "main/query_result.h"
-
-#include <memory>
-
-#include "common/arrow/arrow_converter.h"
-#include "common/exception/runtime.h"
-#include "processor/result/factorized_table.h"
 #include "processor/result/flat_tuple.h"
+#include "common/arrow/arrow_converter.h"
+#include "main/query_result/materialized_query_result.h"
 
 using namespace kuzu::common;
 using namespace kuzu::processor;
@@ -14,80 +10,44 @@ namespace kuzu {
 namespace main {
 
 QueryResult::QueryResult()
-    : nextQueryResult{nullptr}, queryResultIterator{this}, dbLifeCycleManager{nullptr} {}
+    : type{QueryResultType::FTABLE}, nextQueryResult{nullptr},
+      queryResultIterator{this}, dbLifeCycleManager{nullptr} {}
 
-QueryResult::QueryResult(const PreparedSummary& preparedSummary)
-    : nextQueryResult{nullptr}, queryResultIterator{this}, dbLifeCycleManager{nullptr} {
-    querySummary = std::make_unique<QuerySummary>();
-    querySummary->setPreparedSummary(preparedSummary);
+QueryResult::QueryResult(QueryResultType type, std::vector<std::string> columnNames,
+    std::vector<LogicalType> columnTypes)
+    : type{type}, columnNames{std::move(columnNames)}, columnTypes{std::move(columnTypes)},
+      nextQueryResult{nullptr}, queryResultIterator{this}, dbLifeCycleManager{nullptr} {
+    tuple = std::make_shared<FlatTuple>(this->columnTypes);
 }
-QueryResult::~QueryResult() {
-    if (!dbLifeCycleManager) {
-        return;
-    }
-    if (!factorizedTable) {
-        return;
-    }
-    factorizedTable->setPreventDestruction(dbLifeCycleManager->isDatabaseClosed);
-}
+
+QueryResult::~QueryResult() = default;
 
 bool QueryResult::isSuccess() const {
-    checkDatabaseClosedOrThrow();
     return success;
 }
 
 std::string QueryResult::getErrorMessage() const {
-    checkDatabaseClosedOrThrow();
     return errMsg;
 }
 
 size_t QueryResult::getNumColumns() const {
-    checkDatabaseClosedOrThrow();
-    return columnDataTypes.size();
+    return columnTypes.size();
 }
 
 std::vector<std::string> QueryResult::getColumnNames() const {
-    checkDatabaseClosedOrThrow();
     return columnNames;
 }
 
 std::vector<LogicalType> QueryResult::getColumnDataTypes() const {
-    checkDatabaseClosedOrThrow();
-    return LogicalType::copy(columnDataTypes);
-}
-
-uint64_t QueryResult::getNumTuples() const {
-    checkDatabaseClosedOrThrow();
-    return factorizedTable->getTotalNumFlatTuples();
+    return LogicalType::copy(columnTypes);
 }
 
 QuerySummary* QueryResult::getQuerySummary() const {
-    checkDatabaseClosedOrThrow();
     return querySummary.get();
 }
 
-void QueryResult::resetIterator() {
-    checkDatabaseClosedOrThrow();
-    iterator->resetState();
-}
-
-void QueryResult::setColumnHeader(std::vector<std::string> columnNames_,
-    std::vector<LogicalType> columnTypes_) {
-    columnNames = std::move(columnNames_);
-    columnDataTypes = std::move(columnTypes_);
-}
-
-std::pair<std::unique_ptr<FlatTuple>, std::unique_ptr<FlatTupleIterator>>
-QueryResult::getIterator() const {
-    std::vector<Value*> valuesToCollect;
-    auto tuple = std::make_unique<FlatTuple>();
-    for (auto& type : columnDataTypes) {
-        auto value = std::make_unique<Value>(Value::createDefaultValue(type.copy()));
-        valuesToCollect.push_back(value.get());
-        tuple->addValue(std::move(value));
-    }
-    return std::make_pair(std::move(tuple),
-        std::make_unique<FlatTupleIterator>(*factorizedTable, std::move(valuesToCollect)));
+QuerySummary* QueryResult::getQuerySummaryUnsafe() {
+    return querySummary.get();
 }
 
 void QueryResult::checkDatabaseClosedOrThrow() const {
@@ -95,20 +55,6 @@ void QueryResult::checkDatabaseClosedOrThrow() const {
         return;
     }
     dbLifeCycleManager->checkDatabaseClosedOrThrow();
-}
-
-void QueryResult::initResultTableAndIterator(
-    std::shared_ptr<processor::FactorizedTable> factorizedTable_) {
-    factorizedTable = std::move(factorizedTable_);
-    auto [tuple, iterator] = getIterator();
-    this->iterator = std::move(iterator);
-    this->tuple = std::move(tuple);
-}
-
-bool QueryResult::hasNext() const {
-    checkDatabaseClosedOrThrow();
-    validateQuerySucceed();
-    return iterator->hasNextFlatTuple();
 }
 
 bool QueryResult::hasNextQueryResult() const {
@@ -125,38 +71,9 @@ QueryResult* QueryResult::getNextQueryResult() {
     return nullptr;
 }
 
-std::shared_ptr<FlatTuple> QueryResult::getNext() {
+std::unique_ptr<ArrowSchema> QueryResult::getArrowSchema() const {
     checkDatabaseClosedOrThrow();
-    if (!hasNext()) {
-        throw RuntimeException(
-            "No more tuples in QueryResult, Please check hasNext() before calling getNext().");
-    }
-    validateQuerySucceed();
-    iterator->getNextFlatTuple();
-    return tuple;
-}
-
-std::string QueryResult::toString() const {
-    checkDatabaseClosedOrThrow();
-    std::string result;
-    if (isSuccess()) {
-        // print header
-        for (auto i = 0u; i < columnNames.size(); ++i) {
-            if (i != 0) {
-                result += "|";
-            }
-            result += columnNames[i];
-        }
-        result += "\n";
-        auto [tuple, iterator] = getIterator();
-        while (iterator->hasNextFlatTuple()) {
-            iterator->getNextFlatTuple();
-            result += tuple->toString();
-        }
-    } else {
-        result = errMsg;
-    }
-    return result;
+    return ArrowConverter::toArrowSchema(getColumnDataTypes(), getColumnNames(), false /* fallbackExtensionTypes */);
 }
 
 void QueryResult::validateQuerySucceed() const {
@@ -165,20 +82,26 @@ void QueryResult::validateQuerySucceed() const {
     }
 }
 
-std::unique_ptr<ArrowSchema> QueryResult::getArrowSchema() const {
-    checkDatabaseClosedOrThrow();
-    return ArrowConverter::toArrowSchema(getColumnDataTypes(), getColumnNames());
+void QueryResult::addNextResult(std::unique_ptr<QueryResult> next_) {
+    nextQueryResult = std::move(next_);
 }
 
-std::unique_ptr<ArrowArray> QueryResult::getNextArrowChunk(int64_t chunkSize) {
-    checkDatabaseClosedOrThrow();
-    auto data = std::make_unique<ArrowArray>();
-    ArrowConverter::toArrowArray(*this, data.get(), chunkSize);
-    return data;
+std::unique_ptr<QueryResult> QueryResult::moveNextResult() {
+    return std::move(nextQueryResult);
+}
+
+void QueryResult::setQuerySummary(std::unique_ptr<QuerySummary> summary) {
+    querySummary = std::move(summary);
+}
+
+void QueryResult::setDBLifeCycleManager(
+    std::shared_ptr<DatabaseLifeCycleManager> dbLifeCycleManager) {
+    this->dbLifeCycleManager = dbLifeCycleManager;
 }
 
 std::unique_ptr<QueryResult> QueryResult::getQueryResultWithError(const std::string& errorMessage) {
-    auto queryResult = std::make_unique<QueryResult>();
+    // TODO(Xiyang): consider introduce error query result class.
+    auto queryResult = std::make_unique<MaterializedQueryResult>();
     queryResult->success = false;
     queryResult->errMsg = errorMessage;
     queryResult->nextQueryResult = nullptr;

--- a/src/main/query_result/CMakeLists.txt
+++ b/src/main/query_result/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(kuzu_main_query_result
+        OBJECT
+        arrow_query_result.cpp
+        materialized_query_result.cpp)
+
+set(ALL_OBJECT_FILES
+        ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_main_query_result>
+        PARENT_SCOPE)

--- a/src/main/query_result/arrow_query_result.cpp
+++ b/src/main/query_result/arrow_query_result.cpp
@@ -2,8 +2,8 @@
 
 #include "common/arrow/arrow_row_batch.h"
 #include "common/exception/not_implemented.h"
-#include "processor/result/factorized_table.h"
 #include "common/exception/runtime.h"
+#include "processor/result/factorized_table.h"
 
 using namespace kuzu::common;
 using namespace kuzu::processor;
@@ -24,9 +24,9 @@ uint64_t ArrowQueryResult::getNumTuples() const {
     return numTuples;
 }
 
-ArrowArray ArrowQueryResult::getArray(FactorizedTableIterator& iterator,
-    int64_t chunkSize) {
-    auto rowBatch = std::make_unique<ArrowRowBatch>(copyVector(columnTypes), chunkSize, false /* fallbackExtensionTypes */);
+ArrowArray ArrowQueryResult::getArray(FactorizedTableIterator& iterator, int64_t chunkSize) {
+    auto rowBatch = std::make_unique<ArrowRowBatch>(copyVector(columnTypes), chunkSize,
+        false /* fallbackExtensionTypes */);
     auto rowBatchSize = 0u;
     while (rowBatchSize < chunkSize) {
         if (!iterator.hasNext()) {
@@ -40,11 +40,13 @@ ArrowArray ArrowQueryResult::getArray(FactorizedTableIterator& iterator,
 }
 
 bool ArrowQueryResult::hasNext() const {
-    throw NotImplementedException("ArrowQueryResult does not implement hasNext. Use MaterializedQueryResult instead.");
+    throw NotImplementedException(
+        "ArrowQueryResult does not implement hasNext. Use MaterializedQueryResult instead.");
 }
 
 std::shared_ptr<FlatTuple> ArrowQueryResult::getNext() {
-    throw NotImplementedException("ArrowQueryResult does not implement getNext. Use MaterializedQueryResult instead.");
+    throw NotImplementedException(
+        "ArrowQueryResult does not implement getNext. Use MaterializedQueryResult instead.");
 }
 
 void ArrowQueryResult::resetIterator() {
@@ -52,7 +54,8 @@ void ArrowQueryResult::resetIterator() {
 }
 
 std::string ArrowQueryResult::toString() const {
-    throw NotImplementedException("ArrowQueryResult does not implement toString. Use MaterializedQueryResult instead.");
+    throw NotImplementedException(
+        "ArrowQueryResult does not implement toString. Use MaterializedQueryResult instead.");
 }
 
 bool ArrowQueryResult::hasNextArrowChunk() {
@@ -61,10 +64,11 @@ bool ArrowQueryResult::hasNextArrowChunk() {
 
 std::unique_ptr<ArrowArray> ArrowQueryResult::getNextArrowChunk(int64_t chunkSize) {
     if (chunkSize != chunkSize_) {
-        throw RuntimeException(stringFormat("Chunk size does not match expected value {}.", chunkSize_));
+        throw RuntimeException(
+            stringFormat("Chunk size does not match expected value {}.", chunkSize_));
     }
     return std::make_unique<ArrowArray>(arrays[cursor++]);
 }
 
-}
-}
+} // namespace main
+} // namespace kuzu

--- a/src/main/query_result/arrow_query_result.cpp
+++ b/src/main/query_result/arrow_query_result.cpp
@@ -1,0 +1,70 @@
+#include "main/query_result/arrow_query_result.h"
+
+#include "common/arrow/arrow_row_batch.h"
+#include "common/exception/not_implemented.h"
+#include "processor/result/factorized_table.h"
+#include "common/exception/runtime.h"
+
+using namespace kuzu::common;
+using namespace kuzu::processor;
+
+namespace kuzu {
+namespace main {
+
+ArrowQueryResult::ArrowQueryResult(std::vector<std::string> columnNames,
+    std::vector<LogicalType> columnTypes, FactorizedTable& table, int64_t chunkSize)
+    : QueryResult{type_, std::move(columnNames), std::move(columnTypes)}, chunkSize_{chunkSize} {
+    auto iterator = FactorizedTableIterator(table);
+    while (iterator.hasNext()) {
+        arrays.push_back(getArray(iterator, chunkSize));
+    }
+}
+
+uint64_t ArrowQueryResult::getNumTuples() const {
+    return numTuples;
+}
+
+ArrowArray ArrowQueryResult::getArray(FactorizedTableIterator& iterator,
+    int64_t chunkSize) {
+    auto rowBatch = std::make_unique<ArrowRowBatch>(copyVector(columnTypes), chunkSize, false /* fallbackExtensionTypes */);
+    auto rowBatchSize = 0u;
+    while (rowBatchSize < chunkSize) {
+        if (!iterator.hasNext()) {
+            break;
+        }
+        (void)iterator.getNext(*tuple);
+        rowBatch->append(*tuple);
+        numTuples++;
+    }
+    return rowBatch->toArray();
+}
+
+bool ArrowQueryResult::hasNext() const {
+    throw NotImplementedException("ArrowQueryResult does not implement hasNext. Use MaterializedQueryResult instead.");
+}
+
+std::shared_ptr<FlatTuple> ArrowQueryResult::getNext() {
+    throw NotImplementedException("ArrowQueryResult does not implement getNext. Use MaterializedQueryResult instead.");
+}
+
+void ArrowQueryResult::resetIterator() {
+    cursor = 0u;
+}
+
+std::string ArrowQueryResult::toString() const {
+    throw NotImplementedException("ArrowQueryResult does not implement toString. Use MaterializedQueryResult instead.");
+}
+
+bool ArrowQueryResult::hasNextArrowChunk() {
+    return cursor < arrays.size();
+}
+
+std::unique_ptr<ArrowArray> ArrowQueryResult::getNextArrowChunk(int64_t chunkSize) {
+    if (chunkSize != chunkSize_) {
+        throw RuntimeException(stringFormat("Chunk size does not match expected value {}.", chunkSize_));
+    }
+    return std::make_unique<ArrowArray>(arrays[cursor++]);
+}
+
+}
+}

--- a/src/main/query_result/materialized_query_result.cpp
+++ b/src/main/query_result/materialized_query_result.cpp
@@ -1,9 +1,9 @@
 #include "main/query_result/materialized_query_result.h"
 
+#include "common/arrow/arrow_row_batch.h"
 #include "common/exception/runtime.h"
 #include "processor/result/factorized_table.h"
 #include "processor/result/flat_tuple.h"
-#include "common/arrow/arrow_row_batch.h"
 
 using namespace kuzu::common;
 using namespace kuzu::processor;
@@ -87,7 +87,8 @@ bool MaterializedQueryResult::hasNextArrowChunk() {
 
 std::unique_ptr<ArrowArray> MaterializedQueryResult::getNextArrowChunk(int64_t chunkSize) {
     checkDatabaseClosedOrThrow();
-    auto rowBatch = std::make_unique<ArrowRowBatch>(copyVector(columnTypes), chunkSize, false /* fallbackExtensionTypes */);
+    auto rowBatch = std::make_unique<ArrowRowBatch>(copyVector(columnTypes), chunkSize,
+        false /* fallbackExtensionTypes */);
     auto rowBatchSize = 0u;
     while (rowBatchSize < chunkSize) {
         if (!iterator->hasNext()) {
@@ -100,5 +101,5 @@ std::unique_ptr<ArrowArray> MaterializedQueryResult::getNextArrowChunk(int64_t c
     return std::make_unique<ArrowArray>(rowBatch->toArray());
 }
 
-}
-}
+} // namespace main
+} // namespace kuzu

--- a/src/main/query_result/materialized_query_result.cpp
+++ b/src/main/query_result/materialized_query_result.cpp
@@ -1,0 +1,104 @@
+#include "main/query_result/materialized_query_result.h"
+
+#include "common/exception/runtime.h"
+#include "processor/result/factorized_table.h"
+#include "processor/result/flat_tuple.h"
+#include "common/arrow/arrow_row_batch.h"
+
+using namespace kuzu::common;
+using namespace kuzu::processor;
+
+namespace kuzu {
+namespace main {
+
+MaterializedQueryResult::MaterializedQueryResult() = default;
+
+MaterializedQueryResult::MaterializedQueryResult(std::vector<std::string> columnNames,
+    std::vector<LogicalType> columnTypes, std::shared_ptr<FactorizedTable> table)
+    : QueryResult{type_, std::move(columnNames), std::move(columnTypes)}, table{std::move(table)} {
+    iterator = std::make_unique<FactorizedTableIterator>(*this->table);
+}
+
+MaterializedQueryResult::~MaterializedQueryResult() {
+    if (!dbLifeCycleManager) {
+        return;
+    }
+    if (!table) {
+        return;
+    }
+    table->setPreventDestruction(dbLifeCycleManager->isDatabaseClosed);
+}
+
+uint64_t MaterializedQueryResult::getNumTuples() const {
+    checkDatabaseClosedOrThrow();
+    validateQuerySucceed();
+    return table->getTotalNumFlatTuples();
+}
+
+bool MaterializedQueryResult::hasNext() const {
+    checkDatabaseClosedOrThrow();
+    validateQuerySucceed();
+    return iterator->hasNext();
+}
+
+std::shared_ptr<FlatTuple> MaterializedQueryResult::getNext() {
+    checkDatabaseClosedOrThrow();
+    validateQuerySucceed();
+    if (!hasNext()) {
+        throw RuntimeException(
+            "No more tuples in QueryResult, Please check hasNext() before calling getNext().");
+    }
+    iterator->getNext(*tuple);
+    return tuple;
+}
+
+void MaterializedQueryResult::resetIterator() {
+    checkDatabaseClosedOrThrow();
+    validateQuerySucceed();
+    iterator->resetState();
+}
+
+std::string MaterializedQueryResult::toString() const {
+    checkDatabaseClosedOrThrow();
+    if (!isSuccess()) {
+        return errMsg;
+    }
+    std::string result;
+    // print header
+    for (auto i = 0u; i < columnNames.size(); ++i) {
+        if (i != 0) {
+            result += "|";
+        }
+        result += columnNames[i];
+    }
+    result += "\n";
+    auto tuple_ = FlatTuple(this->columnTypes);
+    auto iterator_ = FactorizedTableIterator(*table);
+    while (iterator->hasNext()) {
+        iterator->getNext(tuple_);
+        result += tuple_.toString();
+    }
+    return result;
+}
+
+bool MaterializedQueryResult::hasNextArrowChunk() {
+    return hasNext();
+}
+
+std::unique_ptr<ArrowArray> MaterializedQueryResult::getNextArrowChunk(int64_t chunkSize) {
+    checkDatabaseClosedOrThrow();
+    auto rowBatch = std::make_unique<ArrowRowBatch>(copyVector(columnTypes), chunkSize, false /* fallbackExtensionTypes */);
+    auto rowBatchSize = 0u;
+    while (rowBatchSize < chunkSize) {
+        if (!iterator->hasNext()) {
+            break;
+        }
+        (void)iterator->getNext(*tuple);
+        rowBatch->append(*tuple);
+        rowBatchSize++;
+    }
+    return std::make_unique<ArrowArray>(rowBatch->toArray());
+}
+
+}
+}

--- a/src/main/query_summary.cpp
+++ b/src/main/query_summary.cpp
@@ -15,6 +15,10 @@ double QuerySummary::getExecutionTime() const {
     return executionTime;
 }
 
+void QuerySummary::setExecutionTime(double time) {
+    executionTime = time;
+}
+
 void QuerySummary::incrementCompilingTime(double increment) {
     preparedSummary.compilingTime += increment;
 }
@@ -23,15 +27,11 @@ void QuerySummary::incrementExecutionTime(double increment) {
     executionTime += increment;
 }
 
-void QuerySummary::setPreparedSummary(PreparedSummary preparedSummary_) {
-    preparedSummary = preparedSummary_;
-}
-
 bool QuerySummary::isExplain() const {
     return preparedSummary.statementType == StatementType::EXPLAIN;
 }
 
-common::StatementType QuerySummary::getStatementType() const {
+StatementType QuerySummary::getStatementType() const {
     return preparedSummary.statementType;
 }
 

--- a/src/processor/processor.cpp
+++ b/src/processor/processor.cpp
@@ -2,6 +2,7 @@
 
 #include "common/task_system/progress_bar.h"
 #include "processor/operator/sink.h"
+#include "processor/physical_plan.h"
 #include "processor/processor_task.h"
 
 using namespace kuzu::common;
@@ -9,6 +10,7 @@ using namespace kuzu::storage;
 
 namespace kuzu {
 namespace processor {
+
 #if defined(__APPLE__)
 QueryProcessor::QueryProcessor(uint64_t numThreads, uint32_t threadQos) {
     taskScheduler = std::make_unique<TaskScheduler>(numThreads, threadQos);
@@ -32,9 +34,10 @@ std::shared_ptr<FactorizedTable> QueryProcessor::execute(PhysicalPlan* physicalP
         decomposePlanIntoTask(sink->getChild(i), task.get(), context);
     }
     initTask(task.get());
-    context->clientContext->getProgressBar()->startProgress(context->queryID);
+    auto progressBar = context->clientContext->getProgressBar();
+    progressBar->startProgress(context->queryID);
     taskScheduler->scheduleTaskAndWaitOrError(task, context);
-    context->clientContext->getProgressBar()->endProgress(context->queryID);
+    progressBar->endProgress(context->queryID);
     return sink->getResultFTable();
 }
 

--- a/src/processor/result/factorized_table.cpp
+++ b/src/processor/result/factorized_table.cpp
@@ -683,7 +683,8 @@ void FactorizedTableIterator::resetState() {
     }
 }
 
-void FactorizedTableIterator::readUnflatColToFlatTuple(ft_col_idx_t colIdx, uint8_t* valueBuffer, FlatTuple& tuple) {
+void FactorizedTableIterator::readUnflatColToFlatTuple(ft_col_idx_t colIdx, uint8_t* valueBuffer,
+    FlatTuple& tuple) {
     auto overflowValue =
         (overflow_value_t*)(valueBuffer + factorizedTable.getTableSchema()->getColOffset(colIdx));
     auto groupID = factorizedTable.getTableSchema()->getColumn(colIdx)->getGroupID();
@@ -700,12 +701,14 @@ void FactorizedTableIterator::readUnflatColToFlatTuple(ft_col_idx_t colIdx, uint
     }
 }
 
-void FactorizedTableIterator::readFlatColToFlatTuple(ft_col_idx_t colIdx, uint8_t* valueBuffer, FlatTuple& tuple) {
+void FactorizedTableIterator::readFlatColToFlatTuple(ft_col_idx_t colIdx, uint8_t* valueBuffer,
+    FlatTuple& tuple) {
     auto isNull = factorizedTable.isNonOverflowColNull(
         valueBuffer + factorizedTable.getTableSchema()->getNullMapOffset(), colIdx);
     tuple[colIdx].setNull(isNull);
     if (!isNull) {
-        tuple[colIdx].copyFromRowLayout(valueBuffer + factorizedTable.getTableSchema()->getColOffset(colIdx));
+        tuple[colIdx].copyFromRowLayout(
+            valueBuffer + factorizedTable.getTableSchema()->getColOffset(colIdx));
     }
 }
 

--- a/src/processor/result/factorized_table.cpp
+++ b/src/processor/result/factorized_table.cpp
@@ -644,14 +644,13 @@ void FactorizedTable::readFlatColToUnflatVector(uint8_t** tuplesToRead, ft_col_i
     }
 }
 
-FlatTupleIterator::FlatTupleIterator(FactorizedTable& factorizedTable, std::vector<Value*> values)
+FactorizedTableIterator::FactorizedTableIterator(FactorizedTable& factorizedTable)
     : factorizedTable{factorizedTable}, currentTupleBuffer{nullptr}, numFlatTuples{0},
-      nextFlatTupleIdx{0}, nextTupleIdx{1}, values{std::move(values)} {
+      nextFlatTupleIdx{0}, nextTupleIdx{1} {
     resetState();
-    KU_ASSERT(this->values.size() == factorizedTable.tableSchema.getNumColumns());
 }
 
-void FlatTupleIterator::getNextFlatTuple() {
+void FactorizedTableIterator::getNext(FlatTuple& tuple) {
     // Go to the next tuple if we have iterated all the flat tuples of the current tuple.
     if (nextFlatTupleIdx >= numFlatTuples) {
         currentTupleBuffer = factorizedTable.getTuple(nextTupleIdx);
@@ -663,16 +662,16 @@ void FlatTupleIterator::getNextFlatTuple() {
     for (auto i = 0ul; i < factorizedTable.getTableSchema()->getNumColumns(); i++) {
         auto column = factorizedTable.getTableSchema()->getColumn(i);
         if (column->isFlat()) {
-            readFlatColToFlatTuple(i, currentTupleBuffer);
+            readFlatColToFlatTuple(i, currentTupleBuffer, tuple);
         } else {
-            readUnflatColToFlatTuple(i, currentTupleBuffer);
+            readUnflatColToFlatTuple(i, currentTupleBuffer, tuple);
         }
     }
     updateFlatTuplePositionsInDataChunk();
     nextFlatTupleIdx++;
 }
 
-void FlatTupleIterator::resetState() {
+void FactorizedTableIterator::resetState() {
     numFlatTuples = 0;
     nextFlatTupleIdx = 0;
     nextTupleIdx = 1;
@@ -684,34 +683,33 @@ void FlatTupleIterator::resetState() {
     }
 }
 
-void FlatTupleIterator::readUnflatColToFlatTuple(ft_col_idx_t colIdx, uint8_t* valueBuffer) {
+void FactorizedTableIterator::readUnflatColToFlatTuple(ft_col_idx_t colIdx, uint8_t* valueBuffer, FlatTuple& tuple) {
     auto overflowValue =
         (overflow_value_t*)(valueBuffer + factorizedTable.getTableSchema()->getColOffset(colIdx));
     auto groupID = factorizedTable.getTableSchema()->getColumn(colIdx)->getGroupID();
     auto tupleSizeInOverflowBuffer =
-        LogicalTypeUtils::getRowLayoutSize(values[colIdx]->getDataType());
+        LogicalTypeUtils::getRowLayoutSize(tuple[colIdx].getDataType());
     valueBuffer = overflowValue->value +
                   tupleSizeInOverflowBuffer * flatTuplePositionsInDataChunk[groupID].first;
     auto isNull = factorizedTable.isOverflowColNull(
         overflowValue->value + tupleSizeInOverflowBuffer * overflowValue->numElements,
         flatTuplePositionsInDataChunk[groupID].first, colIdx);
-    values[colIdx]->setNull(isNull);
+    tuple[colIdx].setNull(isNull);
     if (!isNull) {
-        readValueBufferToValue(colIdx, valueBuffer);
+        tuple[colIdx].copyFromRowLayout(valueBuffer);
     }
 }
 
-void FlatTupleIterator::readFlatColToFlatTuple(ft_col_idx_t colIdx, uint8_t* valueBuffer) {
+void FactorizedTableIterator::readFlatColToFlatTuple(ft_col_idx_t colIdx, uint8_t* valueBuffer, FlatTuple& tuple) {
     auto isNull = factorizedTable.isNonOverflowColNull(
         valueBuffer + factorizedTable.getTableSchema()->getNullMapOffset(), colIdx);
-    values[colIdx]->setNull(isNull);
+    tuple[colIdx].setNull(isNull);
     if (!isNull) {
-        readValueBufferToValue(colIdx,
-            valueBuffer + factorizedTable.getTableSchema()->getColOffset(colIdx));
+        tuple[colIdx].copyFromRowLayout(valueBuffer + factorizedTable.getTableSchema()->getColOffset(colIdx));
     }
 }
 
-void FlatTupleIterator::updateInvalidEntriesInFlatTuplePositionsInDataChunk() {
+void FactorizedTableIterator::updateInvalidEntriesInFlatTuplePositionsInDataChunk() {
     for (auto i = 0u; i < flatTuplePositionsInDataChunk.size(); i++) {
         bool isValidEntry = false;
         for (auto j = 0u; j < factorizedTable.getTableSchema()->getNumColumns(); j++) {
@@ -726,7 +724,7 @@ void FlatTupleIterator::updateInvalidEntriesInFlatTuplePositionsInDataChunk() {
     }
 }
 
-void FlatTupleIterator::updateNumElementsInDataChunk() {
+void FactorizedTableIterator::updateNumElementsInDataChunk() {
     auto colOffsetInTupleBuffer = 0ul;
     for (auto i = 0u; i < factorizedTable.getTableSchema()->getNumColumns(); i++) {
         auto column = factorizedTable.getTableSchema()->getColumn(i);
@@ -746,7 +744,7 @@ void FlatTupleIterator::updateNumElementsInDataChunk() {
     }
 }
 
-void FlatTupleIterator::updateFlatTuplePositionsInDataChunk() {
+void FactorizedTableIterator::updateFlatTuplePositionsInDataChunk() {
     for (auto i = 0u; i < flatTuplePositionsInDataChunk.size(); i++) {
         if (!isValidDataChunkPos(i)) {
             continue;

--- a/src/processor/result/flat_tuple.cpp
+++ b/src/processor/result/flat_tuple.cpp
@@ -15,9 +15,9 @@ namespace kuzu {
 namespace processor {
 
 FlatTuple::FlatTuple(const std::vector<LogicalType>& types) {
-   for (auto& type : types) {
-       values.emplace_back(Value::createDefaultValue(type));
-   }
+    for (auto& type : types) {
+        values.emplace_back(Value::createDefaultValue(type));
+    }
 }
 
 uint32_t FlatTuple::len() const {

--- a/src/processor/result/flat_tuple.cpp
+++ b/src/processor/result/flat_tuple.cpp
@@ -14,29 +14,45 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace processor {
 
-void FlatTuple::addValue(std::unique_ptr<Value> value) {
-    values.push_back(std::move(value));
+FlatTuple::FlatTuple(const std::vector<LogicalType>& types) {
+   for (auto& type : types) {
+       values.emplace_back(Value::createDefaultValue(type));
+   }
 }
 
 uint32_t FlatTuple::len() const {
     return values.size();
 }
 
-Value* FlatTuple::getValue(uint32_t idx) const {
-    if (idx >= len()) {
+static void checkOutOfRange(idx_t idx, idx_t size) {
+    if (idx >= size) {
         throw RuntimeException(stringFormat(
-            "ValIdx is out of range. Number of values in flatTuple: {}, valIdx: {}.", len(), idx));
+            "ValIdx is out of range. Number of values in flatTuple: {}, valIdx: {}.", size, idx));
     }
-    return values[idx].get();
 }
 
-std::string FlatTuple::toString() {
+Value* FlatTuple::getValue(uint32_t idx) {
+    checkOutOfRange(idx, len());
+    return &values[idx];
+}
+
+Value& FlatTuple::operator[](idx_t idx) {
+    checkOutOfRange(idx, len());
+    return values[idx];
+}
+
+const Value& FlatTuple::operator[](idx_t idx) const {
+    checkOutOfRange(idx, len());
+    return values[idx];
+}
+
+std::string FlatTuple::toString() const {
     std::string result;
     for (auto i = 0ul; i < values.size(); i++) {
         if (i != 0) {
             result += "|";
         }
-        result += values[i]->toString();
+        result += values[i].toString();
     }
     result += "\n";
     return result;
@@ -46,7 +62,7 @@ std::string FlatTuple::toString(const std::vector<uint32_t>& colsWidth,
     const std::string& delimiter, const uint32_t maxWidth) {
     std::ostringstream result;
     for (auto i = 0ul; i < values.size(); i++) {
-        auto value = values[i]->toString();
+        auto value = values[i].toString();
         auto fieldLen = 0u;
         auto cutoff = 0u, cutoffLen = 0u;
         for (auto iter = 0u; iter < value.length();) {

--- a/test/api/api_test.cpp
+++ b/test/api/api_test.cpp
@@ -328,7 +328,7 @@ TEST_F(ApiTest, CloseDatabaseBeforeQueryResultAndConnection) {
 
     auto inMemoryDatabase = std::make_unique<Database>(":memory:", systemConfig);
     auto conn = std::make_unique<Connection>(inMemoryDatabase.get());
-    auto result = conn->query("RETURN 1+1;");
+    auto result = conn->query("RETURN 1+1 AS col;");
     ASSERT_TRUE(result->isSuccess());
     ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 2);
     result->resetIterator();
@@ -386,92 +386,71 @@ TEST_F(ApiTest, CloseDatabaseBeforeQueryResultAndConnection) {
                                "the parent database is closed.");
     }
     // All public QueryResult methods that check for closed DB
+    ASSERT_TRUE(result->isSuccess());
+    ASSERT_NO_THROW(result->getErrorMessage());
+    ASSERT_NO_THROW(result->getNumColumns());
+    ASSERT_NO_THROW(result->getColumnNames());
+    ASSERT_NO_THROW(result->getColumnDataTypes());
+    ASSERT_NO_THROW(result->getQuerySummary());
     try {
-        result->isSuccess();
-    } catch (Exception& e) {
-        ASSERT_STREQ(e.what(), "Runtime exception: The current operation is not allowed because "
-                               "the parent database is closed.");
-    }
-    try {
-        result->getErrorMessage();
-    } catch (Exception& e) {
-        ASSERT_STREQ(e.what(), "Runtime exception: The current operation is not allowed because "
-                               "the parent database is closed.");
-    }
-    try {
-        result->getNumColumns();
-    } catch (Exception& e) {
-        ASSERT_STREQ(e.what(), "Runtime exception: The current operation is not allowed because "
-                               "the parent database is closed.");
-    }
-    try {
-        result->getColumnNames();
-    } catch (Exception& e) {
-        ASSERT_STREQ(e.what(), "Runtime exception: The current operation is not allowed because "
-                               "the parent database is closed.");
-    }
-    try {
-        result->getColumnDataTypes();
-    } catch (Exception& e) {
-        ASSERT_STREQ(e.what(), "Runtime exception: The current operation is not allowed because "
-                               "the parent database is closed.");
-    }
-    try {
-        result->getNumTuples();
-    } catch (Exception& e) {
-        ASSERT_STREQ(e.what(), "Runtime exception: The current operation is not allowed because "
-                               "the parent database is closed.");
-    }
-    try {
-        result->getQuerySummary();
+        (void)result->getNumTuples();
+        FAIL();
     } catch (Exception& e) {
         ASSERT_STREQ(e.what(), "Runtime exception: The current operation is not allowed because "
                                "the parent database is closed.");
     }
     try {
         result->resetIterator();
+        FAIL();
     } catch (Exception& e) {
         ASSERT_STREQ(e.what(), "Runtime exception: The current operation is not allowed because "
                                "the parent database is closed.");
     }
     try {
-        result->hasNext();
+        (void)result->hasNext();
+        FAIL();
     } catch (Exception& e) {
         ASSERT_STREQ(e.what(), "Runtime exception: The current operation is not allowed because "
                                "the parent database is closed.");
     }
     try {
-        result->hasNextQueryResult();
+        (void)result->hasNextQueryResult();
+        FAIL();
     } catch (Exception& e) {
         ASSERT_STREQ(e.what(), "Runtime exception: The current operation is not allowed because "
                                "the parent database is closed.");
     }
     try {
         result->getNextQueryResult();
+        FAIL();
     } catch (Exception& e) {
         ASSERT_STREQ(e.what(), "Runtime exception: The current operation is not allowed because "
                                "the parent database is closed.");
     }
     try {
         result->getNext();
+        FAIL();
     } catch (Exception& e) {
         ASSERT_STREQ(e.what(), "Runtime exception: The current operation is not allowed because "
                                "the parent database is closed.");
     }
     try {
-        result->toString();
+        (void)result->toString();
+        FAIL();
     } catch (Exception& e) {
         ASSERT_STREQ(e.what(), "Runtime exception: The current operation is not allowed because "
                                "the parent database is closed.");
     }
     try {
-        result->getArrowSchema();
+        (void)result->getArrowSchema();
+        FAIL();
     } catch (Exception& e) {
         ASSERT_STREQ(e.what(), "Runtime exception: The current operation is not allowed because "
                                "the parent database is closed.");
     }
     try {
         result->getNextArrowChunk(1);
+        FAIL();
     } catch (Exception& e) {
         ASSERT_STREQ(e.what(), "Runtime exception: The current operation is not allowed because "
                                "the parent database is closed.");

--- a/test/api/arrow_test.cpp
+++ b/test/api/arrow_test.cpp
@@ -6,7 +6,7 @@ using namespace kuzu::testing;
 
 class ArrowTest : public ApiTest {};
 
-TEST_F(ArrowTest, getArrowResult) {
+TEST_F(ArrowTest, resultToArrow) {
     auto query = "MATCH (a:person) WHERE a.fName = 'Bob' RETURN a.fName";
     auto result = conn->query(query);
     auto arrowArray = result->getNextArrowChunk(1);
@@ -15,6 +15,42 @@ TEST_F(ArrowTest, getArrowResult) {
     ASSERT_EQ(arrowArray->n_children, 1);
     // FIXME: Not sure where the length of the string is stored
     ASSERT_EQ(std::string((const char*)arrowArray->children[0]->buffers[2], 3), "Bob");
+    ASSERT_FALSE(result->hasNextArrowChunk());
+    arrowArray->release(arrowArray.get());
+}
+
+TEST_F(ArrowTest, getArrowResult) {
+    auto query = "MATCH (a:person) WHERE a.fName = 'Bob' RETURN a.fName";
+    auto result = conn->queryAsArrow(query, 1);
+    try {
+        result->getNextArrowChunk(2);
+        FAIL();
+    } catch (const Exception& e) {
+        ASSERT_STREQ(e.what(), "Runtime exception: Chunk size does not match expected value 1.");
+    }
+    try {
+        (void)result->hasNext();
+        FAIL();
+    } catch (const Exception& e) {
+        ASSERT_STREQ(e.what(), "ArrowQueryResult does not implement hasNext. Use MaterializedQueryResult instead.");
+    }
+    try {
+        (void)result->getNext();
+        FAIL();
+    } catch (const Exception& e) {
+        ASSERT_STREQ(e.what(), "ArrowQueryResult does not implement getNext. Use MaterializedQueryResult instead.");
+    }
+    try {
+        (void)result->toString();
+        FAIL();
+    } catch (const Exception& e) {
+        ASSERT_STREQ(e.what(), "ArrowQueryResult does not implement toString. Use MaterializedQueryResult instead.");
+    }
+    ASSERT_TRUE(result->hasNextArrowChunk());
+    auto arrowArray = result->getNextArrowChunk(1);
+    ASSERT_EQ(arrowArray->length, 1);
+    ASSERT_EQ(arrowArray->null_count, 0);
+    ASSERT_FALSE(result->hasNextArrowChunk());
     arrowArray->release(arrowArray.get());
 }
 

--- a/test/api/arrow_test.cpp
+++ b/test/api/arrow_test.cpp
@@ -32,19 +32,22 @@ TEST_F(ArrowTest, getArrowResult) {
         (void)result->hasNext();
         FAIL();
     } catch (const Exception& e) {
-        ASSERT_STREQ(e.what(), "ArrowQueryResult does not implement hasNext. Use MaterializedQueryResult instead.");
+        ASSERT_STREQ(e.what(),
+            "ArrowQueryResult does not implement hasNext. Use MaterializedQueryResult instead.");
     }
     try {
         (void)result->getNext();
         FAIL();
     } catch (const Exception& e) {
-        ASSERT_STREQ(e.what(), "ArrowQueryResult does not implement getNext. Use MaterializedQueryResult instead.");
+        ASSERT_STREQ(e.what(),
+            "ArrowQueryResult does not implement getNext. Use MaterializedQueryResult instead.");
     }
     try {
         (void)result->toString();
         FAIL();
     } catch (const Exception& e) {
-        ASSERT_STREQ(e.what(), "ArrowQueryResult does not implement toString. Use MaterializedQueryResult instead.");
+        ASSERT_STREQ(e.what(),
+            "ArrowQueryResult does not implement toString. Use MaterializedQueryResult instead.");
     }
     ASSERT_TRUE(result->hasNextArrowChunk());
     auto arrowArray = result->getNextArrowChunk(1);

--- a/tools/python_api/src_cpp/include/py_query_result.h
+++ b/tools/python_api/src_cpp/include/py_query_result.h
@@ -55,10 +55,10 @@ public:
 private:
     static py::dict convertNodeIdToPyDict(const kuzu::common::nodeID_t& nodeId);
 
-    bool getNextArrowChunk(const std::vector<kuzu::common::LogicalType>& types,
-        const std::vector<std::string>& names, py::list& batches, std::int64_t chunk_size);
+    void getNextArrowChunk(const std::vector<kuzu::common::LogicalType>& types,
+        const std::vector<std::string>& names, py::list& batches, std::int64_t chunkSize, bool fallbackExtensionTypes);
     py::object getArrowChunks(const std::vector<kuzu::common::LogicalType>& types,
-        const std::vector<std::string>& names, std::int64_t chunkSize);
+        const std::vector<std::string>& names, std::int64_t chunkSize, bool fallbackExtensionTypes);
 
 private:
     QueryResult* queryResult = nullptr;

--- a/tools/python_api/src_cpp/include/py_query_result.h
+++ b/tools/python_api/src_cpp/include/py_query_result.h
@@ -56,7 +56,8 @@ private:
     static py::dict convertNodeIdToPyDict(const kuzu::common::nodeID_t& nodeId);
 
     void getNextArrowChunk(const std::vector<kuzu::common::LogicalType>& types,
-        const std::vector<std::string>& names, py::list& batches, std::int64_t chunkSize, bool fallbackExtensionTypes);
+        const std::vector<std::string>& names, py::list& batches, std::int64_t chunkSize,
+        bool fallbackExtensionTypes);
     py::object getArrowChunks(const std::vector<kuzu::common::LogicalType>& types,
         const std::vector<std::string>& names, std::int64_t chunkSize, bool fallbackExtensionTypes);
 

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -13,10 +13,10 @@
 #include "function/cast/functions/cast_string_non_nested_functions.h"
 #include "include/py_udf.h"
 #include "main/connection.h"
+#include "main/query_result/materialized_query_result.h"
 #include "pandas/pandas_scan.h"
 #include "processor/result/factorized_table.h"
 #include "pyarrow/pyarrow_scan.h"
-#include "main/query_result/materialized_query_result.h"
 
 using namespace kuzu::common;
 using namespace kuzu;

--- a/tools/python_api/src_cpp/py_query_result.cpp
+++ b/tools/python_api/src_cpp/py_query_result.cpp
@@ -4,12 +4,12 @@
 
 #include "cached_import/py_cached_import.h"
 #include "common/arrow/arrow_converter.h"
+#include "common/arrow/arrow_row_batch.h"
 #include "common/exception/not_implemented.h"
 #include "common/types/uuid.h"
 #include "common/types/value/nested.h"
 #include "common/types/value/node.h"
 #include "common/types/value/rel.h"
-#include "common/arrow/arrow_row_batch.h"
 #include "datetime.h" // python lib
 #include "include/py_query_result_converter.h"
 
@@ -288,8 +288,10 @@ py::object PyQueryResult::getAsDF() {
 }
 
 void PyQueryResult::getNextArrowChunk(const std::vector<LogicalType>& types,
-    const std::vector<std::string>& names, py::list& batches, std::int64_t chunkSize, bool fallbackExtensionTypes) {
-    auto rowBatch = std::make_unique<ArrowRowBatch>(copyVector(types), chunkSize, fallbackExtensionTypes);
+    const std::vector<std::string>& names, py::list& batches, std::int64_t chunkSize,
+    bool fallbackExtensionTypes) {
+    auto rowBatch =
+        std::make_unique<ArrowRowBatch>(copyVector(types), chunkSize, fallbackExtensionTypes);
     auto rowBatchSize = 0u;
     while (rowBatchSize < chunkSize) {
         if (!queryResult->hasNext()) {

--- a/tools/rust_api/src/kuzu_rs.cpp
+++ b/tools/rust_api/src/kuzu_rs.cpp
@@ -179,7 +179,7 @@ uint32_t flat_tuple_len(const kuzu::processor::FlatTuple& flatTuple) {
 }
 const kuzu::common::Value& flat_tuple_get_value(const kuzu::processor::FlatTuple& flatTuple,
     uint32_t index) {
-    return *flatTuple.getValue(index);
+    return flatTuple[index];
 }
 
 const std::string& value_get_string(const kuzu::common::Value& value) {

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -490,8 +490,8 @@ std::string decodeEscapeSequences(const std::string& input) {
     return result;
 }
 
-void EmbeddedShell::checkConfidentialStatement(const std::string& query,
-    QueryResult* queryResult, std::string& input) {
+void EmbeddedShell::checkConfidentialStatement(const std::string& query, QueryResult* queryResult,
+    std::string& input) {
     if (queryResult->isSuccess() && !database->getConfig().readOnly &&
         queryResult->getQuerySummary()->getStatementType() ==
             common::StatementType::STANDALONE_CALL) {

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -491,7 +491,7 @@ std::string decodeEscapeSequences(const std::string& input) {
 }
 
 void EmbeddedShell::checkConfidentialStatement(const std::string& query,
-    const QueryResult* queryResult, std::string& input) {
+    QueryResult* queryResult, std::string& input) {
     if (queryResult->isSuccess() && !database->getConfig().readOnly &&
         queryResult->getQuerySummary()->getStatementType() ==
             common::StatementType::STANDALONE_CALL) {
@@ -543,10 +543,10 @@ std::vector<std::unique_ptr<QueryResult>> EmbeddedShell::processInput(std::strin
         checkConfidentialStatement(unicodeInput, curr, input);
         while (true) {
             queryResults.push_back(std::move(result));
-            if (!curr->getNextQueryResult()) {
+            if (!curr->hasNextQueryResult()) {
                 break;
             }
-            result = std::move(curr->nextQueryResult);
+            result = curr->moveNextResult();
             curr = result.get();
             checkConfidentialStatement(unicodeInput, curr, input);
         }

--- a/tools/shell/include/embedded_shell.h
+++ b/tools/shell/include/embedded_shell.h
@@ -71,7 +71,7 @@ private:
 
     void setComplete(const std::string& completeString);
 
-    void checkConfidentialStatement(const std::string& query, const QueryResult* queryResult,
+    void checkConfidentialStatement(const std::string& query, QueryResult* queryResult,
         std::string& input);
 
 private:

--- a/tools/shell/include/printer/json_printer.h
+++ b/tools/shell/include/printer/json_printer.h
@@ -5,6 +5,9 @@
 #include "printer.h"
 
 namespace kuzu {
+namespace storage {
+class MemoryManager;
+}
 namespace main {
 
 class JsonPrinter : public Printer {

--- a/tools/shell/printer/json_printer.cpp
+++ b/tools/shell/printer/json_printer.cpp
@@ -1,10 +1,10 @@
 #include "printer/json_printer.h"
 
 #include "json_utils.h"
+#include "main/query_result/materialized_query_result.h"
 #include "processor/result/factorized_table.h"
 #include "storage/buffer_manager/memory_manager.h"
 #include "yyjson.h"
-#include "main/query_result/materialized_query_result.h"
 
 namespace kuzu {
 namespace main {
@@ -39,8 +39,7 @@ std::string JsonPrinter::printBody(QueryResult& queryResult, MemoryManager& mm) 
     KU_ASSERT(queryResult.getType() == QueryResultType::FTABLE);
     auto& table = queryResult.constCast<MaterializedQueryResult>().getFactorizedTable();
     uint64_t numTuplesScanned = 0;
-    auto maxNumTuplesToScanInBatch =
-        table.hasUnflatCol() ? 1 : DEFAULT_VECTOR_CAPACITY;
+    auto maxNumTuplesToScanInBatch = table.hasUnflatCol() ? 1 : DEFAULT_VECTOR_CAPACITY;
     auto totalNumTuplesToScan = table.getNumTuples();
     while (numTuplesScanned < totalNumTuplesToScan) {
         auto numTuplesToScanInBatch =

--- a/tools/shell/printer/json_printer.cpp
+++ b/tools/shell/printer/json_printer.cpp
@@ -4,6 +4,7 @@
 #include "processor/result/factorized_table.h"
 #include "storage/buffer_manager/memory_manager.h"
 #include "yyjson.h"
+#include "main/query_result/materialized_query_result.h"
 
 namespace kuzu {
 namespace main {
@@ -24,25 +25,27 @@ std::string JsonPrinter::print(QueryResult& queryResult, storage::MemoryManager&
     return result;
 }
 
+// TODO(Ziyi): I'm inclined to move this as a QueryResult interface.
 std::string JsonPrinter::printBody(QueryResult& queryResult, MemoryManager& mm) const {
     std::string result;
-    std::vector<std::shared_ptr<common::ValueVector>> resultVectors;
-    std::vector<common::ValueVector*> scanVectors;
+    std::vector<std::shared_ptr<ValueVector>> resultVectors;
+    std::vector<ValueVector*> scanVectors;
     for (auto& type : queryResult.getColumnDataTypes()) {
         auto resultVector = std::make_shared<ValueVector>(type.copy(), &mm, resultVectorState);
         resultVectors.push_back(resultVector);
         scanVectors.push_back(resultVector.get());
     }
     std::span<ValueVector*> vectorsToScan{scanVectors};
-
+    KU_ASSERT(queryResult.getType() == QueryResultType::FTABLE);
+    auto& table = queryResult.constCast<MaterializedQueryResult>().getFactorizedTable();
     uint64_t numTuplesScanned = 0;
     auto maxNumTuplesToScanInBatch =
-        queryResult.getTable()->hasUnflatCol() ? 1 : DEFAULT_VECTOR_CAPACITY;
-    auto totalNumTuplesToScan = queryResult.getTable()->getNumTuples();
+        table.hasUnflatCol() ? 1 : DEFAULT_VECTOR_CAPACITY;
+    auto totalNumTuplesToScan = table.getNumTuples();
     while (numTuplesScanned < totalNumTuplesToScan) {
         auto numTuplesToScanInBatch =
             std::min<uint64_t>(maxNumTuplesToScanInBatch, totalNumTuplesToScan - numTuplesScanned);
-        queryResult.getTable()->scan(vectorsToScan, numTuplesScanned, numTuplesToScanInBatch);
+        table.scan(vectorsToScan, numTuplesScanned, numTuplesToScanInBatch);
         numTuplesScanned += numTuplesToScanInBatch;
         auto queryResultsInJson =
             json_extension::jsonifyQueryResult(resultVectors, queryResult.getColumnNames());

--- a/tools/wasm/src_cpp/main.cpp
+++ b/tools/wasm/src_cpp/main.cpp
@@ -366,8 +366,7 @@ val valueGetAsEmscriptenValue(const Value& value) {
 val flatTupleGetAsEmscriptenValue(const FlatTuple& flatTuple) {
     auto jsArray = val::array();
     for (auto i = 0u; i < flatTuple.len(); ++i) {
-        auto val = flatTuple.getValue(i);
-        jsArray.set(i, valueGetAsEmscriptenValue(*val));
+        jsArray.set(i, valueGetAsEmscriptenValue(flatTuple[i]));
     }
     return jsArray;
 }


### PR DESCRIPTION
# Description

This PR mainly abstract query result interface so that we are prepared to have different type of query results, specifically  

- MaterializedResult: backed by FactorizedTable
- ArrowResult: currently converted from FactorizedTable but we will create this result natively through operator in the next RP.
- StreamingArrowResult: to be added

This PR also refactors arrow converter/rowBatch class. I found it not well designed by passing QueryResult directly into their public interface. As a principle, we should try to avoid include other module in common module.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
