### PR TITLE
Remove default value for buffer pool size in ci workflow file

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -18,7 +18,6 @@ on:
       buffer_pool_size:
         description: 'Database config - buffer pool size'
         required: false
-        default: 67108864
         type: number
 
       max_num_threads:


### PR DESCRIPTION
# Description

Remove default value for buffer pool size in ci workflow file. When the default value is not present, the testing framework should fall back to its own default setting, which is adaptive to PAGE_SIZE.
