### PR TITLE
Forward declare transaction

### DIFF
--- a/extension/algo/src/function/k_core_decomposition.cpp
+++ b/extension/algo/src/function/k_core_decomposition.cpp
@@ -6,6 +6,7 @@
 #include "function/gds/gds_vertex_compute.h"
 #include "main/client_context.h"
 #include "processor/execution_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -170,7 +171,7 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
     auto mm = MemoryManager::Get(*clientContext);
     auto sharedState = input.sharedState->ptrCast<GDSFuncSharedState>();
     auto graph = sharedState->graph.get();
-    auto transaction = clientContext->getTransaction();
+    auto transaction = transaction::Transaction::Get(*clientContext);
     auto degrees = Degrees(graph->getMaxOffsetMap(transaction), mm);
     DegreesUtils::computeDegree(input.context, graph, sharedState->getGraphNodeMaskMap(), &degrees,
         ExtendDirection::BOTH);
@@ -187,7 +188,7 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
     auto computeState = GDSComputeState(std::move(frontierPair), std::move(removeVertexEdgeCompute),
         std::move(auxiliaryState));
     auto coreValue = 0u;
-    auto numNodes = graph->getNumNodes(clientContext->getTransaction());
+    auto numNodes = graph->getNumNodes(transaction);
     auto numNodesComputed = 0u;
     while (numNodes != numNodesComputed) {
         // Compute current core value

--- a/extension/algo/src/function/louvain.cpp
+++ b/extension/algo/src/function/louvain.cpp
@@ -10,8 +10,10 @@
 #include "function/config/max_iterations_config.h"
 #include "function/gds/gds_utils.h"
 #include "function/gds/gds_vertex_compute.h"
-#include "main/client_context.h"
 #include "processor/execution_context.h"
+#include "transaction/transaction.h"
+#include "function/table/bind_input.h"
+#include "main/client_context.h"
 
 using namespace std;
 using namespace kuzu::binder;
@@ -572,14 +574,14 @@ void aggregateCommunities(const offset_t newCommCount, PhaseState& state, Memory
 
 static common::offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
     const auto clientContext = input.context->clientContext;
-    const auto transaction = clientContext->getTransaction();
+    const auto transaction = transaction::Transaction::Get(*clientContext);
     auto sharedState = input.sharedState->ptrCast<GDSFuncSharedState>();
     auto mm = MemoryManager::Get(*clientContext);
     const auto graph = sharedState->graph.get();
     auto maxOffsetMap = graph->getMaxOffsetMap(transaction);
     KU_ASSERT(graph->getNodeTableIDs().size() == 1);
     const auto tableID = graph->getNodeTableIDs()[0];
-    const auto origNumNodes = graph->getMaxOffset(clientContext->getTransaction(), tableID);
+    const auto origNumNodes = graph->getMaxOffset(transaction, tableID);
 
     auto louvainBindData = input.bindData->constPtrCast<LouvainBindData>();
     auto& config = louvainBindData->optionalParams->constCast<LouvainOptionalParams>();

--- a/extension/algo/src/function/louvain.cpp
+++ b/extension/algo/src/function/louvain.cpp
@@ -10,10 +10,10 @@
 #include "function/config/max_iterations_config.h"
 #include "function/gds/gds_utils.h"
 #include "function/gds/gds_vertex_compute.h"
-#include "processor/execution_context.h"
-#include "transaction/transaction.h"
 #include "function/table/bind_input.h"
 #include "main/client_context.h"
+#include "processor/execution_context.h"
+#include "transaction/transaction.h"
 
 using namespace std;
 using namespace kuzu::binder;

--- a/extension/algo/src/function/page_rank.cpp
+++ b/extension/algo/src/function/page_rank.cpp
@@ -8,8 +8,10 @@
 #include "function/degrees.h"
 #include "function/gds/gds_utils.h"
 #include "function/gds/gds_vertex_compute.h"
-#include "main/client_context.h"
 #include "processor/execution_context.h"
+#include "function/table/bind_input.h"
+#include "main/client_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::processor;
 using namespace kuzu::common;
@@ -265,7 +267,7 @@ private:
 
 static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
     auto clientContext = input.context->clientContext;
-    auto transaction = clientContext->getTransaction();
+    auto transaction = transaction::Transaction::Get(*clientContext);
     auto sharedState = input.sharedState->ptrCast<GDSFuncSharedState>();
     auto graph = sharedState->graph.get();
     auto maxOffsetMap = graph->getMaxOffsetMap(transaction);

--- a/extension/algo/src/function/page_rank.cpp
+++ b/extension/algo/src/function/page_rank.cpp
@@ -8,9 +8,9 @@
 #include "function/degrees.h"
 #include "function/gds/gds_utils.h"
 #include "function/gds/gds_vertex_compute.h"
-#include "processor/execution_context.h"
 #include "function/table/bind_input.h"
 #include "main/client_context.h"
+#include "processor/execution_context.h"
 #include "transaction/transaction.h"
 
 using namespace kuzu::processor;

--- a/extension/algo/src/function/spanning_forest.cpp
+++ b/extension/algo/src/function/spanning_forest.cpp
@@ -15,10 +15,10 @@
 #include "function/gds/gds_object_manager.h"
 #include "function/gds/weight_utils.h"
 #include "function/table/bind_input.h"
-#include "main/client_context.h"
 #include "planner/operator/logical_table_function_call.h"
 #include "planner/planner.h"
 #include "processor/execution_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -326,7 +326,7 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
     // Set randomLookup=false to enable caching during graph materialization.
     const auto scanState = graph->prepareRelScan(*nbrInfo.relGroupEntry, nbrInfo.relTableID,
         nbrInfo.dstTableID, relProps, false /*randomLookup*/);
-    const auto numNodes = graph->getMaxOffset(clientContext->getTransaction(), tableId);
+    const auto numNodes = graph->getMaxOffset(transaction::Transaction::Get(*clientContext), tableId);
 
     KruskalCompute compute(mm, numNodes);
     WeightUtils::visit(SpanningForest::name, propertyType, [&]<typename T>(T) {

--- a/extension/algo/src/function/spanning_forest.cpp
+++ b/extension/algo/src/function/spanning_forest.cpp
@@ -326,7 +326,8 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
     // Set randomLookup=false to enable caching during graph materialization.
     const auto scanState = graph->prepareRelScan(*nbrInfo.relGroupEntry, nbrInfo.relTableID,
         nbrInfo.dstTableID, relProps, false /*randomLookup*/);
-    const auto numNodes = graph->getMaxOffset(transaction::Transaction::Get(*clientContext), tableId);
+    const auto numNodes =
+        graph->getMaxOffset(transaction::Transaction::Get(*clientContext), tableId);
 
     KruskalCompute compute(mm, numNodes);
     WeightUtils::visit(SpanningForest::name, propertyType, [&]<typename T>(T) {

--- a/extension/algo/src/function/strongly_connected_components.cpp
+++ b/extension/algo/src/function/strongly_connected_components.cpp
@@ -10,6 +10,7 @@
 #include "function/gds/gds_vertex_compute.h"
 #include "main/client_context.h"
 #include "processor/execution_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -196,7 +197,8 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
     auto nodeMask = sharedState->getGraphNodeMaskMap();
     auto mm = MemoryManager::Get(*clientContext);
     auto graph = sharedState->graph.get();
-    auto maxOffsetMap = graph->getMaxOffsetMap(clientContext->getTransaction());
+    auto transaction = transaction::Transaction::Get(*clientContext);
+    auto maxOffsetMap = graph->getMaxOffsetMap(transaction);
     auto maxIterations = input.bindData->optionalParams->constCast<MaxIterationOptionalParams>()
                              .maxIterations.getParamVal();
     auto currentFrontier = DenseFrontier::getUnvisitedFrontier(input.context, graph);

--- a/extension/algo/src/function/strongly_connected_components_kosaraju.cpp
+++ b/extension/algo/src/function/strongly_connected_components_kosaraju.cpp
@@ -9,6 +9,7 @@
 #include "function/gds/gds_vertex_compute.h"
 #include "main/client_context.h"
 #include "processor/execution_context.h"
+#include "transaction/transaction.h"
 
 using namespace std;
 using namespace kuzu::binder;
@@ -231,7 +232,7 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
     if (nodeMask) {
         nodeMask->pin(tableID);
     }
-    auto maxOffset = graph->getMaxOffset(clientContext->getTransaction(), tableID);
+    auto maxOffset = graph->getMaxOffset(transaction::Transaction::Get(*clientContext), tableID);
     auto visitedState = KosarajuVisitedState(tableID, maxOffset, mm);
     auto visitedOrder = KosarajuVisitedOrder(tableID, maxOffset, mm);
     auto kosaraju = Kosaraju(graph, visitedState, visitedOrder);

--- a/extension/algo/src/function/weakly_connected_components.cpp
+++ b/extension/algo/src/function/weakly_connected_components.cpp
@@ -4,9 +4,9 @@
 #include "function/config/connected_components_config.h"
 #include "function/config/max_iterations_config.h"
 #include "function/gds/gds_utils.h"
+#include "function/table/bind_input.h"
 #include "processor/execution_context.h"
 #include "transaction/transaction.h"
-#include "function/table/bind_input.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;

--- a/extension/algo/src/function/weakly_connected_components.cpp
+++ b/extension/algo/src/function/weakly_connected_components.cpp
@@ -4,8 +4,9 @@
 #include "function/config/connected_components_config.h"
 #include "function/config/max_iterations_config.h"
 #include "function/gds/gds_utils.h"
-#include "main/client_context.h"
 #include "processor/execution_context.h"
+#include "transaction/transaction.h"
+#include "function/table/bind_input.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -68,7 +69,7 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
     auto frontierPair =
         std::make_unique<DenseFrontierPair>(std::move(currentFrontier), std::move(nextFrontier));
     frontierPair->setActiveNodesForNextIter();
-    auto maxOffsetMap = graph->getMaxOffsetMap(clientContext->getTransaction());
+    auto maxOffsetMap = graph->getMaxOffsetMap(transaction::Transaction::Get(*clientContext));
     auto offsetManager = OffsetManager(maxOffsetMap);
     auto mm = MemoryManager::Get(*clientContext);
     auto componentIDs = ComponentIDs::getSequenceComponentIDs(maxOffsetMap, offsetManager, mm);

--- a/extension/fts/src/catalog/fts_index_catalog_entry.cpp
+++ b/extension/fts/src/catalog/fts_index_catalog_entry.cpp
@@ -4,8 +4,8 @@
 #include "common/serializer/buffer_reader.h"
 #include "common/serializer/buffer_writer.h"
 #include "common/string_utils.h"
-#include "main/client_context.h"
 #include "utils/fts_utils.h"
+#include "transaction/transaction.h"
 
 namespace kuzu {
 namespace fts_extension {
@@ -49,8 +49,9 @@ std::string FTSIndexAuxInfo::toCypher(const catalog::IndexCatalogEntry& indexEnt
     auto& indexToCypherInfo = info.constCast<catalog::IndexToCypherInfo>();
     std::string cypher;
     auto catalog = catalog::Catalog::Get(*indexToCypherInfo.context);
+    auto transaction = transaction::Transaction::Get(*indexToCypherInfo.context);
     auto tableCatalogEntry = catalog->getTableCatalogEntry(
-        indexToCypherInfo.context->getTransaction(), indexEntry.getTableID());
+        transaction, indexEntry.getTableID());
     auto tableName = tableCatalogEntry->getName();
     std::string propertyStr;
     auto propertyIDs = indexEntry.getPropertyIDs();
@@ -72,7 +73,8 @@ catalog::TableCatalogEntry* FTSIndexAuxInfo::getTableEntryToExport(
     if (config.stopWordsTableName == FTSUtils::getDefaultStopWordsTableName()) {
         return nullptr;
     }
-    return catalog::Catalog::Get(*context)->getTableCatalogEntry(context->getTransaction(),
+    auto transaction = transaction::Transaction::Get(*context);
+    return catalog::Catalog::Get(*context)->getTableCatalogEntry(transaction,
         config.stopWordsTableName);
 }
 

--- a/extension/fts/src/catalog/fts_index_catalog_entry.cpp
+++ b/extension/fts/src/catalog/fts_index_catalog_entry.cpp
@@ -4,8 +4,8 @@
 #include "common/serializer/buffer_reader.h"
 #include "common/serializer/buffer_writer.h"
 #include "common/string_utils.h"
-#include "utils/fts_utils.h"
 #include "transaction/transaction.h"
+#include "utils/fts_utils.h"
 
 namespace kuzu {
 namespace fts_extension {
@@ -50,8 +50,7 @@ std::string FTSIndexAuxInfo::toCypher(const catalog::IndexCatalogEntry& indexEnt
     std::string cypher;
     auto catalog = catalog::Catalog::Get(*indexToCypherInfo.context);
     auto transaction = transaction::Transaction::Get(*indexToCypherInfo.context);
-    auto tableCatalogEntry = catalog->getTableCatalogEntry(
-        transaction, indexEntry.getTableID());
+    auto tableCatalogEntry = catalog->getTableCatalogEntry(transaction, indexEntry.getTableID());
     auto tableName = tableCatalogEntry->getName();
     std::string propertyStr;
     auto propertyIDs = indexEntry.getPropertyIDs();

--- a/extension/fts/src/function/create_fts_index.cpp
+++ b/extension/fts/src/function/create_fts_index.cpp
@@ -104,7 +104,7 @@ static std::string createStopWordsTable(const ClientContext& context,
     auto catalog = catalog::Catalog::Get(context);
     switch (info.source) {
     case StopWordsSource::DEFAULT: {
-        if (catalog->containsTable(context.getTransaction(), info.tableName)) {
+        if (catalog->containsTable(transaction::Transaction::Get(context), info.tableName)) {
             return query;
         }
         query +=
@@ -150,13 +150,13 @@ std::string createFTSIndexQuery(ClientContext& context, const TableFuncBindData&
     auto tableID = ftsBindData->tableID;
     auto indexName = ftsBindData->indexName;
     validateInternalTablesNotExist(ftsBindData->tableID, ftsBindData->indexName,
-        *catalog::Catalog::Get(context), context.getTransaction());
+        *catalog::Catalog::Get(context), transaction::Transaction::Get(context));
     context.setUseInternalCatalogEntry(true /* useInternalCatalogEntry */);
     // TODO(Ziyi): Copy statement can't be wrapped in manual transaction, so we can't wrap all
     // statements in a single transaction there.
     // Create the tokenize macro.
     std::string query = "";
-    if (!catalog::Catalog::Get(context)->containsMacro(context.getTransaction(),
+    if (!catalog::Catalog::Get(context)->containsMacro(transaction::Transaction::Get(context),
             FTSUtils::getTokenizeMacroName(tableID, indexName))) {
         // TOKENIZE(text, tokenizer, extra_param)
         query += common::stringFormat(R"(CREATE MACRO `{}`(query) AS
@@ -179,7 +179,7 @@ std::string createFTSIndexQuery(ClientContext& context, const TableFuncBindData&
         appearsInfoTableName);
     auto tableName = ftsBindData->tableName;
     auto tableEntry =
-        catalog::Catalog::Get(context)->getTableCatalogEntry(context.getTransaction(), tableName);
+        catalog::Catalog::Get(context)->getTableCatalogEntry(transaction::Transaction::Get(context), tableName);
     for (auto& property : ftsBindData->propertyIDs) {
         auto propertyName = tableEntry->getProperty(property).getName();
         query += stringFormat("COPY `{}` FROM "
@@ -279,7 +279,7 @@ void LenCompute::vertexCompute(const graph::VertexScanState::Chunk& chunk) {
 static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
     auto& bindData = *input.bindData->constPtrCast<CreateFTSBindData>();
     auto& context = *input.context;
-    auto transaction = context.clientContext->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context.clientContext);
     auto catalog = catalog::Catalog::Get(*context.clientContext);
     auto docTableName = FTSUtils::getDocsTableName(bindData.tableID, bindData.indexName);
     auto docTableEntry = catalog->getTableCatalogEntry(transaction, docTableName);
@@ -312,7 +312,7 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
         ftsIndexType.constraintType == storage::IndexConstraintType::PRIMARY,
         ftsIndexType.definitionType == storage::IndexDefinitionType::BUILTIN};
     auto storageInfo = std::make_unique<FTSStorageInfo>(numDocs, avgDocLen,
-        nodeTable->getNumTotalRows(context.clientContext->getTransaction()));
+        nodeTable->getNumTotalRows(transaction::Transaction::Get(*context.clientContext)));
     auto onDiskIndex = std::make_unique<FTSIndex>(std::move(indexInfo), std::move(storageInfo),
         std::move(ftsConfig), context.clientContext);
     if (!context.clientContext->isInMemory()) {

--- a/extension/fts/src/function/create_fts_index.cpp
+++ b/extension/fts/src/function/create_fts_index.cpp
@@ -178,8 +178,8 @@ std::string createFTSIndexQuery(ClientContext& context, const TableFuncBindData&
                           "key(ID));",
         appearsInfoTableName);
     auto tableName = ftsBindData->tableName;
-    auto tableEntry =
-        catalog::Catalog::Get(context)->getTableCatalogEntry(transaction::Transaction::Get(context), tableName);
+    auto tableEntry = catalog::Catalog::Get(context)->getTableCatalogEntry(
+        transaction::Transaction::Get(context), tableName);
     for (auto& property : ftsBindData->propertyIDs) {
         auto propertyName = tableEntry->getProperty(property).getName();
         query += stringFormat("COPY `{}` FROM "

--- a/extension/fts/src/function/drop_fts_index.cpp
+++ b/extension/fts/src/function/drop_fts_index.cpp
@@ -45,7 +45,7 @@ static offset_t internalTableFunc(const TableFuncInput& input, TableFuncOutput& 
     auto& ftsBindData = *input.bindData->constPtrCast<FTSBindData>();
     auto& context = *input.context;
     catalog::Catalog::Get(*context.clientContext)
-        ->dropIndex(input.context->clientContext->getTransaction(), ftsBindData.tableID,
+        ->dropIndex(transaction::Transaction::Get(*context.clientContext), ftsBindData.tableID,
             ftsBindData.indexName);
     storage::StorageManager::Get(*context.clientContext)
         ->getTable(ftsBindData.tableID)

--- a/extension/fts/src/function/fts_config.cpp
+++ b/extension/fts/src/function/fts_config.cpp
@@ -8,7 +8,7 @@
 #include "common/serializer/serializer.h"
 #include "common/string_utils.h"
 #include "function/stem.h"
-#include "main/client_context.h"
+#include "transaction/transaction.h"
 #include "re2.h"
 #include "utils/fts_utils.h"
 
@@ -104,8 +104,8 @@ StopWordsTableInfo StopWords::bind(main::ClientContext& context, common::table_i
     if (stopWords == DEFAULT_VALUE) {
         return StopWordsTableInfo{stopWords, FTSUtils::getDefaultStopWordsTableName(),
             StopWordsSource::DEFAULT};
-    } else if (catalog->containsTable(context.getTransaction(), stopWords)) {
-        auto entry = catalog->getTableCatalogEntry(context.getTransaction(), stopWords);
+    } else if (catalog->containsTable(transaction::Transaction::Get(context), stopWords)) {
+        auto entry = catalog->getTableCatalogEntry(transaction::Transaction::Get(context), stopWords);
         if (entry->getTableType() != common::TableType::NODE) {
             throw common::BinderException{"The stop words table must be a node table."};
         }

--- a/extension/fts/src/function/fts_config.cpp
+++ b/extension/fts/src/function/fts_config.cpp
@@ -8,8 +8,8 @@
 #include "common/serializer/serializer.h"
 #include "common/string_utils.h"
 #include "function/stem.h"
-#include "transaction/transaction.h"
 #include "re2.h"
+#include "transaction/transaction.h"
 #include "utils/fts_utils.h"
 
 namespace kuzu {
@@ -105,7 +105,8 @@ StopWordsTableInfo StopWords::bind(main::ClientContext& context, common::table_i
         return StopWordsTableInfo{stopWords, FTSUtils::getDefaultStopWordsTableName(),
             StopWordsSource::DEFAULT};
     } else if (catalog->containsTable(transaction::Transaction::Get(context), stopWords)) {
-        auto entry = catalog->getTableCatalogEntry(transaction::Transaction::Get(context), stopWords);
+        auto entry =
+            catalog->getTableCatalogEntry(transaction::Transaction::Get(context), stopWords);
         if (entry->getTableType() != common::TableType::NODE) {
             throw common::BinderException{"The stop words table must be a node table."};
         }

--- a/extension/fts/src/function/fts_index_utils.cpp
+++ b/extension/fts/src/function/fts_index_utils.cpp
@@ -4,8 +4,8 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "common/exception/binder.h"
-#include "transaction/transaction_context.h"
 #include "main/client_context.h"
+#include "transaction/transaction_context.h"
 
 namespace kuzu {
 namespace fts_extension {
@@ -16,15 +16,16 @@ void FTSIndexUtils::validateIndexExistence(const main::ClientContext& context,
     auto catalog = catalog::Catalog::Get(context);
     switch (indexOperation) {
     case IndexOperation::CREATE: {
-        if (catalog->containsIndex(transaction::Transaction::Get(context), tableEntry->getTableID(), indexName)) {
+        if (catalog->containsIndex(transaction::Transaction::Get(context), tableEntry->getTableID(),
+                indexName)) {
             throw common::BinderException{common::stringFormat(
                 "Index {} already exists in table {}.", indexName, tableEntry->getName())};
         }
     } break;
     case IndexOperation::DROP:
     case IndexOperation::QUERY: {
-        if (!catalog->containsIndex(transaction::Transaction::Get(context), tableEntry->getTableID(),
-                indexName)) {
+        if (!catalog->containsIndex(transaction::Transaction::Get(context),
+                tableEntry->getTableID(), indexName)) {
             throw common::BinderException{common::stringFormat(
                 "Table {} doesn't have an index with name {}.", tableEntry->getName(), indexName)};
         }
@@ -38,8 +39,8 @@ void FTSIndexUtils::validateIndexExistence(const main::ClientContext& context,
 catalog::NodeTableCatalogEntry* FTSIndexUtils::bindNodeTable(const main::ClientContext& context,
     const std::string& tableName, const std::string& indexName, IndexOperation indexOperation) {
     binder::Binder::validateTableExistence(context, tableName);
-    const auto tableEntry =
-        catalog::Catalog::Get(context)->getTableCatalogEntry(transaction::Transaction::Get(context), tableName);
+    const auto tableEntry = catalog::Catalog::Get(context)->getTableCatalogEntry(
+        transaction::Transaction::Get(context), tableName);
     binder::Binder::validateNodeTableType(tableEntry);
     validateIndexExistence(context, tableEntry, indexName, indexOperation);
     return tableEntry->ptrCast<catalog::NodeTableCatalogEntry>();

--- a/extension/fts/src/function/fts_index_utils.cpp
+++ b/extension/fts/src/function/fts_index_utils.cpp
@@ -4,6 +4,7 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "common/exception/binder.h"
+#include "transaction/transaction_context.h"
 #include "main/client_context.h"
 
 namespace kuzu {
@@ -15,14 +16,14 @@ void FTSIndexUtils::validateIndexExistence(const main::ClientContext& context,
     auto catalog = catalog::Catalog::Get(context);
     switch (indexOperation) {
     case IndexOperation::CREATE: {
-        if (catalog->containsIndex(context.getTransaction(), tableEntry->getTableID(), indexName)) {
+        if (catalog->containsIndex(transaction::Transaction::Get(context), tableEntry->getTableID(), indexName)) {
             throw common::BinderException{common::stringFormat(
                 "Index {} already exists in table {}.", indexName, tableEntry->getName())};
         }
     } break;
     case IndexOperation::DROP:
     case IndexOperation::QUERY: {
-        if (!catalog->containsIndex(context.getTransaction(), tableEntry->getTableID(),
+        if (!catalog->containsIndex(transaction::Transaction::Get(context), tableEntry->getTableID(),
                 indexName)) {
             throw common::BinderException{common::stringFormat(
                 "Table {} doesn't have an index with name {}.", tableEntry->getName(), indexName)};
@@ -38,7 +39,7 @@ catalog::NodeTableCatalogEntry* FTSIndexUtils::bindNodeTable(const main::ClientC
     const std::string& tableName, const std::string& indexName, IndexOperation indexOperation) {
     binder::Binder::validateTableExistence(context, tableName);
     const auto tableEntry =
-        catalog::Catalog::Get(context)->getTableCatalogEntry(context.getTransaction(), tableName);
+        catalog::Catalog::Get(context)->getTableCatalogEntry(transaction::Transaction::Get(context), tableName);
     binder::Binder::validateNodeTableType(tableEntry);
     validateIndexExistence(context, tableEntry, indexName, indexOperation);
     return tableEntry->ptrCast<catalog::NodeTableCatalogEntry>();

--- a/extension/fts/src/function/query_fts_bind_data.cpp
+++ b/extension/fts/src/function/query_fts_bind_data.cpp
@@ -50,12 +50,12 @@ std::vector<std::string> QueryFTSBindData::getQueryTerms(main::ClientContext& co
     auto terms = FTSUtils::tokenizeString(queryInStr, config);
     auto stopWordsTable = StorageManager::Get(context)
                               ->getTable(catalog::Catalog::Get(context)
-                                             ->getTableCatalogEntry(context.getTransaction(),
+                                             ->getTableCatalogEntry(transaction::Transaction::Get(context),
                                                  config.stopWordsTableName)
                                              ->getTableID())
                               ->ptrCast<NodeTable>();
     return FTSUtils::stemTerms(terms, entry.getAuxInfo().cast<FTSIndexAuxInfo>().config,
-        MemoryManager::Get(context), stopWordsTable, context.getTransaction(),
+        MemoryManager::Get(context), stopWordsTable, transaction::Transaction::Get(context),
         optionalParams->constCast<QueryFTSOptionalParams>().conjunctive.getParamVal(),
         true /* isQuery */);
 }

--- a/extension/fts/src/function/query_fts_bind_data.cpp
+++ b/extension/fts/src/function/query_fts_bind_data.cpp
@@ -48,12 +48,13 @@ std::vector<std::string> QueryFTSBindData::getQueryTerms(main::ClientContext& co
     auto config = entry.getAuxInfo().cast<FTSIndexAuxInfo>().config;
     FTSUtils::normalizeQuery(queryInStr, config.ignorePatternQuery);
     auto terms = FTSUtils::tokenizeString(queryInStr, config);
-    auto stopWordsTable = StorageManager::Get(context)
-                              ->getTable(catalog::Catalog::Get(context)
-                                             ->getTableCatalogEntry(transaction::Transaction::Get(context),
-                                                 config.stopWordsTableName)
-                                             ->getTableID())
-                              ->ptrCast<NodeTable>();
+    auto stopWordsTable =
+        StorageManager::Get(context)
+            ->getTable(catalog::Catalog::Get(context)
+                           ->getTableCatalogEntry(transaction::Transaction::Get(context),
+                               config.stopWordsTableName)
+                           ->getTableID())
+            ->ptrCast<NodeTable>();
     return FTSUtils::stemTerms(terms, entry.getAuxInfo().cast<FTSIndexAuxInfo>().config,
         MemoryManager::Get(context), stopWordsTable, transaction::Transaction::Get(context),
         optionalParams->constCast<QueryFTSOptionalParams>().conjunctive.getParamVal(),

--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -305,7 +305,8 @@ static std::unordered_map<offset_t, uint64_t> getDFs(main::ClientContext& contex
     termsVector.state = dataChunk.state;
     auto nodeTableScanState =
         NodeTableScanState(nodeIDVector, std::vector{dfVector}, dataChunk.state);
-    nodeTableScanState.setToTable(transaction::Transaction::Get(context), &termsNodeTable, {dfColumnID}, {});
+    nodeTableScanState.setToTable(transaction::Transaction::Get(context), &termsNodeTable,
+        {dfColumnID}, {});
     std::unordered_map<offset_t, uint64_t> dfs;
     std::vector<VCQueryTerm> vcQueryTerms;
     vcQueryTerms.reserve(queryTerms.size());

--- a/extension/fts/src/function/query_fts_index.cpp
+++ b/extension/fts/src/function/query_fts_index.cpp
@@ -292,7 +292,7 @@ static std::unordered_map<offset_t, uint64_t> getDFs(main::ClientContext& contex
     auto storageManager = StorageManager::Get(context);
     auto tableID = termsEntry->getTableID();
     auto& termsNodeTable = storageManager->getTable(tableID)->cast<NodeTable>();
-    auto tx = context.getTransaction();
+    auto tx = transaction::Transaction::Get(context);
     auto dfColumnID = termsEntry->getColumnID(DOC_FREQUENCY_PROP_NAME);
     std::vector<LogicalType> vectorTypes;
     vectorTypes.push_back(LogicalType::INTERNAL_ID());
@@ -305,7 +305,7 @@ static std::unordered_map<offset_t, uint64_t> getDFs(main::ClientContext& contex
     termsVector.state = dataChunk.state;
     auto nodeTableScanState =
         NodeTableScanState(nodeIDVector, std::vector{dfVector}, dataChunk.state);
-    nodeTableScanState.setToTable(context.getTransaction(), &termsNodeTable, {dfColumnID}, {});
+    nodeTableScanState.setToTable(transaction::Transaction::Get(context), &termsNodeTable, {dfColumnID}, {});
     std::unordered_map<offset_t, uint64_t> dfs;
     std::vector<VCQueryTerm> vcQueryTerms;
     vcQueryTerms.reserve(queryTerms.size());
@@ -369,7 +369,7 @@ static void initFrontier(FrontierPair& frontierPair, table_id_t termsTableID,
 
 static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
     auto& clientContext = *input.context->clientContext;
-    auto transaction = clientContext.getTransaction();
+    auto transaction = transaction::Transaction::Get(clientContext);
     auto sharedState = input.sharedState->ptrCast<QFTSSharedState>();
     auto graph = sharedState->graph.get();
     auto graphEntry = graph->getGraphEntry();
@@ -447,7 +447,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     auto tableEntry = FTSIndexUtils::bindNodeTable(*context, inputTableName, indexName,
         FTSIndexUtils::IndexOperation::QUERY);
     auto catalog = catalog::Catalog::Get(*context);
-    auto transaction = context->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context);
     auto ftsIndexEntry = catalog->getIndex(transaction, tableEntry->getTableID(), indexName);
     auto entry = catalog->getTableCatalogEntry(transaction, inputTableName);
     auto nodeOutput = GDSFunction::bindNodeOutput(*input, {entry});

--- a/extension/fts/src/index/fts_index.cpp
+++ b/extension/fts/src/index/fts_index.cpp
@@ -25,8 +25,8 @@ std::unique_ptr<Index> FTSIndex::load(main::ClientContext* context, StorageManag
     auto reader =
         std::make_unique<BufferReader>(storageInfoBuffer.data(), storageInfoBuffer.size());
     auto storageInfo = FTSStorageInfo::deserialize(std::move(reader));
-    auto indexEntry =
-        catalog->getIndex(transaction::Transaction::Get(*context), indexInfo.tableID, indexInfo.name);
+    auto indexEntry = catalog->getIndex(transaction::Transaction::Get(*context), indexInfo.tableID,
+        indexInfo.name);
     auto ftsConfig = indexEntry->getAuxInfo().cast<FTSIndexAuxInfo>().config;
     return std::make_unique<FTSIndex>(std::move(indexInfo), std::move(storageInfo),
         std::move(ftsConfig), context);
@@ -140,8 +140,8 @@ std::unique_ptr<Index::UpdateState> FTSIndex::initUpdateState(main::ClientContex
     auto ftsUpdateState =
         std::make_unique<FTSUpdateState>(context, internalTableInfo, indexInfo.columnIDs, columnID);
     ftsUpdateState->ftsInsertState = initInsertState(context, isVisible);
-    ftsUpdateState->ftsDeleteState =
-        initDeleteState(transaction::Transaction::Get(*context), MemoryManager::Get(*context), isVisible);
+    ftsUpdateState->ftsDeleteState = initDeleteState(transaction::Transaction::Get(*context),
+        MemoryManager::Get(*context), isVisible);
     return ftsUpdateState;
 }
 

--- a/extension/fts/src/index/fts_internal_table_info.cpp
+++ b/extension/fts/src/index/fts_internal_table_info.cpp
@@ -13,29 +13,25 @@ FTSInternalTableInfo::FTSInternalTableInfo(main::ClientContext* context, common:
     auto appearsInTableName = FTSUtils::getAppearsInTableName(tableID, indexName);
     auto storageManager = storage::StorageManager::Get(*context);
     auto catalog = catalog::Catalog::Get(*context);
+    auto transaction = transaction::Transaction::Get(*context);
     table = storageManager->getTable(tableID)->ptrCast<storage::NodeTable>();
-    stopWordsTable =
-        storageManager
-            ->getTable(catalog->getTableCatalogEntry(context->getTransaction(), stopWordsTableName)
+    stopWordsTable = storageManager->getTable(catalog->getTableCatalogEntry(transaction, stopWordsTableName)
                            ->getTableID())
             ->ptrCast<storage::NodeTable>();
-    docTable = storageManager
-                   ->getTable(catalog->getTableCatalogEntry(context->getTransaction(), docTableName)
+    docTable = storageManager->getTable(catalog->getTableCatalogEntry(transaction, docTableName)
                                   ->getTableID())
                    ->ptrCast<storage::NodeTable>();
-    termsTable =
-        storageManager
-            ->getTable(catalog->getTableCatalogEntry(context->getTransaction(), termsTableName)
+    termsTable = storageManager->getTable(catalog->getTableCatalogEntry(transaction, termsTableName)
                            ->getTableID())
             ->ptrCast<storage::NodeTable>();
     auto appearsInTableEntry =
-        catalog->getTableCatalogEntry(context->getTransaction(), appearsInTableName)
+        catalog->getTableCatalogEntry(transaction, appearsInTableName)
             ->constPtrCast<catalog::RelGroupCatalogEntry>()
             ->getRelEntryInfo(termsTable->getTableID(), docTable->getTableID());
     appearsInfoTable =
         storageManager->getTable(appearsInTableEntry->oid)->ptrCast<storage::RelTable>();
     dfColumnID =
-        catalog->getTableCatalogEntry(context->getTransaction(), termsTableName)->getColumnID("df");
+        catalog->getTableCatalogEntry(transaction, termsTableName)->getColumnID("df");
 }
 
 } // namespace fts_extension

--- a/extension/fts/src/index/fts_internal_table_info.cpp
+++ b/extension/fts/src/index/fts_internal_table_info.cpp
@@ -15,14 +15,17 @@ FTSInternalTableInfo::FTSInternalTableInfo(main::ClientContext* context, common:
     auto catalog = catalog::Catalog::Get(*context);
     auto transaction = transaction::Transaction::Get(*context);
     table = storageManager->getTable(tableID)->ptrCast<storage::NodeTable>();
-    stopWordsTable = storageManager->getTable(catalog->getTableCatalogEntry(transaction, stopWordsTableName)
-                           ->getTableID())
+    stopWordsTable =
+        storageManager
+            ->getTable(catalog->getTableCatalogEntry(transaction, stopWordsTableName)->getTableID())
             ->ptrCast<storage::NodeTable>();
-    docTable = storageManager->getTable(catalog->getTableCatalogEntry(transaction, docTableName)
-                                  ->getTableID())
-                   ->ptrCast<storage::NodeTable>();
-    termsTable = storageManager->getTable(catalog->getTableCatalogEntry(transaction, termsTableName)
-                           ->getTableID())
+    docTable =
+        storageManager
+            ->getTable(catalog->getTableCatalogEntry(transaction, docTableName)->getTableID())
+            ->ptrCast<storage::NodeTable>();
+    termsTable =
+        storageManager
+            ->getTable(catalog->getTableCatalogEntry(transaction, termsTableName)->getTableID())
             ->ptrCast<storage::NodeTable>();
     auto appearsInTableEntry =
         catalog->getTableCatalogEntry(transaction, appearsInTableName)
@@ -30,8 +33,7 @@ FTSInternalTableInfo::FTSInternalTableInfo(main::ClientContext* context, common:
             ->getRelEntryInfo(termsTable->getTableID(), docTable->getTableID());
     appearsInfoTable =
         storageManager->getTable(appearsInTableEntry->oid)->ptrCast<storage::RelTable>();
-    dfColumnID =
-        catalog->getTableCatalogEntry(transaction, termsTableName)->getColumnID("df");
+    dfColumnID = catalog->getTableCatalogEntry(transaction, termsTableName)->getColumnID("df");
 }
 
 } // namespace fts_extension

--- a/extension/fts/src/index/fts_update_state.cpp
+++ b/extension/fts/src/index/fts_update_state.cpp
@@ -32,7 +32,7 @@ FTSInsertState::FTSInsertState(main::ClientContext* context, FTSInternalTableInf
     : updateVectors{MemoryManager::Get(*context)},
       docTableInsertState{updateVectors.idVector, updateVectors.int64PKVector,
           std::vector<ValueVector*>{&updateVectors.int64PKVector, &updateVectors.uint64PropVector}},
-      termsTableState{context->getTransaction(), updateVectors, tableInfo},
+      termsTableState{transaction::Transaction::Get(*context), updateVectors, tableInfo},
       termsTableInsertState{updateVectors.idVector, updateVectors.stringPKVector,
           std::vector<ValueVector*>{&updateVectors.stringPKVector,
               &updateVectors.uint64PropVector}},
@@ -79,7 +79,7 @@ FTSUpdateState::FTSUpdateState(main::ClientContext* context, FTSInternalTableInf
     std::vector<common::column_id_t> columnIDs, common::column_id_t colIdxWithUpdate)
     : dataChunkState{DataChunkState::getSingleValueDataChunkState()},
       nodeIDVector{LogicalType::INTERNAL_ID(), MemoryManager::Get(*context), dataChunkState},
-      indexTableState{MemoryManager::Get(*context), context->getTransaction(), tableInfo, columnIDs,
+      indexTableState{MemoryManager::Get(*context), transaction::Transaction::Get(*context), tableInfo, columnIDs,
           nodeIDVector, dataChunkState},
       columnIdxWithUpdate{UINT32_MAX} {
     for (auto i = 0u; i < columnIDs.size(); i++) {

--- a/extension/fts/src/index/fts_update_state.cpp
+++ b/extension/fts/src/index/fts_update_state.cpp
@@ -79,8 +79,8 @@ FTSUpdateState::FTSUpdateState(main::ClientContext* context, FTSInternalTableInf
     std::vector<common::column_id_t> columnIDs, common::column_id_t colIdxWithUpdate)
     : dataChunkState{DataChunkState::getSingleValueDataChunkState()},
       nodeIDVector{LogicalType::INTERNAL_ID(), MemoryManager::Get(*context), dataChunkState},
-      indexTableState{MemoryManager::Get(*context), transaction::Transaction::Get(*context), tableInfo, columnIDs,
-          nodeIDVector, dataChunkState},
+      indexTableState{MemoryManager::Get(*context), transaction::Transaction::Get(*context),
+          tableInfo, columnIDs, nodeIDVector, dataChunkState},
       columnIdxWithUpdate{UINT32_MAX} {
     for (auto i = 0u; i < columnIDs.size(); i++) {
         if (columnIDs[i] == colIdxWithUpdate) {

--- a/extension/fts/src/main/fts_extension.cpp
+++ b/extension/fts/src/main/fts_extension.cpp
@@ -18,7 +18,7 @@ using namespace extension;
 
 static void initFTSEntries(main::ClientContext* context, catalog::Catalog& catalog) {
     auto storageManager = storage::StorageManager::Get(*context);
-    for (auto& indexEntry : catalog.getIndexEntries(context->getTransaction())) {
+    for (auto& indexEntry : catalog.getIndexEntries(transaction::Transaction::Get(*context))) {
         if (indexEntry->getIndexType() == FTSIndexCatalogEntry::TYPE_NAME &&
             !indexEntry->isLoaded()) {
             indexEntry->setAuxInfo(FTSIndexAuxInfo::deserialize(indexEntry->getAuxBufferReader()));

--- a/extension/httpfs/src/cached_file_manager.cpp
+++ b/extension/httpfs/src/cached_file_manager.cpp
@@ -40,7 +40,7 @@ std::unique_ptr<FileInfo> CachedFileManager::getCachedFileInfo(HTTPFileInfo* htt
 }
 
 void CachedFileManager::cleanUP(main::ClientContext* context) {
-    auto cacheDirForTrx = getCachedDirForTrx(context->getTransaction()->getID());
+    auto cacheDirForTrx = getCachedDirForTrx(transaction::Transaction::Get(*context)->getID());
     vfs->removeFileIfExists(cacheDirForTrx, context);
 }
 

--- a/extension/httpfs/src/httpfs.cpp
+++ b/extension/httpfs/src/httpfs.cpp
@@ -111,8 +111,8 @@ void HTTPFileInfo::initMetadata() {
 void HTTPFileInfo::initialize(main::ClientContext* context) {
     if (httpConfig.cacheFile && !VirtualFileSystem::GetUnsafe(*context)->isCompressedFile(path)) {
         auto hfs = fileSystem->ptrCast<HTTPFileSystem>();
-        cachedFileInfo =
-            hfs->getCachedFileManager().getCachedFileInfo(this, transaction::Transaction::Get(*context)->getID());
+        cachedFileInfo = hfs->getCachedFileManager().getCachedFileInfo(this,
+            transaction::Transaction::Get(*context)->getID());
         return;
     }
     initMetadata();

--- a/extension/httpfs/src/httpfs.cpp
+++ b/extension/httpfs/src/httpfs.cpp
@@ -3,6 +3,7 @@
 #include "common/cast.h"
 #include "common/exception/io.h"
 #include "common/exception/not_implemented.h"
+#include "transaction/transaction.h"
 
 namespace kuzu {
 namespace httpfs_extension {
@@ -111,7 +112,7 @@ void HTTPFileInfo::initialize(main::ClientContext* context) {
     if (httpConfig.cacheFile && !VirtualFileSystem::GetUnsafe(*context)->isCompressedFile(path)) {
         auto hfs = fileSystem->ptrCast<HTTPFileSystem>();
         cachedFileInfo =
-            hfs->getCachedFileManager().getCachedFileInfo(this, context->getTransaction()->getID());
+            hfs->getCachedFileManager().getCachedFileInfo(this, transaction::Transaction::Get(*context)->getID());
         return;
     }
     initMetadata();

--- a/extension/vector/src/catalog/hnsw_index_catalog_entry.cpp
+++ b/extension/vector/src/catalog/hnsw_index_catalog_entry.cpp
@@ -33,8 +33,8 @@ std::string HNSWIndexAuxInfo::toCypher(const IndexCatalogEntry& indexEntry,
     auto context = indexToCypherInfo.context;
     std::string cypher;
     auto catalog = Catalog::Get(*context);
-    auto tableEntry =
-        catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), indexEntry.getTableID());
+    auto tableEntry = catalog->getTableCatalogEntry(transaction::Transaction::Get(*context),
+        indexEntry.getTableID());
     auto tableName = tableEntry->getName();
     auto propertyName = tableEntry->getProperty(indexEntry.getPropertyIDs()[0]).getName();
     auto metricName = HNSWIndexConfig::metricToString(config.metric);

--- a/extension/vector/src/catalog/hnsw_index_catalog_entry.cpp
+++ b/extension/vector/src/catalog/hnsw_index_catalog_entry.cpp
@@ -6,7 +6,7 @@
 #include "common/serializer/buffer_writer.h"
 #include "common/serializer/deserializer.h"
 #include "index/hnsw_config.h"
-#include "main/client_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::catalog;
 
@@ -34,7 +34,7 @@ std::string HNSWIndexAuxInfo::toCypher(const IndexCatalogEntry& indexEntry,
     std::string cypher;
     auto catalog = Catalog::Get(*context);
     auto tableEntry =
-        catalog->getTableCatalogEntry(context->getTransaction(), indexEntry.getTableID());
+        catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), indexEntry.getTableID());
     auto tableName = tableEntry->getName();
     auto propertyName = tableEntry->getProperty(indexEntry.getPropertyIDs()[0]).getName();
     auto metricName = HNSWIndexConfig::metricToString(config.metric);

--- a/extension/vector/src/function/create_hnsw_index.cpp
+++ b/extension/vector/src/function/create_hnsw_index.cpp
@@ -119,8 +119,10 @@ static std::unique_ptr<PhysicalOperator> getPhysicalPlan(PlanMapper* planMapper,
     // Append _FinalizeHNSWIndex table function.
     auto clientContext = planMapper->clientContext;
     auto transaction = transaction::Transaction::Get(*clientContext);
-    auto finalizeFuncEntry = catalog::Catalog::Get(*clientContext)->getFunctionEntry(transaction,
-                InternalFinalizeHNSWIndexFunction::name, true /* useInternal */);
+    auto finalizeFuncEntry =
+        catalog::Catalog::Get(*clientContext)
+            ->getFunctionEntry(transaction, InternalFinalizeHNSWIndexFunction::name,
+                true /* useInternal */);
     auto func = BuiltInFunctionsUtils::matchFunction(InternalFinalizeHNSWIndexFunction::name,
         finalizeFuncEntry->ptrCast<catalog::FunctionCatalogEntry>());
     auto info = TableFunctionCallInfo();

--- a/extension/vector/src/function/create_hnsw_index.cpp
+++ b/extension/vector/src/function/create_hnsw_index.cpp
@@ -52,7 +52,8 @@ static std::unique_ptr<TableFuncBindData> createInMemHNSWBindFunc(main::ClientCo
         storage::StorageManager::Get(*context)->getTable(tableID)->cast<storage::NodeTable>();
     auto propertyID = tableEntry->getPropertyID(columnName);
     auto config = HNSWIndexConfig{input->optionalParams};
-    auto numNodes = table.getStats(context->getTransaction()).getTableCard();
+    auto transaction = transaction::Transaction::Get(*context);
+    auto numNodes = table.getStats(transaction).getTableCard();
     return std::make_unique<CreateHNSWIndexBindData>(context, indexName, tableEntry, propertyID,
         numNodes, std::move(config));
 }
@@ -117,9 +118,8 @@ static std::unique_ptr<PhysicalOperator> getPhysicalPlan(PlanMapper* planMapper,
     createDummySink->setDescriptor(std::make_unique<ResultSetDescriptor>(logicalOp->getSchema()));
     // Append _FinalizeHNSWIndex table function.
     auto clientContext = planMapper->clientContext;
-    auto finalizeFuncEntry =
-        catalog::Catalog::Get(*clientContext)
-            ->getFunctionEntry(clientContext->getTransaction(),
+    auto transaction = transaction::Transaction::Get(*clientContext);
+    auto finalizeFuncEntry = catalog::Catalog::Get(*clientContext)->getFunctionEntry(transaction,
                 InternalFinalizeHNSWIndexFunction::name, true /* useInternal */);
     auto func = BuiltInFunctionsUtils::matchFunction(InternalFinalizeHNSWIndexFunction::name,
         finalizeFuncEntry->ptrCast<catalog::FunctionCatalogEntry>());
@@ -150,7 +150,6 @@ static std::unique_ptr<PhysicalOperator> getPhysicalPlan(PlanMapper* planMapper,
     // Get tables from storage.
     const auto storageManager = storage::StorageManager::Get(*clientContext);
     const auto catalog = catalog::Catalog::Get(*clientContext);
-    const auto transaction = clientContext->getTransaction();
     auto nodeTable = storageManager->getTable(logicalCallBoundData->tableEntry->getTableID())
                          ->ptrCast<storage::NodeTable>();
     auto nodeTableID = nodeTable->getTableID();
@@ -249,7 +248,7 @@ static offset_t finalizeHNSWTableFunc(const TableFuncInput& input, TableFuncOutp
 static void finalizeHNSWTableFinalizeFunc(const ExecutionContext* context,
     TableFuncSharedState* sharedState) {
     const auto clientContext = context->clientContext;
-    const auto transaction = clientContext->getTransaction();
+    const auto transaction = transaction::Transaction::Get(*clientContext);
     const auto hnswSharedState = sharedState->ptrCast<FinalizeHNSWSharedState>();
     const auto index = hnswSharedState->hnswIndex.get();
     const auto bindData = hnswSharedState->bindData->constPtrCast<CreateHNSWIndexBindData>();

--- a/extension/vector/src/function/drop_hnsw_index.cpp
+++ b/extension/vector/src/function/drop_hnsw_index.cpp
@@ -6,6 +6,7 @@
 #include "main/client_context.h"
 #include "processor/execution_context.h"
 #include "storage/storage_manager.h"
+#include "transaction/transaction_context.h"
 
 using namespace kuzu::function;
 
@@ -37,7 +38,8 @@ static common::offset_t internalTableFunc(const TableFuncInput& input, TableFunc
     const auto& context = *input.context->clientContext;
     const auto bindData = input.bindData->constPtrCast<DropHNSWIndexBindData>();
     auto tableID = bindData->tableEntry->getTableID();
-    catalog::Catalog::Get(context)->dropIndex(context.getTransaction(), tableID,
+    auto transaction = transaction::Transaction::Get(context);
+    catalog::Catalog::Get(context)->dropIndex(transaction, tableID,
         bindData->indexName);
     storage::StorageManager::Get(context)->getTable(tableID)->cast<storage::NodeTable>().dropIndex(
         bindData->indexName);

--- a/extension/vector/src/function/drop_hnsw_index.cpp
+++ b/extension/vector/src/function/drop_hnsw_index.cpp
@@ -39,8 +39,7 @@ static common::offset_t internalTableFunc(const TableFuncInput& input, TableFunc
     const auto bindData = input.bindData->constPtrCast<DropHNSWIndexBindData>();
     auto tableID = bindData->tableEntry->getTableID();
     auto transaction = transaction::Transaction::Get(context);
-    catalog::Catalog::Get(context)->dropIndex(transaction, tableID,
-        bindData->indexName);
+    catalog::Catalog::Get(context)->dropIndex(transaction, tableID, bindData->indexName);
     storage::StorageManager::Get(context)->getTable(tableID)->cast<storage::NodeTable>().dropIndex(
         bindData->indexName);
     return 0;

--- a/extension/vector/src/function/query_hnsw_index.cpp
+++ b/extension/vector/src/function/query_hnsw_index.cpp
@@ -72,7 +72,7 @@ std::unique_ptr<TableFuncBindData> QueryHNSWIndexBindData::copy() const {
 static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     const TableFuncBindInput* input) {
     auto catalog = Catalog::Get(*context);
-    auto transaction = context->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context);
     context->setUseInternalCatalogEntry(true /* useInternalCatalogEntry */);
     const auto tableOrGraphName = input->getLiteralVal<std::string>(0);
     auto indexName = input->getLiteralVal<std::string>(1);
@@ -242,7 +242,7 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput& output) 
                 auto queryVector = HNSWQueryVector<T>(input.context->clientContext,
                     bindData->queryExpression, index.getElementType(), dimension);
                 auto queryVectorHandle = EmbeddingHandle{0, &queryVector};
-                localState->result = index.search(input.context->clientContext->getTransaction(),
+                localState->result = index.search(transaction::Transaction::Get(*input.context->clientContext),
                     queryVectorHandle, localState->searchState);
             },
             [&](auto) { KU_UNREACHABLE; });
@@ -272,7 +272,7 @@ static std::unique_ptr<TableFuncSharedState> initQueryHNSWSharedState(
     auto nodeTable = storage::StorageManager::Get(*context)
                          ->getTable(bindData->nodeTableEntry->getTableID())
                          ->ptrCast<storage::NodeTable>();
-    auto numNodes = nodeTable->getStats(context->getTransaction()).getTableCard();
+    auto numNodes = nodeTable->getStats(transaction::Transaction::Get(*context)).getTableCard();
     return std::make_unique<QueryHNSWIndexSharedState>(nodeTable, numNodes);
 }
 
@@ -290,10 +290,10 @@ std::unique_ptr<TableFuncLocalState> initQueryHNSWLocalState(
         hnswBindData->nodeTableEntry->getTableID(), hnswBindData->indexEntry->getIndexName());
     auto catalog = Catalog::Get(*context);
     auto upperRelTableEntry =
-        catalog->getTableCatalogEntry(context->getTransaction(), upperRelTableName, true)
+        catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), upperRelTableName, true)
             ->ptrCast<RelGroupCatalogEntry>();
     auto lowerRelTableEntry =
-        catalog->getTableCatalogEntry(context->getTransaction(), lowerRelTableName, true)
+        catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), lowerRelTableName, true)
             ->ptrCast<RelGroupCatalogEntry>();
     HNSWSearchState searchState{context, hnswBindData->nodeTableEntry, upperRelTableEntry,
         lowerRelTableEntry, *hnswSharedState->nodeTable, hnswBindData->indexColumnID,

--- a/extension/vector/src/function/query_hnsw_index.cpp
+++ b/extension/vector/src/function/query_hnsw_index.cpp
@@ -242,8 +242,9 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput& output) 
                 auto queryVector = HNSWQueryVector<T>(input.context->clientContext,
                     bindData->queryExpression, index.getElementType(), dimension);
                 auto queryVectorHandle = EmbeddingHandle{0, &queryVector};
-                localState->result = index.search(transaction::Transaction::Get(*input.context->clientContext),
-                    queryVectorHandle, localState->searchState);
+                localState->result =
+                    index.search(transaction::Transaction::Get(*input.context->clientContext),
+                        queryVectorHandle, localState->searchState);
             },
             [&](auto) { KU_UNREACHABLE; });
     }
@@ -290,10 +291,12 @@ std::unique_ptr<TableFuncLocalState> initQueryHNSWLocalState(
         hnswBindData->nodeTableEntry->getTableID(), hnswBindData->indexEntry->getIndexName());
     auto catalog = Catalog::Get(*context);
     auto upperRelTableEntry =
-        catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), upperRelTableName, true)
+        catalog
+            ->getTableCatalogEntry(transaction::Transaction::Get(*context), upperRelTableName, true)
             ->ptrCast<RelGroupCatalogEntry>();
     auto lowerRelTableEntry =
-        catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), lowerRelTableName, true)
+        catalog
+            ->getTableCatalogEntry(transaction::Transaction::Get(*context), lowerRelTableName, true)
             ->ptrCast<RelGroupCatalogEntry>();
     HNSWSearchState searchState{context, hnswBindData->nodeTableEntry, upperRelTableEntry,
         lowerRelTableEntry, *hnswSharedState->nodeTable, hnswBindData->indexColumnID,

--- a/extension/vector/src/index/hnsw_index.cpp
+++ b/extension/vector/src/index/hnsw_index.cpp
@@ -4,7 +4,6 @@
 #include "catalog/hnsw_index_catalog_entry.h"
 #include "function/hnsw_index_functions.h"
 #include "index/hnsw_rel_batch_insert.h"
-#include "main/client_context.h"
 #include "storage/storage_manager.h"
 #include "storage/table/node_table.h"
 #include "storage/table/rel_table.h"
@@ -297,12 +296,13 @@ static common::ArrayTypeInfo getArrayTypeInfo(NodeTable& table, common::column_i
 static std::unique_ptr<HNSWIndexEmbeddings> constructEmbeddingsColumn(
     const main::ClientContext* context, const common::ArrayTypeInfo& typeInfo, NodeTable& table,
     common::column_id_t columnID, const HNSWIndexConfig& config) {
+    auto transaction = Transaction::Get(*context);
     if (config.cacheEmbeddingsColumn) {
-        return std::make_unique<InMemEmbeddings>(context->getTransaction(),
+        return std::make_unique<InMemEmbeddings>(transaction,
             common::ArrayTypeInfo{typeInfo.getChildType().copy(), typeInfo.getNumElements()},
             table.getTableID(), columnID);
     } else {
-        return std::make_unique<OnDiskEmbeddings>(context->getTransaction(),
+        return std::make_unique<OnDiskEmbeddings>(transaction,
             MemoryManager::Get(*context),
             common::ArrayTypeInfo{typeInfo.getChildType().copy(), typeInfo.getNumElements()}, table,
             columnID);
@@ -332,7 +332,8 @@ InMemHNSWIndex::InMemHNSWIndex(const main::ClientContext* context, IndexInfo ind
     HNSWIndexConfig config)
     : HNSWIndex{std::move(indexInfo), std::move(storageInfo), std::move(config),
           getArrayTypeInfo(table, columnID)} {
-    const auto numNodes = table.getNumTotalRows(context->getTransaction());
+    auto transaction = Transaction::Get(*context);
+    const auto numNodes = table.getNumTotalRows(transaction);
     embeddings = constructEmbeddingsColumn(context, typeInfo, table, columnID, this->config);
     upperLayerSelectionMask =
         getUpperLayerSelectionMask(*embeddings, numNodes, this->config, randomEngine);
@@ -409,10 +410,10 @@ HNSWSearchState::HNSWSearchState(main::ClientContext* context,
     catalog::TableCatalogEntry* nodeTableEntry, catalog::TableCatalogEntry* upperRelTableEntry,
     catalog::TableCatalogEntry* lowerRelTableEntry, NodeTable& nodeTable,
     common::column_id_t columnID, common::offset_t numNodes, uint64_t k, QueryHNSWConfig config)
-    : visited{numNodes}, embeddings{std::make_unique<OnDiskEmbeddings>(context->getTransaction(),
+    : visited{numNodes}, embeddings{std::make_unique<OnDiskEmbeddings>(Transaction::Get(*context),
                              MemoryManager::Get(*context), getArrayTypeInfo(nodeTable, columnID),
                              nodeTable, columnID)},
-      embeddingScanState{context->getTransaction(), MemoryManager::Get(*context), nodeTable,
+      embeddingScanState{Transaction::Get(*context), MemoryManager::Get(*context), nodeTable,
           columnID, embeddings->getDimension()},
       k{k}, config{config}, semiMask{nullptr}, upperRelTableEntry{upperRelTableEntry},
       lowerRelTableEntry{lowerRelTableEntry}, searchType{SearchType::UNFILTERED},
@@ -429,7 +430,7 @@ OnDiskHNSWIndex::HNSWInsertState::HNSWInsertState(main::ClientContext* context,
     catalog::TableCatalogEntry* lowerRelTableEntry, NodeTable& nodeTable,
     common::column_id_t columnID, uint64_t degree)
     : searchState{context, nodeTableEntry, upperRelTableEntry, lowerRelTableEntry, nodeTable,
-          columnID, nodeTable.getNumTotalRows(context->getTransaction()), degree,
+          columnID, nodeTable.getNumTotalRows(Transaction::Get(*context)), degree,
           QueryHNSWConfig{}} {
     std::vector<common::LogicalType> insertTypes;
     insertTypes.push_back(common::LogicalType::INTERNAL_ID());
@@ -473,8 +474,9 @@ std::unique_ptr<Index> OnDiskHNSWIndex::load(main::ClientContext* context, Stora
         std::make_unique<common::BufferReader>(storageInfoBuffer.data(), storageInfoBuffer.size());
     auto storageInfo = HNSWStorageInfo::deserialize(std::move(reader));
     const auto catalog = catalog::Catalog::Get(*context);
+    const auto transaction = Transaction::Get(*context);
     const auto indexEntry =
-        catalog->getIndex(context->getTransaction(), indexInfo.tableID, indexInfo.name);
+        catalog->getIndex(transaction, indexInfo.tableID, indexInfo.name);
     const auto auxInfo = indexEntry->getAuxInfo().cast<HNSWIndexAuxInfo>();
     return std::make_unique<OnDiskHNSWIndex>(context, std::move(indexInfo), std::move(storageInfo),
         auxInfo.config.copy());
@@ -547,8 +549,9 @@ getIndexTableCatalogEntries(const catalog::Catalog* catalog, const Transaction* 
 
 std::unique_ptr<Index::InsertState> OnDiskHNSWIndex::initInsertState(main::ClientContext* context,
     visible_func) {
+    auto transaction = Transaction::Get(*context);
     auto [nodeTableEntry, upperRelTableEntry, lowerRelTableEntry] = getIndexTableCatalogEntries(
-        catalog::Catalog::Get(*context), context->getTransaction(), indexInfo);
+        catalog::Catalog::Get(*context), transaction, indexInfo);
     return std::make_unique<HNSWInsertState>(context, nodeTableEntry, upperRelTableEntry,
         lowerRelTableEntry, nodeTable, indexInfo.columnIDs[0], config.ml);
 }
@@ -608,10 +611,11 @@ void OnDiskHNSWIndex::finalize(main::ClientContext* context) {
     if (numTotalRows == hnswStorageInfo.numCheckpointedNodes) {
         return;
     }
+    auto transaction = Transaction::Get(*context);
     auto [nodeTableEntry, upperRelTableEntry, lowerRelTableEntry] = getIndexTableCatalogEntries(
-        catalog::Catalog::Get(*context), context->getTransaction(), indexInfo);
+        catalog::Catalog::Get(*context), transaction, indexInfo);
     const auto embeddingDim = typeInfo.constPtrCast<common::ArrayTypeInfo>()->getNumElements();
-    const auto scanState = std::make_unique<OnDiskEmbeddingScanState>(context->getTransaction(), mm,
+    const auto scanState = std::make_unique<OnDiskEmbeddingScanState>(transaction, mm,
         nodeTable, indexInfo.columnIDs[0], embeddingDim);
     const auto insertState = std::make_unique<HNSWInsertState>(context, nodeTableEntry,
         upperRelTableEntry, lowerRelTableEntry, nodeTable, indexInfo.columnIDs[0], config.ml);
@@ -621,13 +625,13 @@ void OnDiskHNSWIndex::finalize(main::ClientContext* context) {
         if (vector.isNull()) {
             continue;
         }
-        insertInternal(context->getTransaction(), offset, vector, *insertState);
+        insertInternal(transaction, offset, vector, *insertState);
     }
     for (const auto offset : insertState->upperNodesToShrink) {
-        shrinkForNode(context->getTransaction(), offset, true, config.mu, *insertState);
+        shrinkForNode(transaction, offset, true, config.mu, *insertState);
     }
     for (const auto offset : insertState->lowerNodesToShrink) {
-        shrinkForNode(context->getTransaction(), offset, false, config.ml, *insertState);
+        shrinkForNode(transaction, offset, false, config.ml, *insertState);
     }
     hnswStorageInfo.numCheckpointedNodes = numTotalRows;
 }

--- a/extension/vector/src/index/hnsw_index.cpp
+++ b/extension/vector/src/index/hnsw_index.cpp
@@ -302,8 +302,7 @@ static std::unique_ptr<HNSWIndexEmbeddings> constructEmbeddingsColumn(
             common::ArrayTypeInfo{typeInfo.getChildType().copy(), typeInfo.getNumElements()},
             table.getTableID(), columnID);
     } else {
-        return std::make_unique<OnDiskEmbeddings>(transaction,
-            MemoryManager::Get(*context),
+        return std::make_unique<OnDiskEmbeddings>(transaction, MemoryManager::Get(*context),
             common::ArrayTypeInfo{typeInfo.getChildType().copy(), typeInfo.getNumElements()}, table,
             columnID);
     }
@@ -475,8 +474,7 @@ std::unique_ptr<Index> OnDiskHNSWIndex::load(main::ClientContext* context, Stora
     auto storageInfo = HNSWStorageInfo::deserialize(std::move(reader));
     const auto catalog = catalog::Catalog::Get(*context);
     const auto transaction = Transaction::Get(*context);
-    const auto indexEntry =
-        catalog->getIndex(transaction, indexInfo.tableID, indexInfo.name);
+    const auto indexEntry = catalog->getIndex(transaction, indexInfo.tableID, indexInfo.name);
     const auto auxInfo = indexEntry->getAuxInfo().cast<HNSWIndexAuxInfo>();
     return std::make_unique<OnDiskHNSWIndex>(context, std::move(indexInfo), std::move(storageInfo),
         auxInfo.config.copy());
@@ -550,8 +548,8 @@ getIndexTableCatalogEntries(const catalog::Catalog* catalog, const Transaction* 
 std::unique_ptr<Index::InsertState> OnDiskHNSWIndex::initInsertState(main::ClientContext* context,
     visible_func) {
     auto transaction = Transaction::Get(*context);
-    auto [nodeTableEntry, upperRelTableEntry, lowerRelTableEntry] = getIndexTableCatalogEntries(
-        catalog::Catalog::Get(*context), transaction, indexInfo);
+    auto [nodeTableEntry, upperRelTableEntry, lowerRelTableEntry] =
+        getIndexTableCatalogEntries(catalog::Catalog::Get(*context), transaction, indexInfo);
     return std::make_unique<HNSWInsertState>(context, nodeTableEntry, upperRelTableEntry,
         lowerRelTableEntry, nodeTable, indexInfo.columnIDs[0], config.ml);
 }
@@ -612,11 +610,11 @@ void OnDiskHNSWIndex::finalize(main::ClientContext* context) {
         return;
     }
     auto transaction = Transaction::Get(*context);
-    auto [nodeTableEntry, upperRelTableEntry, lowerRelTableEntry] = getIndexTableCatalogEntries(
-        catalog::Catalog::Get(*context), transaction, indexInfo);
+    auto [nodeTableEntry, upperRelTableEntry, lowerRelTableEntry] =
+        getIndexTableCatalogEntries(catalog::Catalog::Get(*context), transaction, indexInfo);
     const auto embeddingDim = typeInfo.constPtrCast<common::ArrayTypeInfo>()->getNumElements();
-    const auto scanState = std::make_unique<OnDiskEmbeddingScanState>(transaction, mm,
-        nodeTable, indexInfo.columnIDs[0], embeddingDim);
+    const auto scanState = std::make_unique<OnDiskEmbeddingScanState>(transaction, mm, nodeTable,
+        indexInfo.columnIDs[0], embeddingDim);
     const auto insertState = std::make_unique<HNSWInsertState>(context, nodeTableEntry,
         upperRelTableEntry, lowerRelTableEntry, nodeTable, indexInfo.columnIDs[0], config.ml);
     // TODO(Guodong): Perhaps should switch to scan instead of lookup here.

--- a/extension/vector/src/index/hnsw_index_utils.cpp
+++ b/extension/vector/src/index/hnsw_index_utils.cpp
@@ -5,6 +5,7 @@
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "common/exception/binder.h"
 #include "common/types/types.h"
+#include "transaction/transaction_context.h"
 #include "main/client_context.h"
 #include "simsimd.h"
 
@@ -14,9 +15,10 @@ namespace vector_extension {
 void HNSWIndexUtils::validateIndexExistence(const main::ClientContext& context,
     const catalog::TableCatalogEntry* tableEntry, const std::string& indexName,
     IndexOperation indexOperation) {
+    auto transaction = transaction::Transaction::Get(context);
     switch (indexOperation) {
     case IndexOperation::CREATE: {
-        if (catalog::Catalog::Get(context)->containsIndex(context.getTransaction(),
+        if (catalog::Catalog::Get(context)->containsIndex(transaction,
                 tableEntry->getTableID(), indexName)) {
             throw common::BinderException{common::stringFormat(
                 "Index {} already exists in table {}.", indexName, tableEntry->getName())};
@@ -24,7 +26,7 @@ void HNSWIndexUtils::validateIndexExistence(const main::ClientContext& context,
     } break;
     case IndexOperation::DROP:
     case IndexOperation::QUERY: {
-        if (!catalog::Catalog::Get(context)->containsIndex(context.getTransaction(),
+        if (!catalog::Catalog::Get(context)->containsIndex(transaction,
                 tableEntry->getTableID(), indexName)) {
             throw common::BinderException{common::stringFormat(
                 "Table {} doesn't have an index with name {}.", tableEntry->getName(), indexName)};
@@ -39,8 +41,9 @@ void HNSWIndexUtils::validateIndexExistence(const main::ClientContext& context,
 catalog::NodeTableCatalogEntry* HNSWIndexUtils::bindNodeTable(const main::ClientContext& context,
     const std::string& tableName, const std::string& indexName, IndexOperation indexOperation) {
     binder::Binder::validateTableExistence(context, tableName);
+    auto transaction = transaction::Transaction::Get(context);
     const auto tableEntry =
-        catalog::Catalog::Get(context)->getTableCatalogEntry(context.getTransaction(), tableName);
+        catalog::Catalog::Get(context)->getTableCatalogEntry(transaction, tableName);
     binder::Binder::validateNodeTableType(tableEntry);
     validateIndexExistence(context, tableEntry, indexName, indexOperation);
     return tableEntry->ptrCast<catalog::NodeTableCatalogEntry>();

--- a/extension/vector/src/index/hnsw_index_utils.cpp
+++ b/extension/vector/src/index/hnsw_index_utils.cpp
@@ -5,9 +5,9 @@
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "common/exception/binder.h"
 #include "common/types/types.h"
-#include "transaction/transaction_context.h"
 #include "main/client_context.h"
 #include "simsimd.h"
+#include "transaction/transaction_context.h"
 
 namespace kuzu {
 namespace vector_extension {
@@ -18,16 +18,16 @@ void HNSWIndexUtils::validateIndexExistence(const main::ClientContext& context,
     auto transaction = transaction::Transaction::Get(context);
     switch (indexOperation) {
     case IndexOperation::CREATE: {
-        if (catalog::Catalog::Get(context)->containsIndex(transaction,
-                tableEntry->getTableID(), indexName)) {
+        if (catalog::Catalog::Get(context)->containsIndex(transaction, tableEntry->getTableID(),
+                indexName)) {
             throw common::BinderException{common::stringFormat(
                 "Index {} already exists in table {}.", indexName, tableEntry->getName())};
         }
     } break;
     case IndexOperation::DROP:
     case IndexOperation::QUERY: {
-        if (!catalog::Catalog::Get(context)->containsIndex(transaction,
-                tableEntry->getTableID(), indexName)) {
+        if (!catalog::Catalog::Get(context)->containsIndex(transaction, tableEntry->getTableID(),
+                indexName)) {
             throw common::BinderException{common::stringFormat(
                 "Table {} doesn't have an index with name {}.", tableEntry->getName(), indexName)};
         }

--- a/extension/vector/src/main/vector_extension.cpp
+++ b/extension/vector/src/main/vector_extension.cpp
@@ -12,7 +12,7 @@ namespace vector_extension {
 static void initHNSWEntries(main::ClientContext* context) {
     auto storageManager = storage::StorageManager::Get(*context);
     auto catalog = catalog::Catalog::Get(*context);
-    for (auto& indexEntry : catalog->getIndexEntries(context->getTransaction())) {
+    for (auto& indexEntry : catalog->getIndexEntries(transaction::Transaction::Get(*context))) {
         if (indexEntry->getIndexType() == HNSWIndexCatalogEntry::TYPE_NAME &&
             !indexEntry->isLoaded()) {
             indexEntry->setAuxInfo(HNSWIndexAuxInfo::deserialize(indexEntry->getAuxBufferReader()));

--- a/scripts/headers.txt
+++ b/scripts/headers.txt
@@ -81,5 +81,3 @@ src/include/processor/result/result_set_descriptor.h
 src/include/processor/result/flat_tuple.h
 src/include/processor/warning_context.h
 src/include/storage/storage_version_info.h
-src/include/transaction/transaction.h
-src/include/transaction/transaction_context.h

--- a/src/binder/bind/bind_create_macro.cpp
+++ b/src/binder/bind/bind_create_macro.cpp
@@ -4,8 +4,8 @@
 #include "common/exception/binder.h"
 #include "common/string_format.h"
 #include "common/string_utils.h"
-#include "main/client_context.h"
 #include "parser/create_macro.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::parser;
@@ -18,7 +18,7 @@ std::unique_ptr<BoundStatement> Binder::bindCreateMacro(const Statement& stateme
     auto macroName = createMacro.getMacroName();
     StringUtils::toUpper(macroName);
     if (catalog::Catalog::Get(*clientContext)
-            ->containsMacro(clientContext->getTransaction(), macroName)) {
+            ->containsMacro(transaction::Transaction::Get(*clientContext), macroName)) {
         throw BinderException{stringFormat("Macro {} already exists.", macroName)};
     }
     parser::default_macro_args defaultArgs;

--- a/src/binder/bind/bind_export_database.cpp
+++ b/src/binder/bind/bind_export_database.cpp
@@ -11,6 +11,7 @@
 #include "parser/parser.h"
 #include "parser/port_db.h"
 #include "parser/query/regular_query.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -68,7 +69,7 @@ static std::string getExportRelTableDataQuery(const TableCatalogEntry& relGroupE
 
 static std::vector<ExportedTableData> getExportInfo(const Catalog& catalog,
     main::ClientContext* context, Binder* binder, FileTypeInfo& fileTypeInfo) {
-    auto transaction = context->getTransaction();
+    auto transaction = Transaction::Get(*context);
     std::vector<ExportedTableData> exportData;
     for (auto entry : catalog.getNodeTableEntries(transaction, false /*useInternal*/)) {
         ExportedTableData tableData;

--- a/src/binder/bind/bind_file_scan.cpp
+++ b/src/binder/bind/bind_file_scan.cpp
@@ -190,7 +190,7 @@ static TableFunction getObjectScanFunc(const std::string& dbName, const std::str
     // Bind external database table
     auto attachedDB = main::DatabaseManager::Get(*clientContext)->getAttachedDatabase(dbName);
     auto attachedCatalog = attachedDB->getCatalog();
-    auto entry = attachedCatalog->getTableCatalogEntry(clientContext->getTransaction(), tableName);
+    auto entry = attachedCatalog->getTableCatalogEntry(transaction::Transaction::Get(*clientContext), tableName);
     return entry->ptrCast<TableCatalogEntry>()->getScanFunction();
 }
 

--- a/src/binder/bind/bind_file_scan.cpp
+++ b/src/binder/bind/bind_file_scan.cpp
@@ -190,7 +190,8 @@ static TableFunction getObjectScanFunc(const std::string& dbName, const std::str
     // Bind external database table
     auto attachedDB = main::DatabaseManager::Get(*clientContext)->getAttachedDatabase(dbName);
     auto attachedCatalog = attachedDB->getCatalog();
-    auto entry = attachedCatalog->getTableCatalogEntry(transaction::Transaction::Get(*clientContext), tableName);
+    auto entry = attachedCatalog->getTableCatalogEntry(
+        transaction::Transaction::Get(*clientContext), tableName);
     return entry->ptrCast<TableCatalogEntry>()->getScanFunction();
 }
 

--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -14,6 +14,7 @@
 #include "function/gds/rec_joins.h"
 #include "function/rewrite_function.h"
 #include "function/schema/vector_node_rel_functions.h"
+#include "transaction/transaction.h"
 #include "main/client_context.h"
 
 using namespace kuzu::common;
@@ -348,7 +349,7 @@ std::shared_ptr<RelExpression> Binder::createRecursiveQueryRel(const parser::Rel
     const std::vector<TableCatalogEntry*>& entries, std::shared_ptr<NodeExpression> srcNode,
     std::shared_ptr<NodeExpression> dstNode, RelDirectionType directionType) {
     auto catalog = Catalog::Get(*clientContext);
-    auto transaction = clientContext->getTransaction();
+    auto transaction = transaction::Transaction::Get(*clientContext);
     table_catalog_entry_set_t nodeEntrySet;
     for (auto entry : entries) {
         auto& relGroupEntry = entry->constCast<RelGroupCatalogEntry>();
@@ -632,7 +633,7 @@ static std::vector<TableCatalogEntry*> sortEntries(const table_catalog_entry_set
 
 std::vector<TableCatalogEntry*> Binder::bindNodeTableEntries(
     const std::vector<std::string>& tableNames) const {
-    auto transaction = clientContext->getTransaction();
+    auto transaction = transaction::Transaction::Get(*clientContext);
     auto catalog = Catalog::Get(*clientContext);
     auto useInternal = clientContext->useInternalCatalogEntry();
     table_catalog_entry_set_t entrySet;
@@ -654,7 +655,7 @@ std::vector<TableCatalogEntry*> Binder::bindNodeTableEntries(
 }
 
 TableCatalogEntry* Binder::bindNodeTableEntry(const std::string& name) const {
-    auto transaction = clientContext->getTransaction();
+    auto transaction = transaction::Transaction::Get(*clientContext);
     auto catalog = Catalog::Get(*clientContext);
     auto useInternal = clientContext->useInternalCatalogEntry();
     if (!catalog->containsTable(transaction, name, useInternal)) {
@@ -665,7 +666,7 @@ TableCatalogEntry* Binder::bindNodeTableEntry(const std::string& name) const {
 
 std::vector<TableCatalogEntry*> Binder::bindRelGroupEntries(
     const std::vector<std::string>& tableNames) const {
-    auto transaction = clientContext->getTransaction();
+    auto transaction = transaction::Transaction::Get(*clientContext);
     auto catalog = Catalog::Get(*clientContext);
     auto useInternal = clientContext->useInternalCatalogEntry();
     table_catalog_entry_set_t entrySet;

--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -14,8 +14,8 @@
 #include "function/gds/rec_joins.h"
 #include "function/rewrite_function.h"
 #include "function/schema/vector_node_rel_functions.h"
-#include "transaction/transaction.h"
 #include "main/client_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::parser;

--- a/src/binder/bind/bind_standalone_call_function.cpp
+++ b/src/binder/bind/bind_standalone_call_function.cpp
@@ -20,8 +20,8 @@ std::unique_ptr<BoundStatement> Binder::bindStandaloneCallFunction(
     auto funcName = funcExpr.getFunctionName();
     auto catalog = catalog::Catalog::Get(*clientContext);
     auto transaction = transaction::Transaction::Get(*clientContext);
-    auto entry = catalog->getFunctionEntry(transaction, funcName,
-                         clientContext->useInternalCatalogEntry());
+    auto entry =
+        catalog->getFunctionEntry(transaction, funcName, clientContext->useInternalCatalogEntry());
     KU_ASSERT(entry);
     if (entry->getType() != catalog::CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY) {
         throw BinderException(

--- a/src/binder/bind/bind_standalone_call_function.cpp
+++ b/src/binder/bind/bind_standalone_call_function.cpp
@@ -5,6 +5,7 @@
 #include "main/client_context.h"
 #include "parser/expression/parsed_function_expression.h"
 #include "parser/standalone_call_function.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 
@@ -17,8 +18,9 @@ std::unique_ptr<BoundStatement> Binder::bindStandaloneCallFunction(
     auto& funcExpr =
         callStatement.getFunctionExpression()->constCast<parser::ParsedFunctionExpression>();
     auto funcName = funcExpr.getFunctionName();
-    auto entry = catalog::Catalog::Get(*clientContext)
-                     ->getFunctionEntry(clientContext->getTransaction(), funcName,
+    auto catalog = catalog::Catalog::Get(*clientContext);
+    auto transaction = transaction::Transaction::Get(*clientContext);
+    auto entry = catalog->getFunctionEntry(transaction, funcName,
                          clientContext->useInternalCatalogEntry());
     KU_ASSERT(entry);
     if (entry->getType() != catalog::CatalogEntryType::STANDALONE_TABLE_FUNCTION_ENTRY) {

--- a/src/binder/bind/bind_table_function.cpp
+++ b/src/binder/bind/bind_table_function.cpp
@@ -4,8 +4,8 @@
 #include "binder/expression/literal_expression.h"
 #include "catalog/catalog.h"
 #include "function/built_in_function_utils.h"
-#include "transaction/transaction.h"
 #include "main/client_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::function;
@@ -18,7 +18,7 @@ BoundTableScanInfo Binder::bindTableFunc(const std::string& tableFuncName,
     auto catalog = catalog::Catalog::Get(*clientContext);
     auto transaction = transaction::Transaction::Get(*clientContext);
     auto entry = catalog->getFunctionEntry(transaction, tableFuncName,
-                         clientContext->useInternalCatalogEntry());
+        clientContext->useInternalCatalogEntry());
     expression_vector positionalParams;
     std::vector<LogicalType> positionalParamTypes;
     optional_params_t optionalParams;

--- a/src/binder/bind/bind_table_function.cpp
+++ b/src/binder/bind/bind_table_function.cpp
@@ -4,6 +4,7 @@
 #include "binder/expression/literal_expression.h"
 #include "catalog/catalog.h"
 #include "function/built_in_function_utils.h"
+#include "transaction/transaction.h"
 #include "main/client_context.h"
 
 using namespace kuzu::common;
@@ -14,8 +15,9 @@ namespace binder {
 
 BoundTableScanInfo Binder::bindTableFunc(const std::string& tableFuncName,
     const parser::ParsedExpression& expr, std::vector<parser::YieldVariable> yieldVariables) {
-    auto entry = catalog::Catalog::Get(*clientContext)
-                     ->getFunctionEntry(clientContext->getTransaction(), tableFuncName,
+    auto catalog = catalog::Catalog::Get(*clientContext);
+    auto transaction = transaction::Transaction::Get(*clientContext);
+    auto entry = catalog->getFunctionEntry(transaction, tableFuncName,
                          clientContext->useInternalCatalogEntry());
     expression_vector positionalParams;
     std::vector<LogicalType> positionalParamTypes;

--- a/src/binder/bind/copy/bind_copy_to.cpp
+++ b/src/binder/bind/copy/bind_copy_to.cpp
@@ -4,7 +4,7 @@
 #include "common/exception/catalog.h"
 #include "common/exception/runtime.h"
 #include "function/built_in_function_utils.h"
-#include "main/client_context.h"
+#include "transaction/transaction.h"
 #include "parser/copy.h"
 
 using namespace kuzu::common;
@@ -26,9 +26,9 @@ std::unique_ptr<BoundStatement> Binder::bindCopyToClause(const Statement& statem
     catalog::CatalogEntry* entry = nullptr;
     try {
         entry = catalog::Catalog::Get(*clientContext)
-                    ->getFunctionEntry(clientContext->getTransaction(), name);
-    } catch (common::CatalogException& exception) {
-        throw common::RuntimeException{common::stringFormat(
+                    ->getFunctionEntry(transaction::Transaction::Get(*clientContext), name);
+    } catch (CatalogException& exception) {
+        throw RuntimeException{common::stringFormat(
             "Exporting query result to the '{}' file is currently not supported.", fileTypeStr)};
     }
     auto exportFunc = function::BuiltInFunctionsUtils::matchFunction(name,

--- a/src/binder/bind/copy/bind_copy_to.cpp
+++ b/src/binder/bind/copy/bind_copy_to.cpp
@@ -4,8 +4,8 @@
 #include "common/exception/catalog.h"
 #include "common/exception/runtime.h"
 #include "function/built_in_function_utils.h"
-#include "transaction/transaction.h"
 #include "parser/copy.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::parser;

--- a/src/binder/bind/read/bind_in_query_call.cpp
+++ b/src/binder/bind/read/bind_in_query_call.cpp
@@ -2,9 +2,9 @@
 #include "binder/query/reading_clause/bound_table_function_call.h"
 #include "catalog/catalog.h"
 #include "common/exception/binder.h"
-#include "main/client_context.h"
 #include "parser/expression/parsed_function_expression.h"
 #include "parser/query/reading_clause/in_query_call_clause.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::catalog;
@@ -21,8 +21,8 @@ std::unique_ptr<BoundReadingClause> Binder::bindInQueryCall(const ReadingClause&
     auto functionExpr = expr->constPtrCast<ParsedFunctionExpression>();
     auto functionName = functionExpr->getFunctionName();
     std::unique_ptr<BoundReadingClause> boundReadingClause;
-    auto entry = Catalog::Get(*clientContext)
-                     ->getFunctionEntry(clientContext->getTransaction(), functionName);
+    auto transaction = transaction::Transaction::Get(*clientContext);
+    auto entry = Catalog::Get(*clientContext)->getFunctionEntry(transaction, functionName);
     switch (entry->getType()) {
     case CatalogEntryType::TABLE_FUNCTION_ENTRY: {
         auto boundTableFunction =

--- a/src/binder/bind_expression/bind_comparison_expression.cpp
+++ b/src/binder/bind_expression/bind_comparison_expression.cpp
@@ -5,7 +5,7 @@
 #include "catalog/catalog.h"
 #include "common/exception/binder.h"
 #include "function/built_in_function_utils.h"
-#include "main/client_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::catalog;
@@ -47,7 +47,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindComparisonExpression(
     }
 
     auto catalog = Catalog::Get(*context);
-    auto transaction = context->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context);
     auto functionName = ExpressionTypeUtil::toString(expressionType);
     LogicalType combinedType(LogicalTypeID::ANY);
     if (!ExpressionUtil::tryCombineDataType(children, combinedType)) {

--- a/src/binder/bind_expression/bind_function_expression.cpp
+++ b/src/binder/bind_expression/bind_function_expression.cpp
@@ -8,9 +8,9 @@
 #include "function/cast/vector_cast_functions.h"
 #include "function/rewrite_function.h"
 #include "function/scalar_macro_function.h"
-#include "main/client_context.h"
 #include "parser/expression/parsed_expression_visitor.h"
 #include "parser/expression/parsed_function_expression.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::parser;
@@ -23,7 +23,9 @@ namespace binder {
 std::shared_ptr<Expression> ExpressionBinder::bindFunctionExpression(const ParsedExpression& expr) {
     auto funcExpr = expr.constPtrCast<ParsedFunctionExpression>();
     auto functionName = funcExpr->getNormalizedFunctionName();
-    auto entry = Catalog::Get(*context)->getFunctionEntry(context->getTransaction(), functionName);
+    auto transaction = transaction::Transaction::Get(*context);
+    auto catalog = Catalog::Get(*context);
+    auto entry = catalog->getFunctionEntry(transaction, functionName);
     switch (entry->getType()) {
     case CatalogEntryType::SCALAR_FUNCTION_ENTRY:
         return bindScalarFunctionExpression(expr, functionName);
@@ -66,7 +68,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindScalarFunctionExpression(
     const expression_vector& children, const std::string& functionName,
     std::vector<std::string> optionalArguments) {
     auto catalog = Catalog::Get(*context);
-    auto transaction = context->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context);
     auto childrenTypes = getTypes(children);
 
     auto entry = catalog->getFunctionEntry(transaction, functionName);
@@ -133,7 +135,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindRewriteFunctionExpression(
     }
     auto childrenTypes = getTypes(children);
     auto functionName = funcExpr.getNormalizedFunctionName();
-    auto entry = Catalog::Get(*context)->getFunctionEntry(context->getTransaction(), functionName);
+    auto transaction = transaction::Transaction::Get(*context);
+    auto entry = Catalog::Get(*context)->getFunctionEntry(transaction, functionName);
     auto match = BuiltInFunctionsUtils::matchFunction(functionName, childrenTypes,
         entry->ptrCast<FunctionCatalogEntry>());
     auto function = match->constPtrCast<RewriteFunction>();
@@ -151,7 +154,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindAggregateFunctionExpression(
         childrenTypes.push_back(child->dataType.copy());
         children.push_back(std::move(child));
     }
-    auto entry = Catalog::Get(*context)->getFunctionEntry(context->getTransaction(), functionName);
+    auto transaction = transaction::Transaction::Get(*context);
+    auto entry = Catalog::Get(*context)->getFunctionEntry(transaction, functionName);
     auto function = BuiltInFunctionsUtils::matchAggregateFunction(functionName, childrenTypes,
         isDistinct, entry->ptrCast<FunctionCatalogEntry>())
                         ->copy();
@@ -182,8 +186,9 @@ std::shared_ptr<Expression> ExpressionBinder::bindAggregateFunctionExpression(
 
 std::shared_ptr<Expression> ExpressionBinder::bindMacroExpression(
     const ParsedExpression& parsedExpression, const std::string& macroName) {
+    auto transaction = transaction::Transaction::Get(*context);
     auto scalarMacroFunction =
-        Catalog::Get(*context)->getScalarMacroFunction(context->getTransaction(), macroName);
+        Catalog::Get(*context)->getScalarMacroFunction(transaction, macroName);
     auto macroExpr = scalarMacroFunction->expression->copy();
     auto parameterVals = scalarMacroFunction->getDefaultParameterVals();
     auto& parsedFuncExpr = parsedExpression.constCast<ParsedFunctionExpression>();

--- a/src/binder/bind_expression/bind_subquery_expression.cpp
+++ b/src/binder/bind_expression/bind_subquery_expression.cpp
@@ -6,8 +6,8 @@
 #include "common/types/value/value.h"
 #include "function/aggregate/count_star.h"
 #include "function/built_in_function_utils.h"
-#include "main/client_context.h"
 #include "parser/expression/parsed_subquery_expression.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::parser;
 using namespace kuzu::common;
@@ -34,7 +34,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindSubqueryExpression(
         std::move(boundGraphPattern.queryGraphCollection), uniqueName, std::move(rawName));
     boundSubqueryExpr->setWhereExpression(boundGraphPattern.where);
     // Bind projection
-    auto entry = catalog::Catalog::Get(*context)->getFunctionEntry(context->getTransaction(),
+    auto entry = catalog::Catalog::Get(*context)->getFunctionEntry(transaction::Transaction::Get(*context),
         CountStarFunction::name);
     auto function = BuiltInFunctionsUtils::matchAggregateFunction(CountStarFunction::name,
         std::vector<LogicalType>{}, false, entry->ptrCast<catalog::FunctionCatalogEntry>());

--- a/src/binder/bind_expression/bind_subquery_expression.cpp
+++ b/src/binder/bind_expression/bind_subquery_expression.cpp
@@ -34,8 +34,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindSubqueryExpression(
         std::move(boundGraphPattern.queryGraphCollection), uniqueName, std::move(rawName));
     boundSubqueryExpr->setWhereExpression(boundGraphPattern.where);
     // Bind projection
-    auto entry = catalog::Catalog::Get(*context)->getFunctionEntry(transaction::Transaction::Get(*context),
-        CountStarFunction::name);
+    auto entry = catalog::Catalog::Get(*context)->getFunctionEntry(
+        transaction::Transaction::Get(*context), CountStarFunction::name);
     auto function = BuiltInFunctionsUtils::matchAggregateFunction(CountStarFunction::name,
         std::vector<LogicalType>{}, false, entry->ptrCast<catalog::FunctionCatalogEntry>());
     auto bindData = std::make_unique<FunctionBindData>(LogicalType(function->returnTypeID));

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -8,12 +8,12 @@
 #include "common/string_utils.h"
 #include "function/built_in_function_utils.h"
 #include "function/table/table_function.h"
-#include "main/client_context.h"
 #include "parser/statement.h"
 #include "processor/operator/persistent/reader/csv/parallel_csv_reader.h"
 #include "processor/operator/persistent/reader/csv/serial_csv_reader.h"
 #include "processor/operator/persistent/reader/npy/npy_reader.h"
 #include "processor/operator/persistent/reader/parquet/parquet_reader.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;
@@ -221,8 +221,8 @@ TableFunction Binder::getScanFunction(const FileTypeInfo& typeInfo,
     Function* func = nullptr;
     std::vector<LogicalType> inputTypes;
     inputTypes.push_back(LogicalType::STRING());
-    auto catalog = catalog::Catalog::Get(*clientContext);
-    auto transaction = clientContext->getTransaction();
+    auto catalog = Catalog::Get(*clientContext);
+    auto transaction = transaction::Transaction::Get(*clientContext);
     switch (typeInfo.fileType) {
     case FileType::PARQUET: {
         auto entry = catalog->getFunctionEntry(transaction, ParquetScanFunction::name);

--- a/src/binder/query/query_graph_label_analyzer.cpp
+++ b/src/binder/query/query_graph_label_analyzer.cpp
@@ -4,7 +4,7 @@
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
 #include "common/exception/binder.h"
 #include "common/string_format.h"
-#include "main/client_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::catalog;
@@ -59,7 +59,7 @@ void QueryGraphLabelAnalyzer::pruneNode(const QueryGraph& graph, NodeExpression&
         Candidates candidates;
         auto isSrcConnect = *queryRel->getSrcNode() == node;
         auto isDstConnect = *queryRel->getDstNode() == node;
-        auto tx = clientContext.getTransaction();
+        auto tx = transaction::Transaction::Get(clientContext);
         if (queryRel->getDirectionType() == RelDirectionType::BOTH) {
             if (isSrcConnect || isDstConnect) {
                 for (auto entry : queryRel->getEntries()) {

--- a/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
@@ -5,7 +5,6 @@
 #include "binder/ddl/bound_create_table_info.h"
 #include "catalog/catalog.h"
 #include "common/serializer/deserializer.h"
-#include "common/exception/binder.h"
 #include "transaction/transaction.h"
 
 using namespace kuzu::common;

--- a/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
@@ -5,8 +5,8 @@
 #include "binder/ddl/bound_create_table_info.h"
 #include "catalog/catalog.h"
 #include "common/serializer/deserializer.h"
-#include "main/client_context.h"
-#include <common/exception/binder.h>
+#include "common/exception/binder.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::main;
@@ -133,7 +133,7 @@ static std::string getFromToStr(const NodeTableIDPair& pair, const Catalog* cata
 std::string RelGroupCatalogEntry::toCypher(const ToCypherInfo& info) const {
     auto relGroupInfo = info.constCast<RelGroupToCypherInfo>();
     auto catalog = Catalog::Get(*relGroupInfo.context);
-    auto transaction = relGroupInfo.context->getTransaction();
+    auto transaction = transaction::Transaction::Get(*relGroupInfo.context);
     std::stringstream ss;
     ss << stringFormat("CREATE REL TABLE `{}` (", getName());
     KU_ASSERT(!relTableInfos.empty());

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -18,8 +18,8 @@
 #include "common/types/ku_string.h"
 #include "function/built_in_function_utils.h"
 #include "function/cast/functions/numeric_limits.h"
-#include "main/client_context.h"
 #include "storage/compression/float_compression.h"
+#include "transaction/transaction.h"
 
 using kuzu::function::BuiltInFunctionsUtils;
 
@@ -732,8 +732,8 @@ LogicalType LogicalType::convertFromString(const std::string& str, main::ClientC
     } else if (tryGetIDFromString(upperDataTypeString, type.typeID)) {
         type.physicalType = LogicalType::getPhysicalType(type.typeID, type.extraTypeInfo);
     } else if (context != nullptr) {
-        type = catalog::Catalog::Get(*context)->getType(context->getTransaction(),
-            upperDataTypeString);
+        auto transaction = transaction::Transaction::Get(*context);
+        type = catalog::Catalog::Get(*context)->getType(transaction, upperDataTypeString);
     } else {
         throw common::RuntimeException{"Invalid datatype string: " + str};
     }

--- a/src/extension/extension_manager.cpp
+++ b/src/extension/extension_manager.cpp
@@ -5,6 +5,7 @@
 #include "extension/extension.h"
 #include "generated_extension_loader.h"
 #include "storage/wal/local_wal.h"
+#include "transaction/transaction_context.h"
 
 namespace kuzu {
 namespace extension {
@@ -43,7 +44,7 @@ void ExtensionManager::loadExtension(const std::string& path, main::ClientContex
     (*init)(context);
     loadedExtensions.push_back(LoadedExtension(extensionName, fullPath,
         isOfficial ? ExtensionSource::OFFICIAL : ExtensionSource::USER));
-    auto transaction = context->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context);
     if (transaction->shouldLogToWAL()) {
         transaction->getLocalWAL().logLoadExtension(path);
     }

--- a/src/function/date/date_functions.cpp
+++ b/src/function/date/date_functions.cpp
@@ -1,21 +1,21 @@
 #include "function/date/date_functions.h"
-
-#include "main/client_context.h"
+#include "transaction/transaction.h"
+#include "function/function.h"
 
 namespace kuzu {
 namespace function {
 
 void CurrentDate::operation(common::date_t& result, void* dataPtr) {
-    auto currentTS = reinterpret_cast<FunctionBindData*>(dataPtr)
-                         ->clientContext->getTransaction()
-                         ->getCurrentTS();
+    auto clientContext = reinterpret_cast<FunctionBindData*>(dataPtr)->clientContext;
+    auto transaction = transaction::Transaction::Get(*clientContext);
+    auto currentTS = transaction->getCurrentTS();
     result = common::Timestamp::getDate(common::timestamp_tz_t(currentTS));
 }
 
 void CurrentTimestamp::operation(common::timestamp_tz_t& result, void* dataPtr) {
-    auto currentTS = reinterpret_cast<FunctionBindData*>(dataPtr)
-                         ->clientContext->getTransaction()
-                         ->getCurrentTS();
+    auto clientContext = reinterpret_cast<FunctionBindData*>(dataPtr)->clientContext;
+    auto transaction = transaction::Transaction::Get(*clientContext);
+    auto currentTS = transaction->getCurrentTS();
     result = common::timestamp_tz_t(currentTS);
 }
 

--- a/src/function/date/date_functions.cpp
+++ b/src/function/date/date_functions.cpp
@@ -1,6 +1,7 @@
 #include "function/date/date_functions.h"
-#include "transaction/transaction.h"
+
 #include "function/function.h"
+#include "transaction/transaction.h"
 
 namespace kuzu {
 namespace function {

--- a/src/function/gds/asp_destinations.cpp
+++ b/src/function/gds/asp_destinations.cpp
@@ -1,8 +1,8 @@
 #include "binder/expression/node_expression.h"
 #include "function/gds/gds_function_collection.h"
 #include "function/gds/rec_joins.h"
-#include "main/client_context.h"
 #include "processor/execution_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::processor;
 using namespace kuzu::common;
@@ -302,7 +302,7 @@ private:
         auto clientContext = context->clientContext;
         auto graph = sharedState->graph.get();
         auto multiplicitiesPair = std::make_unique<MultiplicitiesPair>(
-            graph->getMaxOffsetMap(clientContext->getTransaction()));
+            graph->getMaxOffsetMap(transaction::Transaction::Get(*clientContext)));
         auto frontier = DenseFrontier::getUnvisitedFrontier(context, graph);
         auto frontierPair = std::make_unique<SPFrontierPair>(std::move(frontier));
         auto edgeCompute = std::make_unique<ASPDestinationsEdgeCompute>(frontierPair.get(),

--- a/src/function/gds/asp_paths.cpp
+++ b/src/function/gds/asp_paths.cpp
@@ -2,8 +2,8 @@
 #include "function/gds/auxiliary_state/path_auxiliary_state.h"
 #include "function/gds/gds_function_collection.h"
 #include "function/gds/rec_joins.h"
-#include "main/client_context.h"
 #include "processor/execution_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -86,7 +86,7 @@ private:
             DenseFrontier::getUninitializedFrontier(context, sharedState->graph.get());
         auto frontierPair = std::make_unique<SPFrontierPair>(std::move(denseFrontier));
         auto bfsGraph = std::make_unique<BFSGraphManager>(
-            sharedState->graph->getMaxOffsetMap(clientContext->getTransaction()), mm);
+            sharedState->graph->getMaxOffsetMap(transaction::Transaction::Get(*clientContext)), mm);
         auto edgeCompute =
             std::make_unique<ASPPathsEdgeCompute>(frontierPair.get(), bfsGraph.get());
         auto auxiliaryState = std::make_unique<PathAuxiliaryState>(std::move(bfsGraph));

--- a/src/function/gds/awsp_paths.cpp
+++ b/src/function/gds/awsp_paths.cpp
@@ -4,8 +4,9 @@
 #include "function/gds/gds_function_collection.h"
 #include "function/gds/rec_joins.h"
 #include "function/gds/weight_utils.h"
-#include "main/client_context.h"
 #include "processor/execution_context.h"
+#include "transaction/transaction.h"
+#include "main/client_context.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -151,7 +152,7 @@ private:
         auto frontierPair = std::make_unique<DenseSparseDynamicFrontierPair>(
             std::move(curDenseFrontier), std::move(nextDenseFrontier));
         auto bfsGraph = std::make_unique<BFSGraphManager>(
-            sharedState->graph->getMaxOffsetMap(clientContext->getTransaction()), mm);
+            sharedState->graph->getMaxOffsetMap(transaction::Transaction::Get(*clientContext)), mm);
         std::unique_ptr<GDSComputeState> gdsState;
         WeightUtils::visit(AllWeightedSPPathsFunction::name,
             bindData.weightPropertyExpr->getDataType(), [&]<typename T>(T) {

--- a/src/function/gds/awsp_paths.cpp
+++ b/src/function/gds/awsp_paths.cpp
@@ -4,9 +4,9 @@
 #include "function/gds/gds_function_collection.h"
 #include "function/gds/rec_joins.h"
 #include "function/gds/weight_utils.h"
+#include "main/client_context.h"
 #include "processor/execution_context.h"
 #include "transaction/transaction.h"
-#include "main/client_context.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -6,16 +6,16 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
 #include "common/exception/binder.h"
+#include "function/table/bind_input.h"
 #include "graph/graph_entry_set.h"
 #include "graph/on_disk_graph.h"
+#include "main/client_context.h"
 #include "parser/parser.h"
 #include "planner/operator/logical_table_function_call.h"
 #include "planner/operator/sip/logical_semi_masker.h"
 #include "planner/planner.h"
 #include "processor/operator/table_function_call.h"
 #include "processor/plan_mapper.h"
-#include "function/table/bind_input.h"
-#include "main/client_context.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -8,13 +8,14 @@
 #include "common/exception/binder.h"
 #include "graph/graph_entry_set.h"
 #include "graph/on_disk_graph.h"
-#include "main/client_context.h"
 #include "parser/parser.h"
 #include "planner/operator/logical_table_function_call.h"
 #include "planner/operator/sip/logical_semi_masker.h"
 #include "planner/planner.h"
 #include "processor/operator/table_function_call.h"
 #include "processor/plan_mapper.h"
+#include "function/table/bind_input.h"
+#include "main/client_context.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;
@@ -76,7 +77,7 @@ NativeGraphEntry GDSFunction::bindGraphEntry(ClientContext& context, const std::
 static NativeGraphEntryTableInfo bindNodeEntry(ClientContext& context, const std::string& tableName,
     const std::string& predicate) {
     auto catalog = Catalog::Get(context);
-    auto transaction = context.getTransaction();
+    auto transaction = transaction::Transaction::Get(context);
     auto nodeEntry = catalog->getTableCatalogEntry(transaction, tableName);
     if (nodeEntry->getType() != CatalogEntryType::NODE_TABLE_ENTRY) {
         throw BinderException(stringFormat("{} is not a NODE table.", tableName));
@@ -97,7 +98,7 @@ static NativeGraphEntryTableInfo bindNodeEntry(ClientContext& context, const std
 static NativeGraphEntryTableInfo bindRelEntry(ClientContext& context, const std::string& tableName,
     const std::string& predicate) {
     auto catalog = Catalog::Get(context);
-    auto transaction = context.getTransaction();
+    auto transaction = transaction::Transaction::Get(context);
     auto relEntry = catalog->getTableCatalogEntry(transaction, tableName);
     if (relEntry->getType() != CatalogEntryType::REL_GROUP_ENTRY) {
         throw BinderException(
@@ -120,7 +121,7 @@ static NativeGraphEntryTableInfo bindRelEntry(ClientContext& context, const std:
 NativeGraphEntry GDSFunction::bindGraphEntry(ClientContext& context,
     const ParsedNativeGraphEntry& entry) {
     auto catalog = Catalog::Get(context);
-    auto transaction = context.getTransaction();
+    auto transaction = transaction::Transaction::Get(context);
     auto result = NativeGraphEntry();
     table_id_set_t projectedNodeTableIDSet;
     for (auto& nodeInfo : entry.nodeInfos) {

--- a/src/function/gds/gds_frontier.cpp
+++ b/src/function/gds/gds_frontier.cpp
@@ -1,8 +1,8 @@
 #include "function/gds/gds_frontier.h"
 
 #include "function/gds/gds_utils.h"
-#include "transaction/transaction.h"
 #include "processor/execution_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::graph;

--- a/src/function/gds/gds_frontier.cpp
+++ b/src/function/gds/gds_frontier.cpp
@@ -1,7 +1,7 @@
 #include "function/gds/gds_frontier.h"
 
 #include "function/gds/gds_utils.h"
-#include "main/client_context.h"
+#include "transaction/transaction.h"
 #include "processor/execution_context.h"
 
 using namespace kuzu::common;
@@ -143,13 +143,13 @@ iteration_t DenseFrontier::getIteration(offset_t offset) const {
 
 std::unique_ptr<DenseFrontier> DenseFrontier::getUninitializedFrontier(ExecutionContext* context,
     Graph* graph) {
-    auto transaction = context->clientContext->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context->clientContext);
     return std::make_unique<DenseFrontier>(graph->getMaxOffsetMap(transaction));
 }
 
 std::unique_ptr<DenseFrontier> DenseFrontier::getUnvisitedFrontier(ExecutionContext* context,
     Graph* graph) {
-    auto transaction = context->clientContext->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context->clientContext);
     auto frontier = std::make_unique<DenseFrontier>(graph->getMaxOffsetMap(transaction));
     frontier->init(context, graph, FRONTIER_UNVISITED);
     return frontier;
@@ -157,7 +157,7 @@ std::unique_ptr<DenseFrontier> DenseFrontier::getUnvisitedFrontier(ExecutionCont
 
 std::unique_ptr<DenseFrontier> DenseFrontier::getVisitedFrontier(ExecutionContext* context,
     Graph* graph) {
-    auto transaction = context->clientContext->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context->clientContext);
     auto frontier = std::make_unique<DenseFrontier>(graph->getMaxOffsetMap(transaction));
     frontier->init(context, graph, FRONTIER_INITIAL_VISITED);
     return frontier;
@@ -168,10 +168,10 @@ std::unique_ptr<DenseFrontier> DenseFrontier::getVisitedFrontier(ExecutionContex
     if (maskMap == nullptr) {
         return getVisitedFrontier(context, graph);
     }
-    auto tx = context->clientContext->getTransaction();
-    auto frontier = std::make_unique<DenseFrontier>(graph->getMaxOffsetMap(tx));
+    auto transaction = transaction::Transaction::Get(*context->clientContext);
+    auto frontier = std::make_unique<DenseFrontier>(graph->getMaxOffsetMap(transaction));
     frontier->init(context, graph, FRONTIER_INITIAL_VISITED);
-    for (auto [tableID, numNodes] : graph->getMaxOffsetMap(tx)) {
+    for (auto [tableID, numNodes] : graph->getMaxOffsetMap(transaction)) {
         frontier->pinTableID(tableID);
         if (maskMap->containsTableID(tableID)) {
             auto mask = maskMap->getOffsetMask(tableID);

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -28,7 +28,8 @@ static std::shared_ptr<FrontierTask> getFrontierTask(const main::ClientContext* 
     auto numThreads = context->getMaxNumThreadForExec();
     auto sharedState =
         std::make_shared<FrontierTaskSharedState>(numThreads, *computeState.frontierPair);
-    auto maxOffset = graph->getMaxOffset(transaction::Transaction::Get(*context), info.getBoundTableID());
+    auto maxOffset =
+        graph->getMaxOffset(transaction::Transaction::Get(*context), info.getBoundTableID());
     sharedState->morselDispatcher.init(maxOffset);
     return std::make_shared<FrontierTask>(numThreads, info, sharedState);
 }
@@ -127,8 +128,8 @@ static void runVertexComputeInternal(const TableCatalogEntry* currentEntry,
         task->runSparse();
         return;
     }
-    auto maxOffset =
-        graph->getMaxOffset(transaction::Transaction::Get(*context->clientContext), currentEntry->getTableID());
+    auto maxOffset = graph->getMaxOffset(transaction::Transaction::Get(*context->clientContext),
+        currentEntry->getTableID());
     auto sharedState = task->getSharedState();
     sharedState->morselDispatcher.init(maxOffset);
     context->clientContext->getTaskScheduler()->scheduleTaskAndWaitOrError(task, context,

--- a/src/function/gds/gds_utils.cpp
+++ b/src/function/gds/gds_utils.cpp
@@ -8,6 +8,7 @@
 #include "graph/graph.h"
 #include "graph/graph_entry.h"
 #include "main/client_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::catalog;
@@ -27,7 +28,7 @@ static std::shared_ptr<FrontierTask> getFrontierTask(const main::ClientContext* 
     auto numThreads = context->getMaxNumThreadForExec();
     auto sharedState =
         std::make_shared<FrontierTaskSharedState>(numThreads, *computeState.frontierPair);
-    auto maxOffset = graph->getMaxOffset(context->getTransaction(), info.getBoundTableID());
+    auto maxOffset = graph->getMaxOffset(transaction::Transaction::Get(*context), info.getBoundTableID());
     sharedState->morselDispatcher.init(maxOffset);
     return std::make_shared<FrontierTask>(numThreads, info, sharedState);
 }
@@ -127,7 +128,7 @@ static void runVertexComputeInternal(const TableCatalogEntry* currentEntry,
         return;
     }
     auto maxOffset =
-        graph->getMaxOffset(context->clientContext->getTransaction(), currentEntry->getTableID());
+        graph->getMaxOffset(transaction::Transaction::Get(*context->clientContext), currentEntry->getTableID());
     auto sharedState = task->getSharedState();
     sharedState->morselDispatcher.init(maxOffset);
     context->clientContext->getTaskScheduler()->scheduleTaskAndWaitOrError(task, context,

--- a/src/function/gds/ssp_paths.cpp
+++ b/src/function/gds/ssp_paths.cpp
@@ -2,8 +2,9 @@
 #include "function/gds/auxiliary_state/path_auxiliary_state.h"
 #include "function/gds/gds_function_collection.h"
 #include "function/gds/rec_joins.h"
-#include "main/client_context.h"
+// #include "main/client_context.h"
 #include "processor/execution_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -76,8 +77,8 @@ private:
         auto clientContext = context->clientContext;
         auto frontier = DenseFrontier::getUninitializedFrontier(context, sharedState->graph.get());
         auto frontierPair = std::make_unique<SPFrontierPair>(std::move(frontier));
-        auto bfsGraph = std::make_unique<BFSGraphManager>(
-            sharedState->graph->getMaxOffsetMap(clientContext->getTransaction()),
+        auto transaction = transaction::Transaction::Get(*context->clientContext);
+        auto bfsGraph = std::make_unique<BFSGraphManager>(sharedState->graph->getMaxOffsetMap(transaction),
             storage::MemoryManager::Get(*clientContext));
         auto edgeCompute =
             std::make_unique<SSPPathsEdgeCompute>(frontierPair.get(), bfsGraph.get());

--- a/src/function/gds/ssp_paths.cpp
+++ b/src/function/gds/ssp_paths.cpp
@@ -78,8 +78,9 @@ private:
         auto frontier = DenseFrontier::getUninitializedFrontier(context, sharedState->graph.get());
         auto frontierPair = std::make_unique<SPFrontierPair>(std::move(frontier));
         auto transaction = transaction::Transaction::Get(*context->clientContext);
-        auto bfsGraph = std::make_unique<BFSGraphManager>(sharedState->graph->getMaxOffsetMap(transaction),
-            storage::MemoryManager::Get(*clientContext));
+        auto bfsGraph =
+            std::make_unique<BFSGraphManager>(sharedState->graph->getMaxOffsetMap(transaction),
+                storage::MemoryManager::Get(*clientContext));
         auto edgeCompute =
             std::make_unique<SSPPathsEdgeCompute>(frontierPair.get(), bfsGraph.get());
         auto auxiliaryState = std::make_unique<PathAuxiliaryState>(std::move(bfsGraph));

--- a/src/function/gds/variable_length_path.cpp
+++ b/src/function/gds/variable_length_path.cpp
@@ -3,8 +3,8 @@
 #include "function/gds/gds_function_collection.h"
 #include "function/gds/rec_joins.h"
 #include "graph/graph.h"
-#include "main/client_context.h"
 #include "processor/execution_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -117,8 +117,9 @@ private:
     std::unique_ptr<GDSComputeState> getComputeState(ExecutionContext* context, const RJBindData&,
         RecursiveExtendSharedState* sharedState) override {
         auto clientContext = context->clientContext;
+        auto transaction = transaction::Transaction::Get(*clientContext);
         auto bfsGraph = std::make_unique<BFSGraphManager>(
-            sharedState->graph->getMaxOffsetMap(clientContext->getTransaction()),
+            sharedState->graph->getMaxOffsetMap(transaction),
             storage::MemoryManager::Get(*clientContext));
         auto currentDenseFrontier =
             DenseFrontier::getUninitializedFrontier(context, sharedState->graph.get());

--- a/src/function/gds/variable_length_path.cpp
+++ b/src/function/gds/variable_length_path.cpp
@@ -118,9 +118,9 @@ private:
         RecursiveExtendSharedState* sharedState) override {
         auto clientContext = context->clientContext;
         auto transaction = transaction::Transaction::Get(*clientContext);
-        auto bfsGraph = std::make_unique<BFSGraphManager>(
-            sharedState->graph->getMaxOffsetMap(transaction),
-            storage::MemoryManager::Get(*clientContext));
+        auto bfsGraph =
+            std::make_unique<BFSGraphManager>(sharedState->graph->getMaxOffsetMap(transaction),
+                storage::MemoryManager::Get(*clientContext));
         auto currentDenseFrontier =
             DenseFrontier::getUninitializedFrontier(context, sharedState->graph.get());
         auto nextDenseFrontier =

--- a/src/function/gds/wsp_destinations.cpp
+++ b/src/function/gds/wsp_destinations.cpp
@@ -2,8 +2,8 @@
 #include "function/gds/gds_function_collection.h"
 #include "function/gds/rec_joins.h"
 #include "function/gds/weight_utils.h"
-#include "main/client_context.h"
 #include "processor/execution_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -307,7 +307,7 @@ private:
         auto frontierPair = std::make_unique<DenseSparseDynamicFrontierPair>(
             std::move(curDenseFrontier), std::move(nextDenseFrontier));
         auto costsPair =
-            std::make_unique<CostsPair>(graph->getMaxOffsetMap(clientContext->getTransaction()));
+            std::make_unique<CostsPair>(graph->getMaxOffsetMap(transaction::Transaction::Get(*clientContext)));
         auto costPairPtr = costsPair.get();
         auto auxiliaryState = std::make_unique<WSPDestinationsAuxiliaryState>(std::move(costsPair));
         std::unique_ptr<GDSComputeState> gdsState;
@@ -328,7 +328,7 @@ private:
         auto clientContext = context->clientContext;
         return std::make_unique<WSPDestinationsOutputWriter>(clientContext,
             sharedState->getOutputNodeMaskMap(), sourceNodeID, costs,
-            sharedState->graph->getMaxOffsetMap(clientContext->getTransaction()));
+            sharedState->graph->getMaxOffsetMap(transaction::Transaction::Get(*clientContext)));
     }
 };
 

--- a/src/function/gds/wsp_destinations.cpp
+++ b/src/function/gds/wsp_destinations.cpp
@@ -306,8 +306,8 @@ private:
         auto nextDenseFrontier = DenseFrontier::getUninitializedFrontier(context, graph);
         auto frontierPair = std::make_unique<DenseSparseDynamicFrontierPair>(
             std::move(curDenseFrontier), std::move(nextDenseFrontier));
-        auto costsPair =
-            std::make_unique<CostsPair>(graph->getMaxOffsetMap(transaction::Transaction::Get(*clientContext)));
+        auto costsPair = std::make_unique<CostsPair>(
+            graph->getMaxOffsetMap(transaction::Transaction::Get(*clientContext)));
         auto costPairPtr = costsPair.get();
         auto auxiliaryState = std::make_unique<WSPDestinationsAuxiliaryState>(std::move(costsPair));
         std::unique_ptr<GDSComputeState> gdsState;

--- a/src/function/gds/wsp_paths.cpp
+++ b/src/function/gds/wsp_paths.cpp
@@ -3,8 +3,8 @@
 #include "function/gds/gds_function_collection.h"
 #include "function/gds/rec_joins.h"
 #include "function/gds/weight_utils.h"
-#include "main/client_context.h"
 #include "processor/execution_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::storage;
@@ -122,7 +122,7 @@ private:
         auto frontierPair = std::make_unique<DenseSparseDynamicFrontierPair>(
             std::move(curDenseFrontier), std::move(nextDenseFrontier));
         auto bfsGraph = std::make_unique<BFSGraphManager>(
-            sharedState->graph->getMaxOffsetMap(clientContext->getTransaction()),
+            sharedState->graph->getMaxOffsetMap(transaction::Transaction::Get(*clientContext)),
             MemoryManager::Get(*clientContext));
         std::unique_ptr<GDSComputeState> gdsState;
         WeightUtils::visit(WeightedSPPathsFunction::name,

--- a/src/function/sequence/sequence_functions.cpp
+++ b/src/function/sequence/sequence_functions.cpp
@@ -3,8 +3,8 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/sequence_catalog_entry.h"
 #include "function/scalar_function.h"
-#include "transaction/transaction.h"
 #include "main/client_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 
@@ -17,8 +17,8 @@ struct CurrVal {
         auto catalog = catalog::Catalog::Get(*ctx);
         auto transaction = transaction::Transaction::Get(*ctx);
         auto sequenceName = input.getAsString();
-        auto sequenceEntry = catalog->getSequenceEntry(transaction, sequenceName,
-            ctx->useInternalCatalogEntry());
+        auto sequenceEntry =
+            catalog->getSequenceEntry(transaction, sequenceName, ctx->useInternalCatalogEntry());
         result.setValue(0, sequenceEntry->currVal());
     }
 };
@@ -30,8 +30,8 @@ struct NextVal {
         auto catalog = catalog::Catalog::Get(*ctx);
         auto transaction = transaction::Transaction::Get(*ctx);
         auto sequenceName = input.getAsString();
-        auto sequenceEntry = catalog->getSequenceEntry(transaction, sequenceName,
-            ctx->useInternalCatalogEntry());
+        auto sequenceEntry =
+            catalog->getSequenceEntry(transaction, sequenceName, ctx->useInternalCatalogEntry());
         sequenceEntry->nextKVal(transaction, cnt, result);
         result.state->getSelVectorUnsafe().setSelSize(cnt);
     }
@@ -41,8 +41,7 @@ function_set CurrValFunction::getFunctionSet() {
     function_set functionSet;
     functionSet.push_back(make_unique<ScalarFunction>(name,
         std::vector<LogicalTypeID>{LogicalTypeID::STRING}, LogicalTypeID::INT64,
-        ScalarFunction::UnarySequenceExecFunction<ku_string_t, ValueVector,
-            CurrVal>));
+        ScalarFunction::UnarySequenceExecFunction<ku_string_t, ValueVector, CurrVal>));
     return functionSet;
 }
 
@@ -50,8 +49,7 @@ function_set NextValFunction::getFunctionSet() {
     function_set functionSet;
     auto func = make_unique<ScalarFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING},
         LogicalTypeID::INT64,
-        ScalarFunction::UnarySequenceExecFunction<ku_string_t, ValueVector,
-            NextVal>);
+        ScalarFunction::UnarySequenceExecFunction<ku_string_t, ValueVector, NextVal>);
     func->isReadOnly = false;
     functionSet.push_back(std::move(func));
     return functionSet;

--- a/src/function/sequence/sequence_functions.cpp
+++ b/src/function/sequence/sequence_functions.cpp
@@ -3,6 +3,7 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/sequence_catalog_entry.h"
 #include "function/scalar_function.h"
+#include "transaction/transaction.h"
 #include "main/client_context.h"
 
 using namespace kuzu::common;
@@ -11,25 +12,27 @@ namespace kuzu {
 namespace function {
 
 struct CurrVal {
-    static void operation(common::ku_string_t& input, common::ValueVector& result, void* dataPtr) {
+    static void operation(ku_string_t& input, ValueVector& result, void* dataPtr) {
         auto ctx = reinterpret_cast<FunctionBindData*>(dataPtr)->clientContext;
         auto catalog = catalog::Catalog::Get(*ctx);
+        auto transaction = transaction::Transaction::Get(*ctx);
         auto sequenceName = input.getAsString();
-        auto sequenceEntry = catalog->getSequenceEntry(ctx->getTransaction(), sequenceName,
+        auto sequenceEntry = catalog->getSequenceEntry(transaction, sequenceName,
             ctx->useInternalCatalogEntry());
         result.setValue(0, sequenceEntry->currVal());
     }
 };
 
 struct NextVal {
-    static void operation(common::ku_string_t& input, common::ValueVector& result, void* dataPtr) {
+    static void operation(ku_string_t& input, ValueVector& result, void* dataPtr) {
         auto ctx = reinterpret_cast<FunctionBindData*>(dataPtr)->clientContext;
         auto cnt = reinterpret_cast<FunctionBindData*>(dataPtr)->count;
         auto catalog = catalog::Catalog::Get(*ctx);
+        auto transaction = transaction::Transaction::Get(*ctx);
         auto sequenceName = input.getAsString();
-        auto sequenceEntry = catalog->getSequenceEntry(ctx->getTransaction(), sequenceName,
+        auto sequenceEntry = catalog->getSequenceEntry(transaction, sequenceName,
             ctx->useInternalCatalogEntry());
-        sequenceEntry->nextKVal(ctx->getTransaction(), cnt, result);
+        sequenceEntry->nextKVal(transaction, cnt, result);
         result.state->getSelVectorUnsafe().setSelSize(cnt);
     }
 };
@@ -38,7 +41,7 @@ function_set CurrValFunction::getFunctionSet() {
     function_set functionSet;
     functionSet.push_back(make_unique<ScalarFunction>(name,
         std::vector<LogicalTypeID>{LogicalTypeID::STRING}, LogicalTypeID::INT64,
-        ScalarFunction::UnarySequenceExecFunction<common::ku_string_t, common::ValueVector,
+        ScalarFunction::UnarySequenceExecFunction<ku_string_t, ValueVector,
             CurrVal>));
     return functionSet;
 }
@@ -47,7 +50,7 @@ function_set NextValFunction::getFunctionSet() {
     function_set functionSet;
     auto func = make_unique<ScalarFunction>(name, std::vector<LogicalTypeID>{LogicalTypeID::STRING},
         LogicalTypeID::INT64,
-        ScalarFunction::UnarySequenceExecFunction<common::ku_string_t, common::ValueVector,
+        ScalarFunction::UnarySequenceExecFunction<ku_string_t, ValueVector,
             NextVal>);
     func->isReadOnly = false;
     functionSet.push_back(std::move(func));

--- a/src/function/table/cache_column.cpp
+++ b/src/function/table/cache_column.cpp
@@ -45,8 +45,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     const auto tableName = input->getLiteralVal<std::string>(0);
     const auto columnName = input->getLiteralVal<std::string>(1);
     binder::Binder::validateTableExistence(*context, tableName);
-    const auto tableEntry =
-        catalog::Catalog::Get(*context)->getTableCatalogEntry(transaction::Transaction::Get(*context), tableName);
+    const auto tableEntry = catalog::Catalog::Get(*context)->getTableCatalogEntry(
+        transaction::Transaction::Get(*context), tableName);
     binder::Binder::validateNodeTableType(tableEntry);
     binder::Binder::validateColumnExistence(tableEntry, columnName);
     auto propertyID = tableEntry->getPropertyID(columnName);
@@ -162,7 +162,8 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
             data->cast<storage::ListChunkData>().getDataColumnChunk()->resize(
                 numRows * arrayTypeInfo->getNumElements());
         }
-        scanTableDataToChunk(i, scanState, data.get(), transaction::Transaction::Get(*context), table);
+        scanTableDataToChunk(i, scanState, data.get(), transaction::Transaction::Get(*context),
+            table);
         sharedState->merge(i, std::move(data));
     }
     return morsel.endOffset - morsel.startOffset;

--- a/src/function/table/cache_column.cpp
+++ b/src/function/table/cache_column.cpp
@@ -5,7 +5,6 @@
 #include "function/table/bind_data.h"
 #include "function/table/bind_input.h"
 #include "function/table/simple_table_function.h"
-#include "main/client_context.h"
 #include "processor/execution_context.h"
 #include "storage/local_cached_column.h"
 #include "storage/storage_manager.h"
@@ -13,10 +12,6 @@
 #include "storage/table/node_table.h"
 #include "storage/table/table.h"
 #include "transaction/transaction.h"
-
-namespace kuzu::catalog {
-class TableCatalogEntry;
-}
 
 using namespace kuzu::common;
 
@@ -51,7 +46,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     const auto columnName = input->getLiteralVal<std::string>(1);
     binder::Binder::validateTableExistence(*context, tableName);
     const auto tableEntry =
-        catalog::Catalog::Get(*context)->getTableCatalogEntry(context->getTransaction(), tableName);
+        catalog::Catalog::Get(*context)->getTableCatalogEntry(transaction::Transaction::Get(*context), tableName);
     binder::Binder::validateNodeTableType(tableEntry);
     binder::Binder::validateColumnExistence(tableEntry, columnName);
     auto propertyID = tableEntry->getPropertyID(columnName);
@@ -107,7 +102,7 @@ struct CacheArrayColumnLocalState final : TableFuncLocalState {
             std::make_unique<storage::NodeTableScanState>(&dataChunk.getValueVectorMutable(0),
                 std::vector{&dataChunk.getValueVectorMutable(1)}, dataChunk.state);
         scanState->source = storage::TableScanSource::COMMITTED;
-        scanState->setToTable(context.getTransaction(), &table, columnIDs, {});
+        scanState->setToTable(transaction::Transaction::Get(context), &table, columnIDs, {});
     }
 
     DataChunk dataChunk;
@@ -167,7 +162,7 @@ static offset_t tableFunc(const TableFuncInput& input, TableFuncOutput&) {
             data->cast<storage::ListChunkData>().getDataColumnChunk()->resize(
                 numRows * arrayTypeInfo->getNumElements());
         }
-        scanTableDataToChunk(i, scanState, data.get(), context->getTransaction(), table);
+        scanTableDataToChunk(i, scanState, data.get(), transaction::Transaction::Get(*context), table);
         sharedState->merge(i, std::move(data));
     }
     return morsel.endOffset - morsel.startOffset;
@@ -187,7 +182,7 @@ static double progressFunc(TableFuncSharedState* sharedState) {
 
 static void finalizeFunc(const processor::ExecutionContext* context,
     TableFuncSharedState* sharedState) {
-    auto transaction = context->clientContext->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context->clientContext);
     auto cacheColumnSharedState = sharedState->ptrCast<CacheArrayColumnSharedState>();
     auto& localCacheManager = transaction->getLocalCacheManager();
     localCacheManager.put(std::move(cacheColumnSharedState->cachedColumn));

--- a/src/function/table/show_connection.cpp
+++ b/src/function/table/show_connection.cpp
@@ -6,7 +6,7 @@
 #include "function/table/bind_data.h"
 #include "function/table/bind_input.h"
 #include "function/table/simple_table_function.h"
-#include "main/client_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;
@@ -64,7 +64,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const ClientContext* context,
     columnTypes.emplace_back(LogicalType::STRING());
     const auto name = input->getLiteralVal<std::string>(0);
     const auto catalog = Catalog::Get(*context);
-    const auto transaction = context->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context);
     std::vector<std::pair<NodeTableCatalogEntry*, NodeTableCatalogEntry*>> srcDstEntries;
     if (catalog->containsTable(transaction, name)) {
         auto entry = catalog->getTableCatalogEntry(transaction, name);

--- a/src/function/table/show_functions.cpp
+++ b/src/function/table/show_functions.cpp
@@ -1,8 +1,8 @@
 #include "binder/binder.h"
 #include "catalog/catalog.h"
 #include "function/table/bind_data.h"
-#include "function/table/simple_table_function.h"
 #include "function/table/bind_input.h"
+#include "function/table/simple_table_function.h"
 #include "transaction/transaction.h"
 
 using namespace kuzu::common;

--- a/src/function/table/show_functions.cpp
+++ b/src/function/table/show_functions.cpp
@@ -2,7 +2,8 @@
 #include "catalog/catalog.h"
 #include "function/table/bind_data.h"
 #include "function/table/simple_table_function.h"
-#include "main/client_context.h"
+#include "function/table/bind_input.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::catalog;
@@ -56,7 +57,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* co
     columnTypes.emplace_back(LogicalType::STRING());
     std::vector<FunctionInfo> FunctionInfos;
     for (const auto& entry :
-        Catalog::Get(*context)->getFunctionEntries(context->getTransaction())) {
+        Catalog::Get(*context)->getFunctionEntries(transaction::Transaction::Get(*context))) {
         const auto& functionSet = entry->getFunctionSet();
         const auto type = FunctionEntryTypeUtils::toString(entry->getType());
         for (auto& function : functionSet) {

--- a/src/function/table/show_indexes.cpp
+++ b/src/function/table/show_indexes.cpp
@@ -2,8 +2,9 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/index_catalog_entry.h"
 #include "function/table/bind_data.h"
+#include "function/table/bind_input.h"
 #include "function/table/simple_table_function.h"
-#include "main/client_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;
@@ -84,10 +85,11 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* co
     const TableFuncBindInput* input) {
     std::vector<IndexInfo> indexesInfo;
     auto catalog = Catalog::Get(*context);
-    auto indexEntries = catalog->getIndexEntries(context->getTransaction());
+    auto transaction = transaction::Transaction::Get(*context);
+    auto indexEntries = catalog->getIndexEntries(transaction);
     for (auto indexEntry : indexEntries) {
         auto tableEntry =
-            catalog->getTableCatalogEntry(context->getTransaction(), indexEntry->getTableID());
+            catalog->getTableCatalogEntry(transaction, indexEntry->getTableID());
         auto tableName = tableEntry->getName();
         auto indexName = indexEntry->getIndexName();
         auto indexType = indexEntry->getIndexType();

--- a/src/function/table/show_indexes.cpp
+++ b/src/function/table/show_indexes.cpp
@@ -88,8 +88,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* co
     auto transaction = transaction::Transaction::Get(*context);
     auto indexEntries = catalog->getIndexEntries(transaction);
     for (auto indexEntry : indexEntries) {
-        auto tableEntry =
-            catalog->getTableCatalogEntry(transaction, indexEntry->getTableID());
+        auto tableEntry = catalog->getTableCatalogEntry(transaction, indexEntry->getTableID());
         auto tableName = tableEntry->getName();
         auto indexName = indexEntry->getIndexName();
         auto indexType = indexEntry->getIndexType();

--- a/src/function/table/show_sequences.cpp
+++ b/src/function/table/show_sequences.cpp
@@ -2,8 +2,8 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/sequence_catalog_entry.h"
 #include "function/table/bind_data.h"
-#include "function/table/simple_table_function.h"
 #include "function/table/bind_input.h"
+#include "function/table/simple_table_function.h"
 #include "transaction/transaction.h"
 
 using namespace kuzu::common;

--- a/src/function/table/show_sequences.cpp
+++ b/src/function/table/show_sequences.cpp
@@ -3,7 +3,8 @@
 #include "catalog/catalog_entry/sequence_catalog_entry.h"
 #include "function/table/bind_data.h"
 #include "function/table/simple_table_function.h"
-#include "main/client_context.h"
+#include "function/table/bind_input.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::catalog;
@@ -75,7 +76,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* co
     columnTypes.emplace_back(LogicalType::BOOL());
     std::vector<SequenceInfo> sequenceInfos;
     for (const auto& entry :
-        Catalog::Get(*context)->getSequenceEntries(context->getTransaction())) {
+        Catalog::Get(*context)->getSequenceEntries(transaction::Transaction::Get(*context))) {
         const auto sequenceData = entry->getSequenceData();
         auto sequenceInfo = SequenceInfo{entry->getName(), LOCAL_DB_NAME, sequenceData.startValue,
             sequenceData.increment, sequenceData.minValue, sequenceData.maxValue,

--- a/src/function/table/show_tables.cpp
+++ b/src/function/table/show_tables.cpp
@@ -67,7 +67,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* co
     columnNames.emplace_back("comment");
     columnTypes.emplace_back(LogicalType::STRING());
     std::vector<TableInfo> tableInfos;
-    auto transaction = context->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context);
     if (!context->hasDefaultDatabase()) {
         auto catalog = Catalog::Get(*context);
         for (auto& entry :
@@ -82,7 +82,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* co
         auto databaseName = attachedDatabase->getDBName();
         auto databaseType = attachedDatabase->getDBType();
         for (auto& entry : attachedDatabase->getCatalog()->getTableEntries(
-                 context->getTransaction(), context->useInternalCatalogEntry())) {
+                 transaction, context->useInternalCatalogEntry())) {
             auto tableInfo = TableInfo{entry->getName(), entry->getTableID(),
                 TableTypeUtils::toString(entry->getTableType()),
                 stringFormat("{}({})", databaseName, databaseType), entry->getComment()};

--- a/src/function/table/show_tables.cpp
+++ b/src/function/table/show_tables.cpp
@@ -81,8 +81,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* co
     for (auto attachedDatabase : main::DatabaseManager::Get(*context)->getAttachedDatabases()) {
         auto databaseName = attachedDatabase->getDBName();
         auto databaseType = attachedDatabase->getDBType();
-        for (auto& entry : attachedDatabase->getCatalog()->getTableEntries(
-                 transaction, context->useInternalCatalogEntry())) {
+        for (auto& entry : attachedDatabase->getCatalog()->getTableEntries(transaction,
+                 context->useInternalCatalogEntry())) {
             auto tableInfo = TableInfo{entry->getName(), entry->getTableID(),
                 TableTypeUtils::toString(entry->getTableType()),
                 stringFormat("{}({})", databaseName, databaseType), entry->getComment()};

--- a/src/function/table/stats_info.cpp
+++ b/src/function/table/stats_info.cpp
@@ -2,11 +2,11 @@
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "common/exception/binder.h"
 #include "function/table/bind_data.h"
+#include "function/table/bind_input.h"
 #include "function/table/simple_table_function.h"
 #include "storage/storage_manager.h"
 #include "storage/table/node_table.h"
 #include "transaction/transaction.h"
-#include "function/table/bind_input.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;
@@ -57,7 +57,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const ClientContext* context,
     if (!catalog->containsTable(transaction::Transaction::Get(*context), tableName)) {
         throw BinderException{"Table " + tableName + " does not exist!"};
     }
-    auto tableEntry = catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), tableName);
+    auto tableEntry =
+        catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), tableName);
     if (tableEntry->getTableType() != TableType::NODE) {
         throw BinderException{
             "Stats from a non-node table " + tableName + " is not supported yet!"};

--- a/src/function/table/stats_info.cpp
+++ b/src/function/table/stats_info.cpp
@@ -3,9 +3,10 @@
 #include "common/exception/binder.h"
 #include "function/table/bind_data.h"
 #include "function/table/simple_table_function.h"
-#include "main/client_context.h"
 #include "storage/storage_manager.h"
 #include "storage/table/node_table.h"
+#include "transaction/transaction.h"
+#include "function/table/bind_input.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;
@@ -36,7 +37,7 @@ static offset_t internalTableFunc(const TableFuncMorsel& /*morsel*/, const Table
     switch (table->getTableType()) {
     case TableType::NODE: {
         const auto& nodeTable = table->cast<storage::NodeTable>();
-        const auto stats = nodeTable.getStats(bindData->context->getTransaction());
+        const auto stats = nodeTable.getStats(transaction::Transaction::Get(*bindData->context));
         output.getValueVectorMutable(0).setValue<cardinality_t>(0, stats.getTableCard());
         for (auto i = 0u; i < nodeTable.getNumColumns(); ++i) {
             output.getValueVectorMutable(i + 1).setValue(0, stats.getNumDistinctValues(i));
@@ -53,10 +54,10 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const ClientContext* context,
     const TableFuncBindInput* input) {
     const auto tableName = input->getLiteralVal<std::string>(0);
     const auto catalog = Catalog::Get(*context);
-    if (!catalog->containsTable(context->getTransaction(), tableName)) {
+    if (!catalog->containsTable(transaction::Transaction::Get(*context), tableName)) {
         throw BinderException{"Table " + tableName + " does not exist!"};
     }
-    auto tableEntry = catalog->getTableCatalogEntry(context->getTransaction(), tableName);
+    auto tableEntry = catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), tableName);
     if (tableEntry->getTableType() != TableType::NODE) {
         throw BinderException{
             "Stats from a non-node table " + tableName + " is not supported yet!"};

--- a/src/function/table/storage_info.cpp
+++ b/src/function/table/storage_info.cpp
@@ -351,10 +351,10 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const ClientContext* context,
     columnTypes.emplace_back(LogicalType::STRING());
     auto tableName = input->getLiteralVal<std::string>(0);
     auto catalog = Catalog::Get(*context);
-    if (!catalog->containsTable(context->getTransaction(), tableName)) {
+    if (!catalog->containsTable(transaction::Transaction::Get(*context), tableName)) {
         throw BinderException{"Table " + tableName + " does not exist!"};
     }
-    auto tableEntry = catalog->getTableCatalogEntry(context->getTransaction(), tableName);
+    auto tableEntry = catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), tableName);
     columnNames = TableFunction::extractYieldVariables(columnNames, input->yieldVariables);
     auto columns = input->binder->createVariables(columnNames, columnTypes);
     return std::make_unique<StorageInfoBindData>(columns, tableEntry, context);

--- a/src/function/table/storage_info.cpp
+++ b/src/function/table/storage_info.cpp
@@ -354,7 +354,8 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const ClientContext* context,
     if (!catalog->containsTable(transaction::Transaction::Get(*context), tableName)) {
         throw BinderException{"Table " + tableName + " does not exist!"};
     }
-    auto tableEntry = catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), tableName);
+    auto tableEntry =
+        catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), tableName);
     columnNames = TableFunction::extractYieldVariables(columnNames, input->yieldVariables);
     auto columns = input->binder->createVariables(columnNames, columnTypes);
     return std::make_unique<StorageInfoBindData>(columns, tableEntry, context);

--- a/src/function/table/table_info.cpp
+++ b/src/function/table/table_info.cpp
@@ -171,7 +171,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(const main::ClientContext* co
 
     std::vector<PropertyInfo> infos;
     CatalogEntryType type = CatalogEntryType::DUMMY_ENTRY;
-    auto transaction = context->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context);
     if (name.size() == 1) {
         auto tableName = name[0];
         auto catalog = Catalog::Get(*context);

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -1133,8 +1133,9 @@ static std::unique_ptr<FunctionBindData> castBindFunc(ScalarBindFuncInput input)
         std::vector<LogicalType> typeVec;
         typeVec.push_back(input.arguments[0]->getDataType().copy());
         try {
-            auto entry = catalog::Catalog::Get(*input.context)
-                             ->getFunctionEntry(transaction::Transaction::Get(*input.context), func->name);
+            auto entry =
+                catalog::Catalog::Get(*input.context)
+                    ->getFunctionEntry(transaction::Transaction::Get(*input.context), func->name);
             auto match = BuiltInFunctionsUtils::matchFunction(func->name, typeVec,
                 entry->ptrCast<catalog::FunctionCatalogEntry>());
             func->execFunc = match->constPtrCast<ScalarFunction>()->execFunc;

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -11,7 +11,7 @@
 #include "function/cast/functions/cast_decimal.h"
 #include "function/cast/functions/cast_from_string_functions.h"
 #include "function/cast/functions/cast_functions.h"
-#include "main/client_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::binder;
@@ -1134,7 +1134,7 @@ static std::unique_ptr<FunctionBindData> castBindFunc(ScalarBindFuncInput input)
         typeVec.push_back(input.arguments[0]->getDataType().copy());
         try {
             auto entry = catalog::Catalog::Get(*input.context)
-                             ->getFunctionEntry(input.context->getTransaction(), func->name);
+                             ->getFunctionEntry(transaction::Transaction::Get(*input.context), func->name);
             auto match = BuiltInFunctionsUtils::matchFunction(func->name, typeVec,
                 entry->ptrCast<catalog::FunctionCatalogEntry>());
             func->execFunc = match->constPtrCast<ScalarFunction>()->execFunc;

--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -128,7 +128,8 @@ OnDiskGraphNbrScanState::OnDiskGraphNbrScanState(ClientContext* context,
         }
         auto scanState = std::make_unique<RelTableScanState>(*MemoryManager::Get(*context),
             srcNodeIDVector.get(), outVectors, dstNodeIDVector->state, randomLookup);
-        scanState->setToTable(transaction::Transaction::Get(*context), table, columnIDs, {}, dataDirection);
+        scanState->setToTable(transaction::Transaction::Get(*context), table, columnIDs, {},
+            dataDirection);
         directedIterators.emplace_back(context, table, std::move(scanState));
     }
 }
@@ -321,8 +322,8 @@ void OnDiskGraphVertexScanState::startScan(offset_t beginOffset, offset_t endOff
     for (auto& vector : tableScanState->outputVectors) {
         vector->resetAuxiliaryBuffer();
     }
-    nodeTable.initScanState(transaction::Transaction::Get(context), *tableScanState, nodeTable.getTableID(),
-        beginOffset);
+    nodeTable.initScanState(transaction::Transaction::Get(context), *tableScanState,
+        nodeTable.getTableID(), beginOffset);
 }
 
 bool OnDiskGraphVertexScanState::next() {

--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -12,7 +12,6 @@
 #include "common/vector/value_vector.h"
 #include "expression_evaluator/expression_evaluator.h"
 #include "graph/graph.h"
-#include "main/client_context.h"
 #include "planner/operator/schema.h"
 #include "processor/expression_mapper.h"
 #include "storage/local_storage/local_rel_table.h"
@@ -129,7 +128,7 @@ OnDiskGraphNbrScanState::OnDiskGraphNbrScanState(ClientContext* context,
         }
         auto scanState = std::make_unique<RelTableScanState>(*MemoryManager::Get(*context),
             srcNodeIDVector.get(), outVectors, dstNodeIDVector->state, randomLookup);
-        scanState->setToTable(context->getTransaction(), table, columnIDs, {}, dataDirection);
+        scanState->setToTable(transaction::Transaction::Get(*context), table, columnIDs, {}, dataDirection);
         directedIterators.emplace_back(context, table, std::move(scanState));
     }
 }
@@ -239,7 +238,7 @@ bool OnDiskGraphNbrScanState::InnerIterator::next(evaluator::ExpressionEvaluator
     bool hasAtLeastOneSelectedValue = false;
     do {
         restoreSelVector(*tableScanState->outState);
-        if (!relTable->scan(context->getTransaction(), *tableScanState)) {
+        if (!relTable->scan(transaction::Transaction::Get(*context), *tableScanState)) {
             return false;
         }
         saveSelVector(*tableScanState->outState);
@@ -270,7 +269,7 @@ OnDiskGraphNbrScanState::InnerIterator::InnerIterator(const ClientContext* conte
     : context{context}, relTable{relTable}, tableScanState{std::move(tableScanState)} {}
 
 void OnDiskGraphNbrScanState::InnerIterator::initScan() const {
-    relTable->initScanState(context->getTransaction(), *tableScanState);
+    relTable->initScanState(transaction::Transaction::Get(*context), *tableScanState);
 }
 
 void OnDiskGraphNbrScanState::startScan(RelDataDirection direction) {
@@ -311,7 +310,7 @@ OnDiskGraphVertexScanState::OnDiskGraphVertexScanState(ClientContext& context,
     tableScanState =
         std::make_unique<NodeTableScanState>(nodeIDVector.get(), outVectors, propertyVectors.state);
     auto table = StorageManager::Get(context)->getTable(tableEntry->getTableID());
-    tableScanState->setToTable(context.getTransaction(), table, propertyColumnIDs);
+    tableScanState->setToTable(transaction::Transaction::Get(context), table, propertyColumnIDs);
 }
 
 void OnDiskGraphVertexScanState::startScan(offset_t beginOffset, offset_t endOffsetExclusive) {
@@ -322,7 +321,7 @@ void OnDiskGraphVertexScanState::startScan(offset_t beginOffset, offset_t endOff
     for (auto& vector : tableScanState->outputVectors) {
         vector->resetAuxiliaryBuffer();
     }
-    nodeTable.initScanState(context.getTransaction(), *tableScanState, nodeTable.getTableID(),
+    nodeTable.initScanState(transaction::Transaction::Get(context), *tableScanState, nodeTable.getTableID(),
         beginOffset);
 }
 
@@ -334,13 +333,14 @@ bool OnDiskGraphVertexScanState::next() {
 
     auto startOffsetOfNextGroup =
         StorageUtils::getStartOffsetOfNodeGroup(tableScanState->nodeGroupIdx + 1);
+    auto transaction = transaction::Transaction::Get(context);
     auto endOffset = std::min(endOffsetExclusive,
         tableScanState->source == TableScanSource::COMMITTED ?
             startOffsetOfNextGroup :
-            startOffsetOfNextGroup + context.getTransaction()->getUncommittedOffset(
+            startOffsetOfNextGroup + transaction->getUncommittedOffset(
                                          tableScanState->table->getTableID(), currentOffset));
     numNodesToScan = std::min(endOffset - currentOffset, DEFAULT_VECTOR_CAPACITY);
-    auto result = tableScanState->scanNext(context.getTransaction(), currentOffset, numNodesToScan);
+    auto result = tableScanState->scanNext(transaction, currentOffset, numNodesToScan);
     currentOffset += result.numRows;
     return result != NODE_GROUP_SCAN_EMPTY_RESULT;
 }

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -47,7 +47,7 @@ class ImportDB;
 namespace transaction {
 class TransactionContext;
 class Transaction;
-}
+} // namespace transaction
 
 namespace main {
 struct DBConfig;

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -15,7 +15,6 @@
 #include "parser/statement.h"
 #include "prepared_statement.h"
 #include "processor/warning_context.h"
-#include "transaction/transaction_context.h"
 
 namespace kuzu {
 namespace common {
@@ -44,6 +43,11 @@ class StorageManager;
 namespace processor {
 class ImportDB;
 } // namespace processor
+
+namespace transaction {
+class TransactionContext;
+class Transaction;
+}
 
 namespace main {
 struct DBConfig;
@@ -100,7 +104,6 @@ public:
     uint64_t getMaxNumThreadForExec() const;
 
     // Transaction.
-    transaction::Transaction* getTransaction() const;
     transaction::TransactionContext* getTransactionContext() const;
 
     // Progress bar

--- a/src/include/transaction/transaction.h
+++ b/src/include/transaction/transaction.h
@@ -143,6 +143,8 @@ public:
     void pushVectorUpdateInfo(storage::UpdateInfo& updateInfo, common::idx_t vectorIdx,
         storage::VectorUpdateInfo& vectorUpdateInfo) const;
 
+    static Transaction* Get(const main::ClientContext& context);
+
 private:
     common::offset_t getMinUncommittedNodeOffset(common::table_id_t tableID) const;
 

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -14,6 +14,7 @@
 #include "optimizer/schema_populator.h"
 #include "optimizer/top_k_optimizer.h"
 #include "planner/operator/logical_explain.h"
+#include "transaction/transaction.h"
 
 namespace kuzu {
 namespace optimizer {
@@ -64,7 +65,7 @@ void Optimizer::optimize(planner::LogicalPlan* plan, main::ClientContext* contex
             const auto& explain = plan->getLastOperatorRef().cast<planner::LogicalExplain>();
             if (explain.getExplainType() == common::ExplainType::LOGICAL_PLAN) {
                 auto cardinalityUpdater =
-                    CardinalityUpdater(cardinalityEstimator, context->getTransaction());
+                    CardinalityUpdater(cardinalityEstimator, transaction::Transaction::Get(*context));
                 cardinalityUpdater.rewrite(plan);
             }
         }

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -64,8 +64,8 @@ void Optimizer::optimize(planner::LogicalPlan* plan, main::ClientContext* contex
         if (plan->getLastOperatorRef().getOperatorType() == planner::LogicalOperatorType::EXPLAIN) {
             const auto& explain = plan->getLastOperatorRef().cast<planner::LogicalExplain>();
             if (explain.getExplainType() == common::ExplainType::LOGICAL_PLAN) {
-                auto cardinalityUpdater =
-                    CardinalityUpdater(cardinalityEstimator, transaction::Transaction::Get(*context));
+                auto cardinalityUpdater = CardinalityUpdater(cardinalityEstimator,
+                    transaction::Transaction::Get(*context));
                 cardinalityUpdater.rewrite(plan);
             }
         }

--- a/src/parser/expression/parsed_expression_visitor.cpp
+++ b/src/parser/expression/parsed_expression_visitor.cpp
@@ -3,10 +3,10 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/function_catalog_entry.h"
 #include "common/exception/not_implemented.h"
-#include "main/client_context.h"
 #include "parser/expression/parsed_case_expression.h"
 #include "parser/expression/parsed_function_expression.h"
 #include "parser/expression/parsed_lambda_expression.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::catalog;

--- a/src/parser/visitor/standalone_call_rewriter.cpp
+++ b/src/parser/visitor/standalone_call_rewriter.cpp
@@ -25,8 +25,8 @@ void StandaloneCallRewriter::visitStandaloneCallFunction(const Statement& statem
             auto funcName = standaloneCallFunc.getFunctionExpression()
                                 ->constPtrCast<ParsedFunctionExpression>()
                                 ->getFunctionName();
-            if (!catalog::Catalog::Get(*context)->containsFunction(transaction::Transaction::Get(*context),
-                    funcName) &&
+            if (!catalog::Catalog::Get(*context)->containsFunction(
+                    transaction::Transaction::Get(*context), funcName) &&
                 !singleStatement) {
                 throw common::ParserException{
                     funcName + " must be called in a query which doesn't have other statements."};

--- a/src/parser/visitor/standalone_call_rewriter.cpp
+++ b/src/parser/visitor/standalone_call_rewriter.cpp
@@ -7,6 +7,7 @@
 #include "main/client_context.h"
 #include "parser/expression/parsed_function_expression.h"
 #include "parser/standalone_call_function.h"
+#include "transaction/transaction.h"
 
 namespace kuzu {
 namespace parser {
@@ -24,7 +25,7 @@ void StandaloneCallRewriter::visitStandaloneCallFunction(const Statement& statem
             auto funcName = standaloneCallFunc.getFunctionExpression()
                                 ->constPtrCast<ParsedFunctionExpression>()
                                 ->getFunctionName();
-            if (!catalog::Catalog::Get(*context)->containsFunction(context->getTransaction(),
+            if (!catalog::Catalog::Get(*context)->containsFunction(transaction::Transaction::Get(*context),
                     funcName) &&
                 !singleStatement) {
                 throw common::ParserException{

--- a/src/planner/join_order/cardinality_estimator.cpp
+++ b/src/planner/join_order/cardinality_estimator.cpp
@@ -37,11 +37,11 @@ void CardinalityEstimator::init(const QueryGraph& queryGraph) {
 void CardinalityEstimator::init(const NodeExpression& node) {
     auto key = node.getInternalID()->getUniqueName();
     cardinality_t numNodes = 0u;
+    auto storageManager = storage::StorageManager::Get(*context);
+    auto transaction = transaction::Transaction::Get(*context);
     for (auto tableID : node.getTableIDs()) {
-        auto stats = storage::StorageManager::Get(*context)
-                         ->getTable(tableID)
-                         ->cast<storage::NodeTable>()
-                         .getStats(context->getTransaction());
+        auto stats = storageManager->getTable(tableID)->cast<storage::NodeTable>()
+                         .getStats(transaction);
         numNodes += stats.getTableCard();
         if (!nodeTableStats.contains(tableID)) {
             nodeTableStats.insert({tableID, std::move(stats)});
@@ -158,8 +158,9 @@ static std::optional<cardinality_t> getTableStatsIfPossible(main::ClientContext*
         auto& propertyExpr = predicate.getChild(0)->cast<PropertyExpression>();
         auto tableID = propertyExpr.getSingleTableID();
         if (nodeTableStats.contains(tableID) && propertyExpr.hasProperty(tableID)) {
+            auto transaction = Transaction::Get(*context);
             auto entry = catalog::Catalog::Get(*context)->getTableCatalogEntry(
-                context->getTransaction(), tableID);
+                transaction, tableID);
             auto columnID = entry->getColumnID(propertyExpr.getPropertyName());
             if (columnID != INVALID_COLUMN_ID && columnID != ROW_IDX_COLUMN_ID) {
                 auto& stats = nodeTableStats.at(tableID);

--- a/src/planner/join_order/cardinality_estimator.cpp
+++ b/src/planner/join_order/cardinality_estimator.cpp
@@ -40,8 +40,8 @@ void CardinalityEstimator::init(const NodeExpression& node) {
     auto storageManager = storage::StorageManager::Get(*context);
     auto transaction = transaction::Transaction::Get(*context);
     for (auto tableID : node.getTableIDs()) {
-        auto stats = storageManager->getTable(tableID)->cast<storage::NodeTable>()
-                         .getStats(transaction);
+        auto stats =
+            storageManager->getTable(tableID)->cast<storage::NodeTable>().getStats(transaction);
         numNodes += stats.getTableCard();
         if (!nodeTableStats.contains(tableID)) {
             nodeTableStats.insert({tableID, std::move(stats)});
@@ -159,8 +159,8 @@ static std::optional<cardinality_t> getTableStatsIfPossible(main::ClientContext*
         auto tableID = propertyExpr.getSingleTableID();
         if (nodeTableStats.contains(tableID) && propertyExpr.hasProperty(tableID)) {
             auto transaction = Transaction::Get(*context);
-            auto entry = catalog::Catalog::Get(*context)->getTableCatalogEntry(
-                transaction, tableID);
+            auto entry =
+                catalog::Catalog::Get(*context)->getTableCatalogEntry(transaction, tableID);
             auto columnID = entry->getColumnID(propertyExpr.getPropertyName());
             if (columnID != INVALID_COLUMN_ID && columnID != ROW_IDX_COLUMN_ID) {
                 auto& stats = nodeTableStats.at(tableID);

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -3,7 +3,6 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
 #include "common/enums/join_type.h"
-#include "main/client_context.h"
 #include "planner/join_order/cost_model.h"
 #include "planner/operator/extend/logical_extend.h"
 #include "planner/operator/extend/logical_recursive_extend.h"
@@ -11,6 +10,7 @@
 #include "planner/operator/logical_node_label_filter.h"
 #include "planner/operator/logical_path_property_probe.h"
 #include "planner/planner.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::binder;
@@ -83,8 +83,9 @@ void Planner::appendNonRecursiveExtend(const std::shared_ptr<NodeExpression>& bo
         properties_, plan.getLastOperator());
     extend->computeFactorizedSchema();
     // Update cost & cardinality. Note that extend does not change factorized cardinality.
+    auto transaction = Transaction::Get(*clientContext);
     const auto extensionRate =
-        cardinalityEstimator.getExtensionRate(*rel, *boundNode, clientContext->getTransaction());
+        cardinalityEstimator.getExtensionRate(*rel, *boundNode, transaction);
     extend->setCardinality(plan.getLastOperator()->getCardinality());
     plan.setCost(CostModel::computeExtendCost(plan));
     auto group = extend->getSchema()->getGroup(nbrNode->getInternalID());
@@ -148,8 +149,9 @@ void Planner::appendRecursiveExtend(const std::shared_ptr<NodeExpression>& bound
     pathPropertyProbe->pathNodeIDs = recursiveInfo->bindData->pathNodeIDsExpr;
     pathPropertyProbe->pathEdgeIDs = recursiveInfo->bindData->pathEdgeIDsExpr;
     pathPropertyProbe->computeFactorizedSchema();
+    auto transaction = Transaction::Get(*clientContext);
     auto extensionRate =
-        cardinalityEstimator.getExtensionRate(*rel, *boundNode, clientContext->getTransaction());
+        cardinalityEstimator.getExtensionRate(*rel, *boundNode, transaction);
     auto resultCard =
         cardinalityEstimator.multiply(extensionRate, plan.getLastOperator()->getCardinality());
     pathPropertyProbe->setCardinality(resultCard);

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -84,8 +84,7 @@ void Planner::appendNonRecursiveExtend(const std::shared_ptr<NodeExpression>& bo
     extend->computeFactorizedSchema();
     // Update cost & cardinality. Note that extend does not change factorized cardinality.
     auto transaction = Transaction::Get(*clientContext);
-    const auto extensionRate =
-        cardinalityEstimator.getExtensionRate(*rel, *boundNode, transaction);
+    const auto extensionRate = cardinalityEstimator.getExtensionRate(*rel, *boundNode, transaction);
     extend->setCardinality(plan.getLastOperator()->getCardinality());
     plan.setCost(CostModel::computeExtendCost(plan));
     auto group = extend->getSchema()->getGroup(nbrNode->getInternalID());
@@ -150,8 +149,7 @@ void Planner::appendRecursiveExtend(const std::shared_ptr<NodeExpression>& bound
     pathPropertyProbe->pathEdgeIDs = recursiveInfo->bindData->pathEdgeIDsExpr;
     pathPropertyProbe->computeFactorizedSchema();
     auto transaction = Transaction::Get(*clientContext);
-    auto extensionRate =
-        cardinalityEstimator.getExtensionRate(*rel, *boundNode, transaction);
+    auto extensionRate = cardinalityEstimator.getExtensionRate(*rel, *boundNode, transaction);
     auto resultCard =
         cardinalityEstimator.multiply(extensionRate, plan.getLastOperator()->getCardinality());
     pathPropertyProbe->setCardinality(resultCard);

--- a/src/planner/plan/plan_copy.cpp
+++ b/src/planner/plan/plan_copy.cpp
@@ -2,12 +2,12 @@
 #include "binder/copy/bound_copy_to.h"
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
-#include "main/client_context.h"
 #include "planner/operator/logical_partitioner.h"
 #include "planner/operator/persistent/logical_copy_from.h"
 #include "planner/operator/persistent/logical_copy_to.h"
 #include "planner/operator/scan/logical_index_look_up.h"
 #include "planner/planner.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::storage;
@@ -110,7 +110,7 @@ LogicalPlan Planner::planCopyRelFrom(const BoundCopyFromInfo* info) {
     // If the table entry doesn't exist, assume both directions
     std::vector<RelDataDirection> directions = {RelDataDirection::FWD, RelDataDirection::BWD};
     auto catalog = Catalog::Get(*clientContext);
-    auto transaction = clientContext->getTransaction();
+    auto transaction = transaction::Transaction::Get(*clientContext);
     if (catalog->containsTable(transaction, info->tableName)) {
         const auto& relGroupEntry = catalog->getTableCatalogEntry(transaction, info->tableName)
                                         ->constCast<RelGroupCatalogEntry>();

--- a/src/planner/plan/plan_port_db.cpp
+++ b/src/planner/plan/plan_port_db.cpp
@@ -4,11 +4,11 @@
 #include "common/file_system/virtual_file_system.h"
 #include "common/string_utils.h"
 #include "function/built_in_function_utils.h"
-#include "main/client_context.h"
 #include "planner/operator/persistent/logical_copy_to.h"
 #include "planner/operator/simple/logical_export_db.h"
 #include "planner/operator/simple/logical_import_db.h"
 #include "planner/planner.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::storage;
@@ -29,7 +29,7 @@ std::vector<std::shared_ptr<LogicalOperator>> Planner::planExportTableData(
     std::string name =
         stringFormat("COPY_{}", FileTypeUtils::toString(boundExportDatabase.getFileType()));
     auto entry =
-        Catalog::Get(*clientContext)->getFunctionEntry(clientContext->getTransaction(), name);
+        Catalog::Get(*clientContext)->getFunctionEntry(Transaction::Get(*clientContext), name);
     auto func = function::BuiltInFunctionsUtils::matchFunction(name,
         entry->ptrCast<FunctionCatalogEntry>());
     KU_ASSERT(func != nullptr);

--- a/src/processor/map/map_copy_from.cpp
+++ b/src/processor/map/map_copy_from.cpp
@@ -123,7 +123,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyRelFrom(
     KU_ASSERT(partitioner->getOperatorType() == PhysicalOperatorType::PARTITIONER);
     auto partitionerSharedState = partitioner->ptrCast<Partitioner>()->getSharedState();
     const auto catalog = Catalog::Get(*clientContext);
-    const auto transaction = clientContext->getTransaction();
+    const auto transaction = transaction::Transaction::Get(*clientContext);
     auto extraInfo = copyFromInfo->extraInfo->constCast<ExtraBoundCopyRelInfo>();
     auto fromTableID =
         catalog->getTableCatalogEntry(transaction, extraInfo.fromTableName)->getTableID();

--- a/src/processor/map/map_delete.cpp
+++ b/src/processor/map/map_delete.cpp
@@ -1,7 +1,6 @@
 #include "binder/expression/node_expression.h"
 #include "binder/expression/rel_expression.h"
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
-#include "main/client_context.h"
 #include "planner/operator/persistent/logical_delete.h"
 #include "processor/operator/persistent/delete.h"
 #include "processor/plan_mapper.h"
@@ -18,8 +17,8 @@ namespace processor {
 
 std::vector<RelTable*> getFwdRelTables(table_id_t nodeTableID, const main::ClientContext* context) {
     std::vector<RelTable*> result;
-    for (const auto entry :
-        Catalog::Get(*context)->getRelGroupEntries(context->getTransaction(), false)) {
+    auto transaction = transaction::Transaction::Get(*context);
+    for (const auto entry : Catalog::Get(*context)->getRelGroupEntries(transaction, false)) {
         auto& relGroupEntry = entry->constCast<RelGroupCatalogEntry>();
         for (auto& relEntryInfo : relGroupEntry.getRelEntryInfos()) {
             const auto srcTableID = relEntryInfo.nodePair.srcTableID;
@@ -34,8 +33,8 @@ std::vector<RelTable*> getFwdRelTables(table_id_t nodeTableID, const main::Clien
 
 std::vector<RelTable*> getBwdRelTables(table_id_t nodeTableID, const main::ClientContext* context) {
     std::vector<RelTable*> result;
-    for (const auto entry :
-        Catalog::Get(*context)->getRelGroupEntries(context->getTransaction(), false)) {
+    auto transaction = transaction::Transaction::Get(*context);
+    for (const auto entry : Catalog::Get(*context)->getRelGroupEntries(transaction, false)) {
         auto& relGroupEntry = entry->constCast<RelGroupCatalogEntry>();
         for (auto& relEntryInfo : relGroupEntry.getRelEntryInfos()) {
             const auto dstTableID = relEntryInfo.nodePair.dstTableID;

--- a/src/processor/map/map_scan_node_table.cpp
+++ b/src/processor/map/map_scan_node_table.cpp
@@ -2,7 +2,6 @@
 #include "binder/expression/property_expression.h"
 #include "binder/expression_binder.h"
 #include "common/mask.h"
-#include "main/client_context.h"
 #include "planner/operator/scan/logical_scan_node_table.h"
 #include "processor/expression_mapper.h"
 #include "processor/operator/scan/primary_key_scan_node_table.h"
@@ -21,7 +20,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapScanNodeTable(
     const LogicalOperator* logicalOperator) {
     auto storageManager = storage::StorageManager::Get(*clientContext);
     auto catalog = catalog::Catalog::Get(*clientContext);
-    auto transaction = clientContext->getTransaction();
+    auto transaction = transaction::Transaction::Get(*clientContext);
     auto& scan = logicalOperator->constCast<LogicalScanNodeTable>();
     const auto outSchema = scan.getSchema();
     auto nodeIDPos = getDataPos(*scan.getNodeID(), *outSchema);

--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -226,7 +226,8 @@ FactorizedTableSchema PlanMapper::createFlatFTableSchema(const expression_vector
 
 std::unique_ptr<SemiMask> PlanMapper::createSemiMask(table_id_t tableID) const {
     auto table = StorageManager::Get(*clientContext)->getTable(tableID)->ptrCast<NodeTable>();
-    return SemiMaskUtil::createMask(table->getNumTotalRows(transaction::Transaction::Get(*clientContext)));
+    return SemiMaskUtil::createMask(
+        table->getNumTotalRows(transaction::Transaction::Get(*clientContext)));
 }
 
 } // namespace processor

--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -226,7 +226,7 @@ FactorizedTableSchema PlanMapper::createFlatFTableSchema(const expression_vector
 
 std::unique_ptr<SemiMask> PlanMapper::createSemiMask(table_id_t tableID) const {
     auto table = StorageManager::Get(*clientContext)->getTable(tableID)->ptrCast<NodeTable>();
-    return SemiMaskUtil::createMask(table->getNumTotalRows(clientContext->getTransaction()));
+    return SemiMaskUtil::createMask(table->getNumTotalRows(transaction::Transaction::Get(*clientContext)));
 }
 
 } // namespace processor

--- a/src/processor/operator/base_partitioner_shared_state.cpp
+++ b/src/processor/operator/base_partitioner_shared_state.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/base_partitioner_shared_state.h"
-#include "transaction/transaction.h"
+
 #include "storage/table/node_table.h"
+#include "transaction/transaction.h"
 
 namespace kuzu::processor {
 void PartitionerSharedState::initialize(const common::logical_type_vec_t&,

--- a/src/processor/operator/base_partitioner_shared_state.cpp
+++ b/src/processor/operator/base_partitioner_shared_state.cpp
@@ -1,15 +1,15 @@
 #include "processor/operator/base_partitioner_shared_state.h"
-
-#include "main/client_context.h"
+#include "transaction/transaction.h"
 #include "storage/table/node_table.h"
 
 namespace kuzu::processor {
 void PartitionerSharedState::initialize(const common::logical_type_vec_t&,
     common::idx_t numPartitioners, const main::ClientContext* clientContext) {
     KU_ASSERT(numPartitioners >= 1 && numPartitioners <= DIRECTIONS);
-    numNodes[0] = srcNodeTable->getNumTotalRows(clientContext->getTransaction());
+    auto transaction = transaction::Transaction::Get(*clientContext);
+    numNodes[0] = srcNodeTable->getNumTotalRows(transaction);
     if (numPartitioners > 1) {
-        numNodes[1] = dstNodeTable->getNumTotalRows(clientContext->getTransaction());
+        numNodes[1] = dstNodeTable->getNumTotalRows(transaction);
     }
     numPartitions[0] = getNumPartitionsFromRows(numNodes[0]);
     if (numPartitioners > 1) {

--- a/src/processor/operator/ddl/create_sequence.cpp
+++ b/src/processor/operator/ddl/create_sequence.cpp
@@ -2,9 +2,9 @@
 
 #include "catalog/catalog.h"
 #include "common/string_format.h"
-#include "main/client_context.h"
 #include "processor/execution_context.h"
 #include "storage/buffer_manager/memory_manager.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;
@@ -19,7 +19,7 @@ std::string CreateSequencePrintInfo::toString() const {
 void CreateSequence::executeInternal(ExecutionContext* context) {
     auto clientContext = context->clientContext;
     auto catalog = Catalog::Get(*clientContext);
-    auto transaction = clientContext->getTransaction();
+    auto transaction = transaction::Transaction::Get(*clientContext);
     auto memoryManager = storage::MemoryManager::Get(*clientContext);
     if (catalog->containsSequence(transaction, info.sequenceName)) {
         switch (info.onConflict) {

--- a/src/processor/operator/ddl/create_table.cpp
+++ b/src/processor/operator/ddl/create_table.cpp
@@ -3,7 +3,6 @@
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "common/exception/binder.h"
 #include "common/string_format.h"
-#include "main/client_context.h"
 #include "processor/execution_context.h"
 #include "storage/storage_manager.h"
 
@@ -16,7 +15,7 @@ namespace processor {
 void CreateTable::executeInternal(ExecutionContext* context) {
     auto clientContext = context->clientContext;
     auto catalog = Catalog::Get(*clientContext);
-    auto transaction = clientContext->getTransaction();
+    auto transaction = transaction::Transaction::Get(*clientContext);
     auto memoryManager = storage::MemoryManager::Get(*clientContext);
     // Check conflict
     if (catalog->containsTable(transaction, info.tableName)) {

--- a/src/processor/operator/ddl/create_type.cpp
+++ b/src/processor/operator/ddl/create_type.cpp
@@ -1,9 +1,9 @@
 #include "processor/operator/ddl/create_type.h"
 
 #include "catalog/catalog.h"
-#include "main/client_context.h"
 #include "processor/execution_context.h"
 #include "storage/buffer_manager/memory_manager.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;
@@ -17,7 +17,8 @@ std::string CreateTypePrintInfo::toString() const {
 
 void CreateType::executeInternal(ExecutionContext* context) {
     auto clientContext = context->clientContext;
-    Catalog::Get(*clientContext)->createType(clientContext->getTransaction(), name, type.copy());
+    auto transaction = transaction::Transaction::Get(*clientContext);
+    Catalog::Get(*clientContext)->createType(transaction, name, type.copy());
     appendMessage(stringFormat("Type {}({}) has been created.", name, type.toString()),
         storage::MemoryManager::Get(*clientContext));
 }

--- a/src/processor/operator/ddl/drop.cpp
+++ b/src/processor/operator/ddl/drop.cpp
@@ -8,6 +8,7 @@
 #include "main/client_context.h"
 #include "processor/execution_context.h"
 #include "storage/buffer_manager/memory_manager.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;
@@ -31,7 +32,7 @@ void Drop::executeInternal(ExecutionContext* context) {
 
 void Drop::dropSequence(const main::ClientContext* context) {
     auto catalog = Catalog::Get(*context);
-    auto transaction = context->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context);
     auto memoryManager = storage::MemoryManager::Get(*context);
     if (!catalog->containsSequence(transaction, dropInfo.name)) {
         auto message = stringFormat("Sequence {} does not exist.", dropInfo.name);
@@ -53,7 +54,7 @@ void Drop::dropSequence(const main::ClientContext* context) {
 
 void Drop::dropTable(const main::ClientContext* context) {
     auto catalog = Catalog::Get(*context);
-    auto transaction = context->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context);
     auto memoryManager = storage::MemoryManager::Get(*context);
     if (!catalog->containsTable(transaction, dropInfo.name, context->useInternalCatalogEntry())) {
         auto message = stringFormat("Table {} does not exist.", dropInfo.name);

--- a/src/processor/operator/index_lookup.cpp
+++ b/src/processor/operator/index_lookup.cpp
@@ -126,7 +126,7 @@ bool IndexLookup::getNextTuplesInternal(ExecutionContext* context) {
     }
     for (auto& info : infos) {
         info.keyEvaluator->evaluate();
-        lookup(context->clientContext->getTransaction(), info);
+        lookup(transaction::Transaction::Get(*context->clientContext), info);
     }
     localState->errorHandler->flushStoredErrors();
     return true;

--- a/src/processor/operator/macro/create_macro.cpp
+++ b/src/processor/operator/macro/create_macro.cpp
@@ -1,9 +1,9 @@
 #include "processor/operator/macro/create_macro.h"
 
 #include "common/string_format.h"
-#include "main/client_context.h"
 #include "processor/execution_context.h"
 #include "storage/buffer_manager/memory_manager.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 
@@ -17,7 +17,7 @@ std::string CreateMacroPrintInfo::toString() const {
 void CreateMacro::executeInternal(ExecutionContext* context) {
     auto clientContext = context->clientContext;
     auto catalog = catalog::Catalog::Get(*clientContext);
-    auto transaction = clientContext->getTransaction();
+    auto transaction = transaction::Transaction::Get(*clientContext);
     catalog->addScalarMacroFunction(transaction, info.macroName, info.macro->copy());
     appendMessage(stringFormat("Macro: {} has been created.", info.macroName),
         storage::MemoryManager::Get(*clientContext));

--- a/src/processor/operator/partitioner.cpp
+++ b/src/processor/operator/partitioner.cpp
@@ -1,11 +1,11 @@
 #include "processor/operator/partitioner.h"
 
 #include "binder/expression/expression_util.h"
-#include "main/client_context.h"
 #include "processor/execution_context.h"
 #include "storage/storage_manager.h"
 #include "storage/table/node_table.h"
 #include "storage/table/rel_table.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::storage;
@@ -75,7 +75,7 @@ void Partitioner::initGlobalStateInternal(ExecutionContext* context) {
     if (!sharedState->srcNodeTable) {
         auto storageManager = StorageManager::Get(*clientContext);
         auto catalog = catalog::Catalog::Get(*clientContext);
-        auto transaction = clientContext->getTransaction();
+        auto transaction = transaction::Transaction::Get(*clientContext);
         auto fromTableID =
             catalog->getTableCatalogEntry(transaction, dataInfo.fromTableName)->getTableID();
         auto toTableID =

--- a/src/processor/operator/persistent/node_batch_insert_error_handler.cpp
+++ b/src/processor/operator/persistent/node_batch_insert_error_handler.cpp
@@ -1,4 +1,5 @@
 #include "processor/operator/persistent/node_batch_insert_error_handler.h"
+
 #include "processor/execution_context.h"
 #include "storage/table/node_table.h"
 

--- a/src/processor/operator/persistent/node_batch_insert_error_handler.cpp
+++ b/src/processor/operator/persistent/node_batch_insert_error_handler.cpp
@@ -1,6 +1,4 @@
 #include "processor/operator/persistent/node_batch_insert_error_handler.h"
-
-#include "main/client_context.h"
 #include "processor/execution_context.h"
 #include "storage/table/node_table.h"
 
@@ -10,8 +8,8 @@ namespace kuzu {
 namespace processor {
 
 NodeBatchInsertErrorHandler::NodeBatchInsertErrorHandler(ExecutionContext* context,
-    common::LogicalTypeID pkType, storage::NodeTable* nodeTable, bool ignoreErrors,
-    std::shared_ptr<common::row_idx_t> sharedErrorCounter, std::mutex* sharedErrorCounterMtx)
+    LogicalTypeID pkType, storage::NodeTable* nodeTable, bool ignoreErrors,
+    std::shared_ptr<row_idx_t> sharedErrorCounter, std::mutex* sharedErrorCounterMtx)
     : nodeTable(nodeTable), context(context),
       keyVector(std::make_shared<ValueVector>(pkType,
           storage::MemoryManager::Get(*context->clientContext))),
@@ -27,7 +25,7 @@ void NodeBatchInsertErrorHandler::deleteCurrentErroneousRow() {
         *offsetVector,
         *keyVector,
     };
-    nodeTable->delete_(context->clientContext->getTransaction(), deleteState);
+    nodeTable->delete_(transaction::Transaction::Get(*context->clientContext), deleteState);
 }
 
 void NodeBatchInsertErrorHandler::flushStoredErrors() {

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -33,11 +33,10 @@ void RelBatchInsert::initLocalStateInternal(ResultSet*, ExecutionContext* contex
     localState->chunkedGroup =
         std::make_unique<ChunkedCSRNodeGroup>(*MemoryManager::Get(*context->clientContext),
             relInfo->columnTypes, relInfo->compressionEnabled, 0, 0, ResidencyState::IN_MEMORY);
-    localState->optimisticAllocator =
-        context->clientContext->getTransaction()->getLocalStorage()->addOptimisticAllocator();
+    const auto transaction = transaction::Transaction::Get(*context->clientContext);
+    localState->optimisticAllocator = transaction->getLocalStorage()->addOptimisticAllocator();
     const auto clientContext = context->clientContext;
     const auto catalog = Catalog::Get(*clientContext);
-    const auto transaction = clientContext->getTransaction();
     const auto catalogEntry = catalog->getTableCatalogEntry(transaction, info->tableName);
     const auto& relGroupEntry = catalogEntry->constCast<RelGroupCatalogEntry>();
     auto tableID = relGroupEntry.getRelEntryInfo(relInfo->fromTableID, relInfo->toTableID)->oid;
@@ -62,7 +61,7 @@ void RelBatchInsert::initGlobalStateInternal(ExecutionContext* context) {
     const auto relBatchInsertInfo = info->ptrCast<RelBatchInsertInfo>();
     const auto clientContext = context->clientContext;
     const auto catalog = Catalog::Get(*clientContext);
-    const auto transaction = clientContext->getTransaction();
+    const auto transaction = transaction::Transaction::Get(*clientContext);
     const auto catalogEntry = catalog->getTableCatalogEntry(transaction, info->tableName);
     const auto& relGroupEntry = catalogEntry->constCast<RelGroupCatalogEntry>();
     // Init info
@@ -98,9 +97,9 @@ void RelBatchInsert::executeInternal(ExecutionContext* context) {
     const auto relTable = sharedState->table->ptrCast<RelTable>();
     const auto relLocalState = localState->ptrCast<RelBatchInsertLocalState>();
     const auto clientContext = context->clientContext;
-    const auto& relGroupEntry =
-        Catalog::Get(*context->clientContext)
-            ->getTableCatalogEntry(clientContext->getTransaction(), relInfo->tableName)
+    const auto catalog = Catalog::Get(*clientContext);
+    const auto transaction = transaction::Transaction::Get(*clientContext);
+    const auto& relGroupEntry = catalog->getTableCatalogEntry(transaction, relInfo->tableName)
             ->constCast<RelGroupCatalogEntry>();
     while (true) {
         relLocalState->nodeGroupIdx =
@@ -113,11 +112,11 @@ void RelBatchInsert::executeInternal(ExecutionContext* context) {
         // TODO(Guodong): We need to handle the concurrency between COPY and other insertions
         // into the same node group.
         auto& nodeGroup = relTable
-                              ->getOrCreateNodeGroup(context->clientContext->getTransaction(),
+                              ->getOrCreateNodeGroup(transaction,
                                   relLocalState->nodeGroupIdx, relInfo->direction)
                               ->cast<CSRNodeGroup>();
         appendNodeGroup(relGroupEntry, *MemoryManager::Get(*clientContext),
-            clientContext->getTransaction(), nodeGroup, *relInfo, *relLocalState);
+            transaction, nodeGroup, *relInfo, *relLocalState);
         updateProgress(context);
     }
 }

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -100,7 +100,7 @@ void RelBatchInsert::executeInternal(ExecutionContext* context) {
     const auto catalog = Catalog::Get(*clientContext);
     const auto transaction = transaction::Transaction::Get(*clientContext);
     const auto& relGroupEntry = catalog->getTableCatalogEntry(transaction, relInfo->tableName)
-            ->constCast<RelGroupCatalogEntry>();
+                                    ->constCast<RelGroupCatalogEntry>();
     while (true) {
         relLocalState->nodeGroupIdx =
             partitionerSharedState->getNextPartition(relInfo->partitioningIdx);
@@ -111,12 +111,12 @@ void RelBatchInsert::executeInternal(ExecutionContext* context) {
         ++progressSharedState->partitionsDone;
         // TODO(Guodong): We need to handle the concurrency between COPY and other insertions
         // into the same node group.
-        auto& nodeGroup = relTable
-                              ->getOrCreateNodeGroup(transaction,
-                                  relLocalState->nodeGroupIdx, relInfo->direction)
-                              ->cast<CSRNodeGroup>();
-        appendNodeGroup(relGroupEntry, *MemoryManager::Get(*clientContext),
-            transaction, nodeGroup, *relInfo, *relLocalState);
+        auto& nodeGroup =
+            relTable
+                ->getOrCreateNodeGroup(transaction, relLocalState->nodeGroupIdx, relInfo->direction)
+                ->cast<CSRNodeGroup>();
+        appendNodeGroup(relGroupEntry, *MemoryManager::Get(*clientContext), transaction, nodeGroup,
+            *relInfo, *relLocalState);
         updateProgress(context);
     }
 }

--- a/src/processor/operator/persistent/set_executor.cpp
+++ b/src/processor/operator/persistent/set_executor.cpp
@@ -1,6 +1,6 @@
 #include "processor/operator/persistent/set_executor.h"
 
-#include "main/client_context.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 
@@ -54,7 +54,7 @@ void SingleLabelNodeSetExecutor::set(ExecutionContext* context) {
     auto updateState = std::make_unique<storage::NodeTableUpdateState>(tableInfo.columnID,
         *info.nodeIDVector, *info.columnDataVector);
     tableInfo.table->initUpdateState(context->clientContext, *updateState);
-    tableInfo.table->update(context->clientContext->getTransaction(), *updateState);
+    tableInfo.table->update(transaction::Transaction::Get(*context->clientContext), *updateState);
     if (info.columnVectorPos.isValid()) {
         writeColumnUpdateResult(info.nodeIDVector, info.columnVector, info.columnDataVector);
     }
@@ -76,7 +76,7 @@ void MultiLabelNodeSetExecutor::set(ExecutionContext* context) {
     auto updateState = std::make_unique<storage::NodeTableUpdateState>(tableInfo.columnID,
         *info.nodeIDVector, *info.columnDataVector);
     tableInfo.table->initUpdateState(context->clientContext, *updateState);
-    tableInfo.table->update(context->clientContext->getTransaction(), *updateState);
+    tableInfo.table->update(transaction::Transaction::Get(*context->clientContext), *updateState);
     if (info.columnVectorPos.isValid()) {
         writeColumnUpdateResult(info.nodeIDVector, info.columnVector, info.columnDataVector);
     }
@@ -111,7 +111,7 @@ void SingleLabelRelSetExecutor::set(ExecutionContext* context) {
     info.evaluator->evaluate();
     auto updateState = std::make_unique<storage::RelTableUpdateState>(tableInfo.columnID,
         *info.srcNodeIDVector, *info.dstNodeIDVector, *info.relIDVector, *info.columnDataVector);
-    tableInfo.table->update(context->clientContext->getTransaction(), *updateState);
+    tableInfo.table->update(transaction::Transaction::Get(*context->clientContext), *updateState);
     if (info.columnVectorPos.isValid()) {
         writeColumnUpdateResult(info.relIDVector, info.columnVector, info.columnDataVector);
     }
@@ -131,7 +131,7 @@ void MultiLabelRelSetExecutor::set(ExecutionContext* context) {
     auto& tableInfo = tableInfos.at(relID.tableID);
     auto updateState = std::make_unique<storage::RelTableUpdateState>(tableInfo.columnID,
         *info.srcNodeIDVector, *info.dstNodeIDVector, *info.relIDVector, *info.columnDataVector);
-    tableInfo.table->update(context->clientContext->getTransaction(), *updateState);
+    tableInfo.table->update(transaction::Transaction::Get(*context->clientContext), *updateState);
     if (info.columnVectorPos.isValid()) {
         writeColumnUpdateResult(info.relIDVector, info.columnVector, info.columnDataVector);
     }

--- a/src/processor/operator/scan/primary_key_scan_node_table.cpp
+++ b/src/processor/operator/scan/primary_key_scan_node_table.cpp
@@ -1,7 +1,6 @@
 #include "processor/operator/scan/primary_key_scan_node_table.h"
 
 #include "binder/expression/expression_util.h"
-#include "main/client_context.h"
 #include "processor/execution_context.h"
 
 using namespace kuzu::common;
@@ -40,7 +39,7 @@ void PrimaryKeyScanNodeTable::initLocalStateInternal(ResultSet* resultSet,
 }
 
 bool PrimaryKeyScanNodeTable::getNextTuplesInternal(ExecutionContext* context) {
-    auto transaction = context->clientContext->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context->clientContext);
     auto tableIdx = sharedState->getTableIdx();
     if (tableIdx >= tableInfos.size()) {
         return false;

--- a/src/processor/operator/scan/scan_multi_rel_tables.cpp
+++ b/src/processor/operator/scan/scan_multi_rel_tables.cpp
@@ -1,6 +1,5 @@
 #include "processor/operator/scan/scan_multi_rel_tables.h"
 
-#include "main/client_context.h"
 #include "processor/execution_context.h"
 #include "storage/local_storage/local_storage.h"
 
@@ -23,7 +22,7 @@ bool DirectionInfo::needFlip(RelDataDirection relDataDirection) const {
 
 bool RelTableCollectionScanner::scan(main::ClientContext* context, RelTableScanState& scanState,
     const std::vector<ValueVector*>& outVectors) {
-    auto transaction = context->getTransaction();
+    auto transaction = Transaction::Get(*context);
     while (true) {
         auto& relInfo = relInfos[currentTableIdx];
         if (relInfo.table->scan(transaction, scanState)) {

--- a/src/processor/operator/scan/scan_rel_table.cpp
+++ b/src/processor/operator/scan/scan_rel_table.cpp
@@ -1,7 +1,6 @@
 #include "processor/operator/scan/scan_rel_table.h"
 
 #include "binder/expression/expression_util.h"
-#include "main/client_context.h"
 #include "processor/execution_context.h"
 #include "storage/local_storage/local_rel_table.h"
 
@@ -57,7 +56,7 @@ std::string ScanRelTablePrintInfo::toString() const {
 
 void ScanRelTableInfo::initScanState(TableScanState& scanState,
     const std::vector<ValueVector*>& outVectors, main::ClientContext* context) {
-    auto transaction = context->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context);
     scanState.setToTable(transaction, table, columnIDs, copyVector(columnPredicates), direction);
     initScanStateVectors(scanState, outVectors, MemoryManager::Get(*context));
 }
@@ -73,7 +72,7 @@ void ScanRelTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext
 }
 
 bool ScanRelTable::getNextTuplesInternal(ExecutionContext* context) {
-    const auto transaction = context->clientContext->getTransaction();
+    const auto transaction = transaction::Transaction::Get(*context->clientContext);
     while (true) {
         while (tableInfo.table->scan(transaction, *scanState)) {
             const auto outputSize = scanState->outState->getSelVector().getSelSize();

--- a/src/processor/operator/simple/import_db.cpp
+++ b/src/processor/operator/simple/import_db.cpp
@@ -1,9 +1,10 @@
 #include "processor/operator/simple/import_db.h"
 
 #include "common/exception/runtime.h"
-#include "main/client_context.h"
 #include "processor/execution_context.h"
 #include "storage/buffer_manager/memory_manager.h"
+#include "main/client_context.h"
+#include "transaction/transaction_context.h"
 
 using namespace kuzu::common;
 using namespace kuzu::transaction;

--- a/src/processor/operator/simple/import_db.cpp
+++ b/src/processor/operator/simple/import_db.cpp
@@ -1,9 +1,9 @@
 #include "processor/operator/simple/import_db.h"
 
 #include "common/exception/runtime.h"
+#include "main/client_context.h"
 #include "processor/execution_context.h"
 #include "storage/buffer_manager/memory_manager.h"
-#include "main/client_context.h"
 #include "transaction/transaction_context.h"
 
 using namespace kuzu::common;

--- a/src/storage/local_storage/local_storage.cpp
+++ b/src/storage/local_storage/local_storage.cpp
@@ -1,6 +1,5 @@
 #include "storage/local_storage/local_storage.h"
 
-#include "main/client_context.h"
 #include "storage/local_storage/local_node_table.h"
 #include "storage/local_storage/local_rel_table.h"
 #include "storage/local_storage/local_table.h"
@@ -17,7 +16,7 @@ namespace storage {
 LocalTable* LocalStorage::getOrCreateLocalTable(Table& table) {
     const auto tableID = table.getTableID();
     auto catalog = catalog::Catalog::Get(clientContext);
-    auto transaction = clientContext.getTransaction();
+    auto transaction = transaction::Transaction::Get(clientContext);
     auto& mm = *MemoryManager::Get(clientContext);
     if (!tables.contains(tableID)) {
         switch (table.getTableType()) {
@@ -58,7 +57,7 @@ PageAllocator* LocalStorage::addOptimisticAllocator() {
 
 void LocalStorage::commit() {
     auto catalog = catalog::Catalog::Get(clientContext);
-    auto transaction = clientContext.getTransaction();
+    auto transaction = transaction::Transaction::Get(clientContext);
     auto storageManager = StorageManager::Get(clientContext);
     for (auto& [tableID, localTable] : tables) {
         if (localTable->getTableType() == TableType::NODE) {

--- a/src/storage/table/node_table.cpp
+++ b/src/storage/table/node_table.cpp
@@ -138,7 +138,8 @@ bool UncommittedIndexInserter::processScanOutput(main::ClientContext* context,
     if (!insertState) {
         insertState = index->initInsertState(context, isVisible);
     }
-    index->commitInsert(transaction::Transaction::Get(*context), nodeIDVector, {scannedVectors}, *insertState);
+    index->commitInsert(transaction::Transaction::Get(*context), nodeIDVector, {scannedVectors},
+        *insertState);
     startNodeOffset += scanResult.numRows;
     return true;
 }
@@ -167,8 +168,8 @@ bool RollbackPKDeleter::processScanOutput(main::ClientContext* context,
             const auto pos = scannedVector.state->getSelVector()[i];
             T key = scannedVector.getValue<T>(pos);
             static constexpr auto isVisible = [](offset_t) { return true; };
-            if (offset_t lookupOffset = 0;
-                pkIndex.lookup(transaction::Transaction::Get(*context), key, lookupOffset, isVisible)) {
+            if (offset_t lookupOffset = 0; pkIndex.lookup(transaction::Transaction::Get(*context),
+                    key, lookupOffset, isVisible)) {
                 // If we delete the key then it will not be visible to future transactions within
                 // this process
                 pkIndex.discardLocal(key);
@@ -409,8 +410,10 @@ void NodeTable::initInsertState(main::ClientContext* context, TableInsertState& 
     for (auto i = 0u; i < indexes.size(); i++) {
         auto& indexHolder = indexes[i];
         const auto index = indexHolder.getIndex();
-        nodeInsertState.indexInsertStates[i] = index->initInsertState(context,
-            [&](offset_t offset) { return isVisible(transaction::Transaction::Get(*context), offset); });
+        nodeInsertState.indexInsertStates[i] =
+            index->initInsertState(context, [&](offset_t offset) {
+                return isVisible(transaction::Transaction::Get(*context), offset);
+            });
     }
 }
 
@@ -455,8 +458,9 @@ void NodeTable::initUpdateState(main::ClientContext* context, TableUpdateState& 
             continue;
         }
         nodeUpdateState.indexUpdateState[i] =
-            index->initUpdateState(context, nodeUpdateState.columnID,
-                [&](offset_t offset) { return isVisible(transaction::Transaction::Get(*context), offset); });
+            index->initUpdateState(context, nodeUpdateState.columnID, [&](offset_t offset) {
+                return isVisible(transaction::Transaction::Get(*context), offset);
+            });
     }
 }
 
@@ -741,7 +745,8 @@ bool NodeTable::lookupPK(const Transaction* transaction, ValueVector* keyVector,
 void NodeTable::scanIndexColumns(main::ClientContext* context, IndexScanHelper& scanHelper,
     const NodeGroupCollection& nodeGroups_) const {
     auto dataChunk = constructDataChunkForColumns(scanHelper.index->getIndexInfo().columnIDs);
-    const auto scanState = scanHelper.initScanState(transaction::Transaction::Get(*context), dataChunk);
+    const auto scanState =
+        scanHelper.initScanState(transaction::Transaction::Get(*context), dataChunk);
 
     const auto numNodeGroups = nodeGroups_.getNumNodeGroups();
     for (node_group_idx_t nodeGroupToScan = 0u; nodeGroupToScan < numNodeGroups;
@@ -753,10 +758,11 @@ void NodeTable::scanIndexColumns(main::ClientContext* context, IndexScanHelper& 
         if (scanState->nodeGroup->getNumChunkedGroups() > 0) {
             scanState->nodeGroupIdx = nodeGroupToScan;
             KU_ASSERT(scanState->nodeGroup);
-            scanState->nodeGroup->initializeScanState(transaction::Transaction::Get(*context), *scanState);
+            scanState->nodeGroup->initializeScanState(transaction::Transaction::Get(*context),
+                *scanState);
             while (true) {
-                if (const auto scanResult =
-                        scanState->nodeGroup->scan(transaction::Transaction::Get(*context), *scanState);
+                if (const auto scanResult = scanState->nodeGroup->scan(
+                        transaction::Transaction::Get(*context), *scanState);
                     !scanHelper.processScanOutput(context, scanResult, scanState->outputVectors)) {
                     break;
                 }

--- a/src/storage/table/rel_table.cpp
+++ b/src/storage/table/rel_table.cpp
@@ -416,7 +416,7 @@ void RelTable::commit(main::ClientContext* context, TableCatalogEntry* tableEntr
         columnIDsToCommit.push_back(columnID);
     }
     // commit rel table data
-    auto transaction = context->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context);
     for (auto& relData : directedRelData) {
         const auto direction = relData->getDirection();
         const auto columnToSkip = (direction == RelDataDirection::FWD) ?

--- a/src/storage/table/version_record_handler.cpp
+++ b/src/storage/table/version_record_handler.cpp
@@ -9,7 +9,7 @@ void VersionRecordHandler::rollbackInsert(main::ClientContext* context,
     common::node_group_idx_t nodeGroupIdx, common::row_idx_t startRow,
     common::row_idx_t numRows) const {
     applyFuncToChunkedGroups(&ChunkedNodeGroup::rollbackInsert, nodeGroupIdx, startRow, numRows,
-        context->getTransaction()->getCommitTS());
+        transaction::Transaction::Get(*context)->getCommitTS());
 }
 
 } // namespace kuzu::storage

--- a/src/storage/undo_buffer.cpp
+++ b/src/storage/undo_buffer.cpp
@@ -4,7 +4,6 @@
 #include "catalog/catalog_entry/sequence_catalog_entry.h"
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "catalog/catalog_set.h"
-#include "main/client_context.h"
 #include "storage/table/chunked_node_group.h"
 #include "storage/table/update_info.h"
 #include "storage/table/version_record_handler.h"
@@ -240,7 +239,7 @@ void UndoBuffer::rollbackRecord(ClientContext* context, const UndoRecordType rec
         rollbackVersionInfo(context, recordType, record);
     } break;
     case UndoRecordType::UPDATE_INFO: {
-        rollbackVectorUpdateInfo(context->getTransaction(), record);
+        rollbackVectorUpdateInfo(transaction::Transaction::Get(*context), record);
     } break;
     default: {
         KU_UNREACHABLE;
@@ -289,7 +288,7 @@ void UndoBuffer::rollbackVersionInfo(ClientContext* context, UndoRecordType reco
     case UndoRecordType::DELETE_INFO: {
         undoRecord.versionRecordHandler->applyFuncToChunkedGroups(&ChunkedNodeGroup::rollbackDelete,
             undoRecord.nodeGroupIdx, undoRecord.startRow, undoRecord.numRows,
-            context->getTransaction()->getCommitTS());
+            transaction::Transaction::Get(*context)->getCommitTS());
     } break;
     default: {
         KU_UNREACHABLE;

--- a/src/storage/wal/wal_replayer.cpp
+++ b/src/storage/wal/wal_replayer.cpp
@@ -10,7 +10,6 @@
 #include "common/file_system/virtual_file_system.h"
 #include "common/serializer/buffered_file.h"
 #include "extension/extension_manager.h"
-#include "main/client_context.h"
 #include "processor/expression_mapper.h"
 #include "storage/file_db_id_utils.h"
 #include "storage/local_storage/local_rel_table.h"
@@ -19,6 +18,8 @@
 #include "storage/table/rel_table.h"
 #include "storage/wal/checksum_reader.h"
 #include "storage/wal/wal_record.h"
+#include "main/client_context.h"
+#include "transaction/transaction_context.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::catalog;
@@ -254,7 +255,7 @@ void WALReplayer::replayWALRecord(WALRecord& walRecord) const {
 
 void WALReplayer::replayCreateCatalogEntryRecord(WALRecord& walRecord) const {
     auto catalog = Catalog::Get(clientContext);
-    auto transaction = clientContext.getTransaction();
+    auto transaction = transaction::Transaction::Get(clientContext);
     auto storageManager = StorageManager::Get(clientContext);
     auto& record = walRecord.cast<CreateCatalogEntryRecord>();
     switch (record.ownedCatalogEntry->getType()) {
@@ -291,7 +292,7 @@ void WALReplayer::replayCreateCatalogEntryRecord(WALRecord& walRecord) const {
 void WALReplayer::replayDropCatalogEntryRecord(const WALRecord& walRecord) const {
     auto& dropEntryRecord = walRecord.constCast<DropCatalogEntryRecord>();
     auto catalog = Catalog::Get(clientContext);
-    auto transaction = clientContext.getTransaction();
+    auto transaction = transaction::Transaction::Get(clientContext);
     const auto entryID = dropEntryRecord.entryID;
     switch (dropEntryRecord.entryType) {
     case CatalogEntryType::NODE_TABLE_ENTRY:
@@ -315,7 +316,7 @@ void WALReplayer::replayAlterTableEntryRecord(const WALRecord& walRecord) const 
     auto binder = Binder(&clientContext);
     auto& alterEntryRecord = walRecord.constCast<AlterTableEntryRecord>();
     auto catalog = Catalog::Get(clientContext);
-    auto transaction = clientContext.getTransaction();
+    auto transaction = transaction::Transaction::Get(clientContext);
     auto storageManager = StorageManager::Get(clientContext);
     auto ownedAlterInfo = alterEntryRecord.ownedAlterInfo.get();
     catalog->alterTableEntry(transaction, *ownedAlterInfo);
@@ -398,12 +399,12 @@ void WALReplayer::replayNodeTableInsertRecord(const WALRecord& walRecord) const 
     nodeIDVector->setState(anchorState);
     const auto insertState =
         std::make_unique<NodeTableInsertState>(*nodeIDVector, pkVector, propertyVectors);
-    KU_ASSERT(clientContext.getTransaction() && clientContext.getTransaction()->isRecovery());
+    KU_ASSERT(transaction::Transaction::Get(clientContext) && transaction::Transaction::Get(clientContext)->isRecovery());
     table.initInsertState(&clientContext, *insertState);
     anchorState->getSelVectorUnsafe().setToFiltered(1);
     for (auto i = 0u; i < numNodes; i++) {
         anchorState->getSelVectorUnsafe()[0] = i;
-        table.insert(clientContext.getTransaction(), *insertState);
+        table.insert(transaction::Transaction::Get(clientContext), *insertState);
     }
 }
 
@@ -429,11 +430,11 @@ void WALReplayer::replayRelTableInsertRecord(const WALRecord& walRecord) const {
     const auto insertState = std::make_unique<RelTableInsertState>(
         *insertionRecord.ownedVectors[LOCAL_BOUND_NODE_ID_COLUMN_ID],
         *insertionRecord.ownedVectors[LOCAL_NBR_NODE_ID_COLUMN_ID], propertyVectors);
-    KU_ASSERT(clientContext.getTransaction() && clientContext.getTransaction()->isRecovery());
+    KU_ASSERT(transaction::Transaction::Get(clientContext) && transaction::Transaction::Get(clientContext)->isRecovery());
     for (auto i = 0u; i < numRels; i++) {
         anchorState->getSelVectorUnsafe()[0] = i;
         table.initInsertState(&clientContext, *insertState);
-        table.insert(clientContext.getTransaction(), *insertState);
+        table.insert(transaction::Transaction::Get(clientContext), *insertState);
     }
 }
 
@@ -449,8 +450,8 @@ void WALReplayer::replayNodeDeletionRecord(const WALRecord& walRecord) const {
         internalID_t{deletionRecord.nodeOffset, deletionRecord.tableID});
     const auto deleteState =
         std::make_unique<NodeTableDeleteState>(*nodeIDVector, *deletionRecord.ownedPKVector);
-    KU_ASSERT(clientContext.getTransaction() && clientContext.getTransaction()->isRecovery());
-    table.delete_(clientContext.getTransaction(), *deleteState);
+    KU_ASSERT(transaction::Transaction::Get(clientContext) && transaction::Transaction::Get(clientContext)->isRecovery());
+    table.delete_(transaction::Transaction::Get(clientContext), *deleteState);
 }
 
 void WALReplayer::replayNodeUpdateRecord(const WALRecord& walRecord) const {
@@ -465,8 +466,8 @@ void WALReplayer::replayNodeUpdateRecord(const WALRecord& walRecord) const {
         internalID_t{updateRecord.nodeOffset, updateRecord.tableID});
     const auto updateState = std::make_unique<NodeTableUpdateState>(updateRecord.columnID,
         *nodeIDVector, *updateRecord.ownedPropertyVector);
-    KU_ASSERT(clientContext.getTransaction() && clientContext.getTransaction()->isRecovery());
-    table.update(clientContext.getTransaction(), *updateState);
+    KU_ASSERT(transaction::Transaction::Get(clientContext) && transaction::Transaction::Get(clientContext)->isRecovery());
+    table.update(transaction::Transaction::Get(clientContext), *updateState);
 }
 
 void WALReplayer::replayRelDeletionRecord(const WALRecord& walRecord) const {
@@ -478,15 +479,15 @@ void WALReplayer::replayRelDeletionRecord(const WALRecord& walRecord) const {
     const auto deleteState =
         std::make_unique<RelTableDeleteState>(*deletionRecord.ownedSrcNodeIDVector,
             *deletionRecord.ownedDstNodeIDVector, *deletionRecord.ownedRelIDVector);
-    KU_ASSERT(clientContext.getTransaction() && clientContext.getTransaction()->isRecovery());
-    table.delete_(clientContext.getTransaction(), *deleteState);
+    KU_ASSERT(transaction::Transaction::Get(clientContext) && transaction::Transaction::Get(clientContext)->isRecovery());
+    table.delete_(transaction::Transaction::Get(clientContext), *deleteState);
 }
 
 void WALReplayer::replayRelDetachDeletionRecord(const WALRecord& walRecord) const {
     const auto& deletionRecord = walRecord.constCast<RelDetachDeleteRecord>();
     const auto tableID = deletionRecord.tableID;
     auto& table = StorageManager::Get(clientContext)->getTable(tableID)->cast<RelTable>();
-    KU_ASSERT(clientContext.getTransaction() && clientContext.getTransaction()->isRecovery());
+    KU_ASSERT(transaction::Transaction::Get(clientContext) && transaction::Transaction::Get(clientContext)->isRecovery());
     const auto anchorState = deletionRecord.ownedSrcNodeIDVector->state;
     KU_ASSERT(anchorState->getSelVector().getSelSize() == 1);
     const auto dstNodeIDVector =
@@ -497,7 +498,7 @@ void WALReplayer::replayRelDetachDeletionRecord(const WALRecord& walRecord) cons
     const auto deleteState = std::make_unique<RelTableDeleteState>(
         *deletionRecord.ownedSrcNodeIDVector, *dstNodeIDVector, *relIDVector);
     deleteState->detachDeleteDirection = deletionRecord.direction;
-    table.detachDelete(clientContext.getTransaction(), deleteState.get());
+    table.detachDelete(transaction::Transaction::Get(clientContext), deleteState.get());
 }
 
 void WALReplayer::replayRelUpdateRecord(const WALRecord& walRecord) const {
@@ -512,8 +513,8 @@ void WALReplayer::replayRelUpdateRecord(const WALRecord& walRecord) const {
     const auto updateState = std::make_unique<RelTableUpdateState>(updateRecord.columnID,
         *updateRecord.ownedSrcNodeIDVector, *updateRecord.ownedDstNodeIDVector,
         *updateRecord.ownedRelIDVector, *updateRecord.ownedPropertyVector);
-    KU_ASSERT(clientContext.getTransaction() && clientContext.getTransaction()->isRecovery());
-    table.update(clientContext.getTransaction(), *updateState);
+    KU_ASSERT(transaction::Transaction::Get(clientContext) && transaction::Transaction::Get(clientContext)->isRecovery());
+    table.update(transaction::Transaction::Get(clientContext), *updateState);
 }
 
 void WALReplayer::replayCopyTableRecord(const WALRecord&) const {
@@ -524,8 +525,8 @@ void WALReplayer::replayUpdateSequenceRecord(const WALRecord& walRecord) const {
     auto& sequenceEntryRecord = walRecord.constCast<UpdateSequenceRecord>();
     const auto sequenceID = sequenceEntryRecord.sequenceID;
     const auto entry =
-        Catalog::Get(clientContext)->getSequenceEntry(clientContext.getTransaction(), sequenceID);
-    entry->nextKVal(clientContext.getTransaction(), sequenceEntryRecord.kCount);
+        Catalog::Get(clientContext)->getSequenceEntry(transaction::Transaction::Get(clientContext), sequenceID);
+    entry->nextKVal(transaction::Transaction::Get(clientContext), sequenceEntryRecord.kCount);
 }
 
 void WALReplayer::replayLoadExtensionRecord(const WALRecord& walRecord) const {

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -213,7 +213,6 @@ Transaction* Transaction::Get(const main::ClientContext& context) {
     return context.getTransactionContext()->getActiveTransaction();
 }
 
-
 Transaction DUMMY_TRANSACTION = Transaction(TransactionType::DUMMY);
 Transaction DUMMY_CHECKPOINT_TRANSACTION = Transaction(TransactionType::CHECKPOINT,
     Transaction::DUMMY_TRANSACTION_ID, Transaction::START_TRANSACTION_ID - 1);

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -8,6 +8,7 @@
 #include "storage/storage_manager.h"
 #include "storage/undo_buffer.h"
 #include "storage/wal/local_wal.h"
+#include "transaction/transaction_context.h"
 
 using namespace kuzu::catalog;
 
@@ -207,6 +208,11 @@ common::offset_t Transaction::getMinUncommittedNodeOffset(common::table_id_t tab
     }
     return 0;
 }
+
+Transaction* Transaction::Get(const main::ClientContext& context) {
+    return context.getTransactionContext()->getActiveTransaction();
+}
+
 
 Transaction DUMMY_TRANSACTION = Transaction(TransactionType::DUMMY);
 Transaction DUMMY_CHECKPOINT_TRANSACTION = Transaction(TransactionType::CHECKPOINT,

--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -38,8 +38,9 @@ public:
 
         const bool inCheckpoint =
             ctx && !transaction::TransactionManager::Get(*ctx)->hasActiveWriteTransactionNoLock();
-        const bool inCommit = !inCheckpoint && ctx && transaction::Transaction::Get(*ctx) &&
-                              transaction::Transaction::Get(*ctx)->getCommitTS() != common::INVALID_TRANSACTION;
+        const bool inCommit =
+            !inCheckpoint && ctx && transaction::Transaction::Get(*ctx) &&
+            transaction::Transaction::Get(*ctx)->getCommitTS() != common::INVALID_TRANSACTION;
         const bool inExecute = (!inCommit && !inCheckpoint);
         reserveCount = (reserveCount + 1) % failureFrequency;
         if (!inRollback && !inDBInit && (canFailDuringCommit || !inCommit) &&

--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -38,8 +38,8 @@ public:
 
         const bool inCheckpoint =
             ctx && !transaction::TransactionManager::Get(*ctx)->hasActiveWriteTransactionNoLock();
-        const bool inCommit = !inCheckpoint && ctx && ctx->getTransaction() &&
-                              ctx->getTransaction()->getCommitTS() != common::INVALID_TRANSACTION;
+        const bool inCommit = !inCheckpoint && ctx && transaction::Transaction::Get(*ctx) &&
+                              transaction::Transaction::Get(*ctx)->getCommitTS() != common::INVALID_TRANSACTION;
         const bool inExecute = (!inCommit && !inCheckpoint);
         reserveCount = (reserveCount + 1) % failureFrequency;
         if (!inRollback && !inDBInit && (canFailDuringCommit || !inCommit) &&

--- a/test/storage/rel_delete_test.cpp
+++ b/test/storage/rel_delete_test.cpp
@@ -30,9 +30,8 @@ void RelDeleteTest::detachDeleteNode(std::string_view nodeTable, std::string_vie
     int64_t idOfNode) {
     auto* catalog = database->getCatalog();
     auto transaction = transaction::Transaction::Get(*conn->getClientContext());
-    const auto& knowsTableEntry = catalog->getTableCatalogEntry(transaction,
-                std::string{relTable})
-            ->constCast<catalog::RelGroupCatalogEntry>();
+    const auto& knowsTableEntry = catalog->getTableCatalogEntry(transaction, std::string{relTable})
+                                      ->constCast<catalog::RelGroupCatalogEntry>();
     auto& knowsTable = storage::StorageManager::Get(*conn->getClientContext())
                            ->getTable(knowsTableEntry.getRelEntryInfos()[0].oid)
                            ->cast<storage::RelTable>();

--- a/test/storage/rel_delete_test.cpp
+++ b/test/storage/rel_delete_test.cpp
@@ -29,9 +29,8 @@ public:
 void RelDeleteTest::detachDeleteNode(std::string_view nodeTable, std::string_view relTable,
     int64_t idOfNode) {
     auto* catalog = database->getCatalog();
-    const auto& knowsTableEntry =
-        catalog
-            ->getTableCatalogEntry(conn->getClientContext()->getTransaction(),
+    auto transaction = transaction::Transaction::Get(*conn->getClientContext());
+    const auto& knowsTableEntry = catalog->getTableCatalogEntry(transaction,
                 std::string{relTable})
             ->constCast<catalog::RelGroupCatalogEntry>();
     auto& knowsTable = storage::StorageManager::Get(*conn->getClientContext())
@@ -66,7 +65,7 @@ void RelDeleteTest::detachDeleteNode(std::string_view nodeTable, std::string_vie
 
     // perform delete
     detachDeleteState->detachDeleteDirection = common::RelDataDirection::FWD;
-    knowsTable.detachDelete(conn->getClientContext()->getTransaction(), detachDeleteState.get());
+    knowsTable.detachDelete(transaction, detachDeleteState.get());
 }
 
 // Delete all edges attached to a node without deleting the node

--- a/test/storage/rel_scan_test.cpp
+++ b/test/storage/rel_scan_test.cpp
@@ -197,7 +197,8 @@ TEST_F(EmptyVertexScanTest, ScanVertexProperties) {
     auto entry = graph::NativeGraphEntry(nodeEntries, {});
     graph = std::make_unique<graph::OnDiskGraph>(context, std::move(entry));
 
-    auto tableEntry = catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), "account");
+    auto tableEntry =
+        catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), "account");
     std::vector<std::string> properties = {"id"};
     auto scanState = graph->prepareVertexScan(tableEntry, properties);
     const auto compare = [&](offset_t startNode, offset_t endNode) {
@@ -250,7 +251,8 @@ TEST_F(EmptyVertexScanTest, ScanVertexPropertiesAfterDeletionReInsert) {
     auto entry = graph::NativeGraphEntry(nodeEntries, {});
     graph = std::make_unique<graph::OnDiskGraph>(context, std::move(entry));
 
-    auto tableEntry = catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), "account");
+    auto tableEntry =
+        catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), "account");
     std::vector<std::string> properties = {"id"};
     auto scanState = graph->prepareVertexScan(tableEntry, properties);
     const auto compare = [&](offset_t startNode, offset_t endNode) {
@@ -316,7 +318,8 @@ TEST_F(EmptyVertexScanTest, ScanVertexPropertiesDuringTransaction) {
     auto entry = graph::NativeGraphEntry(nodeEntries, {});
     graph = std::make_unique<graph::OnDiskGraph>(context, std::move(entry));
 
-    auto tableEntry = catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), "account");
+    auto tableEntry =
+        catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), "account");
     std::vector<std::string> properties = {"id"};
     auto scanState = graph->prepareVertexScan(tableEntry, properties);
     const auto compare = [&](offset_t startNode, offset_t endNode) {

--- a/test/storage/rel_scan_test.cpp
+++ b/test/storage/rel_scan_test.cpp
@@ -25,7 +25,7 @@ public:
         conn->query("BEGIN TRANSACTION");
         context = getClientContext(*conn);
         catalog = catalog::Catalog::Get(*context);
-        auto transaction = context->getTransaction();
+        auto transaction = transaction::Transaction::Get(*context);
         std::vector<catalog::TableCatalogEntry*> nodeEntries;
         for (auto& entry : catalog->getNodeTableEntries(transaction)) {
             nodeEntries.push_back(entry);
@@ -62,7 +62,7 @@ public:
 
 // Test correctness of scan fwd
 TEST_F(RelScanTest, ScanFwd) {
-    auto transaction = context->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context);
     auto nodeEntry = catalog->getTableCatalogEntry(transaction, "person");
     auto tableID = nodeEntry->getTableID();
     auto relEntry = catalog->getTableCatalogEntry(transaction, "knows");
@@ -154,7 +154,7 @@ TEST_F(RelScanTest, ScanFwd) {
 }
 
 TEST_F(VertexScanTest, ScanVertexProperties) {
-    auto entry = catalog->getTableCatalogEntry(context->getTransaction(), "person");
+    auto entry = catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), "person");
     std::vector<std::string> properties = {"fname", "height"};
 
     auto scanState = graph->prepareVertexScan(entry, properties);
@@ -189,7 +189,7 @@ TEST_F(EmptyVertexScanTest, ScanVertexProperties) {
     conn->query("BEGIN TRANSACTION");
     context = getClientContext(*conn);
     catalog = catalog::Catalog::Get(*context);
-    auto transaction = context->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context);
     std::vector<catalog::TableCatalogEntry*> nodeEntries;
     for (auto& entry : catalog->getNodeTableEntries(transaction)) {
         nodeEntries.push_back(entry);
@@ -197,7 +197,7 @@ TEST_F(EmptyVertexScanTest, ScanVertexProperties) {
     auto entry = graph::NativeGraphEntry(nodeEntries, {});
     graph = std::make_unique<graph::OnDiskGraph>(context, std::move(entry));
 
-    auto tableEntry = catalog->getTableCatalogEntry(context->getTransaction(), "account");
+    auto tableEntry = catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), "account");
     std::vector<std::string> properties = {"id"};
     auto scanState = graph->prepareVertexScan(tableEntry, properties);
     const auto compare = [&](offset_t startNode, offset_t endNode) {
@@ -242,7 +242,7 @@ TEST_F(EmptyVertexScanTest, ScanVertexPropertiesAfterDeletionReInsert) {
     conn->query("BEGIN TRANSACTION");
     context = getClientContext(*conn);
     catalog = catalog::Catalog::Get(*context);
-    auto transaction = context->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context);
     std::vector<catalog::TableCatalogEntry*> nodeEntries;
     for (auto& entry : catalog->getNodeTableEntries(transaction)) {
         nodeEntries.push_back(entry);
@@ -250,7 +250,7 @@ TEST_F(EmptyVertexScanTest, ScanVertexPropertiesAfterDeletionReInsert) {
     auto entry = graph::NativeGraphEntry(nodeEntries, {});
     graph = std::make_unique<graph::OnDiskGraph>(context, std::move(entry));
 
-    auto tableEntry = catalog->getTableCatalogEntry(context->getTransaction(), "account");
+    auto tableEntry = catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), "account");
     std::vector<std::string> properties = {"id"};
     auto scanState = graph->prepareVertexScan(tableEntry, properties);
     const auto compare = [&](offset_t startNode, offset_t endNode) {
@@ -308,7 +308,7 @@ TEST_F(EmptyVertexScanTest, ScanVertexPropertiesDuringTransaction) {
 
     context = getClientContext(*conn);
     catalog = catalog::Catalog::Get(*context);
-    auto transaction = context->getTransaction();
+    auto transaction = transaction::Transaction::Get(*context);
     std::vector<catalog::TableCatalogEntry*> nodeEntries;
     for (auto& entry : catalog->getNodeTableEntries(transaction)) {
         nodeEntries.push_back(entry);
@@ -316,7 +316,7 @@ TEST_F(EmptyVertexScanTest, ScanVertexPropertiesDuringTransaction) {
     auto entry = graph::NativeGraphEntry(nodeEntries, {});
     graph = std::make_unique<graph::OnDiskGraph>(context, std::move(entry));
 
-    auto tableEntry = catalog->getTableCatalogEntry(context->getTransaction(), "account");
+    auto tableEntry = catalog->getTableCatalogEntry(transaction::Transaction::Get(*context), "account");
     std::vector<std::string> properties = {"id"};
     auto scanState = graph->prepareVertexScan(tableEntry, properties);
     const auto compare = [&](offset_t startNode, offset_t endNode) {

--- a/test/test_runner/csv_converter.cpp
+++ b/test/test_runner/csv_converter.cpp
@@ -10,6 +10,7 @@
 #include "graph_test/base_graph_test.h"
 #include "spdlog/spdlog.h"
 #include "test_helper/test_helper.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -25,6 +25,7 @@
 #include "transaction/transaction.h"
 #include "utf8proc.h"
 #include "utf8proc_wrapper.h"
+#include "transaction/transaction_context.h"
 
 using namespace kuzu::common;
 using namespace kuzu::utf8proc;
@@ -103,13 +104,14 @@ void EmbeddedShell::updateTableNames() {
     nodeTableNames.clear();
     relTableNames.clear();
     auto clientContext = conn->getClientContext();
+    auto transaction = transaction::Transaction::Get(*clientContext);
     bool transactionStarted = false;
-    if (clientContext->getTransaction() == NULL) {
+    if (transaction == NULL) {
         clientContext->getTransactionContext()
             ->beginReadTransaction(); // start transaction to get current table names
         transactionStarted = true;
     }
-    for (auto& tableEntry : database->catalog->getTableEntries(clientContext->getTransaction(),
+    for (auto& tableEntry : database->catalog->getTableEntries(transaction,
              false /*useInternal*/)) {
         if (tableEntry->getType() == catalog::CatalogEntryType::NODE_TABLE_ENTRY) {
             nodeTableNames.push_back(tableEntry->getName());

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -23,9 +23,9 @@
 #include "printer/json_printer.h"
 #include "printer/printer_factory.h"
 #include "transaction/transaction.h"
+#include "transaction/transaction_context.h"
 #include "utf8proc.h"
 #include "utf8proc_wrapper.h"
-#include "transaction/transaction_context.h"
 
 using namespace kuzu::common;
 using namespace kuzu::utf8proc;
@@ -110,8 +110,8 @@ void EmbeddedShell::updateTableNames() {
             ->beginReadTransaction(); // start transaction to get current table names
         transactionStarted = true;
     }
-    for (auto& tableEntry : database->catalog->getTableEntries(transaction::Transaction::Get(*clientContext),
-             false /*useInternal*/)) {
+    for (auto& tableEntry : database->catalog->getTableEntries(
+             transaction::Transaction::Get(*clientContext), false /*useInternal*/)) {
         if (tableEntry->getType() == catalog::CatalogEntryType::NODE_TABLE_ENTRY) {
             nodeTableNames.push_back(tableEntry->getName());
         } else if (tableEntry->getType() == catalog::CatalogEntryType::REL_GROUP_ENTRY) {

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -104,14 +104,13 @@ void EmbeddedShell::updateTableNames() {
     nodeTableNames.clear();
     relTableNames.clear();
     auto clientContext = conn->getClientContext();
-    auto transaction = transaction::Transaction::Get(*clientContext);
     bool transactionStarted = false;
-    if (transaction == NULL) {
+    if (transaction::Transaction::Get(*clientContext) == NULL) {
         clientContext->getTransactionContext()
             ->beginReadTransaction(); // start transaction to get current table names
         transactionStarted = true;
     }
-    for (auto& tableEntry : database->catalog->getTableEntries(transaction,
+    for (auto& tableEntry : database->catalog->getTableEntries(transaction::Transaction::Get(*clientContext),
              false /*useInternal*/)) {
         if (tableEntry->getType() == catalog::CatalogEntryType::NODE_TABLE_ENTRY) {
             nodeTableNames.push_back(tableEntry->getName());


### PR DESCRIPTION
# Description

See title. As a result, we are able to get rid of `transaction.h` and `transaction_context.h` from `headers.txt`.
