### PR TITLE
Flush based on the number of values instead of the capacity

### DIFF
--- a/src/include/storage/table/column_chunk_data.h
+++ b/src/include/storage/table/column_chunk_data.h
@@ -266,7 +266,7 @@ private:
 
 protected:
     using get_metadata_func_t = std::function<ColumnChunkMetadata(const std::span<uint8_t>,
-        uint64_t, uint64_t, StorageValue, StorageValue)>;
+        uint64_t, StorageValue, StorageValue)>;
     using get_min_max_func_t =
         std::function<std::pair<StorageValue, StorageValue>(const uint8_t*, uint64_t)>;
 

--- a/src/include/storage/table/column_chunk_metadata.h
+++ b/src/include/storage/table/column_chunk_metadata.h
@@ -40,8 +40,8 @@ public:
 
     GetCompressionMetadata(const GetCompressionMetadata& other) = default;
 
-    ColumnChunkMetadata operator()(std::span<const uint8_t> buffer, uint64_t capacity,
-        uint64_t numValues, StorageValue min, StorageValue max) const;
+    ColumnChunkMetadata operator()(std::span<const uint8_t> buffer, uint64_t numValues,
+        StorageValue min, StorageValue max) const;
 };
 
 class GetBitpackingMetadata {
@@ -54,8 +54,8 @@ public:
 
     GetBitpackingMetadata(const GetBitpackingMetadata& other) = default;
 
-    ColumnChunkMetadata operator()(std::span<const uint8_t> buffer, uint64_t capacity,
-        uint64_t numValues, StorageValue min, StorageValue max);
+    ColumnChunkMetadata operator()(std::span<const uint8_t> buffer, uint64_t numValues,
+        StorageValue min, StorageValue max);
 };
 
 template<std::floating_point T>
@@ -70,13 +70,12 @@ public:
 
     GetFloatCompressionMetadata(const GetFloatCompressionMetadata& other) = default;
 
-    ColumnChunkMetadata operator()(std::span<const uint8_t> buffer, uint64_t capacity,
-        uint64_t numValues, StorageValue min, StorageValue max);
+    ColumnChunkMetadata operator()(std::span<const uint8_t> buffer, uint64_t numValues,
+        StorageValue min, StorageValue max);
 };
 
-ColumnChunkMetadata uncompressedGetMetadata(std::span<const uint8_t> buffer, uint64_t capacity,
-    uint64_t numValues, StorageValue min, StorageValue max);
+ColumnChunkMetadata uncompressedGetMetadata(common::PhysicalTypeID dataType, uint64_t numValues,
+    StorageValue min, StorageValue max);
 
-ColumnChunkMetadata booleanGetMetadata(std::span<const uint8_t> buffer, uint64_t capacity,
-    uint64_t numValues, StorageValue min, StorageValue max);
+ColumnChunkMetadata booleanGetMetadata(uint64_t numValues, StorageValue min, StorageValue max);
 } // namespace kuzu::storage

--- a/src/storage/table/column_chunk_data.cpp
+++ b/src/storage/table/column_chunk_data.cpp
@@ -276,7 +276,7 @@ ColumnChunkMetadata ColumnChunkData::getMetadataToFlush() const {
         maxValue = max.value_or(StorageValue());
     }
     KU_ASSERT(getBufferSize() == getBufferSize(capacity));
-    return getMetadataFunction(buffer->getBuffer(), capacity, numValues, minValue, maxValue);
+    return getMetadataFunction(buffer->getBuffer(), numValues, minValue, maxValue);
 }
 
 void ColumnChunkData::append(ValueVector* vector, const SelectionView& selView) {

--- a/test/storage/compress_chunk_test.cpp
+++ b/test/storage/compress_chunk_test.cpp
@@ -96,9 +96,8 @@ ColumnChunkMetadata compressBuffer(const std::vector<T>& bufferToCompress,
     const std::shared_ptr<FloatCompression<T>>& alg, const CompressionMetadata* metadata,
     FileHandle* dataFH, const LogicalType& dataType) {
 
-    auto preScanMetadata =
-        GetFloatCompressionMetadata<T>{alg, dataType}.operator()(byteSpan(bufferToCompress),
-            bufferToCompress.size(), bufferToCompress.size(), metadata->min, metadata->max);
+    auto preScanMetadata = GetFloatCompressionMetadata<T>{alg, dataType}.operator()(
+        byteSpan(bufferToCompress), bufferToCompress.size(), metadata->min, metadata->max);
     auto allocatedBlock =
         dataFH->getPageManager()->allocatePageRange(preScanMetadata.getNumPages());
 


### PR DESCRIPTION
Since we now reclaim space and are already doing this for compressed data, I thought it would make sense to also store uncompressed values based in a chunk of data which is determined using the number of actual values instead of the capacity of the chunk storing them in memory.

This should improve the size of small databases with compression disabled or using data types which don't support compression.