### PR TITLE
Add WAL replay error handling + enable checksum configs to client APIs

### DIFF
--- a/tools/java_api/src/jni/kuzu_java.cpp
+++ b/tools/java_api/src/jni/kuzu_java.cpp
@@ -364,7 +364,8 @@ JNIEXPORT void JNICALL Java_com_kuzudb_Native_kuzuNativeReloadLibrary(JNIEnv* en
 
 JNIEXPORT jlong JNICALL Java_com_kuzudb_Native_kuzuDatabaseInit(JNIEnv* env, jclass,
     jstring databasePath, jlong bufferPoolSize, jboolean enableCompression, jboolean readOnly,
-    jlong maxDbSize, jboolean autoCheckpoint, jlong checkpointThreshold) {
+    jlong maxDbSize, jboolean autoCheckpoint, jlong checkpointThreshold,
+    jboolean throwOnWalReplayFailure, jboolean enableChecksums) {
     try {
         const char* path = env->GetStringUTFChars(databasePath, JNI_FALSE);
         uint64_t buffer = static_cast<uint64_t>(bufferPoolSize);
@@ -376,6 +377,8 @@ JNIEXPORT jlong JNICALL Java_com_kuzudb_Native_kuzuDatabaseInit(JNIEnv* env, jcl
         systemConfig.autoCheckpoint = autoCheckpoint;
         systemConfig.checkpointThreshold =
             checkpointThreshold >= 0 ? checkpointThreshold : systemConfig.checkpointThreshold;
+        systemConfig.throwOnWalReplayFailure = throwOnWalReplayFailure;
+        systemConfig.enableChecksums = enableChecksums;
         try {
             Database* db = new Database(path, systemConfig);
             uint64_t address = reinterpret_cast<uint64_t>(db);

--- a/tools/java_api/src/main/java/com/kuzudb/Native.java
+++ b/tools/java_api/src/main/java/com/kuzudb/Native.java
@@ -75,7 +75,7 @@ public class Native {
     // Database
     protected static native long kuzuDatabaseInit(String databasePath, long bufferPoolSize,
             boolean enableCompression, boolean readOnly, long maxDbSize, boolean autoCheckpoint,
-            long checkpointThreshold);
+            long checkpointThreshold,boolean throwOnWalReplayFailure, boolean enableChecksums);
 
     protected static native void kuzuDatabaseDestroy(Database db);
 

--- a/tools/java_api/src/test/java/com/kuzudb/DatabaseTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/DatabaseTest.java
@@ -24,7 +24,9 @@ public class DatabaseTest extends TestBase {
                 false /* readOnly */,
                 1 << 30 /* 1 GB */,
                 false /* autoCheckpoint */,
-                1234 /* checkpointThreshold */)) {
+                1234 /* checkpointThreshold */,
+                true /* throwOnWalReplayFailure */,
+                true /* enableChecksums */)) {
             Connection conn = new Connection(database);
             {
                 QueryResult result = conn.query("CALL current_setting('auto_checkpoint') RETURN *");
@@ -58,7 +60,9 @@ public class DatabaseTest extends TestBase {
                             false /* readOnly */,
                             (1 << 30) - 1 /* 1 GB - 1 Byte (Odd Number)*/,
                             false /* autoCheckpoint */,
-                            1234 /* checkpointThreshold */);
+                            1234 /* checkpointThreshold */,
+                            true /* throwOnWalReplayFailure */,
+                            true /* enableChecksums */);
 
             fail("DBCreationWithInvalidMaxDBSize failed:");
         }
@@ -68,7 +72,6 @@ public class DatabaseTest extends TestBase {
         }
         fail("DBCreationWithInvalidMaxDBSize failed:");
     }
-
 
     @Test
     void DBCreationAndDestroyWithPathOnly() {
@@ -99,7 +102,7 @@ public class DatabaseTest extends TestBase {
 
     @Test
     void DBDestroyBeforeConnectionAndQueryResult(){
-        Database database = new Database(":memory:", 1 << 28, true, false, 1 << 30, false, 0);
+        Database database = new Database(":memory:", 1 << 28, true, false, 1 << 30, false, 0, true, true);
         Connection conn = new Connection(database);
         QueryResult result = conn.query("RETURN 1");
         assertTrue(result.hasNext());
@@ -119,5 +122,108 @@ public class DatabaseTest extends TestBase {
         }
         result.close();
         conn.close();
+    }
+
+    @Test
+    void DBCreationTestThrowOnWALReplayFailure() {
+        String dbPath = "";
+        try {
+            dbPath = tempDir.resolve("db4.kz").toString();
+        } catch (Exception e) {
+            fail("Cannot get database path: " + e.getMessage());
+        }
+
+        // Create a DB, don't checkpoint and leave a WAL
+        try (Database database = new Database(
+                dbPath)) {
+            Connection conn = new Connection(database);
+            {
+                conn.query("call force_checkpoint_on_close=false");
+                conn.query("call auto_checkpoint=false");
+                QueryResult result = conn.query("create node table testtest1(id int64 primary key)");
+                assertTrue(result.isSuccess());
+                result = conn.query("call show_tables() where prefix(name, 'testtest') return name");
+                assertEquals(result.getNext().getValue(0).toString(), "testtest1");
+
+                // Trigger an exception, this will also trigger during replay
+                result = conn.query("create node table testtest1(id int64 primary key)");
+                assertFalse(result.isSuccess());
+            }
+            conn.close();
+            // Database will be automatically destroyed after this block
+        } catch (Exception e) {
+            fail("DBCreationTestThrowOnWALReplayFailure failed: " + e.getMessage());
+        }
+
+
+        try (Database database = new Database(
+                dbPath,
+                1 << 28 /* 256 MB */,
+                true /* compression */,
+                false /* readOnly */,
+                1 << 30 /* 1 GB */,
+                false /* autoCheckpoint */,
+                1234 /* checkpointThreshold */,
+                false /* throwOnWalReplayFailure */,
+                true /* enableChecksums */)) {
+            // Database will be automatically destroyed after this block
+            Connection conn = new Connection(database);
+            QueryResult result = conn.query("call show_tables() where prefix(name, 'testtest') return name");
+            assertTrue(result.isSuccess());
+            assertTrue(result.hasNext());
+            assertEquals(result.getNext().getValue(0).toString(), "testtest1");
+        } catch (Exception e) {
+            fail("DBCreationTestThrowOnWALReplayFailure failed: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void DBCreationTestEnableChecksums() {
+        String dbPath = "";
+        try {
+            dbPath = tempDir.resolve("db5.kz").toString();
+        } catch (Exception e) {
+            fail("Cannot get database path: " + e.getMessage());
+        }
+
+        // Create a DB, don't checkpoint and leave a WAL
+        try (Database database = new Database(
+                dbPath,
+                1 << 28 /* 256 MB */,
+                true /* compression */,
+                false /* readOnly */,
+                1 << 30 /* 1 GB */,
+                false /* autoCheckpoint */,
+                1234 /* checkpointThreshold */,
+                true /* throwOnWalReplayFailure */,
+                true /* enableChecksums */)) {
+            Connection conn = new Connection(database);
+            {
+                conn.query("call force_checkpoint_on_close=false");
+                conn.query("call auto_checkpoint=false");
+                QueryResult result = conn.query("create node table testtest1(id int64 primary key)");
+                assertTrue(result.isSuccess());
+            }
+            conn.close();
+            // Database will be automatically destroyed after this block
+        } catch (Exception e) {
+            fail("DBCreationTestEnableChecksums failed: " + e.getMessage());
+        }
+
+
+        try (Database database = new Database(
+                dbPath,
+                1 << 28 /* 256 MB */,
+                true /* compression */,
+                false /* readOnly */,
+                1 << 30 /* 1 GB */,
+                false /* autoCheckpoint */,
+                1234 /* checkpointThreshold */,
+                true /* throwOnWalReplayFailure */,
+                false /* enableChecksums */)) {
+            // Database will be automatically destroyed after this block
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("Please open your database using the correct enableChecksums config."));
+        }
     }
 }

--- a/tools/nodejs_api/src_cpp/include/node_database.h
+++ b/tools/nodejs_api/src_cpp/include/node_database.h
@@ -32,6 +32,8 @@ private:
     uint64_t maxDBSize;
     bool autoCheckpoint;
     int64_t checkpointThreshold;
+    bool throwOnWalReplayFailure;
+    bool enableChecksums;
     std::shared_ptr<Database> database;
 };
 

--- a/tools/nodejs_api/src_cpp/node_database.cpp
+++ b/tools/nodejs_api/src_cpp/node_database.cpp
@@ -26,6 +26,8 @@ NodeDatabase::NodeDatabase(const Napi::CallbackInfo& info) : Napi::ObjectWrap<No
     maxDBSize = info[4].As<Napi::Number>().Int64Value();
     autoCheckpoint = info[5].As<Napi::Boolean>().Value();
     checkpointThreshold = info[6].As<Napi::Number>().Int64Value();
+    throwOnWalReplayFailure = info[7].As<Napi::Boolean>().Value();
+    enableChecksums = info[8].As<Napi::Boolean>().Value();
 }
 
 Napi::Value NodeDatabase::InitSync(const Napi::CallbackInfo& info) {
@@ -63,6 +65,8 @@ void NodeDatabase::InitCppDatabase() {
         systemConfig.maxDBSize = maxDBSize;
     }
     systemConfig.autoCheckpoint = autoCheckpoint;
+    systemConfig.throwOnWalReplayFailure = throwOnWalReplayFailure;
+    systemConfig.enableChecksums = enableChecksums;
     if (checkpointThreshold >= 0) {
         systemConfig.checkpointThreshold = checkpointThreshold;
     }

--- a/tools/nodejs_api/src_js/database.js
+++ b/tools/nodejs_api/src_js/database.js
@@ -17,6 +17,16 @@ class Database {
    * @param {Number} maxDBSize maximum size of the database file in bytes. Note that
    * this is introduced temporarily for now to get around with the default 8TB mmap
    * address space limit some environment.
+   * @param {Boolean} autoCheckpoint If true, the database will automatically checkpoint when the size of
+   * the WAL file exceeds the checkpoint threshold.
+   * @param {Number} checkpointThreshold The threshold of the WAL file size in bytes. When the size of the
+   * WAL file exceeds this threshold, the database will checkpoint if autoCheckpoint is true.
+   * @param {Boolean} forceCheckpointOnClose If true, the database will force checkpoint when closing.
+   * @param {Boolean} throwOnWalReplayFailure If true, any WAL replaying failure when loading the database
+   * will throw an error. Otherwise, Kuzu will silently ignore the failure and replay up to where
+   * the error occured.
+   * @param {Boolean} enableChecksums If true, the database will use checksums to detect corruption in the
+   * WAL file.
    */
   constructor(
     databasePath,
@@ -25,7 +35,9 @@ class Database {
     readOnly = false,
     maxDBSize = 0,
     autoCheckpoint = true,
-    checkpointThreshold = -1
+    checkpointThreshold = -1,
+    throwOnWalReplayFailure = true,
+    enableChecksums = true,
   ) {
     if (!databasePath) {
       databasePath = ":memory:";
@@ -52,7 +64,9 @@ class Database {
       readOnly,
       maxDBSize,
       autoCheckpoint,
-      checkpointThreshold
+      checkpointThreshold,
+      throwOnWalReplayFailure,
+      enableChecksums
     );
     this._isInitialized = false;
     this._initPromise = null;

--- a/tools/python_api/src_cpp/include/py_database.h
+++ b/tools/python_api/src_cpp/include/py_database.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "cached_import/py_cached_import.h"
 #include "main/kuzu.h"
 #include "main/storage_driver.h"
 #include "pybind_include.h" // IWYU pragma: keep (used for py:: namespace)
@@ -19,7 +18,8 @@ public:
 
     explicit PyDatabase(const std::string& databasePath, uint64_t bufferPoolSize,
         uint64_t maxNumThreads, bool compression, bool readOnly, uint64_t maxDBSize,
-        bool autoCheckpoint, int64_t checkpointThreshold);
+        bool autoCheckpoint, int64_t checkpointThreshold, bool throwOnWalReplayFailure = true,
+        bool enableChecksums = true);
 
     ~PyDatabase();
 

--- a/tools/python_api/src_py/database.py
+++ b/tools/python_api/src_py/database.py
@@ -37,6 +37,8 @@ class Database:
         max_db_size: int = (1 << 43),
         auto_checkpoint: bool = True,
         checkpoint_threshold: int = -1,
+        throw_on_wal_replay_failure: bool = True,
+        enable_checksums: bool = True,
     ):
         """
         Parameters
@@ -83,6 +85,15 @@ class Database:
             The threshold of the WAL file size in bytes. When the size of the
             WAL file exceeds this threshold, the database will checkpoint if autoCheckpoint is true.
 
+        throw_on_wal_replay_failure: bool
+            If true, any WAL replaying failure when loading the database will throw an error.
+            Otherwise, Kuzu will silently ignore the failure and replay up to where the error
+            occured.
+
+        enable_checksums: bool
+            If true, the database will use checksums to detect corruption in the
+            WAL file.
+
         """
         if database_path is None:
             database_path = ":memory:"
@@ -97,6 +108,8 @@ class Database:
         self.max_db_size = max_db_size
         self.auto_checkpoint = auto_checkpoint
         self.checkpoint_threshold = checkpoint_threshold
+        self.throw_on_wal_replay_failure = throw_on_wal_replay_failure
+        self.enable_checksums = enable_checksums
         self.is_closed = False
 
         self._database: Any = None  # (type: _kuzu.Database from pybind11)
@@ -161,6 +174,8 @@ class Database:
                 self.max_db_size,
                 self.auto_checkpoint,
                 self.checkpoint_threshold,
+                self.throw_on_wal_replay_failure,
+                self.enable_checksums,
             )
 
     def get_torch_geometric_remote_backend(

--- a/tools/rust_api/include/kuzu_rs.h
+++ b/tools/rust_api/include/kuzu_rs.h
@@ -95,7 +95,8 @@ inline uint32_t logical_type_get_decimal_scale(const kuzu::common::LogicalType& 
 /* Database */
 std::unique_ptr<kuzu::main::Database> new_database(std::string_view databasePath,
     uint64_t bufferPoolSize, uint64_t maxNumThreads, bool enableCompression, bool readOnly,
-    uint64_t maxDBSize, bool autoCheckpoint, int64_t checkpointThreshold);
+    uint64_t maxDBSize, bool autoCheckpoint, int64_t checkpointThreshold,
+    bool throwOnWalReplayFailure, bool enableChecksums);
 
 void database_set_logging_level(kuzu::main::Database& database, const std::string& level);
 

--- a/tools/rust_api/src/database.rs
+++ b/tools/rust_api/src/database.rs
@@ -39,6 +39,10 @@ pub struct SystemConfig {
     auto_checkpoint: bool,
     /// The threshold of the WAL file size in bytes. When the size of the WAL file exceeds this threshold, the database will checkpoint if autoCheckpoint is true.
     checkpoint_threshold: i64,
+    /// If true, any WAL replaying failure when loading the database will throw an error. Otherwise, Kuzu will silently ignore the failure and replay up to where the error occured.
+    throw_on_wal_replay_failure: bool,
+    /// If true, the database will use checksums to detect corruption in the WAL file.
+    enable_checksums: bool,
 }
 
 #[cfg(test)]
@@ -52,6 +56,8 @@ pub(crate) const SYSTEM_CONFIG_FOR_TESTS: SystemConfig = SystemConfig {
     max_db_size: 16 * 1024 * 1024 * 1024,
     auto_checkpoint: true,
     checkpoint_threshold: -1_i64,
+    throw_on_wal_replay_failure: true,
+    enable_checksums: true,
 };
 
 impl Default for SystemConfig {
@@ -65,6 +71,8 @@ impl Default for SystemConfig {
             max_db_size: u64::from(u32::MAX),
             auto_checkpoint: true,
             checkpoint_threshold: -1_i64,
+            throw_on_wal_replay_failure: true,
+            enable_checksums: true,
         }
     }
 }
@@ -98,6 +106,14 @@ impl SystemConfig {
         self.checkpoint_threshold = checkpoint_threshold;
         self
     }
+    pub fn throw_on_wal_replay_failure(mut self, throw_on_wal_replay_failure: bool) -> Self {
+        self.throw_on_wal_replay_failure = throw_on_wal_replay_failure;
+        self
+    }
+    pub fn enable_checksums(mut self, enable_checksums: bool) -> Self {
+        self.enable_checksums = enable_checksums;
+        self
+    }
 }
 
 pub(crate) const IN_MEMORY_DB_NAME: &str = ":memory:";
@@ -120,6 +136,8 @@ impl Database {
                 config.max_db_size,
                 config.auto_checkpoint,
                 config.checkpoint_threshold,
+                config.throw_on_wal_replay_failure,
+                config.enable_checksums,
             )?),
         })
     }
