### PR TITLE
Add test_list in root dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ bazel-*
 .bazelrc
 **/test/test_files/test_list
 extension/test_list
+test_list
 mm-256KB
 history.txt
 


### PR DESCRIPTION
# Description

Solely in response to https://github.com/kuzudb/kuzu/pull/5955#discussion_r2319600626

The testing framework example outlined in https://docs.kuzudb.com/developer-guide/testing-framework/#running-a-specific-group-or-test-case has the user generate a `test_list` file in their current directory (likely the root directory). Might as well spare ~~me~~ them the grief of accidental change commits and `.gitignore` it beforehand.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
