### PR TITLE
Add CI workflow for ENABLE_DESER_DEBUG=1

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1004,6 +1004,9 @@ jobs:
       - name: Test with deserializer debugging info
         env:
           ENABLE_DESER_DEBUG: 1
+          # don't run any tests that use existing serialized data
+          # or any tests that serializing debugging info would make too slow
+          GTEST_FILTER: e2e_test*-*binary_demo*
         run: |
           make test
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1006,7 +1006,8 @@ jobs:
           ENABLE_DESER_DEBUG: 1
           # don't run any tests that use existing serialized data
           # or any tests that serializing debugging info would make too slow
-          GTEST_FILTER: e2e_test*-*binary_demo*
+          # also skip FSM-related tests as the debugging info can mess with database sizes
+          GTEST_FILTER: "*~*-*binary_demo*:*hash_leak*:*Reclaim*"
         run: |
           make test
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1001,6 +1001,12 @@ jobs:
         run: |
           make test
 
+      - name: Test with deserializer debugging info
+        env:
+          ENABLE_DESER_DEBUG: 1
+        run: |
+          make test
+
       - name: C and C++ Examples
         run: |
           ulimit -n 10240
@@ -1260,13 +1266,13 @@ jobs:
         run: |
           python3 scripts/setup-extension-repo.py &
           make extension-static-link-test
-          
+
       - name: Static link extension test in mem mode
         env:
           IN_MEM_MODE: true
           HTTP_CACHE_FILE: false
         run: |
-          make extension-static-link-test && make clean    
+          make extension-static-link-test && make clean
 
   windows-extension-test:
     name: windows extension test

--- a/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
@@ -33,7 +33,7 @@ void RelGroupCatalogEntry::dropFromToConnection(table_id_t srcTableID, table_id_
 
 void RelTableCatalogInfo::serialize(Serializer& ser) const {
     ser.writeDebuggingInfo("nodePair");
-    ser.serializeValue(nodePair);
+    nodePair.serialize(ser);
     ser.writeDebuggingInfo("oid");
     ser.serializeValue(oid);
 }

--- a/src/storage/table/csr_chunked_node_group.cpp
+++ b/src/storage/table/csr_chunked_node_group.cpp
@@ -308,6 +308,7 @@ std::unique_ptr<ChunkedCSRNodeGroup> ChunkedCSRNodeGroup::deserialize(MemoryMana
     deSer.validateDebuggingInfo(key, "chunks");
     deSer.deserializeVectorOfPtrs<ColumnChunk>(chunks,
         [&](Deserializer& deser) { return ColumnChunk::deserialize(memoryManager, deser); });
+    deSer.validateDebuggingInfo(key, "startRowIdx");
     row_idx_t startRowIdx = 0;
     deSer.deserializeValue<row_idx_t>(startRowIdx);
     auto chunkedGroup = std::make_unique<ChunkedCSRNodeGroup>(


### PR DESCRIPTION
# Description

This was broken on master. Adds a CI workflow to test this since the flag is useless as a debugging tool unless we know it was working to begin with.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
