### PR TITLE
(Draft): Adding a new FSM token and running FSMLeakChecker for all e2e tests

### DIFF
--- a/src/include/storage/checkpointer.h
+++ b/src/include/storage/checkpointer.h
@@ -23,6 +23,8 @@ class AttachedKuzuDatabase;
 namespace storage {
 class StorageManager;
 
+struct FSMLeakChecker;
+
 class Checkpointer {
     friend class main::AttachedKuzuDatabase;
     friend struct testing::FSMLeakChecker;

--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -7,6 +7,7 @@
 #include "storage/storage_manager.h"
 #include "test_runner/test_parser.h"
 #include "transaction/transaction_manager.h"
+#include "test_helper/fsm_leak_checker.h"
 
 namespace kuzu {
 namespace testing {
@@ -124,45 +125,6 @@ static decltype(auto) getNumFreePages(main::Connection* conn) {
     return std::accumulate(entries.begin(), entries.end(), 0ull,
         [](auto a, auto b) { return a + b.numPages; });
 }
-
-struct FSMLeakChecker {
-    static void checkForLeakedPages(main::Connection* conn) {
-        conn->query("checkpoint");
-
-        std::vector<std::pair<std::string, std::string>> tableNames;
-        auto tableNamesResult = conn->query("call show_tables() return name, type");
-        while (tableNamesResult->hasNext()) {
-            auto nextResult = tableNamesResult->getNext();
-            tableNames.emplace_back(nextResult->getValue(0)->toString(),
-                nextResult->getValue(1)->toString());
-        }
-
-        // Drop rel tables first
-        for (const auto& [tableName, tableType] : tableNames) {
-            if (tableType == common::TableTypeUtils::toString(common::TableType::REL)) {
-                ASSERT_TRUE(
-                    conn->query(common::stringFormat("drop table {}", tableName))->isSuccess());
-            }
-        }
-        for (const auto& [tableName, tableType] : tableNames) {
-            if (tableType != common::TableTypeUtils::toString(common::TableType::REL)) {
-                ASSERT_TRUE(
-                    conn->query(common::stringFormat("drop table {}", tableName))->isSuccess());
-            }
-        }
-        conn->query("checkpoint");
-
-        const auto numTotalPages = getDbSizeInPages(conn);
-        const auto numUsedPages = numTotalPages - getNumFreePages(conn);
-
-        storage::Checkpointer checkpointer{*conn->getClientContext()};
-        auto databaseHeader = storage::StorageManager::Get(*conn->getClientContext())
-                                  ->getOrInitDatabaseHeader(*conn->getClientContext());
-        ASSERT_EQ(1 + databaseHeader->catalogPageRange.numPages +
-                      databaseHeader->metadataPageRange.numPages,
-            numUsedPages);
-    }
-};
 
 void CopyTest::BMExceptionRecoveryTest(BMExceptionRecoveryTestConfig cfg) {
     if (inMemMode) {

--- a/test/graph_test/CMakeLists.txt
+++ b/test/graph_test/CMakeLists.txt
@@ -13,7 +13,8 @@ target_link_libraries(graph_test PUBLIC GTEST_LIB kuzu)
 add_library(
         api_graph_test
         OBJECT
-        base_graph_test.cpp)
+        base_graph_test.cpp
+        ../include/test_helper/fsm_leak_checker.h)
 target_include_directories(
         api_graph_test
         PUBLIC

--- a/test/graph_test/private_graph_test.cpp
+++ b/test/graph_test/private_graph_test.cpp
@@ -8,6 +8,7 @@
 #include "test_runner/multi_copy_split.h"
 #include "test_runner/test_runner.h"
 #include "transaction/transaction_manager.h"
+#include "test_helper/fsm_leak_checker.h"
 
 using ::testing::Test;
 using namespace kuzu::binder;
@@ -150,6 +151,18 @@ void DBTest::runTest(std::vector<TestStatement>& statements, uint64_t checkpoint
                 throw TestException(
                     stringFormat("No connection name provided for statement: {}", statement.query));
             }
+        }
+    }
+
+    // Run FSM checker for all tests.
+    if (!inMemMode) {
+        main::Connection* leakConn = nullptr;
+        if (connNames.size() == 1) {
+            leakConn = connMap.begin()->second.get();
+            if (!leakConn) {
+                throw TestException("FSM leak check has no available connection.");
+            }
+            FSMLeakChecker::checkForLeakedPages(leakConn);
         }
     }
 }

--- a/test/include/test_helper/fsm_leak_checker.h
+++ b/test/include/test_helper/fsm_leak_checker.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <numeric>
+#include <vector>
+
+#include "common/string_format.h"
+#include "common/types/types.h"
+#include "gtest/gtest.h"
+#include "main/connection.h"
+#include "storage/checkpointer.h"
+#include "storage/storage_manager.h"
+
+namespace kuzu {
+namespace testing {
+
+static decltype(auto) getDbSizeInPages(main::Connection* conn) {
+    return storage::StorageManager::Get(*conn->getClientContext())->getDataFH()->getNumPages();
+}
+
+static decltype(auto) getNumFreePages(main::Connection* conn) {
+    auto& pageManager = *storage::PageManager::Get(*conn->getClientContext());
+    auto numFreeEntries = pageManager.getNumFreeEntries();
+    auto entries = pageManager.getFreeEntries(0, numFreeEntries);
+    return std::accumulate(entries.begin(), entries.end(), 0ull,
+        [](auto a, auto b) { return a + b.numPages; });
+}
+
+struct FSMLeakChecker {
+    static void checkForLeakedPages(main::Connection* conn) {
+        conn->query("checkpoint");
+
+        std::vector<std::pair<std::string, std::string>> tableNames;
+        auto tableNamesResult = conn->query("call show_tables() return name, type");
+        while (tableNamesResult->hasNext()) {
+            auto nextResult = tableNamesResult->getNext();
+            tableNames.emplace_back(nextResult->getValue(0)->toString(),
+                nextResult->getValue(1)->toString());
+        }
+
+        // Drop rel tables first
+        for (const auto& [tableName, tableType] : tableNames) {
+            if (tableType == common::TableTypeUtils::toString(common::TableType::REL)) {
+                ASSERT_TRUE(
+                    conn->query(common::stringFormat("drop table {}", tableName))->isSuccess());
+            }
+        }
+        for (const auto& [tableName, tableType] : tableNames) {
+            if (tableType != common::TableTypeUtils::toString(common::TableType::REL)) {
+                ASSERT_TRUE(
+                    conn->query(common::stringFormat("drop table {}", tableName))->isSuccess());
+            }
+        }
+        conn->query("checkpoint");
+
+        const auto numTotalPages = getDbSizeInPages(conn);
+        const auto numUsedPages = numTotalPages - getNumFreePages(conn);
+
+        storage::Checkpointer checkpointer{*conn->getClientContext()};
+        auto databaseHeader = storage::StorageManager::Get(*conn->getClientContext())
+                                  ->getOrInitDatabaseHeader(*conn->getClientContext());
+        ASSERT_EQ(1 + databaseHeader->catalogPageRange.numPages +
+                      databaseHeader->metadataPageRange.numPages,
+            numUsedPages);
+    }
+};
+
+} // namespace testing
+} // namespace kuzu

--- a/test/include/test_runner/test_group.h
+++ b/test/include/test_runner/test_group.h
@@ -43,6 +43,8 @@ struct TestQueryResult {
     uint64_t numTuples = 0;
     // errorMsg, CSVFile, hashValue uses first element
     std::vector<std::string> expectedResult;
+    TestQueryResult(ResultType type, uint64_t numTuples, std::vector<std::string> expectedResult): type{type}, numTuples{numTuples}, expectedResult{expectedResult} {}
+    TestQueryResult(): type{ResultType::OK}, numTuples{0}, expectedResult{} {}
 };
 
 struct TestStatement {

--- a/test/include/test_runner/test_group.h
+++ b/test/include/test_runner/test_group.h
@@ -85,6 +85,9 @@ struct TestStatement {
     std::string newOutput;
     bool isPartOfStatementBlock = false;
 
+    // for FSM_CHECKER
+    bool fsmLeakCheckerFlag = false;
+
     bool isValid() const { return type != TestStatementType::INVALID; }
 };
 

--- a/test/include/test_runner/test_parser.h
+++ b/test/include/test_runner/test_parser.h
@@ -10,7 +10,6 @@
 
 namespace kuzu {
 namespace testing {
-
 enum class TokenType {
     // header only
     DATASET,
@@ -36,6 +35,7 @@ enum class TokenType {
     DEFINE_STATEMENT_BLOCK,
     EMPTY,
     END_OF_STATEMENT_BLOCK,
+    FSM_LEAK_CHECKER,
     INSERT_STATEMENT_BLOCK,
     LOG,
     RESULT,
@@ -93,7 +93,8 @@ const std::unordered_map<std::string, TokenType> TOKEN_MAP = {{"-DATASET", Token
     {"-CREATE_DATASET_SCHEMA", TokenType::CREATE_DATASET_SCHEMA},
     {"-INSERT_DATASET_BY_ROW", TokenType::INSERT_DATASET_BY_ROW},
     {"-MULTI_COPY_RANDOM", TokenType::MULTI_COPY_RANDOM}, {"-LOOP", TokenType::LOOP},
-    {"-ENDLOOP", TokenType::ENDLOOP}};
+    {"-ENDLOOP", TokenType::ENDLOOP},
+    {"-FSM_LEAK_CHECK", TokenType::FSM_LEAK_CHECKER}};
 
 class LogicToken {
 public:

--- a/test/test_runner/test_parser.cpp
+++ b/test/test_runner/test_parser.cpp
@@ -299,6 +299,11 @@ TestStatement TestParser::parseStatement(const std::string& testCaseName) {
             statement.type = TestStatementType::VALID;
             return statement;
         }
+        case TokenType::FSM_LEAK_CHECKER: {
+            statement.fsmLeakCheckerFlag = true;
+            statement.type = TestStatementType::VALID;
+            return statement;
+        }
         case TokenType::RELOADDB: {
             statement.reloadDBFlag = true;
             statement.type = TestStatementType::VALID;


### PR DESCRIPTION
# Description
This is a draft PR. 
This PR adds a new `FSM_LEAK_CHECK` token to e2e tests. 

Currently, we force it to run the `FSMLeakChecker` on all e2e tests. 

Associated docs (issue or PR): https://github.com/kuzudb/kuzu/issues/5602

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
