### PR TITLE
Add configuration to disable checksumming

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -195,6 +195,12 @@ jobs:
         run: |
           make test
 
+      - name: Test with checksums disabled
+        env:
+          ENABLE_CHECKSUMS: false
+        run: |
+          make test
+
       - name: Ensure Python dependencies
         run: pip install --user -r tools/python_api/requirements_dev.txt
 
@@ -1008,12 +1014,6 @@ jobs:
           # or any tests that serializing debugging info would make too slow
           # also skip FSM-related tests as the debugging info can mess with database sizes
           GTEST_FILTER: "*~*-*binary_demo*:*hash_leak*:*Reclaim*"
-        run: |
-          make test
-
-      - name: Test with checksums disabled
-        env:
-          ENABLE_CHECKSUMS: false
         run: |
           make test
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1011,6 +1011,12 @@ jobs:
         run: |
           make test
 
+      - name: Test with checksums disabled
+        env:
+          ENABLE_CHECKSUMS: false
+        run: |
+          make test
+
       - name: C and C++ Examples
         run: |
           ulimit -n 10240

--- a/src/include/common/serializer/reader.h
+++ b/src/include/common/serializer/reader.h
@@ -13,6 +13,7 @@ public:
     virtual ~Reader() = default;
 
     virtual bool finished() = 0;
+    virtual void onObjectBegin() {};
     virtual void onObjectEnd() {};
 
     template<typename TARGET>

--- a/src/include/common/serializer/reader.h
+++ b/src/include/common/serializer/reader.h
@@ -13,6 +13,7 @@ public:
     virtual ~Reader() = default;
 
     virtual bool finished() = 0;
+    virtual void onObjectEnd() {};
 
     template<typename TARGET>
     TARGET* cast() {

--- a/src/include/common/serializer/serializer.h
+++ b/src/include/common/serializer/serializer.h
@@ -113,6 +113,8 @@ public:
         }
     }
 
+    Writer* getWriter() const { return writer.get(); }
+
 private:
     std::shared_ptr<Writer> writer;
 };

--- a/src/include/common/serializer/writer.h
+++ b/src/include/common/serializer/writer.h
@@ -15,6 +15,7 @@ public:
     virtual void clear() = 0;
     virtual void flush() = 0;
     virtual void sync() = 0;
