### PR TITLE
Fix labels and keys function with null

### DIFF
--- a/src/function/pattern/label_function.cpp
+++ b/src/function/pattern/label_function.cpp
@@ -84,6 +84,9 @@ std::shared_ptr<Expression> LabelFunction::rewriteFunc(const RewriteFunctionBind
     KU_ASSERT(input.arguments.size() == 1);
     auto argument = input.arguments[0].get();
     auto expressionBinder = input.expressionBinder;
+    if (ExpressionUtil::isNullLiteral(*argument)) {
+        return expressionBinder->createNullLiteralExpression();
+    }
     expression_vector children;
     if (argument->expressionType == ExpressionType::VARIABLE) {
         children.push_back(input.arguments[0]);

--- a/src/function/struct/keys_function.cpp
+++ b/src/function/struct/keys_function.cpp
@@ -1,5 +1,7 @@
+#include "binder/expression/expression_util.h"
 #include "binder/expression/literal_expression.h"
 #include "binder/expression/scalar_function_expression.h"
+#include "binder/expression_binder.h"
 #include "function/rewrite_function.h"
 #include "function/struct/vector_struct_functions.h"
 
@@ -11,6 +13,11 @@ namespace function {
 
 static std::shared_ptr<Expression> rewriteFunc(const RewriteFunctionBindInput& input) {
     KU_ASSERT(input.arguments.size() == 1);
+    auto argument = input.arguments[0].get();
+    auto expressionBinder = input.expressionBinder;
+    if (ExpressionUtil::isNullLiteral(*argument)) {
+        return expressionBinder->createNullLiteralExpression();
+    }
     auto uniqueExpressionName =
         ScalarFunctionExpression::getUniqueName(KeysFunctions::name, input.arguments);
     const auto& resultType = LogicalType::LIST(LogicalType::STRING());

--- a/test/test_files/function/label.test
+++ b/test/test_files/function/label.test
@@ -28,3 +28,16 @@ marries
 meets
 studyAt
 workAt
+-STATEMENT MATCH (a:person) RETURN labels(null);
+---- 8
+
+
+
+
+
+
+
+
+-STATEMENT RETURN labels(null);
+---- 1
+

--- a/test/test_files/function/struct.test
+++ b/test/test_files/function/struct.test
@@ -96,3 +96,17 @@ C
 -STATEMENT RETURN STRUCT_PACK(x:=2,y:=3);
 ---- 1
 {x: 2, y: 3}
+
+-LOG MATCH (p:person) RETURN keys(null)
+---- 8
+
+
+
+
+
+
+
+
+-LOG RETURN keys(null)
+---- 1
+

--- a/test/test_files/function/struct.test
+++ b/test/test_files/function/struct.test
@@ -97,7 +97,7 @@ C
 ---- 1
 {x: 2, y: 3}
 
--LOG MATCH (p:person) RETURN keys(null)
+-STATEMENT MATCH (p:person) RETURN keys(null)
 ---- 8
 
 
@@ -107,6 +107,7 @@ C
 
 
 
--LOG RETURN keys(null)
+
+-STATEMENT RETURN keys(null)
 ---- 1
 


### PR DESCRIPTION
Closes #5959
Fixes `labels` and `keys` function with null input
