### PR TITLE
Recursively set database lifecycle manager for multiple query results

### DIFF
--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -99,6 +99,9 @@ void QueryResult::setQuerySummary(std::unique_ptr<QuerySummary> summary) {
 void QueryResult::setDBLifeCycleManager(
     std::shared_ptr<DatabaseLifeCycleManager> dbLifeCycleManager) {
     this->dbLifeCycleManager = dbLifeCycleManager;
+    if (nextQueryResult) {
+        nextQueryResult->setDBLifeCycleManager(dbLifeCycleManager);
+    }
 }
 
 std::unique_ptr<QueryResult> QueryResult::getQueryResultWithError(const std::string& errorMessage) {

--- a/tools/python_api/test/test_database.py
+++ b/tools/python_api/test/test_database.py
@@ -174,9 +174,7 @@ def test_database_close_order() -> None:
 
 
 def test_database_close_order_with_multiple_statements() -> None:
-    in_mem_db = kuzu.Database(
-        database_path=":memory:", buffer_pool_size=1024 * 1024 * 10
-    )
+    in_mem_db = kuzu.Database(database_path=":memory:", buffer_pool_size=1024 * 1024 * 10)
     assert not in_mem_db.is_closed
     assert in_mem_db._database is not None
 
@@ -185,7 +183,7 @@ def test_database_close_order_with_multiple_statements() -> None:
     assert in_mem_conn._connection is not None
 
     query_results = in_mem_conn.execute("RETURN 1+1; RETURN 2+2; RETURN 3+3;")
-    for (i, qr) in enumerate(query_results):
+    for i, qr in enumerate(query_results):
         assert not qr.is_closed
         assert qr._query_result is not None
         assert qr.get_next()[0] == (i + 1) * 2

--- a/tools/python_api/test/test_database.py
+++ b/tools/python_api/test/test_database.py
@@ -171,3 +171,36 @@ def test_database_close_order() -> None:
     # Close the connection and query result, they should not raise any exceptions.
     in_mem_conn.close()
     query_result.close()
+
+
+def test_database_close_order_with_multiple_statements() -> None:
+    in_mem_db = kuzu.Database(
+        database_path=":memory:", buffer_pool_size=1024 * 1024 * 10
+    )
+    assert not in_mem_db.is_closed
+    assert in_mem_db._database is not None
+
+    in_mem_conn = kuzu.Connection(in_mem_db)
+    assert not in_mem_conn.is_closed
+    assert in_mem_conn._connection is not None
+
+    query_results = in_mem_conn.execute("RETURN 1+1; RETURN 2+2; RETURN 3+3;")
+    for (i, qr) in enumerate(query_results):
+        assert not qr.is_closed
+        assert qr._query_result is not None
+        assert qr.get_next()[0] == (i + 1) * 2
+    # Close the database first, it should not cause crashes or exceptions
+    in_mem_db.close()
+
+    # The query result and connection will be unusable after the database is closed.
+    # But calling methods on them should raise exceptions instead of crashing.
+    with pytest.raises(Exception, match="Database is closed"):
+        in_mem_conn.execute("RETURN 1+1")
+
+    with pytest.raises(Exception, match="the parent database is closed"):
+        query_results[0].get_next()
+
+    # Close the connection and query result, they should not raise any exceptions.
+    in_mem_conn.close()
+    for qr in query_results:
+        qr.close()


### PR DESCRIPTION
This is a follow-up of #5665 to handle the closing order issue correctly for query result of multiple statements. Previous PR only sets the database lifecycle manager for the first query result, which did not fix closing order issue when multiple statements are executed and a linked list is returned. This PR sets the database lifecycle manager for all query results in the linked list.