### PR TITLE
Checksum WAL records

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory(file_system)
 add_library(kuzu_common
         OBJECT
         case_insensitive_map.cpp
+        checksum.cpp
         constants.cpp
         database_lifecycle_manager.cpp
         expression_type.cpp

--- a/src/common/checksum.cpp
+++ b/src/common/checksum.cpp
@@ -1,3 +1,8 @@
+/**
+ * The implementation for checksumming is taken from DuckDB:
+ * https://github.com/duckdb/duckdb/blob/v1.3-ossivalis/src/common/checksum.cpp
+ */
+
 #include "common/checksum.h"
 
 #include "common/types/types.h"

--- a/src/common/checksum.cpp
+++ b/src/common/checksum.cpp
@@ -40,26 +40,26 @@ hash_t checksumRemainder(void* ptr, size_t len) noexcept {
     switch (len & 7U) {
     case 7:
         h ^= static_cast<uint64_t>(data8[6]) << 48U;
-
+        [[fallthrough]];
     case 6:
         h ^= static_cast<uint64_t>(data8[5]) << 40U;
-
+        [[fallthrough]];
     case 5:
         h ^= static_cast<uint64_t>(data8[4]) << 32U;
-
+        [[fallthrough]];
     case 4:
         h ^= static_cast<uint64_t>(data8[3]) << 24U;
-
+        [[fallthrough]];
     case 3:
         h ^= static_cast<uint64_t>(data8[2]) << 16U;
-
+        [[fallthrough]];
     case 2:
         h ^= static_cast<uint64_t>(data8[1]) << 8U;
-
+        [[fallthrough]];
     case 1:
         h ^= static_cast<uint64_t>(data8[0]);
         h *= M;
-
+        [[fallthrough]];
     default:
         break;
     }

--- a/src/common/checksum.cpp
+++ b/src/common/checksum.cpp
@@ -1,6 +1,7 @@
 /**
  * The implementation for checksumming is taken from DuckDB:
  * https://github.com/duckdb/duckdb/blob/v1.3-ossivalis/src/common/checksum.cpp
+ * https://github.com/duckdb/duckdb/blob/v1.3-ossivalis/LICENSE
  */
 
 #include "common/checksum.h"

--- a/src/common/checksum.cpp
+++ b/src/common/checksum.cpp
@@ -1,0 +1,82 @@
+#include "common/checksum.h"
+
+#include "common/types/types.h"
+
+namespace kuzu::common {
+
+hash_t checksum(uint64_t x) {
+    return x * UINT64_C(0xbf58476d1ce4e5b9);
+}
+
+// MIT License
+// Copyright (c) 2018-2021 Martin Ankerl
+// https://github.com/martinus/robin-hood-hashing/blob/3.11.5/LICENSE
+hash_t checksumRemainder(void* ptr, size_t len) noexcept {
+    static constexpr uint64_t M = UINT64_C(0xc6a4a7935bd1e995);
+    static constexpr uint64_t SEED = UINT64_C(0xe17a1465);
+    static constexpr unsigned int R = 47;
+
+    auto const* const data64 = static_cast<uint64_t const*>(ptr);
+    uint64_t h = SEED ^ (len * M);
+
+    size_t const n_blocks = len / 8;
+    for (size_t i = 0; i < n_blocks; ++i) {
+        auto k = *reinterpret_cast<const uint64_t*>(data64 + i);
+
+        k *= M;
+        k ^= k >> R;
+        k *= M;
+
+        h ^= k;
+        h *= M;
+    }
+
+    auto const* const data8 = reinterpret_cast<uint8_t const*>(data64 + n_blocks);
+    switch (len & 7U) {
+    case 7:
+        h ^= static_cast<uint64_t>(data8[6]) << 48U;
+
+    case 6:
+        h ^= static_cast<uint64_t>(data8[5]) << 40U;
+
+    case 5:
+        h ^= static_cast<uint64_t>(data8[4]) << 32U;
+
+    case 4:
+        h ^= static_cast<uint64_t>(data8[3]) << 24U;
+
+    case 3:
+        h ^= static_cast<uint64_t>(data8[2]) << 16U;
+
+    case 2:
+        h ^= static_cast<uint64_t>(data8[1]) << 8U;
+
+    case 1:
+        h ^= static_cast<uint64_t>(data8[0]);
+        h *= M;
+
+    default:
+        break;
+    }
+    h ^= h >> R;
+    h *= M;
+    h ^= h >> R;
+    return static_cast<hash_t>(h);
+}
+
+uint64_t checksum(uint8_t* buffer, size_t size) {
+    uint64_t result = 5381;
+    uint64_t* ptr = reinterpret_cast<uint64_t*>(buffer);
+    size_t i{};
+    // for efficiency, we first checksum uint64_t values
+    for (i = 0; i < size / 8; i++) {
+        result ^= checksum(ptr[i]);
+    }
+    if (size - i * 8 > 0) {
+        // the remaining 0-7 bytes we hash using a string hash
+        result ^= checksumRemainder(buffer + i * 8, size - i * 8);
+    }
+    return result;
+}
+
+} // namespace kuzu::common

--- a/src/common/serializer/in_mem_file_writer.cpp
+++ b/src/common/serializer/in_mem_file_writer.cpp
@@ -1,6 +1,5 @@
 #include "common/serializer/in_mem_file_writer.h"
 
-#include "common/serializer/buffered_file.h"
 #include "storage/file_handle.h"
 #include "storage/shadow_file.h"
 #include "storage/shadow_utils.h"
@@ -65,7 +64,7 @@ void InMemFileWriter::flush(storage::PageRange allocatedPageRange, storage::File
     }
 }
 
-void InMemFileWriter::flush(BufferedFileWriter& writer) const {
+void InMemFileWriter::flush(Writer& writer) const {
     for (auto i = 0u; i < pages.size(); i++) {
         auto sizeToFlush = (i == pages.size() - 1) ? pageOffset : KUZU_PAGE_SIZE;
         writer.write(pages[i]->getData(), sizeToFlush);

--- a/src/include/common/checksum.h
+++ b/src/include/common/checksum.h
@@ -1,0 +1,11 @@
+// From DuckDB
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+namespace kuzu::common {
+
+//! Compute a checksum over a buffer of size size
+uint64_t checksum(uint8_t* buffer, size_t size);
+
+} // namespace kuzu::common

--- a/src/include/common/checksum.h
+++ b/src/include/common/checksum.h
@@ -1,4 +1,3 @@
-// From DuckDB
 #pragma once
 
 #include <cstddef>

--- a/src/include/common/serializer/in_mem_file_writer.h
+++ b/src/include/common/serializer/in_mem_file_writer.h
@@ -34,7 +34,7 @@ public:
     page_idx_t getNumPagesToFlush() const { return pages.size(); }
 
     static uint64_t getPageSize();
-    void flush(BufferedFileWriter& writer) const;
+    void flush(Writer& writer) const;
 
     uint64_t getSize() const override {
         uint64_t size = pages.size() > 1 ? KUZU_PAGE_SIZE * (pages.size() - 1) : 0;

--- a/src/include/main/database.h
+++ b/src/include/main/database.h
@@ -61,7 +61,7 @@ struct KUZU_API SystemConfig {
     explicit SystemConfig(uint64_t bufferPoolSize = -1u, uint64_t maxNumThreads = 0,
         bool enableCompression = true, bool readOnly = false, uint64_t maxDBSize = -1u,
         bool autoCheckpoint = true, uint64_t checkpointThreshold = 16777216 /* 16MB */,
-        bool forceCheckpointOnClose = true
+        bool forceCheckpointOnClose = true, bool throwOnWalReplayFailure = true
 #if defined(__APPLE__)
         ,
         uint32_t threadQos = QOS_CLASS_DEFAULT
@@ -76,6 +76,7 @@ struct KUZU_API SystemConfig {
     bool autoCheckpoint;
     uint64_t checkpointThreshold;
     bool forceCheckpointOnClose;
+    bool throwOnWalReplayFailure;
 #if defined(__APPLE__)
     uint32_t threadQos;
 #endif

--- a/src/include/main/db_config.h
+++ b/src/include/main/db_config.h
@@ -63,6 +63,7 @@ struct DBConfig {
     bool autoCheckpoint;
     uint64_t checkpointThreshold;
     bool forceCheckpointOnClose;
+    bool throwOnWalReplayFailure;
     bool enableSpillingToDisk;
 #if defined(__APPLE__)
     uint32_t threadQos;

--- a/src/include/storage/storage_manager.h
+++ b/src/include/storage/storage_manager.h
@@ -34,7 +34,7 @@ public:
 
     Table* getTable(common::table_id_t tableID);
 
-    static void recover(main::ClientContext& clientContext);
+    static void recover(main::ClientContext& clientContext, bool throwOnWalReplayFailure);
 
     void createTable(catalog::TableCatalogEntry* entry);
     void addRelTable(catalog::RelGroupCatalogEntry* entry,

--- a/src/include/storage/wal/checksum_reader.h
+++ b/src/include/storage/wal/checksum_reader.h
@@ -20,6 +20,8 @@ public:
     // Computes + verifies the checksum for the entry that has just been read
     void finishEntry();
 
+    Reader* getReader();
+
 private:
     std::unique_ptr<common::Deserializer> deserializer;
 

--- a/src/include/storage/wal/checksum_reader.h
+++ b/src/include/storage/wal/checksum_reader.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <optional>
 
+#include "common/serializer/deserializer.h"
 #include "common/serializer/reader.h"
 #include "storage/buffer_manager/memory_manager.h"
 
@@ -10,23 +11,22 @@ namespace kuzu {
 namespace storage {
 class ChecksumReader : public common::Reader {
 public:
-    explicit ChecksumReader(std::unique_ptr<Reader> reader, MemoryManager& memoryManager);
+    explicit ChecksumReader(common::FileInfo& fileInfo, MemoryManager& memoryManager);
 
     void read(uint8_t* data, uint64_t size) override;
     bool finished() override;
 
-    // Reads + stores the checksum for the next entry
-    void startEntry();
-    // Computes + verifies the checksum for the entry that has just been read
-    void finishEntry();
+    // Reads the stored checksum
+    // Also computes + verifies the checksum for the entry that has just been read against the
+    // stored value
+    void finishEntry(std::string_view checksumMismatchMessage);
 
-    Reader* getReader();
+    uint64_t getReadOffset() const;
 
 private:
-    std::unique_ptr<common::Deserializer> deserializer;
+    common::Deserializer deserializer;
 
     uint64_t currentEntrySize;
-    std::optional<uint64_t> currentChecksum;
     std::unique_ptr<MemoryBuffer> entryBuffer;
 };
 } // namespace storage

--- a/src/include/storage/wal/checksum_reader.h
+++ b/src/include/storage/wal/checksum_reader.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <memory>
-#include <optional>
 
 #include "common/serializer/deserializer.h"
 #include "common/serializer/reader.h"

--- a/src/include/storage/wal/checksum_reader.h
+++ b/src/include/storage/wal/checksum_reader.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include "common/serializer/reader.h"
+#include "storage/buffer_manager/memory_manager.h"
+
+namespace kuzu {
+namespace storage {
+class ChecksumReader : public common::Reader {
+public:
+    explicit ChecksumReader(std::unique_ptr<Reader> reader, MemoryManager& memoryManager);
+
+    void read(uint8_t* data, uint64_t size) override;
+    bool finished() override;
+
+    // Reads + stores the checksum for the next entry
+    void startEntry();
+    // Computes + verifies the checksum for the entry that has just been read
+    void finishEntry();
+
+private:
+    std::unique_ptr<common::Deserializer> deserializer;
+
+    uint64_t currentEntrySize;
+    std::optional<uint64_t> currentChecksum;
+    std::unique_ptr<MemoryBuffer> entryBuffer;
+};
+} // namespace storage
+} // namespace kuzu

--- a/src/include/storage/wal/checksum_writer.h
+++ b/src/include/storage/wal/checksum_writer.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include "common/serializer/writer.h"
+#include "storage/buffer_manager/memory_manager.h"
+
+namespace kuzu {
+namespace storage {
+// A wrapper on top of another Writer that computes checksums for bytes written between startEntry()
+// and finishEntry() calls
+class ChecksumWriter : public common::Writer {
+public:
+    explicit ChecksumWriter(std::shared_ptr<Writer> writer, MemoryManager& memoryManager);
+
+    void write(const uint8_t* data, uint64_t size) override;
+    uint64_t getSize() const override;
+
+    void clear() override;
+    void flush() override;
+    void sync() override;
+
+    void startEntry();
+    void finishEntry();
+
+private:
+    std::shared_ptr<Writer> writer;
+    std::unique_ptr<common::Serializer> serializer;
+
+    std::optional<uint64_t> currentEntrySize;
+    std::unique_ptr<MemoryBuffer> entryBuffer;
+};
+} // namespace storage
+} // namespace kuzu

--- a/src/include/storage/wal/local_wal.h
+++ b/src/include/storage/wal/local_wal.h
@@ -55,9 +55,8 @@ private:
 
 private:
     std::mutex mtx;
-    std::shared_ptr<ChecksumWriter> writer;
-    std::shared_ptr<common::InMemFileWriter> localWriter;
-    std::unique_ptr<common::Serializer> serializer;
+    std::shared_ptr<common::InMemFileWriter> writer;
+    ChecksumSerializer checksumWriter;
 };
 
 } // namespace storage

--- a/src/include/storage/wal/local_wal.h
+++ b/src/include/storage/wal/local_wal.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "storage/wal/checksum_writer.h"
 #include "storage/wal/wal_record.h"
 
 namespace kuzu {
@@ -54,7 +55,8 @@ private:
 
 private:
     std::mutex mtx;
-    std::shared_ptr<common::InMemFileWriter> writer;
+    std::shared_ptr<ChecksumWriter> writer;
+    std::shared_ptr<common::InMemFileWriter> localWriter;
     std::unique_ptr<common::Serializer> serializer;
 };
 

--- a/src/include/storage/wal/wal.h
+++ b/src/include/storage/wal/wal.h
@@ -40,9 +40,12 @@ private:
     bool readOnly;
     common::VirtualFileSystem* vfs;
     std::unique_ptr<common::FileInfo> fileInfo;
+
+    // Since most writes to the shared WAL will be flushing local WAL (which has its own checksums),
+    // these writes can go through the normal writer We do still need a checksum writer though for
+    // writing COMMIT/CHECKPOINT records
     std::shared_ptr<common::BufferedFileWriter> writer;
-    std::shared_ptr<ChecksumWriter> checksumWriter;
-    std::unique_ptr<common::Serializer> serializer;
+    std::optional<ChecksumSerializer> checksumWriter;
 };
 
 } // namespace storage

--- a/src/include/storage/wal/wal.h
+++ b/src/include/storage/wal/wal.h
@@ -37,12 +37,12 @@ private:
     std::mutex mtx;
     std::string walPath;
     bool inMemory;
-    bool readOnly;
+    [[maybe_unused]] bool readOnly;
     common::VirtualFileSystem* vfs;
     std::unique_ptr<common::FileInfo> fileInfo;
 
     // Since most writes to the shared WAL will be flushing local WAL (which has its own checksums),
-    // these writes can go through the normal writer We do still need a checksum writer though for
+    // these writes can go through the normal writer. We do still need a checksum writer though for
     // writing COMMIT/CHECKPOINT records
     std::shared_ptr<common::BufferedFileWriter> writer;
     std::optional<ChecksumSerializer> checksumWriter;

--- a/src/include/storage/wal/wal.h
+++ b/src/include/storage/wal/wal.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "storage/wal/checksum_writer.h"
 #include "storage/wal/wal_record.h"
 
 namespace kuzu {
@@ -40,6 +41,7 @@ private:
     common::VirtualFileSystem* vfs;
     std::unique_ptr<common::FileInfo> fileInfo;
     std::shared_ptr<common::BufferedFileWriter> writer;
+    std::shared_ptr<ChecksumWriter> checksumWriter;
     std::unique_ptr<common::Serializer> serializer;
 };
 

--- a/src/include/storage/wal/wal_record.h
+++ b/src/include/storage/wal/wal_record.h
@@ -50,7 +50,7 @@ struct WALRecord {
 
     virtual void serialize(common::Serializer& serializer) const;
     static std::unique_ptr<WALRecord> deserialize(common::Deserializer& deserializer,
-        const main::ClientContext& clientContext);
+        const main::ClientContext& clientContext, std::string_view checksumMismatchMessage);
 
     template<class TARGET>
     const TARGET& constCast() const {

--- a/src/include/storage/wal/wal_replayer.h
+++ b/src/include/storage/wal/wal_replayer.h
@@ -12,7 +12,7 @@ class WALReplayer {
 public:
     explicit WALReplayer(main::ClientContext& clientContext);
 
-    void replay() const;
+    void replay(bool throwOnWalReplayFailure) const;
 
 private:
     struct WALReplayInfo {
@@ -40,7 +40,7 @@ private:
 
     // This function is used to deserialize the WAL records without actually applying them to the
     // storage.
-    WALReplayInfo dryReplay(common::FileInfo& fileInfo) const;
+    WALReplayInfo dryReplay(common::FileInfo& fileInfo, bool throwOnWalReplayFailure) const;
 
     void removeWALAndShadowFiles() const;
     void removeFileIfExists(const std::string& path) const;

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -34,7 +34,7 @@ namespace main {
 
 SystemConfig::SystemConfig(uint64_t bufferPoolSize_, uint64_t maxNumThreads, bool enableCompression,
     bool readOnly, uint64_t maxDBSize, bool autoCheckpoint, uint64_t checkpointThreshold,
-    bool forceCheckpointOnClose
+    bool forceCheckpointOnClose, bool throwOnWalReplayFailure
 #if defined(__APPLE__)
     ,
     uint32_t threadQos
@@ -42,7 +42,8 @@ SystemConfig::SystemConfig(uint64_t bufferPoolSize_, uint64_t maxNumThreads, boo
     )
     : maxNumThreads{maxNumThreads}, enableCompression{enableCompression}, readOnly{readOnly},
       autoCheckpoint{autoCheckpoint}, checkpointThreshold{checkpointThreshold},
-      forceCheckpointOnClose{forceCheckpointOnClose} {
+      forceCheckpointOnClose{forceCheckpointOnClose},
+      throwOnWalReplayFailure(throwOnWalReplayFailure) {
 #if defined(__APPLE__)
     this->threadQos = threadQos;
 #endif
@@ -132,7 +133,7 @@ void Database::initMembers(std::string_view dbPath, construct_bm_func_t initBmFu
         extensionManager->autoLoadLinkedExtensions(&clientContext);
         return;
     }
-    StorageManager::recover(clientContext);
+    StorageManager::recover(clientContext, dbConfig.throwOnWalReplayFailure);
 }
 
 Database::~Database() {

--- a/src/main/db_config.cpp
+++ b/src/main/db_config.cpp
@@ -10,7 +10,7 @@ namespace kuzu {
 namespace main {
 
 #define GET_CONFIGURATION(_PARAM)                                                                  \
-    {_PARAM::name, _PARAM::inputType, _PARAM::setContext, _PARAM::getSetting}
+    { _PARAM::name, _PARAM::inputType, _PARAM::setContext, _PARAM::getSetting }
 
 static ConfigurationOption options[] = { // NOLINT(cert-err58-cpp):
     GET_CONFIGURATION(ThreadsSetting), GET_CONFIGURATION(TimeoutSetting),

--- a/src/main/db_config.cpp
+++ b/src/main/db_config.cpp
@@ -10,7 +10,7 @@ namespace kuzu {
 namespace main {
 
 #define GET_CONFIGURATION(_PARAM)                                                                  \
-    { _PARAM::name, _PARAM::inputType, _PARAM::setContext, _PARAM::getSetting }
+    {_PARAM::name, _PARAM::inputType, _PARAM::setContext, _PARAM::getSetting}
 
 static ConfigurationOption options[] = { // NOLINT(cert-err58-cpp):
     GET_CONFIGURATION(ThreadsSetting), GET_CONFIGURATION(TimeoutSetting),
@@ -30,7 +30,8 @@ DBConfig::DBConfig(const SystemConfig& systemConfig)
       maxDBSize{systemConfig.maxDBSize}, enableMultiWrites{false},
       autoCheckpoint{systemConfig.autoCheckpoint},
       checkpointThreshold{systemConfig.checkpointThreshold},
-      forceCheckpointOnClose{systemConfig.forceCheckpointOnClose}, enableSpillingToDisk{true} {
+      forceCheckpointOnClose{systemConfig.forceCheckpointOnClose},
+      throwOnWalReplayFailure(systemConfig.throwOnWalReplayFailure), enableSpillingToDisk{true} {
 #if defined(__APPLE__)
     this->threadQos = systemConfig.threadQos;
 #endif

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -69,9 +69,9 @@ Table* StorageManager::getTable(table_id_t tableID) {
     return tables.at(tableID).get();
 }
 
-void StorageManager::recover(main::ClientContext& clientContext) {
+void StorageManager::recover(main::ClientContext& clientContext, bool throwOnWalReplayFailure) {
     const auto walReplayer = std::make_unique<WALReplayer>(clientContext);
-    walReplayer->replay();
+    walReplayer->replay(throwOnWalReplayFailure);
 }
 
 void StorageManager::createNodeTable(NodeTableCatalogEntry* entry) {

--- a/src/storage/wal/CMakeLists.txt
+++ b/src/storage/wal/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_library(kuzu_storage_wal
         OBJECT
+        checksum_reader.cpp
+        checksum_writer.cpp
         local_wal.cpp
         wal.cpp
         wal_record.cpp

--- a/src/storage/wal/checksum_reader.cpp
+++ b/src/storage/wal/checksum_reader.cpp
@@ -4,46 +4,42 @@
 
 #include "common/checksum.h"
 #include "common/exception/storage.h"
+#include "common/serializer/buffered_file.h"
 #include "common/serializer/deserializer.h"
 
 namespace kuzu::storage {
 static constexpr uint64_t ENTRY_BUFFER_SIZE = common::KUZU_PAGE_SIZE;
 
-ChecksumReader::ChecksumReader(std::unique_ptr<Reader> reader, MemoryManager& memoryManager)
-    : deserializer(std::make_unique<common::Deserializer>(std::move(reader))), currentEntrySize(0),
-      currentChecksum(), entryBuffer(memoryManager.allocateBuffer(false, ENTRY_BUFFER_SIZE)) {}
+ChecksumReader::ChecksumReader(common::FileInfo& fileInfo, MemoryManager& memoryManager)
+    : deserializer(std::make_unique<common::BufferedFileReader>(fileInfo)), currentEntrySize(0),
+      entryBuffer(memoryManager.allocateBuffer(false, ENTRY_BUFFER_SIZE)) {}
 
 void ChecksumReader::read(uint8_t* data, uint64_t size) {
-    deserializer->read(data, size);
-    if (currentChecksum.has_value()) {
-        KU_ASSERT(currentEntrySize + size <= ENTRY_BUFFER_SIZE);
-        std::memcpy(entryBuffer->getData() + currentEntrySize, data, size);
-        currentEntrySize += size;
-    }
+    deserializer.read(data, size);
+    KU_ASSERT(currentEntrySize + size <= ENTRY_BUFFER_SIZE);
+    std::memcpy(entryBuffer->getData() + currentEntrySize, data, size);
+    currentEntrySize += size;
 }
 
 bool ChecksumReader::finished() {
-    return deserializer->finished();
+    return deserializer.finished();
 }
 
-void ChecksumReader::startEntry() {
-    currentEntrySize = 0;
-    uint64_t storedChecksum{};
-    deserializer->deserializeValue(storedChecksum);
-    currentChecksum = storedChecksum;
-}
-
-void ChecksumReader::finishEntry() {
-    KU_ASSERT(currentChecksum.has_value());
+void ChecksumReader::finishEntry(std::string_view checksumMismatchMessage) {
     const uint64_t computedChecksum = common::checksum(entryBuffer->getData(), currentEntrySize);
-    if (currentChecksum != computedChecksum) {
-        // TODO improve error message, maybe make behaviour configurable
-        throw common::StorageException("WAL checksum mismatch");
+    uint64_t storedChecksum{};
+    deserializer.deserializeValue(storedChecksum);
+    if (storedChecksum != computedChecksum) {
+        // TODO: Maybe make behaviour configurable e.g. truncate WAL instead of erroring
+        throw common::StorageException(std::string{checksumMismatchMessage});
     }
+
+    // reset buffer
+    currentEntrySize = 0;
 }
 
-common::Reader* ChecksumReader::getReader() {
-    return deserializer->getReader();
+uint64_t ChecksumReader::getReadOffset() const {
+    return deserializer.getReader()->cast<common::BufferedFileReader>()->getReadOffset();
 }
 
 } // namespace kuzu::storage

--- a/src/storage/wal/checksum_reader.cpp
+++ b/src/storage/wal/checksum_reader.cpp
@@ -6,6 +6,7 @@
 #include "common/exception/storage.h"
 #include "common/serializer/buffered_file.h"
 #include "common/serializer/deserializer.h"
+#include <bit>
 
 namespace kuzu::storage {
 static constexpr uint64_t INITIAL_BUFFER_SIZE = common::KUZU_PAGE_SIZE;

--- a/src/storage/wal/checksum_reader.cpp
+++ b/src/storage/wal/checksum_reader.cpp
@@ -1,0 +1,45 @@
+#include "storage/wal/checksum_reader.h"
+
+#include <cstring>
+
+#include "common/checksum.h"
+#include "common/exception/storage.h"
+#include "common/serializer/deserializer.h"
+
+namespace kuzu::storage {
+static constexpr uint64_t ENTRY_BUFFER_SIZE = common::KUZU_PAGE_SIZE;
+
+ChecksumReader::ChecksumReader(std::unique_ptr<Reader> reader, MemoryManager& memoryManager)
+    : deserializer(std::make_unique<common::Deserializer>(std::move(reader))), currentEntrySize(0),
+      currentChecksum(), entryBuffer(memoryManager.allocateBuffer(false, ENTRY_BUFFER_SIZE)) {}
+
+void ChecksumReader::read(uint8_t* data, uint64_t size) {
+    deserializer->read(data, size);
+    if (currentChecksum.has_value()) {
+        KU_ASSERT(currentEntrySize + size <= ENTRY_BUFFER_SIZE);
+        std::memcpy(entryBuffer->getData() + currentEntrySize, data, size);
+        currentEntrySize += size;
+    }
+}
+
+bool ChecksumReader::finished() {
+    return deserializer->finished();
+}
+
+void ChecksumReader::startEntry() {
+    currentEntrySize = 0;
+    uint64_t storedChecksum{};
+    deserializer->deserializeValue(storedChecksum);
+    currentChecksum = storedChecksum;
+}
+
+void ChecksumReader::finishEntry() {
+    KU_ASSERT(currentChecksum.has_value());
+    const uint64_t computedChecksum = common::checksum(entryBuffer->getData(), currentEntrySize);
+    if (currentChecksum != computedChecksum) {
+        // TODO improve error message, maybe make behaviour configurable
+        throw common::StorageException("WAL checksum mismatch");
+    }
+}
+
+} // namespace kuzu::storage

--- a/src/storage/wal/checksum_reader.cpp
+++ b/src/storage/wal/checksum_reader.cpp
@@ -42,4 +42,8 @@ void ChecksumReader::finishEntry() {
     }
 }
 
+common::Reader* ChecksumReader::getReader() {
+    return deserializer->getReader();
+}
+
 } // namespace kuzu::storage

--- a/src/storage/wal/checksum_writer.cpp
+++ b/src/storage/wal/checksum_writer.cpp
@@ -8,45 +8,37 @@
 namespace kuzu::storage {
 static constexpr uint64_t ENTRY_BUFFER_SIZE = common::KUZU_PAGE_SIZE;
 
-ChecksumWriter::ChecksumWriter(std::shared_ptr<common::Writer> writer, MemoryManager& memoryManager)
-    : writer(std::move(writer)), serializer(std::make_unique<common::Serializer>(this->writer)),
+ChecksumSerializer::ChecksumSerializer(std::shared_ptr<common::Writer> outputWriter,
+    MemoryManager& memoryManager)
+    : writer(std::make_shared<ChecksumWriter>(std::move(outputWriter), memoryManager)),
+      serializer(writer) {}
+
+ChecksumWriter::ChecksumWriter(std::shared_ptr<common::Writer> outputWriter,
+    MemoryManager& memoryManager)
+    : outputSerializer(std::move(outputWriter)), currentEntrySize(0),
       entryBuffer(memoryManager.allocateBuffer(false, ENTRY_BUFFER_SIZE)) {}
 
 void ChecksumWriter::write(const uint8_t* data, uint64_t size) {
-    KU_ASSERT(currentEntrySize.has_value());
-    KU_ASSERT(*currentEntrySize + size <= ENTRY_BUFFER_SIZE);
-    std::memcpy(entryBuffer->getData() + *currentEntrySize, data, size);
-    *currentEntrySize += size;
-}
-
-uint64_t ChecksumWriter::getSize() const {
-    return writer->getSize();
+    KU_ASSERT(currentEntrySize + size <= ENTRY_BUFFER_SIZE);
+    std::memcpy(entryBuffer->getData() + currentEntrySize, data, size);
+    currentEntrySize += size;
 }
 
 void ChecksumWriter::clear() {
-    writer->clear();
-    currentEntrySize.reset();
-}
-
-void ChecksumWriter::flush() {
-    KU_ASSERT(!currentEntrySize.has_value());
-    writer->flush();
-}
-
-void ChecksumWriter::sync() {
-    writer->sync();
-}
-
-void ChecksumWriter::startEntry() {
-    KU_ASSERT(!currentEntrySize.has_value());
     currentEntrySize = 0;
 }
 
-void ChecksumWriter::finishEntry() {
-    KU_ASSERT(currentEntrySize.has_value());
-    const auto checksum = common::checksum(entryBuffer->getData(), *currentEntrySize);
-    serializer->serializeValue(checksum);
-    serializer->write(entryBuffer->getData(), *currentEntrySize);
-    currentEntrySize.reset();
+void ChecksumWriter::flush() {
+    const auto checksum = common::checksum(entryBuffer->getData(), currentEntrySize);
+    outputSerializer.write(entryBuffer->getData(), currentEntrySize);
+    outputSerializer.serializeValue(checksum);
+    clear();
 }
+
+uint64_t ChecksumWriter::getSize() const {
+    return entryBuffer->getBuffer().size();
+}
+
+void ChecksumWriter::sync() {}
+
 } // namespace kuzu::storage

--- a/src/storage/wal/checksum_writer.cpp
+++ b/src/storage/wal/checksum_writer.cpp
@@ -1,0 +1,52 @@
+#include "storage/wal/checksum_writer.h"
+
+#include <cstring>
+
+#include "common/checksum.h"
+#include "common/serializer/serializer.h"
+
+namespace kuzu::storage {
+static constexpr uint64_t ENTRY_BUFFER_SIZE = common::KUZU_PAGE_SIZE;
+
+ChecksumWriter::ChecksumWriter(std::shared_ptr<common::Writer> writer, MemoryManager& memoryManager)
+    : writer(std::move(writer)), serializer(std::make_unique<common::Serializer>(this->writer)),
+      entryBuffer(memoryManager.allocateBuffer(false, ENTRY_BUFFER_SIZE)) {}
+
+void ChecksumWriter::write(const uint8_t* data, uint64_t size) {
+    KU_ASSERT(currentEntrySize.has_value());
+    KU_ASSERT(*currentEntrySize + size <= ENTRY_BUFFER_SIZE);
+    std::memcpy(entryBuffer->getData(), data, size);
+    *currentEntrySize += size;
+}
+
+uint64_t ChecksumWriter::getSize() const {
+    return writer->getSize();
+}
+
+void ChecksumWriter::clear() {
+    writer->clear();
+    currentEntrySize.reset();
+}
+
+void ChecksumWriter::flush() {
+    KU_ASSERT(!currentEntrySize.has_value());
+    writer->flush();
+}
+
+void ChecksumWriter::sync() {
+    writer->sync();
+}
+
+void ChecksumWriter::startEntry() {
+    KU_ASSERT(!currentEntrySize.has_value());
+    currentEntrySize = 0;
+}
+
+void ChecksumWriter::finishEntry() {
+    KU_ASSERT(currentEntrySize.has_value());
+    const auto checksum = common::checksum(entryBuffer->getData(), *currentEntrySize);
+    serializer->serializeValue(checksum);
+    serializer->write(entryBuffer->getData(), *currentEntrySize);
+    currentEntrySize.reset();
+}
+} // namespace kuzu::storage

--- a/src/storage/wal/checksum_writer.cpp
+++ b/src/storage/wal/checksum_writer.cpp
@@ -4,6 +4,7 @@
 
 #include "common/checksum.h"
 #include "common/serializer/serializer.h"
+#include <bit>
 
 namespace kuzu::storage {
 static constexpr uint64_t INITIAL_BUFFER_SIZE = common::KUZU_PAGE_SIZE;

--- a/src/storage/wal/checksum_writer.cpp
+++ b/src/storage/wal/checksum_writer.cpp
@@ -15,7 +15,7 @@ ChecksumWriter::ChecksumWriter(std::shared_ptr<common::Writer> writer, MemoryMan
 void ChecksumWriter::write(const uint8_t* data, uint64_t size) {
     KU_ASSERT(currentEntrySize.has_value());
     KU_ASSERT(*currentEntrySize + size <= ENTRY_BUFFER_SIZE);
-    std::memcpy(entryBuffer->getData(), data, size);
+    std::memcpy(entryBuffer->getData() + *currentEntrySize, data, size);
     *currentEntrySize += size;
 }
 

--- a/src/storage/wal/local_wal.cpp
+++ b/src/storage/wal/local_wal.cpp
@@ -3,7 +3,6 @@
 #include "binder/ddl/bound_alter_info.h"
 #include "catalog/catalog_entry/sequence_catalog_entry.h"
 #include "common/serializer/in_mem_file_writer.h"
-#include "common/serializer/serializer.h"
 #include "common/vector/value_vector.h"
 
 using namespace kuzu::catalog;
@@ -13,11 +12,8 @@ using namespace kuzu::binder;
 namespace kuzu {
 namespace storage {
 
-LocalWAL::LocalWAL(MemoryManager& mm) {
-    localWriter = std::make_shared<InMemFileWriter>(mm);
-    writer = std::make_shared<ChecksumWriter>(localWriter, mm);
-    serializer = std::make_unique<Serializer>(writer);
-}
+LocalWAL::LocalWAL(MemoryManager& mm)
+    : writer(std::make_shared<InMemFileWriter>(mm)), checksumWriter(writer, mm) {}
 
 void LocalWAL::logBeginTransaction() {
     BeginTransactionRecord walRecord;
@@ -93,6 +89,7 @@ void LocalWAL::logLoadExtension(std::string path) {
 // NOLINTNEXTLINE(readability-make-member-function-const): semantically non-const function.
 void LocalWAL::clear() {
     std::unique_lock lck{mtx};
+    checksumWriter.writer->clear();
     writer->clear();
 }
 
@@ -105,9 +102,8 @@ uint64_t LocalWAL::getSize() {
 void LocalWAL::addNewWALRecord(const WALRecord& walRecord) {
     std::unique_lock lck{mtx};
     KU_ASSERT(walRecord.type != WALRecordType::INVALID_RECORD);
-    writer->startEntry();
-    walRecord.serialize(*serializer);
-    writer->finishEntry();
+    walRecord.serialize(checksumWriter.serializer);
+    checksumWriter.writer->flush();
 }
 
 } // namespace storage

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -30,7 +30,7 @@ void WAL::logCommittedWAL(LocalWAL& localWAL, main::ClientContext* context) {
     }
     std::unique_lock lck{mtx};
     initWriter(context);
-    localWAL.localWriter->flush(*writer);
+    localWAL.writer->flush(*writer);
     flushAndSyncNoLock();
 }
 
@@ -52,7 +52,6 @@ void WAL::reset() {
     std::unique_lock lck{mtx};
     fileInfo.reset();
     writer.reset();
-    serializer.reset();
     vfs->removeFileIfExists(walPath);
 }
 
@@ -76,30 +75,29 @@ void WAL::initWriter(main::ClientContext* context) {
         context);
 
     writer = std::make_shared<BufferedFileWriter>(*fileInfo);
-    serializer = std::make_unique<Serializer>(writer);
+    checksumWriter.emplace(writer, *MemoryManager::Get(*context));
 
     // Write the databaseID at the start of the WAL if needed
     // This is used to ensure that when replaying the WAL matches the database
     if (fileInfo->getFileSize() == 0) {
-        FileDBIDUtils::writeDatabaseID(*serializer,
+        FileDBIDUtils::writeDatabaseID(checksumWriter->serializer,
             StorageManager::Get(*context)->getOrInitDatabaseID(*context));
+        checksumWriter->writer->flush();
     }
 
     // WAL should always be APPEND only. We don't want to overwrite the file as it may still
     // contain records not replayed. This can happen if checkpoint is not triggered before the
     // Database is closed last time.
     writer->setFileOffset(fileInfo->getFileSize());
-    checksumWriter = std::make_shared<ChecksumWriter>(writer, *MemoryManager::Get(*context));
-    serializer = std::make_unique<Serializer>(checksumWriter);
 }
 
 // NOLINTNEXTLINE(readability-make-member-function-const): semantically non-const function.
 void WAL::addNewWALRecordNoLock(const WALRecord& walRecord) {
     KU_ASSERT(walRecord.type != WALRecordType::INVALID_RECORD);
     KU_ASSERT(!inMemory);
-    checksumWriter->startEntry();
-    walRecord.serialize(*serializer);
-    checksumWriter->finishEntry();
+    KU_ASSERT(checksumWriter.has_value());
+    walRecord.serialize(checksumWriter->serializer);
+    checksumWriter->writer->flush();
 }
 
 WAL* WAL::Get(const main::ClientContext& context) {

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -89,7 +89,7 @@ void WAL::initWriter(main::ClientContext* context) {
     // contain records not replayed. This can happen if checkpoint is not triggered before the
     // Database is closed last time.
     writer->setFileOffset(fileInfo->getFileSize());
-    checksumWriter = std::make_shared<ChecksumWriter>(writer, MemoryManager::Get(*context));
+    checksumWriter = std::make_shared<ChecksumWriter>(writer, *MemoryManager::Get(*context));
     serializer = std::make_unique<Serializer>(checksumWriter);
 }
 

--- a/src/storage/wal/wal_record.cpp
+++ b/src/storage/wal/wal_record.cpp
@@ -6,6 +6,7 @@
 #include "common/serializer/serializer.h"
 #include "main/client_context.h"
 #include "storage/buffer_manager/memory_manager.h"
+#include "storage/wal/checksum_reader.h"
 
 using namespace kuzu::common;
 using namespace kuzu::binder;
@@ -20,6 +21,8 @@ void WALRecord::serialize(Serializer& serializer) const {
 
 std::unique_ptr<WALRecord> WALRecord::deserialize(Deserializer& deserializer,
     const main::ClientContext& clientContext) {
+    auto* checksumReader = deserializer.getReader()->cast<ChecksumReader>();
+    checksumReader->startEntry();
     std::string key;
     auto type = WALRecordType::INVALID_RECORD;
     deserializer.validateDebuggingInfo(key, "type");
@@ -79,6 +82,7 @@ std::unique_ptr<WALRecord> WALRecord::deserialize(Deserializer& deserializer,
     }
     }
     walRecord->type = type;
+    checksumReader->finishEntry();
     return walRecord;
 }
 

--- a/src/storage/wal/wal_record.cpp
+++ b/src/storage/wal/wal_record.cpp
@@ -20,9 +20,8 @@ void WALRecord::serialize(Serializer& serializer) const {
 }
 
 std::unique_ptr<WALRecord> WALRecord::deserialize(Deserializer& deserializer,
-    const main::ClientContext& clientContext) {
+    const main::ClientContext& clientContext, std::string_view checksumMismatchMessage) {
     auto* checksumReader = deserializer.getReader()->cast<ChecksumReader>();
-    checksumReader->startEntry();
     std::string key;
     auto type = WALRecordType::INVALID_RECORD;
     deserializer.validateDebuggingInfo(key, "type");
@@ -82,7 +81,7 @@ std::unique_ptr<WALRecord> WALRecord::deserialize(Deserializer& deserializer,
     }
     }
     walRecord->type = type;
-    checksumReader->finishEntry();
+    checksumReader->finishEntry(checksumMismatchMessage);
     return walRecord;
 }
 

--- a/src/storage/wal/wal_replayer.cpp
+++ b/src/storage/wal/wal_replayer.cpp
@@ -131,13 +131,19 @@ WALReplayer::WALReplayInfo WALReplayer::dryReplay(FileInfo& fileInfo) const {
                 // If we reach a checkpoint record, we can stop replaying.
                 isLastRecordCheckpoint = true;
                 finishedDeserializing = true;
-                offsetDeserialized =
-                    deserializer.getReader()->cast<BufferedFileReader>()->getReadOffset();
+                offsetDeserialized = deserializer.getReader()
+                                         ->cast<ChecksumReader>()
+                                         ->getReader()
+                                         ->cast<BufferedFileReader>()
+                                         ->getReadOffset();
             } break;
             case WALRecordType::COMMIT_RECORD: {
                 // Update the offset to the end of the last commit record.
-                offsetDeserialized =
-                    deserializer.getReader()->cast<BufferedFileReader>()->getReadOffset();
+                offsetDeserialized = deserializer.getReader()
+                                         ->cast<ChecksumReader>()
+                                         ->getReader()
+                                         ->cast<BufferedFileReader>()
+                                         ->getReadOffset();
             } break;
             default: {
                 // DO NOTHING.

--- a/tools/shell/shell_runner.cpp
+++ b/tools/shell/shell_runner.cpp
@@ -70,6 +70,10 @@ int main(int argc, char* argv[]) {
     args::Flag stats(parser, "no_stats", "Disable query stats", {'s', "no_stats", "nostats"});
     args::Flag progress_bar(parser, "no_progress_bar", "Disable query progress bar",
         {'b', "no_progress_bar", "noprogressbar"});
+    args::Flag ignore_wal_replay_errors(parser, "ignore_wal_replay_errors",
+        "By default something goes wrong when replaying the WAL an exception will be thrown. With "
+        "this flag enabled we will instead ignore these errors and stop replaying the WAL.",
+        {'w', "ignore_wal_replay_errors"});
     args::ValueFlag<std::string> init(parser, "", "Path to file with script to run on startup",
         {'i', "init"});
 
@@ -113,6 +117,7 @@ int main(int argc, char* argv[]) {
     }
     SystemConfig systemConfig(bpSizeInBytes);
     uint64_t maxDBSizeInBytes = args::get(maxDBSize);
+    bool ignoreWalErrors = args::get(ignore_wal_replay_errors);
     if (maxDBSizeInBytes != -1u) {
         systemConfig.maxDBSize = maxDBSizeInBytes;
     }
@@ -121,6 +126,9 @@ int main(int argc, char* argv[]) {
     }
     if (readOnlyMode) {
         systemConfig.readOnly = true;
+    }
+    if (ignoreWalErrors) {
+        systemConfig.throwOnWalReplayFailure = false;
     }
 
     const std::string historyFile = "history.txt";

--- a/tools/shell/test/test_shell_flags.py
+++ b/tools/shell/test/test_shell_flags.py
@@ -562,6 +562,25 @@ def test_no_progress_bar(temp_db, flag) -> None:
 
 @pytest.mark.parametrize(
     "flag",
+    ["-w", "--ignore_wal_replay_errors"],
+)
+def test_ignore_wal_replay_errors(temp_db, flag) -> None:
+    # create garbage WAL file
+    with open(temp_db + ".wal", "w") as wal_file:
+        wal_file.write("abcdefghijklmnopqrstuvwxyz")
+    test = ShellTest().add_argument(temp_db)
+    result = test.run()
+    result.check_stderr("Storage exception")
+
+    with open(temp_db + ".wal", "w") as wal_file:
+        wal_file.write("abcdefghijklmnopqrstuvwxyz")
+    test = ShellTest().add_argument(temp_db).add_argument(flag).statement("RETURN 1")
+    result = test.run()
+    result.check_stdout("1")
+
+
+@pytest.mark.parametrize(
+    "flag",
     [
         "-i",
         "--init",


### PR DESCRIPTION
# Description

Add checksums to each individual record of the WAL, which we check against when replaying the WAL. This is done by making WAL reads/writes go through the new classes `ChecksumReader/Writer`. The functions `startEntry()`/`finishEntry()` are called before/after processing a WAL record, after which a buffer containing the accumulated serialized record in the reader/writer will be used to calculate the checksum.

## Performance

I also did a quick microbenchmark to get a feel for the performance impact of adding the checksum on replaying a transaction.

**Transaction:**

```
with kuzu.Database(tempdir + "/db.kz") as db, kuzu.Connection(db) as conn:
        conn.execute("call force_checkpoint_on_close=false")
        conn.execute("call auto_checkpoint=false")
        conn.execute("begin transaction")
        conn.execute("create node table nodes(id int64 primary key)")
        conn.execute("create rel table edges(from nodes to nodes)")

        NUM_NODES = 1000000
        conn.execute(f"unwind range(1, {NUM_NODES}) as i create (nodes{{id: i}})")
        conn.execute("commit")
```

|Branch|Average transaction execution time|Average replay time|
|--|--|--|
master|2.87s|2.40s
new|2.95s|2.54s

Average replay time on master: 1.23s
Average replay time on new branch: 1.34s

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
