### PR TITLE
Graceful handling of stray WAL/shadow files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(Kuzu VERSION 0.11.1 LANGUAGES CXX C)
+project(Kuzu VERSION 0.11.2.1 LANGUAGES CXX C)
 
 option(SINGLE_THREADED "Single-threaded mode" FALSE)
 if(SINGLE_THREADED)

--- a/extension/fts/src/function/fts_config.cpp
+++ b/extension/fts/src/function/fts_config.cpp
@@ -105,8 +105,7 @@ StopWordsTableInfo StopWords::bind(main::ClientContext& context, common::table_i
         return StopWordsTableInfo{stopWords, FTSUtils::getDefaultStopWordsTableName(),
             StopWordsSource::DEFAULT};
     } else if (catalog->containsTable(context.getTransaction(), stopWords)) {
-        auto entry = catalog->getTableCatalogEntry(context.getTransaction(),
-            stopWords);
+        auto entry = catalog->getTableCatalogEntry(context.getTransaction(), stopWords);
         if (entry->getTableType() != common::TableType::NODE) {
             throw common::BinderException{"The stop words table must be a node table."};
         }

--- a/extension/fts/src/function/fts_index_utils.cpp
+++ b/extension/fts/src/function/fts_index_utils.cpp
@@ -15,16 +15,15 @@ void FTSIndexUtils::validateIndexExistence(const main::ClientContext& context,
     auto catalog = catalog::Catalog::Get(context);
     switch (indexOperation) {
     case IndexOperation::CREATE: {
-        if (catalog->containsIndex(context.getTransaction(),
-                tableEntry->getTableID(), indexName)) {
+        if (catalog->containsIndex(context.getTransaction(), tableEntry->getTableID(), indexName)) {
             throw common::BinderException{common::stringFormat(
                 "Index {} already exists in table {}.", indexName, tableEntry->getName())};
         }
     } break;
     case IndexOperation::DROP:
     case IndexOperation::QUERY: {
-        if (!catalog->containsIndex(context.getTransaction(),
-                tableEntry->getTableID(), indexName)) {
+        if (!catalog->containsIndex(context.getTransaction(), tableEntry->getTableID(),
+                indexName)) {
             throw common::BinderException{common::stringFormat(
                 "Table {} doesn't have an index with name {}.", tableEntry->getName(), indexName)};
         }

--- a/src/include/main/database.h
+++ b/src/include/main/database.h
@@ -159,7 +159,7 @@ private:
     };
 
     static std::unique_ptr<storage::BufferManager> initBufferManager(const Database& db);
-    void initMembers(std::string_view dbPath, construct_bm_func_t initBmFunc = initBufferManager);
+    void initMembers(std::string_view dbPath, construct_bm_func_t initBmFunc);
 
     // factory method only to be used for tests
     Database(std::string_view databasePath, SystemConfig systemConfig,

--- a/src/include/storage/checkpointer.h
+++ b/src/include/storage/checkpointer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "storage/optimistic_allocator.h"
+#include "storage/database_header.h"
 #include "storage/page_range.h"
 
 namespace kuzu {
@@ -12,7 +12,7 @@ class Catalog;
 }
 namespace common {
 class VirtualFileSystem;
-}
+} // namespace common
 namespace testing {
 struct FSMLeakChecker;
 }
@@ -22,17 +22,6 @@ class AttachedKuzuDatabase;
 
 namespace storage {
 class StorageManager;
-
-class PageManager;
-
-struct DatabaseHeader {
-    PageRange catalogPageRange;
-    PageRange metadataPageRange;
-
-    void updateCatalogPageRange(PageManager& pageManager, PageRange newPageRange);
-    void freeMetadataPageRange(PageManager& pageManager) const;
-    void serialize(common::Serializer& ser) const;
-};
 
 class Checkpointer {
     friend class main::AttachedKuzuDatabase;
@@ -61,7 +50,6 @@ private:
     static void readCheckpoint(main::ClientContext* context, catalog::Catalog* catalog,
         StorageManager* storageManager);
 
-    DatabaseHeader getCurrentDatabaseHeader() const;
     PageRange serializeCatalog(const catalog::Catalog& catalog, StorageManager& storageManager);
     PageRange serializeMetadata(const catalog::Catalog& catalog, StorageManager& storageManager);
 

--- a/src/include/storage/database_header.h
+++ b/src/include/storage/database_header.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <optional>
+
+#include "common/types/uuid.h"
+#include "storage/page_range.h"
+
+namespace kuzu {
+namespace storage {
+class PageManager;
+
+struct DatabaseHeader {
+    PageRange catalogPageRange;
+    PageRange metadataPageRange;
+
+    // An ID that is unique between kuzu databases
+    // Used to ensure that files such as the WAL match the current database
+    common::ku_uuid_t databaseID{0};
+
+    void updateCatalogPageRange(PageManager& pageManager, PageRange newPageRange);
+    void freeMetadataPageRange(PageManager& pageManager) const;
+    void serialize(common::Serializer& ser) const;
+
+    static DatabaseHeader deserialize(common::Deserializer& deSer);
+    static DatabaseHeader createInitialHeader(common::RandomEngine* randomEngine);
+
+    // If we haven't written a header to the database file yet (e.g. if the file is empty) this
+    // function will return a nullopt
+    static std::optional<DatabaseHeader> readDatabaseHeader(common::FileInfo& dataFileInfo);
+};
+} // namespace storage
+} // namespace kuzu

--- a/src/include/storage/file_db_id_utils.h
+++ b/src/include/storage/file_db_id_utils.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "common/file_system/file_info.h"
+#include "common/serializer/serializer.h"
+#include "common/types/uuid.h"
+namespace kuzu {
+namespace storage {
+struct FileDBIDUtils {
+    // For some temporary DB files such as the WAL and shadow file
+    // We want to verify that they actually match the current database before replaying
+    // We do this by adding a unique UUID to the header of the data.kz file
+    // And making sure they match the IDs of the temporary files
+    static void verifyDatabaseID(const common::FileInfo& fileInfo,
+        common::ku_uuid_t expectedDatabaseID, common::ku_uuid_t databaseID);
+    static void writeDatabaseID(common::Serializer& ser, common::ku_uuid_t databaseID);
+};
+} // namespace storage
+} // namespace kuzu

--- a/src/include/storage/shadow_file.h
+++ b/src/include/storage/shadow_file.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common/types/uuid.h"
 #include "storage/file_handle.h"
 
 namespace kuzu {
@@ -14,8 +15,10 @@ struct ShadowPageRecord {
 };
 
 struct ShadowFileHeader {
+    common::ku_uuid_t databaseID{0};
     common::page_idx_t numShadowPages = 0;
 };
+static_assert(std::is_trivially_copyable_v<ShadowFileHeader>);
 
 class BufferManager;
 // NOTE: This class is NOT thread-safe for now, as we are not checkpointing in parallel yet.
@@ -38,7 +41,7 @@ public:
 
     void applyShadowPages(main::ClientContext& context) const;
 
-    void flushAll() const;
+    void flushAll(main::ClientContext& context) const;
     // Clear any buffer in the WAL writer. Also truncate the WAL file to 0 bytes.
     void clear(BufferManager& bm);
     // Reset the WAL writer to nullptr, and remove the WAL file if it exists.

--- a/src/include/storage/storage_manager.h
+++ b/src/include/storage/storage_manager.h
@@ -24,6 +24,7 @@ class Table;
 class NodeTable;
 class RelTable;
 class DiskArrayCollection;
+struct DatabaseHeader;
 
 class KUZU_API StorageManager {
 public:
@@ -65,6 +66,14 @@ public:
 
     void initDataFileHandle(common::VirtualFileSystem* vfs, main::ClientContext* context);
 
+    // If the database header hasn't been created yet, calling these methods will create + return
+    // the header
+    common::ku_uuid_t getOrInitDatabaseID(const main::ClientContext& clientContext);
+    const storage::DatabaseHeader* getOrInitDatabaseHeader(
+        const main::ClientContext& clientContext);
+
+    void setDatabaseHeader(std::unique_ptr<storage::DatabaseHeader> header);
+
     static StorageManager* Get(const main::ClientContext& context);
 
 private:
@@ -77,6 +86,7 @@ private:
 private:
     std::mutex mtx;
     std::string databasePath;
+    std::unique_ptr<storage::DatabaseHeader> databaseHeader;
     bool readOnly;
     FileHandle* dataFH;
     std::unordered_map<common::table_id_t, std::unique_ptr<Table>> tables;

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -83,9 +83,7 @@ SystemConfig::SystemConfig(uint64_t bufferPoolSize_, uint64_t maxNumThreads, boo
 }
 
 Database::Database(std::string_view databasePath, SystemConfig systemConfig)
-    : dbConfig{systemConfig} {
-    initMembers(databasePath);
-}
+    : Database(databasePath, systemConfig, initBufferManager) {}
 
 Database::Database(std::string_view databasePath, SystemConfig systemConfig,
     construct_bm_func_t constructBMFunc)

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -10,8 +10,10 @@ add_subdirectory(wal)
 add_library(kuzu_storage
         OBJECT
         checkpointer.cpp
+        database_header.cpp
         disk_array.cpp
         disk_array_collection.cpp
+        file_db_id_utils.cpp
         file_handle.cpp
         free_space_manager.cpp
         optimistic_allocator.cpp

--- a/src/storage/checkpointer.cpp
+++ b/src/storage/checkpointer.cpp
@@ -1,7 +1,6 @@
 #include "storage/checkpointer.h"
 
 #include "catalog/catalog.h"
-#include "common/exception/runtime.h"
 #include "common/file_system/file_system.h"
 #include "common/file_system/virtual_file_system.h"
 #include "common/serializer/buffered_file.h"
@@ -11,46 +10,13 @@
 #include "main/client_context.h"
 #include "main/db_config.h"
 #include "storage/buffer_manager/buffer_manager.h"
+#include "storage/database_header.h"
 #include "storage/shadow_utils.h"
 #include "storage/storage_manager.h"
-#include "storage/storage_version_info.h"
 #include "storage/wal/local_wal.h"
 
 namespace kuzu {
 namespace storage {
-
-void DatabaseHeader::updateCatalogPageRange(PageManager& pageManager, PageRange newPageRange) {
-    if (catalogPageRange.startPageIdx != common::INVALID_PAGE_IDX) {
-        pageManager.freePageRange(catalogPageRange);
-    }
-    catalogPageRange = newPageRange;
-}
-
-void DatabaseHeader::freeMetadataPageRange(PageManager& pageManager) const {
-    if (metadataPageRange.startPageIdx != common::INVALID_PAGE_IDX) {
-        pageManager.freePageRange(metadataPageRange);
-    }
-}
-
-static void writeMagicBytes(common::Serializer& serializer) {
-    serializer.writeDebuggingInfo("magic");
-    const auto numMagicBytes = strlen(StorageVersionInfo::MAGIC_BYTES);
-    for (auto i = 0u; i < numMagicBytes; i++) {
-        serializer.serializeValue<uint8_t>(StorageVersionInfo::MAGIC_BYTES[i]);
-    }
-}
-
-void DatabaseHeader::serialize(common::Serializer& ser) const {
-    writeMagicBytes(ser);
-    ser.writeDebuggingInfo("storage_version");
-    ser.serializeValue(StorageVersionInfo::getStorageVersion());
-    ser.writeDebuggingInfo("catalog");
-    ser.serializeValue(catalogPageRange.startPageIdx);
-    ser.serializeValue(catalogPageRange.numPages);
-    ser.writeDebuggingInfo("metadata");
-    ser.serializeValue(metadataPageRange.startPageIdx);
-    ser.serializeValue(metadataPageRange.numPages);
-}
 
 Checkpointer::Checkpointer(main::ClientContext& clientContext)
     : clientContext{clientContext},
@@ -101,7 +67,8 @@ void Checkpointer::writeCheckpoint() {
         return;
     }
 
-    auto databaseHeader = getCurrentDatabaseHeader();
+    auto databaseHeader =
+        *StorageManager::Get(clientContext)->getOrInitDatabaseHeader(clientContext);
     // Checkpoint storage. Note that we first checkpoint storage before serializing the catalog, as
     // checkpointing storage may overwrite columnIDs in the catalog.
     bool hasStorageChanges = checkpointStorage();
@@ -172,13 +139,16 @@ void Checkpointer::writeDatabaseHeader(const DatabaseHeader& header) {
         shadowFile);
     memcpy(shadowHeader.frame, headerPage.data(), common::KUZU_PAGE_SIZE);
     shadowFile.getShadowingFH().unpinPage(shadowHeader.shadowPage);
+
+    // Update the in-memory database header with the new version
+    StorageManager::Get(clientContext)->setDatabaseHeader(std::make_unique<DatabaseHeader>(header));
 }
 
 void Checkpointer::logCheckpointAndApplyShadowPages() {
     const auto storageManager = StorageManager::Get(clientContext);
     auto& shadowFile = storageManager->getShadowFile();
     // Flush the shadow file.
-    shadowFile.flushAll();
+    shadowFile.flushAll(clientContext);
     auto wal = WAL::Get(clientContext);
     // Log the checkpoint to the WAL and flush WAL. This indicates that all shadow pages and
     // files (snapshots of catalog and metadata) have been written to disk. The part that is not
@@ -220,76 +190,11 @@ bool Checkpointer::canAutoCheckpoint(const main::ClientContext& clientContext,
     return expectedSize > clientContext.getDBConfig()->checkpointThreshold;
 }
 
-static void validateStorageVersion(common::Deserializer& deSer) {
-    std::string key;
-    deSer.validateDebuggingInfo(key, "storage_version");
-    storage_version_t savedStorageVersion = 0;
-    deSer.deserializeValue(savedStorageVersion);
-    const auto storageVersion = StorageVersionInfo::getStorageVersion();
-    if (savedStorageVersion != storageVersion) {
-        // TODO(Guodong): Add a test case for this.
-        throw common::RuntimeException(
-            common::stringFormat("Trying to read a database file with a different version. "
-                                 "Database file version: {}, Current build storage version: {}",
-                savedStorageVersion, storageVersion));
-    }
-}
-
-static void validateMagicBytes(common::Deserializer& deSer) {
-    std::string key;
-    deSer.validateDebuggingInfo(key, "magic");
-    const auto numMagicBytes = strlen(StorageVersionInfo::MAGIC_BYTES);
-    uint8_t magicBytes[4];
-    for (auto i = 0u; i < numMagicBytes; i++) {
-        deSer.deserializeValue<uint8_t>(magicBytes[i]);
-    }
-    if (memcmp(magicBytes, StorageVersionInfo::MAGIC_BYTES, numMagicBytes) != 0) {
-        throw common::RuntimeException(
-            "Unable to open database. The file is not a valid Kuzu database file!");
-    }
-}
-
-static DatabaseHeader readDatabaseHeader(common::Deserializer& deSer) {
-    validateMagicBytes(deSer);
-    validateStorageVersion(deSer);
-    PageRange catalogPageRange{}, metaPageRange{};
-    std::string key;
-    deSer.validateDebuggingInfo(key, "catalog");
-    deSer.deserializeValue(catalogPageRange.startPageIdx);
-    deSer.deserializeValue(catalogPageRange.numPages);
-    deSer.validateDebuggingInfo(key, "metadata");
-    deSer.deserializeValue(metaPageRange.startPageIdx);
-    deSer.deserializeValue(metaPageRange.numPages);
-    return {
-        catalogPageRange,
-        metaPageRange,
-    };
-}
-
-DatabaseHeader Checkpointer::getCurrentDatabaseHeader() const {
-    static const auto defaultHeader = DatabaseHeader{{}, {}};
-    auto dataFileInfo = StorageManager::Get(clientContext)->getDataFH()->getFileInfo();
-    if (dataFileInfo->getFileSize() < common::KUZU_PAGE_SIZE) {
-        // If the data file hasn't been written to there is no existing database header
-        return defaultHeader;
-    }
-    auto reader = std::make_unique<common::BufferedFileReader>(*dataFileInfo);
-    common::Deserializer deSer(std::move(reader));
-    try {
-        return readDatabaseHeader(deSer);
-    } catch (const common::RuntimeException&) {
-        // It is possible we optimistically write to the database file before the first checkpoint
-        // In this case the magic bytes check will fail and we assume there is no existing header
-        return defaultHeader;
-    }
-}
-
 void Checkpointer::readCheckpoint() {
     auto storageManager = StorageManager::Get(clientContext);
     storageManager->initDataFileHandle(clientContext.getVFSUnsafe(), &clientContext);
     if (!isInMemory && storageManager->getDataFH()->getNumPages() > 0) {
-        readCheckpoint(&clientContext, catalog::Catalog::Get(clientContext),
-            StorageManager::Get(clientContext));
+        readCheckpoint(&clientContext, catalog::Catalog::Get(clientContext), storageManager);
     }
     extension::ExtensionManager::Get(clientContext)->autoLoadLinkedExtensions(&clientContext);
 }
@@ -299,19 +204,19 @@ void Checkpointer::readCheckpoint(main::ClientContext* context, catalog::Catalog
     auto fileInfo = storageManager->getDataFH()->getFileInfo();
     auto reader = std::make_unique<common::BufferedFileReader>(*fileInfo);
     common::Deserializer deSer(std::move(reader));
-    auto currentHeader = readDatabaseHeader(deSer);
-    if (currentHeader.catalogPageRange.startPageIdx == common::INVALID_PAGE_IDX) {
-        // If the catalog page range is invalid, it means there is no catalog to read; thus, the
-        // database is empty.
-        return;
+    auto currentHeader = std::make_unique<DatabaseHeader>(DatabaseHeader::deserialize(deSer));
+    // If the catalog page range is invalid, it means there is no catalog to read; thus, the
+    // database is empty.
+    if (currentHeader->catalogPageRange.startPageIdx != common::INVALID_PAGE_IDX) {
+        deSer.getReader()->cast<common::BufferedFileReader>()->resetReadOffset(
+            currentHeader->catalogPageRange.startPageIdx * common::KUZU_PAGE_SIZE);
+        catalog->deserialize(deSer);
+        deSer.getReader()->cast<common::BufferedFileReader>()->resetReadOffset(
+            currentHeader->metadataPageRange.startPageIdx * common::KUZU_PAGE_SIZE);
+        storageManager->deserialize(context, catalog, deSer);
+        storageManager->getDataFH()->getPageManager()->deserialize(deSer);
     }
-    deSer.getReader()->cast<common::BufferedFileReader>()->resetReadOffset(
-        currentHeader.catalogPageRange.startPageIdx * common::KUZU_PAGE_SIZE);
-    catalog->deserialize(deSer);
-    deSer.getReader()->cast<common::BufferedFileReader>()->resetReadOffset(
-        currentHeader.metadataPageRange.startPageIdx * common::KUZU_PAGE_SIZE);
-    storageManager->deserialize(context, catalog, deSer);
-    storageManager->getDataFH()->getPageManager()->deserialize(deSer);
+    storageManager->setDatabaseHeader(std::move(currentHeader));
 }
 
 } // namespace storage

--- a/src/storage/database_header.cpp
+++ b/src/storage/database_header.cpp
@@ -1,0 +1,117 @@
+#include "storage/database_header.h"
+
+#include <cstring>
+
+#include "common/exception/runtime.h"
+#include "common/file_system/file_info.h"
+#include "common/serializer/buffered_file.h"
+#include "common/serializer/deserializer.h"
+#include "common/serializer/serializer.h"
+#include "common/system_config.h"
+#include "main/client_context.h"
+#include "storage/page_manager.h"
+#include "storage/storage_version_info.h"
+
+namespace kuzu::storage {
+static void validateStorageVersion(common::Deserializer& deSer) {
+    std::string key;
+    deSer.validateDebuggingInfo(key, "storage_version");
+    storage_version_t savedStorageVersion = 0;
+    deSer.deserializeValue(savedStorageVersion);
+    const auto storageVersion = StorageVersionInfo::getStorageVersion();
+    if (savedStorageVersion != storageVersion) {
+        // TODO(Guodong): Add a test case for this.
+        throw common::RuntimeException(
+            common::stringFormat("Trying to read a database file with a different version. "
+                                 "Database file version: {}, Current build storage version: {}",
+                savedStorageVersion, storageVersion));
+    }
+}
+
+static void validateMagicBytes(common::Deserializer& deSer) {
+    std::string key;
+    deSer.validateDebuggingInfo(key, "magic");
+    const auto numMagicBytes = strlen(StorageVersionInfo::MAGIC_BYTES);
+    uint8_t magicBytes[4];
+    for (auto i = 0u; i < numMagicBytes; i++) {
+        deSer.deserializeValue<uint8_t>(magicBytes[i]);
+    }
+    if (memcmp(magicBytes, StorageVersionInfo::MAGIC_BYTES, numMagicBytes) != 0) {
+        throw common::RuntimeException(
+            "Unable to open database. The file is not a valid Kuzu database file!");
+    }
+}
+
+void DatabaseHeader::updateCatalogPageRange(PageManager& pageManager, PageRange newPageRange) {
+    if (catalogPageRange.startPageIdx != common::INVALID_PAGE_IDX) {
+        pageManager.freePageRange(catalogPageRange);
+    }
+    catalogPageRange = newPageRange;
+}
+
+void DatabaseHeader::freeMetadataPageRange(PageManager& pageManager) const {
+    if (metadataPageRange.startPageIdx != common::INVALID_PAGE_IDX) {
+        pageManager.freePageRange(metadataPageRange);
+    }
+}
+
+static void writeMagicBytes(common::Serializer& serializer) {
+    serializer.writeDebuggingInfo("magic");
+    const auto numMagicBytes = strlen(StorageVersionInfo::MAGIC_BYTES);
+    for (auto i = 0u; i < numMagicBytes; i++) {
+        serializer.serializeValue<uint8_t>(StorageVersionInfo::MAGIC_BYTES[i]);
+    }
+}
+
+void DatabaseHeader::serialize(common::Serializer& ser) const {
+    writeMagicBytes(ser);
+    ser.writeDebuggingInfo("storage_version");
+    ser.serializeValue(StorageVersionInfo::getStorageVersion());
+    ser.writeDebuggingInfo("catalog");
+    ser.serializeValue(catalogPageRange.startPageIdx);
+    ser.serializeValue(catalogPageRange.numPages);
+    ser.writeDebuggingInfo("metadata");
+    ser.serializeValue(metadataPageRange.startPageIdx);
+    ser.serializeValue(metadataPageRange.numPages);
+    ser.writeDebuggingInfo("databaseID");
+    ser.serializeValue(databaseID.value);
+}
+
+DatabaseHeader DatabaseHeader::deserialize(common::Deserializer& deSer) {
+    validateMagicBytes(deSer);
+    validateStorageVersion(deSer);
+    PageRange catalogPageRange{}, metaPageRange{};
+    common::ku_uuid_t databaseID{};
+    std::string key;
+    deSer.validateDebuggingInfo(key, "catalog");
+    deSer.deserializeValue(catalogPageRange.startPageIdx);
+    deSer.deserializeValue(catalogPageRange.numPages);
+    deSer.validateDebuggingInfo(key, "metadata");
+    deSer.deserializeValue(metaPageRange.startPageIdx);
+    deSer.deserializeValue(metaPageRange.numPages);
+    deSer.validateDebuggingInfo(key, "databaseID");
+    deSer.deserializeValue(databaseID.value);
+    return {catalogPageRange, metaPageRange, databaseID};
+}
+
+DatabaseHeader DatabaseHeader::createInitialHeader(common::RandomEngine* randomEngine) {
+    // We generate a random UUID to act as the database ID
+    return DatabaseHeader{{}, {}, common::UUID::generateRandomUUID(randomEngine)};
+}
+
+std::optional<DatabaseHeader> DatabaseHeader::readDatabaseHeader(common::FileInfo& dataFileInfo) {
+    if (dataFileInfo.getFileSize() < common::KUZU_PAGE_SIZE) {
+        // If the data file hasn't been written to there is no existing database header
+        return std::nullopt;
+    }
+    auto reader = std::make_unique<common::BufferedFileReader>(dataFileInfo);
+    common::Deserializer deSer(std::move(reader));
+    try {
+        return DatabaseHeader::deserialize(deSer);
+    } catch (const common::RuntimeException&) {
+        // It is possible we optimistically write to the database file before the first checkpoint
+        // In this case the magic bytes check will fail and we assume there is no existing header
+        return std::nullopt;
+    }
+}
+} // namespace kuzu::storage

--- a/src/storage/file_db_id_utils.cpp
+++ b/src/storage/file_db_id_utils.cpp
@@ -1,0 +1,20 @@
+#include "storage/file_db_id_utils.h"
+
+#include "common/exception/runtime.h"
+
+namespace kuzu::storage {
+void FileDBIDUtils::verifyDatabaseID(const common::FileInfo& fileInfo,
+    common::ku_uuid_t expectedDatabaseID, common::ku_uuid_t databaseID) {
+    if (expectedDatabaseID.value != databaseID.value) {
+        throw common::RuntimeException(common::stringFormat(
+            "Database ID for temporary file '{}' does not match the current database. This file "
+            "may have been left behind from a previous database with the same name. If it is safe "
+            "to do so, please delete this file and restart the database.",
+            fileInfo.path));
+    }
+}
+
+void FileDBIDUtils::writeDatabaseID(common::Serializer& ser, common::ku_uuid_t databaseID) {
+    ser.write(databaseID);
+}
+} // namespace kuzu::storage

--- a/src/storage/shadow_file.cpp
+++ b/src/storage/shadow_file.cpp
@@ -1,5 +1,6 @@
 #include "storage/shadow_file.h"
 
+#include "common/exception/io.h"
 #include "common/file_system/virtual_file_system.h"
 #include "common/serializer/buffered_file.h"
 #include "common/serializer/deserializer.h"
@@ -8,6 +9,8 @@
 #include "main/db_config.h"
 #include "storage/buffer_manager/buffer_manager.h"
 #include "storage/buffer_manager/memory_manager.h"
+#include "storage/database_header.h"
+#include "storage/file_db_id_utils.h"
 #include "storage/file_handle.h"
 #include "storage/storage_manager.h"
 
@@ -76,6 +79,15 @@ void ShadowFile::applyShadowPages(ClientContext& context) const {
     dataFileInfo->syncFile();
 }
 
+static ku_uuid_t getOldDatabaseID(FileInfo& dataFileInfo) {
+    auto oldHeader = DatabaseHeader::readDatabaseHeader(dataFileInfo);
+    if (!oldHeader.has_value()) {
+        throw InternalException("Found a shadow file for database {} but no valid database header. "
+                                "The database is corrupted, please recreate it.");
+    }
+    return oldHeader->databaseID;
+}
+
 void ShadowFile::replayShadowPageRecords(ClientContext& context) {
     if (context.getDBConfig()->readOnly) {
         throw RuntimeException("Couldn't replay shadow pages under read-only mode. Please re-open "
@@ -84,18 +96,37 @@ void ShadowFile::replayShadowPageRecords(ClientContext& context) {
     auto vfs = context.getVFSUnsafe();
     auto shadowFilePath = StorageUtils::getShadowFilePath(context.getDatabasePath());
     auto shadowFileInfo = vfs->openFile(shadowFilePath, FileOpenFlags(FileFlags::READ_ONLY));
+
+    std::unique_ptr<FileInfo> dataFileInfo;
+    try {
+        dataFileInfo = vfs->openFile(context.getDatabasePath(),
+            FileOpenFlags{FileFlags::WRITE | FileFlags::READ_ONLY, FileLockType::WRITE_LOCK});
+    } catch (IOException& e) {
+        throw RuntimeException(stringFormat(
+            "Found shadow file {} but no corresponding database file. This file "
+            "may have been left behind from a previous database with the same name. If it is safe "
+            "to do so, please delete this file and restart the database.",
+            shadowFilePath));
+    }
+
     ShadowFileHeader header;
     const auto headerBuffer = std::make_unique<uint8_t[]>(KUZU_PAGE_SIZE);
     shadowFileInfo->readFromFile(headerBuffer.get(), KUZU_PAGE_SIZE, 0);
     memcpy(&header, headerBuffer.get(), sizeof(ShadowFileHeader));
+
+    // When replaying the shadow file we haven't read the database ID from the database
+    // header yet
+    // So we need to do it separately here to verify the shadow file matches the database
+    auto oldDatabaseID = getOldDatabaseID(*dataFileInfo);
+    FileDBIDUtils::verifyDatabaseID(*shadowFileInfo, oldDatabaseID, header.databaseID);
+
     std::vector<ShadowPageRecord> shadowPageRecords;
     shadowPageRecords.reserve(header.numShadowPages);
     auto reader = std::make_unique<BufferedFileReader>(*shadowFileInfo);
     reader->resetReadOffset((header.numShadowPages + 1) * KUZU_PAGE_SIZE);
     Deserializer deSer(std::move(reader));
     deSer.deserializeVector(shadowPageRecords);
-    auto dataFileInfo = vfs->openFile(context.getDatabasePath(),
-        FileOpenFlags{FileFlags::WRITE | FileFlags::READ_ONLY, FileLockType::WRITE_LOCK});
+
     const auto pageBuffer = std::make_unique<uint8_t[]>(KUZU_PAGE_SIZE);
     page_idx_t shadowPageIdx = 1;
     for (const auto& record : shadowPageRecords) {
@@ -107,10 +138,11 @@ void ShadowFile::replayShadowPageRecords(ClientContext& context) {
     }
 }
 
-void ShadowFile::flushAll() const {
+void ShadowFile::flushAll(main::ClientContext& context) const {
     // Write header page to file.
     ShadowFileHeader header;
     header.numShadowPages = shadowPageRecords.size();
+    header.databaseID = StorageManager::Get(context)->getOrInitDatabaseID(context);
     const auto headerBuffer = std::make_unique<uint8_t[]>(KUZU_PAGE_SIZE);
     memcpy(headerBuffer.get(), &header, sizeof(ShadowFileHeader));
     KU_ASSERT(shadowingFH && !shadowingFH->isInMemoryMode());

--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -156,9 +156,10 @@ struct FSMLeakChecker {
         const auto numUsedPages = numTotalPages - getNumFreePages(conn);
 
         storage::Checkpointer checkpointer{*conn->getClientContext()};
-        auto databaseHeader = checkpointer.getCurrentDatabaseHeader();
-        ASSERT_EQ(1 + databaseHeader.catalogPageRange.numPages +
-                      databaseHeader.metadataPageRange.numPages,
+        auto databaseHeader = storage::StorageManager::Get(*conn->getClientContext())
+                                  ->getOrInitDatabaseHeader(*conn->getClientContext());
+        ASSERT_EQ(1 + databaseHeader->catalogPageRange.numPages +
+                      databaseHeader->metadataPageRange.numPages,
             numUsedPages);
     }
 };


### PR DESCRIPTION
# Description

Fixes https://github.com/kuzudb/kuzu/issues/5777

Introduces the a database ID to the database header which is used to uniquely identify kuzu databases.

For WAL and shadow files, we write the database ID to the header of the file. We then check the IDs before replaying to make sure that it matches the ID of the data.kz file. If they do not match, an exception is thrown. This helps gracefully deal with the case where stray WAL/shadow files are left (e.g. after closing a Jupyter notebook) before a database file is deleted and prevents the files from erroneously being replayed when creating a new database with the same name.

We avoid doing the same for other temporary files (like the spiller files) as they are not expected to persist after a database is killed and will be deleted if they do persist.

Docs PR: https://github.com/kuzudb/kuzu-docs/pull/632

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
