### PR TITLE
Rollback undo buffer before local storage

### DIFF
--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -74,8 +74,11 @@ void Transaction::commit(storage::WAL* wal) {
 }
 
 void Transaction::rollback(storage::WAL*) {
-    localStorage->rollback();
+    // Rolling back the local storage will free + evict all optimistically-allocated pages
+    // Since the undo buffer may do some scanning (e.g. to delete inserted keys from the hash index)
+    // this must be rolled back first
     undoBuffer->rollback(clientContext);
+    localStorage->rollback();
     hasCatalogChanges = false;
 }
 

--- a/test/test_files/transaction/copy/copy_node.test
+++ b/test/test_files/transaction/copy/copy_node.test
@@ -2,8 +2,6 @@
 --
 
 -CASE CopyNodeAfterPKErrorRollbackFlushedGroups
-# TODO(Guodong): FIX-ME. This test fails randomly when NODE_GROUP_SIZE_LOG2 is set to 12.
--SKIP_NODE_GROUP_SIZE_TESTS
 -STATEMENT create node table Comment (id int64, creationDate INT64, locationIP STRING, browserUsed STRING, content STRING, length INT32, PRIMARY KEY (id));
 ---- ok
 # COPY will trigger duplicate PK once the 2nd file is hit


### PR DESCRIPTION
# Description

Rolling back local storage will evict any optimistically-allocated pages. However, rolling back the undo buffer may require scanning these pages to rollback the PK index so that needs to be done first.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