+    virtual void onObjectEnd() {};
 
     template<class TARGET>
     const TARGET& cast() const {

--- a/src/include/common/serializer/writer.h
+++ b/src/include/common/serializer/writer.h
@@ -15,6 +15,7 @@ public:
     virtual void clear() = 0;
     virtual void flush() = 0;
     virtual void sync() = 0;
+    virtual void onObjectBegin() {};
     virtual void onObjectEnd() {};
 
     template<class TARGET>

--- a/src/include/common/type_utils.h
+++ b/src/include/common/type_utils.h
@@ -46,8 +46,6 @@ public:
             return val;
         } else if constexpr (std::is_same_v<T, ku_string_t>) {
             return val.getAsString();
-        } else if constexpr (std::is_same_v<T, bool>) {
-            return val ? "true" : "false";
         } else {
             static_assert(std::is_same<T, int64_t>::value || std::is_same<T, int32_t>::value ||
                           std::is_same<T, int16_t>::value || std::is_same<T, int8_t>::value ||

--- a/src/include/common/type_utils.h
+++ b/src/include/common/type_utils.h
@@ -46,6 +46,8 @@ public:
             return val;
         } else if constexpr (std::is_same_v<T, ku_string_t>) {
             return val.getAsString();
+        } else if constexpr (std::is_same_v<T, bool>) {
+            return val ? "true" : "false";
         } else {
             static_assert(std::is_same<T, int64_t>::value || std::is_same<T, int32_t>::value ||
                           std::is_same<T, int16_t>::value || std::is_same<T, int8_t>::value ||

--- a/src/include/main/database.h
+++ b/src/include/main/database.h
@@ -57,11 +57,17 @@ struct KUZU_API SystemConfig {
      * @param checkpointThreshold The threshold of the WAL file size in bytes. When the size of the
      * WAL file exceeds this threshold, the database will checkpoint if autoCheckpoint is true.
      * @param forceCheckpointOnClose If true, the database will force checkpoint when closing.
+     * @param throwOnWalReplayFailure If true, any WAL replaying failure when loading the database
+     * will throw an error. Otherwise, Kuzu will silently ignore the failure and replay up to where
+     * the error occured.
+     * @param enableChecksums If true, the database will use checksums to detect corruption in the
+     * WAL file.
      */
     explicit SystemConfig(uint64_t bufferPoolSize = -1u, uint64_t maxNumThreads = 0,
         bool enableCompression = true, bool readOnly = false, uint64_t maxDBSize = -1u,
         bool autoCheckpoint = true, uint64_t checkpointThreshold = 16777216 /* 16MB */,
-        bool forceCheckpointOnClose = true, bool throwOnWalReplayFailure = true
+        bool forceCheckpointOnClose = true, bool throwOnWalReplayFailure = true,
+        bool enableChecksums = true
 #if defined(__APPLE__)
         ,
         uint32_t threadQos = QOS_CLASS_DEFAULT
@@ -77,6 +83,7 @@ struct KUZU_API SystemConfig {
     uint64_t checkpointThreshold;
     bool forceCheckpointOnClose;
     bool throwOnWalReplayFailure;
+    bool enableChecksums;
 #if defined(__APPLE__)
     uint32_t threadQos;
 #endif

--- a/src/include/main/db_config.h
+++ b/src/include/main/db_config.h
@@ -64,6 +64,7 @@ struct DBConfig {
     uint64_t checkpointThreshold;
     bool forceCheckpointOnClose;
     bool throwOnWalReplayFailure;
+    bool enableChecksums;
     bool enableSpillingToDisk;
 #if defined(__APPLE__)
     uint32_t threadQos;

--- a/src/include/storage/storage_manager.h
+++ b/src/include/storage/storage_manager.h
@@ -28,13 +28,14 @@ struct DatabaseHeader;
 
 class KUZU_API StorageManager {
 public:
-    StorageManager(const std::string& databasePath, bool readOnly, MemoryManager& memoryManager,
-        bool enableCompression, common::VirtualFileSystem* vfs);
+    StorageManager(const std::string& databasePath, bool readOnly, bool enableChecksums,
+        MemoryManager& memoryManager, bool enableCompression, common::VirtualFileSystem* vfs);
     ~StorageManager();
 
     Table* getTable(common::table_id_t tableID);
 
-    static void recover(main::ClientContext& clientContext, bool throwOnWalReplayFailure);
+    static void recover(main::ClientContext& clientContext, bool throwOnWalReplayFailure,
+        bool enableChecksums);
 
     void createTable(catalog::TableCatalogEntry* entry);
     void addRelTable(catalog::RelGroupCatalogEntry* entry,

--- a/src/include/storage/wal/checksum_reader.h
+++ b/src/include/storage/wal/checksum_reader.h
@@ -10,7 +10,8 @@ namespace kuzu {
 namespace storage {
 class ChecksumReader : public common::Reader {
 public:
-    explicit ChecksumReader(common::FileInfo& fileInfo, MemoryManager& memoryManager);
+    explicit ChecksumReader(common::FileInfo& fileInfo, MemoryManager& memoryManager,
+        std::string_view checksumMismatchMessage);
 
     void read(uint8_t* data, uint64_t size) override;
     bool finished() override;
@@ -18,7 +19,7 @@ public:
     // Reads the stored checksum
     // Also computes + verifies the checksum for the entry that has just been read against the
     // stored value
-    void finishEntry(std::string_view checksumMismatchMessage);
+    void onObjectEnd() override;
 
     uint64_t getReadOffset() const;
 
@@ -27,6 +28,8 @@ private:
 
     uint64_t currentEntrySize;
     std::unique_ptr<MemoryBuffer> entryBuffer;
+
+    std::string_view checksumMismatchMessage;
 };
 } // namespace storage
 } // namespace kuzu

--- a/src/include/storage/wal/checksum_reader.h
+++ b/src/include/storage/wal/checksum_reader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 
 #include "common/serializer/deserializer.h"
 #include "common/serializer/reader.h"
@@ -16,6 +17,7 @@ public:
     void read(uint8_t* data, uint64_t size) override;
     bool finished() override;
 
+    void onObjectBegin() override;
     // Reads the stored checksum
     // Also computes + verifies the checksum for the entry that has just been read against the
     // stored value
@@ -26,7 +28,7 @@ public:
 private:
     common::Deserializer deserializer;
 
-    uint64_t currentEntrySize;
+    std::optional<uint64_t> currentEntrySize;
     std::unique_ptr<MemoryBuffer> entryBuffer;
 
     std::string_view checksumMismatchMessage;

--- a/src/include/storage/wal/checksum_writer.h
+++ b/src/include/storage/wal/checksum_writer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 
 #include "common/serializer/serializer.h"
 #include "common/serializer/writer.h"
@@ -25,12 +26,13 @@ public:
 
     void flush() override;
 
+    void onObjectBegin() override;
     // Calculate checksum + write the checksum + serialized contents to underlying writer
     void onObjectEnd() override;
 
 private:
     common::Serializer outputSerializer;
-    uint64_t currentEntrySize;
+    std::optional<uint64_t> currentEntrySize;
     std::unique_ptr<MemoryBuffer> entryBuffer;
 };
 

--- a/src/include/storage/wal/checksum_writer.h
+++ b/src/include/storage/wal/checksum_writer.h
@@ -10,13 +10,6 @@ namespace kuzu {
 namespace storage {
 class ChecksumWriter;
 
-struct ChecksumSerializer {
-    ChecksumSerializer(std::shared_ptr<common::Writer> outputWriter, MemoryManager& memoryManager);
-
-    std::shared_ptr<ChecksumWriter> writer;
-    common::Serializer serializer;
-};
-
 // A wrapper on top of another Writer that accumulates serialized data
 // Then flushes that data (along with a computed checksum) when the data has completed serializing
 class ChecksumWriter : public common::Writer {
@@ -30,8 +23,10 @@ public:
     void clear() override;
     void sync() override;
 
-    // Calculate checksum + write the checksum + serialized contents to underlying writer
     void flush() override;
+
+    // Calculate checksum + write the checksum + serialized contents to underlying writer
+    void onObjectEnd() override;
 
 private:
     common::Serializer outputSerializer;

--- a/src/include/storage/wal/local_wal.h
+++ b/src/include/storage/wal/local_wal.h
@@ -51,9 +51,6 @@ public:
     uint64_t getSize();
 
 private:
-    explicit LocalWAL(std::shared_ptr<common::Writer> writer);
-    explicit LocalWAL(std::shared_ptr<common::Writer> fileWriter, bool enableChecksums);
-
     void addNewWALRecord(const WALRecord& walRecord);
 
 private:

--- a/src/include/storage/wal/local_wal.h
+++ b/src/include/storage/wal/local_wal.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "storage/wal/checksum_writer.h"
 #include "storage/wal/wal_record.h"
 
 namespace kuzu {

--- a/src/include/storage/wal/local_wal.h
+++ b/src/include/storage/wal/local_wal.h
@@ -21,7 +21,7 @@ class LocalWAL {
     friend class WAL;
 
 public:
-    explicit LocalWAL(MemoryManager& mm);
+    explicit LocalWAL(MemoryManager& mm, bool enableChecksums);
 
     void logCreateCatalogEntryRecord(catalog::CatalogEntry* catalogEntry, bool isInternal);
     void logDropCatalogEntryRecord(uint64_t tableID, catalog::CatalogEntryType type);
@@ -51,12 +51,15 @@ public:
     uint64_t getSize();
 
 private:
+    explicit LocalWAL(std::shared_ptr<common::Writer> writer);
+    explicit LocalWAL(std::shared_ptr<common::Writer> fileWriter, bool enableChecksums);
+
     void addNewWALRecord(const WALRecord& walRecord);
 
 private:
     std::mutex mtx;
-    std::shared_ptr<common::InMemFileWriter> writer;
-    ChecksumSerializer checksumWriter;
+    std::shared_ptr<common::InMemFileWriter> inMemWriter;
+    common::Serializer serializer;
 };
 
 } // namespace storage

--- a/src/include/storage/wal/wal.h
+++ b/src/include/storage/wal/wal.h
@@ -32,6 +32,7 @@ private:
     void initWriter(main::ClientContext* context);
     void addNewWALRecordNoLock(const WALRecord& walRecord);
     void flushAndSyncNoLock();
+    void writeHeader(main::ClientContext& context);
 
 private:
     std::mutex mtx;

--- a/src/include/storage/wal/wal.h
+++ b/src/include/storage/wal/wal.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "storage/wal/checksum_writer.h"
 #include "storage/wal/wal_record.h"
 
 namespace kuzu {
@@ -13,7 +12,8 @@ namespace storage {
 class LocalWAL;
 class WAL {
 public:
-    WAL(const std::string& dbPath, bool readOnly, common::VirtualFileSystem* vfs);
+    WAL(const std::string& dbPath, bool readOnly, bool enableChecksums,
+        common::VirtualFileSystem* vfs);
     ~WAL();
 
     void logCommittedWAL(LocalWAL& localWAL, main::ClientContext* context);
@@ -44,8 +44,8 @@ private:
     // Since most writes to the shared WAL will be flushing local WAL (which has its own checksums),
     // these writes can go through the normal writer. We do still need a checksum writer though for
     // writing COMMIT/CHECKPOINT records
-    std::shared_ptr<common::BufferedFileWriter> writer;
-    std::optional<ChecksumSerializer> checksumWriter;
+    std::unique_ptr<common::Serializer> serializer;
+    bool enableChecksums;
 };
 
 } // namespace storage

--- a/src/include/storage/wal/wal_record.h
+++ b/src/include/storage/wal/wal_record.h
@@ -7,6 +7,7 @@
 #include "catalog/catalog_entry/sequence_catalog_entry.h"
 #include "common/enums/rel_direction.h"
 #include "common/enums/table_type.h"
+#include "common/types/uuid.h"
 #include "common/vector/value_vector.h"
 
 namespace kuzu {
@@ -40,6 +41,11 @@ enum class WALRecordType : uint8_t {
     CHECKPOINT_RECORD = 254,
 };
 
+struct WALHeader {
+    common::ku_uuid_t databaseID;
+    bool enableChecksums;
+};
+
 struct WALRecord {
     WALRecordType type = WALRecordType::INVALID_RECORD;
 
@@ -50,7 +56,7 @@ struct WALRecord {
 
     virtual void serialize(common::Serializer& serializer) const;
     static std::unique_ptr<WALRecord> deserialize(common::Deserializer& deserializer,
-        const main::ClientContext& clientContext, std::string_view checksumMismatchMessage);
+        const main::ClientContext& clientContext);
 
     template<class TARGET>
     const TARGET& constCast() const {

--- a/src/include/storage/wal/wal_replayer.h
+++ b/src/include/storage/wal/wal_replayer.h
@@ -12,7 +12,7 @@ class WALReplayer {
 public:
     explicit WALReplayer(main::ClientContext& clientContext);
 
-    void replay(bool throwOnWalReplayFailure) const;
+    void replay(bool throwOnWalReplayFailure, bool enableChecksums) const;
 
 private:
     struct WALReplayInfo {
@@ -40,7 +40,8 @@ private:
 
     // This function is used to deserialize the WAL records without actually applying them to the
     // storage.
-    WALReplayInfo dryReplay(common::FileInfo& fileInfo, bool throwOnWalReplayFailure) const;
+    WALReplayInfo dryReplay(common::FileInfo& fileInfo, bool throwOnWalReplayFailure,
+        bool enableChecksums) const;
 
     void removeWALAndShadowFiles() const;
     void removeFileIfExists(const std::string& path) const;

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -53,7 +53,7 @@ AttachedKuzuDatabase::AttachedKuzuDatabase(std::string dbPath, std::string dbNam
     catalog = std::make_unique<catalog::Catalog>();
     validateEmptyWAL(path, clientContext);
     storageManager = std::make_unique<storage::StorageManager>(path, true /* isReadOnly */,
-        *storage::MemoryManager::Get(*clientContext),
+        clientContext->getDBConfig()->enableChecksums, *storage::MemoryManager::Get(*clientContext),
         clientContext->getDBConfig()->enableCompression, vfs);
     transactionManager =
         std::make_unique<transaction::TransactionManager>(storageManager->getWAL());

--- a/src/main/db_config.cpp
+++ b/src/main/db_config.cpp
@@ -31,7 +31,8 @@ DBConfig::DBConfig(const SystemConfig& systemConfig)
       autoCheckpoint{systemConfig.autoCheckpoint},
       checkpointThreshold{systemConfig.checkpointThreshold},
       forceCheckpointOnClose{systemConfig.forceCheckpointOnClose},
-      throwOnWalReplayFailure(systemConfig.throwOnWalReplayFailure), enableSpillingToDisk{true} {
+      throwOnWalReplayFailure(systemConfig.throwOnWalReplayFailure),
+      enableChecksums(systemConfig.enableChecksums), enableSpillingToDisk{true} {
 #if defined(__APPLE__)
     this->threadQos = systemConfig.threadQos;
 #endif

--- a/src/storage/wal/checksum_reader.cpp
+++ b/src/storage/wal/checksum_reader.cpp
@@ -13,7 +13,7 @@ static constexpr uint64_t INITIAL_BUFFER_SIZE = common::KUZU_PAGE_SIZE;
 
 ChecksumReader::ChecksumReader(common::FileInfo& fileInfo, MemoryManager& memoryManager,
     std::string_view checksumMismatchMessage)
-    : deserializer(std::make_unique<common::BufferedFileReader>(fileInfo)), currentEntrySize(0),
+    : deserializer(std::make_unique<common::BufferedFileReader>(fileInfo)),
       entryBuffer(memoryManager.allocateBuffer(false, INITIAL_BUFFER_SIZE)),
       checksumMismatchMessage(checksumMismatchMessage) {}
 

--- a/src/storage/wal/checksum_writer.cpp
+++ b/src/storage/wal/checksum_writer.cpp
@@ -11,7 +11,7 @@ static constexpr uint64_t INITIAL_BUFFER_SIZE = common::KUZU_PAGE_SIZE;
 
 ChecksumWriter::ChecksumWriter(std::shared_ptr<common::Writer> outputWriter,
     MemoryManager& memoryManager)
-    : outputSerializer(std::move(outputWriter)), currentEntrySize(0),
+    : outputSerializer(std::move(outputWriter)),
       entryBuffer(memoryManager.allocateBuffer(false, INITIAL_BUFFER_SIZE)) {}
 
 static void resizeBufferIfNeeded(std::unique_ptr<MemoryBuffer>& entryBuffer,

--- a/src/storage/wal/local_wal.cpp
+++ b/src/storage/wal/local_wal.cpp
@@ -103,6 +103,7 @@ uint64_t LocalWAL::getSize() {
 void LocalWAL::addNewWALRecord(const WALRecord& walRecord) {
     std::unique_lock lck{mtx};
     KU_ASSERT(walRecord.type != WALRecordType::INVALID_RECORD);
+    serializer.getWriter()->onObjectBegin();
     walRecord.serialize(serializer);
     serializer.getWriter()->onObjectEnd();
 }

--- a/src/storage/wal/local_wal.cpp
+++ b/src/storage/wal/local_wal.cpp
@@ -14,8 +14,8 @@ namespace storage {
 
 LocalWAL::LocalWAL(MemoryManager& mm, bool enableChecksums)
     : inMemWriter(std::make_shared<InMemFileWriter>(mm)),
-      serializer(enableChecksums ? std::static_pointer_cast<Writer>(inMemWriter) :
-                                   std::make_shared<ChecksumWriter>(inMemWriter, mm)) {}
+      serializer(enableChecksums ? std::make_shared<ChecksumWriter>(inMemWriter, mm) :
+                                   std::static_pointer_cast<Writer>(inMemWriter)) {}
 
 void LocalWAL::logBeginTransaction() {
     BeginTransactionRecord walRecord;

--- a/src/storage/wal/local_wal.cpp
+++ b/src/storage/wal/local_wal.cpp
@@ -12,16 +12,10 @@ using namespace kuzu::binder;
 namespace kuzu {
 namespace storage {
 
-LocalWAL::LocalWAL(std::shared_ptr<common::Writer> writer) : serializer(std::move(writer)) {}
-
-LocalWAL::LocalWAL(std::shared_ptr<common::Writer> fileWriter, bool enableChecksums)
-    : LocalWAL(
-          enableChecksums ? std::make_shared<ChecksumWriter>(fileWriter) : std::move(fileWriter)) {}
-
 LocalWAL::LocalWAL(MemoryManager& mm, bool enableChecksums)
     : inMemWriter(std::make_shared<InMemFileWriter>(mm)),
       serializer(enableChecksums ? std::static_pointer_cast<Writer>(inMemWriter) :
-                                   std::make_shared<ChecksumWriter>(inMemWriter)) {}
+                                   std::make_shared<ChecksumWriter>(inMemWriter, mm)) {}
 
 void LocalWAL::logBeginTransaction() {
     BeginTransactionRecord walRecord;

--- a/src/storage/wal/local_wal.cpp
+++ b/src/storage/wal/local_wal.cpp
@@ -4,6 +4,7 @@
 #include "catalog/catalog_entry/sequence_catalog_entry.h"
 #include "common/serializer/in_mem_file_writer.h"
 #include "common/vector/value_vector.h"
+#include "storage/wal/checksum_writer.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -10,6 +10,7 @@
 #include "storage/file_db_id_utils.h"
 #include "storage/storage_manager.h"
 #include "storage/storage_utils.h"
+#include "storage/wal/checksum_writer.h"
 #include "storage/wal/local_wal.h"
 
 using namespace kuzu::common;

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -17,9 +17,10 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace storage {
 
-WAL::WAL(const std::string& dbPath, bool readOnly, VirtualFileSystem* vfs)
+WAL::WAL(const std::string& dbPath, bool readOnly, bool enableChecksums, VirtualFileSystem* vfs)
     : walPath{StorageUtils::getWALFilePath(dbPath)},
-      inMemory{main::DBConfig::isDBPathInMemory(dbPath)}, readOnly{readOnly}, vfs{vfs} {}
+      inMemory{main::DBConfig::isDBPathInMemory(dbPath)}, readOnly{readOnly}, vfs{vfs},
+      enableChecksums(enableChecksums) {}
 
 WAL::~WAL() {}
 
@@ -30,7 +31,7 @@ void WAL::logCommittedWAL(LocalWAL& localWAL, main::ClientContext* context) {
     }
     std::unique_lock lck{mtx};
     initWriter(context);
-    localWAL.writer->flush(*writer);
+    localWAL.inMemWriter->flush(*serializer->getWriter());
     flushAndSyncNoLock();
 }
 
@@ -45,59 +46,63 @@ void WAL::logAndFlushCheckpoint(main::ClientContext* context) {
 // NOLINTNEXTLINE(readability-make-member-function-const): semantically non-const function.
 void WAL::clear() {
     std::unique_lock lck{mtx};
-    writer->clear();
+    serializer->getWriter()->clear();
 }
 
 void WAL::reset() {
     std::unique_lock lck{mtx};
     fileInfo.reset();
-    writer.reset();
+    serializer.reset();
     vfs->removeFileIfExists(walPath);
 }
 
 // NOLINTNEXTLINE(readability-make-member-function-const): semantically non-const function.
 void WAL::flushAndSyncNoLock() {
-    writer->flush();
-    writer->sync();
+    serializer->getWriter()->flush();
+    serializer->getWriter()->sync();
 }
 
 uint64_t WAL::getFileSize() {
     std::unique_lock lck{mtx};
-    return writer->getSize();
+    return serializer->getWriter()->getSize();
 }
 
 void WAL::initWriter(main::ClientContext* context) {
-    if (writer) {
+    if (serializer) {
         return;
     }
     fileInfo = vfs->openFile(walPath,
         FileOpenFlags(FileFlags::CREATE_IF_NOT_EXISTS | FileFlags::READ_ONLY | FileFlags::WRITE),
         context);
 
-    writer = std::make_shared<BufferedFileWriter>(*fileInfo);
-    checksumWriter.emplace(writer, *MemoryManager::Get(*context));
+    std::shared_ptr<Writer> writer = std::make_shared<BufferedFileWriter>(*fileInfo);
+    auto& bufferedWriter = writer->cast<BufferedFileWriter>();
+    if (enableChecksums) {
+        writer = std::make_shared<ChecksumWriter>(std::move(writer), *MemoryManager::Get(*context));
+    }
+    serializer = std::make_unique<Serializer>(std::move(writer));
 
     // Write the databaseID at the start of the WAL if needed
     // This is used to ensure that when replaying the WAL matches the database
     if (fileInfo->getFileSize() == 0) {
-        FileDBIDUtils::writeDatabaseID(checksumWriter->serializer,
+        FileDBIDUtils::writeDatabaseID(*serializer,
             StorageManager::Get(*context)->getOrInitDatabaseID(*context));
-        checksumWriter->writer->flush();
+        serializer->getWriter()->onObjectEnd();
     }
 
     // WAL should always be APPEND only. We don't want to overwrite the file as it may still
     // contain records not replayed. This can happen if checkpoint is not triggered before the
     // Database is closed last time.
-    writer->setFileOffset(fileInfo->getFileSize());
+    bufferedWriter.setFileOffset(fileInfo->getFileSize());
 }
 
 // NOLINTNEXTLINE(readability-make-member-function-const): semantically non-const function.
 void WAL::addNewWALRecordNoLock(const WALRecord& walRecord) {
     KU_ASSERT(walRecord.type != WALRecordType::INVALID_RECORD);
     KU_ASSERT(!inMemory);
-    KU_ASSERT(checksumWriter.has_value());
-    walRecord.serialize(checksumWriter->serializer);
-    checksumWriter->writer->flush();
+    KU_ASSERT(serializer != nullptr);
+    walRecord.serialize(*serializer);
+    serializer->getWriter()->onObjectEnd();
 }
 
 WAL* WAL::Get(const main::ClientContext& context) {

--- a/src/storage/wal/wal_record.cpp
+++ b/src/storage/wal/wal_record.cpp
@@ -22,6 +22,7 @@ std::unique_ptr<WALRecord> WALRecord::deserialize(Deserializer& deserializer,
     const main::ClientContext& clientContext) {
     std::string key;
     auto type = WALRecordType::INVALID_RECORD;
+    deserializer.getReader()->onObjectBegin();
     deserializer.validateDebuggingInfo(key, "type");
     deserializer.deserializeValue(type);
     std::unique_ptr<WALRecord> walRecord;

--- a/src/storage/wal/wal_record.cpp
+++ b/src/storage/wal/wal_record.cpp
@@ -6,7 +6,6 @@
 #include "common/serializer/serializer.h"
 #include "main/client_context.h"
 #include "storage/buffer_manager/memory_manager.h"
-#include "storage/wal/checksum_reader.h"
 
 using namespace kuzu::common;
 using namespace kuzu::binder;
@@ -20,8 +19,7 @@ void WALRecord::serialize(Serializer& serializer) const {
 }
 
 std::unique_ptr<WALRecord> WALRecord::deserialize(Deserializer& deserializer,
-    const main::ClientContext& clientContext, std::string_view checksumMismatchMessage) {
-    auto* checksumReader = deserializer.getReader()->cast<ChecksumReader>();
+    const main::ClientContext& clientContext) {
     std::string key;
     auto type = WALRecordType::INVALID_RECORD;
     deserializer.validateDebuggingInfo(key, "type");
@@ -81,7 +79,7 @@ std::unique_ptr<WALRecord> WALRecord::deserialize(Deserializer& deserializer,
     }
     }
     walRecord->type = type;
-    checksumReader->finishEntry(checksumMismatchMessage);
+    deserializer.getReader()->onObjectEnd();
     return walRecord;
 }
 

--- a/src/storage/wal/wal_replayer.cpp
+++ b/src/storage/wal/wal_replayer.cpp
@@ -38,14 +38,43 @@ WALReplayer::WALReplayer(main::ClientContext& clientContext) : clientContext{cli
     shadowFilePath = StorageUtils::getShadowFilePath(clientContext.getDatabasePath());
 }
 
-static ku_uuid_t readDatabaseID(Deserializer& deserializer) {
-    ku_uuid_t walDatabaseID{};
-    deserializer.deserializeValue(walDatabaseID);
-    deserializer.getReader()->cast<ChecksumReader>()->finishEntry(checksumMismatchMessage);
-    return walDatabaseID;
+static WALHeader readWALHeader(Deserializer& deserializer) {
+    WALHeader header{};
+    deserializer.deserializeValue(header.databaseID);
+    deserializer.deserializeValue(header.enableChecksums);
+    deserializer.getReader()->onObjectEnd();
+    return header;
 }
 
-void WALReplayer::replay(bool throwOnWalReplayFailure) const {
+static Deserializer initDeserializer(FileInfo& fileInfo, main::ClientContext& clientContext,
+    bool enableChecksums) {
+    if (enableChecksums) {
+        return Deserializer{std::make_unique<ChecksumReader>(fileInfo,
+            *MemoryManager::Get(clientContext), checksumMismatchMessage)};
+    } else {
+        return Deserializer{std::make_unique<BufferedFileReader>(fileInfo)};
+    }
+}
+
+static void checkWALHeader(const WALHeader& header, bool enableChecksums) {
+    if (enableChecksums != header.enableChecksums) {
+        throw RuntimeException(stringFormat(
+            "The database you are trying to open was serialized with enableChecksums={} but you "
+            "are trying to open it with enableChecksums={}. Please open your database using the "
+            "correct enableChecksums config. If you wish to change this for you database, please "
+            "use the export/import functionality."));
+    }
+}
+
+static uint64_t getReadOffset(Deserializer& deSer, bool enableChecksums) {
+    if (enableChecksums) {
+        return deSer.getReader()->cast<ChecksumReader>()->getReadOffset();
+    } else {
+        return deSer.getReader()->cast<BufferedFileReader>()->getReadOffset();
+    }
+}
+
+void WALReplayer::replay(bool throwOnWalReplayFailure, bool enableChecksums) const {
     auto vfs = VirtualFileSystem::GetUnsafe(clientContext);
     Checkpointer checkpointer(clientContext);
     // First, check if the WAL file exists. If it does not, we can safely remove the shadow file.
@@ -73,7 +102,7 @@ void WALReplayer::replay(bool throwOnWalReplayFailure) const {
         // First, we dry run the replay to find out the offset of the last record that was
         // CHECKPOINT or COMMIT.
         auto [offsetDeserialized, isLastRecordCheckpoint] =
-            dryReplay(*fileInfo, throwOnWalReplayFailure);
+            dryReplay(*fileInfo, throwOnWalReplayFailure, enableChecksums);
         if (isLastRecordCheckpoint) {
             // If the last record is a checkpoint, we resume by replaying the shadow file.
             ShadowFile::replayShadowPageRecords(clientContext);
@@ -86,22 +115,21 @@ void WALReplayer::replay(bool throwOnWalReplayFailure) const {
             // Read the checkpointed data from the disk.
             checkpointer.readCheckpoint();
             // Resume by replaying the WAL file from the beginning until the last COMMIT record.
-            Deserializer deserializer(
-                std::make_unique<ChecksumReader>(*fileInfo, *MemoryManager::Get(clientContext)));
+            Deserializer deserializer = initDeserializer(*fileInfo, clientContext, enableChecksums);
 
             if (offsetDeserialized > 0) {
                 // Make sure the WAL file is for the current database
-                const auto walDatabaseID = readDatabaseID(deserializer);
+                const auto walHeader = readWALHeader(deserializer);
                 FileDBIDUtils::verifyDatabaseID(*fileInfo,
                     StorageManager::Get(clientContext)->getOrInitDatabaseID(clientContext),
-                    walDatabaseID);
+                    walHeader.databaseID);
+                checkWALHeader(walHeader, enableChecksums);
+                deserializer.getReader()->onObjectEnd();
             }
 
-            while (deserializer.getReader()->cast<ChecksumReader>()->getReadOffset() <
-                   offsetDeserialized) {
+            while (getReadOffset(deserializer, enableChecksums) < offsetDeserialized) {
                 KU_ASSERT(!deserializer.finished());
-                auto walRecord =
-                    WALRecord::deserialize(deserializer, clientContext, checksumMismatchMessage);
+                auto walRecord = WALRecord::deserialize(deserializer, clientContext);
                 replayWALRecord(*walRecord);
             }
             // After replaying all the records, we should truncate the WAL file to the last
@@ -120,21 +148,20 @@ void WALReplayer::replay(bool throwOnWalReplayFailure) const {
     }
 }
 
-WALReplayer::WALReplayInfo WALReplayer::dryReplay(FileInfo& fileInfo,
-    bool throwOnWalReplayFailure) const {
+WALReplayer::WALReplayInfo WALReplayer::dryReplay(FileInfo& fileInfo, bool throwOnWalReplayFailure,
+    bool enableChecksums) const {
     uint64_t offsetDeserialized = 0;
     bool isLastRecordCheckpoint = false;
     try {
-        Deserializer deserializer(
-            std::make_unique<ChecksumReader>(fileInfo, *MemoryManager::Get(clientContext)));
+        Deserializer deserializer = initDeserializer(fileInfo, clientContext, enableChecksums);
 
         // Skip the databaseID here, we'll verify it when we actually replay
-        readDatabaseID(deserializer);
+        readWALHeader(deserializer);
+        deserializer.getReader()->onObjectEnd();
 
         bool finishedDeserializing = deserializer.finished();
         while (!finishedDeserializing) {
-            auto walRecord =
-                WALRecord::deserialize(deserializer, clientContext, checksumMismatchMessage);
+            auto walRecord = WALRecord::deserialize(deserializer, clientContext);
             finishedDeserializing = deserializer.finished();
             switch (walRecord->type) {
             case WALRecordType::CHECKPOINT_RECORD: {
@@ -142,13 +169,11 @@ WALReplayer::WALReplayInfo WALReplayer::dryReplay(FileInfo& fileInfo,
                 // If we reach a checkpoint record, we can stop replaying.
                 isLastRecordCheckpoint = true;
                 finishedDeserializing = true;
-                offsetDeserialized =
-                    deserializer.getReader()->cast<ChecksumReader>()->getReadOffset();
+                offsetDeserialized = getReadOffset(deserializer, enableChecksums);
             } break;
             case WALRecordType::COMMIT_RECORD: {
                 // Update the offset to the end of the last commit record.
-                offsetDeserialized =
-                    deserializer.getReader()->cast<ChecksumReader>()->getReadOffset();
+                offsetDeserialized = getReadOffset(deserializer, enableChecksums);
             } break;
             default: {
                 // DO NOTHING.

--- a/src/storage/wal/wal_replayer.cpp
+++ b/src/storage/wal/wal_replayer.cpp
@@ -41,7 +41,13 @@ WALReplayer::WALReplayer(main::ClientContext& clientContext) : clientContext{cli
 static WALHeader readWALHeader(Deserializer& deserializer) {
     WALHeader header{};
     deserializer.deserializeValue(header.databaseID);
-    deserializer.deserializeValue(header.enableChecksums);
+
+    // It is possible to read a value other than 0/1 when deserializing the flag
+    // This causes some weird behaviours with some toolchains so we manually do the conversion here
+    uint8_t enableChecksumsBytes = 0;
+    deserializer.deserializeValue(enableChecksumsBytes);
+    header.enableChecksums = enableChecksumsBytes != 0;
+
     return header;
 }
 

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -32,7 +32,8 @@ Transaction::Transaction(main::ClientContext& clientContext, TransactionType tra
     localStorage = std::make_unique<storage::LocalStorage>(clientContext);
     undoBuffer = std::make_unique<storage::UndoBuffer>(storage::MemoryManager::Get(clientContext));
     currentTS = common::Timestamp::getCurrentTimestamp().value;
-    localWAL = std::make_unique<storage::LocalWAL>(*storage::MemoryManager::Get(clientContext));
+    localWAL = std::make_unique<storage::LocalWAL>(*storage::MemoryManager::Get(clientContext),
+        clientContext.getDBConfig()->enableChecksums);
 }
 
 Transaction::Transaction(TransactionType transactionType) noexcept

--- a/test/test_helper/test_helper.cpp
+++ b/test/test_helper/test_helper.cpp
@@ -93,6 +93,7 @@ std::unique_ptr<SystemConfig> TestHelper::getSystemConfigFromEnv() {
     auto enableCompressionEnv = getSystemEnv("ENABLE_COMPRESSION");
     auto checkpointThresholdEnv = getSystemEnv("CHECKPOINT_THRESHOLD");
     auto forceCheckpointOnCloseEnv = getSystemEnv("FORCE_CHECKPOINT_ON_CLOSE");
+    auto enableChecksumEnv = getSystemEnv("ENABLE_CHECKSUMS");
     auto maxDBSizeEnv = getSystemEnv("MAX_DB_SIZE");
     systemConfig->bufferPoolSize = bufferPoolSizeEnv.empty() ?
                                        DEFAULT_BUFFER_POOL_SIZE_FOR_TESTING :
@@ -109,6 +110,9 @@ std::unique_ptr<SystemConfig> TestHelper::getSystemConfigFromEnv() {
         forceCheckpointOnCloseEnv.empty() ?
             systemConfig->forceCheckpointOnClose :
             StringUtils::caseInsensitiveEquals(forceCheckpointOnCloseEnv, "true");
+    systemConfig->enableChecksums =
+        enableChecksumEnv.empty() ? systemConfig->enableChecksums :
+                                    StringUtils::caseInsensitiveEquals(enableChecksumEnv, "true");
     systemConfig->maxDBSize =
         maxDBSizeEnv.empty() ? systemConfig->maxDBSize : std::stoull(maxDBSizeEnv);
     return systemConfig;

--- a/test/transaction/wal_test.cpp
+++ b/test/transaction/wal_test.cpp
@@ -205,6 +205,22 @@ TEST_F(WalTest, CorruptedWALChecksumMismatchInBodyNoThrow) {
     EXPECT_STREQ("Binder exception: Table test does not exist.", result->getErrorMessage().c_str());
 }
 
+TEST_F(WalTest, WALChecksumConfigMismatch) {
+    if (inMemMode || systemConfig->checkpointThreshold == 0) {
+        GTEST_SKIP();
+    }
+    systemConfig->enableChecksums = false;
+    EXPECT_THROW(
+        {
+            try {
+                createDBAndConn();
+            } catch (std::exception& e) {
+                EXPECT_STREQ(e.what(), "");
+            }
+        },
+        kuzu::common::RuntimeException);
+}
+
 // Simulation of a corrupted WAL tail by truncating the WAL file. Note that in this case, there
 // would only be a single write transaction. This would cause the last wal record to be corrupted
 // and the database should ignore the last record when recovering.

--- a/tools/shell/test/test_shell_flags.py
+++ b/tools/shell/test/test_shell_flags.py
@@ -565,13 +565,20 @@ def test_no_progress_bar(temp_db, flag) -> None:
     ["-w", "--ignore_wal_replay_errors"],
 )
 def test_ignore_wal_replay_errors(temp_db, flag) -> None:
+    # Create an initial DB
+    test = ShellTest().add_argument(temp_db).statement("return 1")
+    result = test.run()
+
     # create garbage WAL file
     with open(temp_db + ".wal", "w") as wal_file:
         wal_file.write("abcdefghijklmnopqrstuvwxyz")
+
+    # Test with ignore_wal_replay_errors off
     test = ShellTest().add_argument(temp_db)
     result = test.run()
-    result.check_stderr("Storage exception")
+    result.check_stderr("Checksum verification failed")
 
+    # Test with ignore_wal_replay_errors on
     with open(temp_db + ".wal", "w") as wal_file:
         wal_file.write("abcdefghijklmnopqrstuvwxyz")
     test = ShellTest().add_argument(temp_db).add_argument(flag).statement("RETURN 1")


### PR DESCRIPTION
# Description

Since checksumming has a performance cost, users may want to disable this feature. This PR adds an `enableChecksums` config to the `SystemConfig`, currently only applies to the WAL. Additionally, when loading an existing DB, add a check to see if the `enableChecksums` config matches the config used to serialize the WAL file.

Currently, the default behaviour is for `enableChecksums=true`. This PR also adds a CI workflow that runs for `enableChecksums=false`.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
