### PR TITLE
Fix progress indicator exceeding 100% for rel batch inserts

### DIFF
--- a/src/common/task_system/terminal_progress_bar_display.cpp
+++ b/src/common/task_system/terminal_progress_bar_display.cpp
@@ -1,3 +1,4 @@
+#include "common/assert.h"
 #include "common/task_system/terminal_progress_bar_display.h"
 
 namespace kuzu {
@@ -5,6 +6,7 @@ namespace common {
 
 void TerminalProgressBarDisplay::updateProgress(uint64_t /*queryID*/, double newPipelineProgress,
     uint32_t newNumPipelinesFinished) {
+    KU_ASSERT(newPipelineProgress <= 1.0);
 
     // There can still be data races as the comparison + update of cur/old progress is not done
     // atomically

--- a/src/common/task_system/terminal_progress_bar_display.cpp
+++ b/src/common/task_system/terminal_progress_bar_display.cpp
@@ -7,7 +7,7 @@ namespace common {
 
 void TerminalProgressBarDisplay::updateProgress(uint64_t /*queryID*/, double newPipelineProgress,
     uint32_t newNumPipelinesFinished) {
-    KU_ASSERT(newPipelineProgress <= 1.0);
+    KU_ASSERT(0.0 <= newPipelineProgress && newPipelineProgress <= 1.0);
 
     // There can still be data races as the comparison + update of cur/old progress is not done
     // atomically

--- a/src/common/task_system/terminal_progress_bar_display.cpp
+++ b/src/common/task_system/terminal_progress_bar_display.cpp
@@ -1,5 +1,6 @@
-#include "common/assert.h"
 #include "common/task_system/terminal_progress_bar_display.h"
+
+#include "common/assert.h"
 
 namespace kuzu {
 namespace common {

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -1,7 +1,5 @@
 #include "processor/operator/persistent/rel_batch_insert.h"
 
-#include <iostream>
-
 #include "catalog/catalog.h"
 #include "common/exception/copy.h"
 #include "common/exception/message.h"

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -14,6 +14,8 @@
 #include "storage/table/column_chunk_data.h"
 #include "storage/table/rel_table.h"
 
+#include <iostream>
+
 using namespace kuzu::catalog;
 using namespace kuzu::common;
 using namespace kuzu::storage;
@@ -105,11 +107,11 @@ void RelBatchInsert::executeInternal(ExecutionContext* context) {
     while (true) {
         relLocalState->nodeGroupIdx =
             partitionerSharedState->getNextPartition(relInfo->partitioningIdx);
-        ++progressSharedState->partitionsDone;
         if (relLocalState->nodeGroupIdx == INVALID_PARTITION_IDX) {
             // No more partitions left in the partitioning buffer.
             break;
         }
+        ++progressSharedState->partitionsDone;
         // TODO(Guodong): We need to handle the concurrency between COPY and other insertions
         // into the same node group.
         auto& nodeGroup = relTable

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/persistent/rel_batch_insert.h"
 
+#include <iostream>
+
 #include "catalog/catalog.h"
 #include "common/exception/copy.h"
 #include "common/exception/message.h"
@@ -13,8 +15,6 @@
 #include "storage/storage_utils.h"
 #include "storage/table/column_chunk_data.h"
 #include "storage/table/rel_table.h"
-
-#include <iostream>
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;


### PR DESCRIPTION
We were updating `partitionsDone` on a thread before checking if there were any partitions left.
Resolves https://github.com/kuzudb/kuzu/issues/5917