@@ -149,6 +167,8 @@ mod tests {
     use crate::database::{Database, SystemConfig};
     use crate::value::Value;
     use std::collections::HashSet;
+    use std::fs::File;
+    use std::io::Write;
 
     #[test]
     fn create_database() -> Result<()> {
@@ -248,6 +268,48 @@ mod tests {
             result?.next().unwrap()[0],
             Value::String("1234".to_string())
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_database_throw_on_wal_replay_failure() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let db_path = temp_dir.path().join("test");
+        let wal_path = db_path.with_extension("wal");
+        let mut wal_file = File::create(wal_path)?;
+        wal_file.write_all(b"aaaaaaaaaaaaaaaaaaaaaaaa")?;
+        let db = Database::new(
+            db_path,
+            SYSTEM_CONFIG_FOR_TESTS.throw_on_wal_replay_failure(false),
+        )?;
+        let conn = Connection::new(&db)?;
+        let result = conn.query("return 1");
+        assert_eq!(
+            result?.next().unwrap()[0],
+            Value::Int64(1)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_database_enable_checksums() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let db_path = temp_dir.path().join("test");
+        {
+            let db = Database::new(
+                db_path.clone(),
+                SYSTEM_CONFIG_FOR_TESTS.auto_checkpoint(false).enable_checksums(true),
+            )?;
+            let conn = Connection::new(&db)?;
+            conn.query("call force_checkpoint_on_close=false")?;
+            conn.query("create node table testtest1(id int64 primary key)")?;
+        }
+        {
+            Database::new(
+                db_path.clone(),
+                SYSTEM_CONFIG_FOR_TESTS.enable_checksums(false),
+            ).expect_err("aaa");
+        }
         Ok(())
     }
 

--- a/tools/rust_api/src/ffi.rs
+++ b/tools/rust_api/src/ffi.rs
@@ -160,6 +160,8 @@ pub(crate) mod ffi {
             maxDBSize: u64,
             auto_checkpoint: bool,
             checkpoint_threshold: i64,
+            throwOnWalReplayFailure: bool,
+            enableChecksums: bool,
         ) -> Result<UniquePtr<Database>>;
 
     }

--- a/tools/rust_api/src/kuzu_rs.cpp
+++ b/tools/rust_api/src/kuzu_rs.cpp
@@ -67,7 +67,8 @@ std::unique_ptr<std::vector<kuzu::common::LogicalType>> logical_type_get_struct_
 
 std::unique_ptr<Database> new_database(std::string_view databasePath, uint64_t bufferPoolSize,
     uint64_t maxNumThreads, bool enableCompression, bool readOnly, uint64_t maxDBSize,
-    bool autoCheckpoint, int64_t checkpointThreshold) {
+    bool autoCheckpoint, int64_t checkpointThreshold, bool throwOnWalReplayFailure,
+    bool enableChecksums) {
     auto systemConfig = SystemConfig();
     if (bufferPoolSize > 0) {
         systemConfig.bufferPoolSize = bufferPoolSize;
@@ -84,6 +85,8 @@ std::unique_ptr<Database> new_database(std::string_view databasePath, uint64_t b
     if (checkpointThreshold >= 0) {
         systemConfig.checkpointThreshold = checkpointThreshold;
     }
+    systemConfig.throwOnWalReplayFailure = throwOnWalReplayFailure;
+    systemConfig.enableChecksums = enableChecksums;
     return std::make_unique<Database>(databasePath, systemConfig);
 }
 


### PR DESCRIPTION
# Description

`throwOnWalReplayFailure` and `enableChecksums` were added to the `SystemConfig` in https://github.com/kuzudb/kuzu/pull/5940 and https://github.com/kuzudb/kuzu/pull/5944 respectively. This PR propagates those config changes to the client APIs.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
