### PR TITLE
Fix more test failures on segmentation branch

### DIFF
--- a/src/storage/table/column_chunk.cpp
+++ b/src/storage/table/column_chunk.cpp
@@ -386,22 +386,19 @@ void ColumnChunk::checkpoint(Column& column,
             const bool isLastSegment = (i == data.size() - 1);
             if (state.startRow + state.numRows > segmentStart &&
                 (isLastSegment || state.startRow < segmentStart + segment->getNumValues())) {
-                auto startOffsetInSegment = state.startRow - segmentStart;
-                uint64_t startRowInChunk = 0;
-                if (state.startRow < segmentStart) {
-                    startRowInChunk = segmentStart - state.startRow;
-                    startOffsetInSegment = 0;
-                }
+                const auto startOffset = std::max(state.startRow, segmentStart);
                 // Generally, we only want to checkpoint the overlapping parts of the old segment
                 // and the new chunk. This is to prevent having duplicate segments. However, for the
                 // last old segment we allow extending it to account for any insertions we have made
                 // in the current checkpoint.
-                const auto endRowInChunk =
-                    isLastSegment ?
-                        state.numRows :
-                        std::min(startRowInChunk + segment->getNumValues(), state.numRows);
+                const auto endOffset = isLastSegment ? state.startRow + state.numRows :
+                                                       std::min(state.startRow + state.numRows,
+                                                           segmentStart + segment->getNumValues());
+
+                const auto startOffsetInSegment = startOffset - segmentStart;
+                const auto startRowInChunk = startOffset - state.startRow;
                 segmentCheckpointStates.push_back({*state.chunkData, startRowInChunk,
-                    startOffsetInSegment, endRowInChunk - startRowInChunk});
+                    startOffsetInSegment, endOffset - startOffset});
             }
         }
         auto segmentEnd = segmentStart + segment->getNumValues();

--- a/src/storage/table/csr_node_group.cpp
+++ b/src/storage/table/csr_node_group.cpp
@@ -92,6 +92,8 @@ void CSRNodeGroup::initScanForCommittedPersistent(const Transaction* transaction
     // Initialize the scan states of a new node group for the csr header.
     csrHeader.offset->initializeScanState(offsetState, relScanState.csrOffsetColumn);
     csrHeader.length->initializeScanState(lengthState, relScanState.csrLengthColumn);
+    nodeGroupScanState.header->offset->setNumValues(0);
+    nodeGroupScanState.header->length->setNumValues(0);
     // Initialize the scan states of a new node group for data columns.
     for (auto i = 0u; i < relScanState.columnIDs.size(); i++) {
         if (relScanState.columnIDs[i] == INVALID_COLUMN_ID ||


### PR DESCRIPTION
# Description

Summary of fixes:
- Correctly calculate offset in segment + offset in new checkpointed chunk in `ColumnChunk::checkpointSegment()`.
- Checkpointing of list data chunk now accounts for the possibility that list entries can be out of order + non-contiguous (by start data offset).
- Reset CSR header's `numValues` between scanning CSR node groups (in `CSRNodeGroup::initScanForCommittedPersistent`). This is because when we try to scan the CSR headers for offsets that are out of range, we don't do anything (including updating the `numValues`) which can cause problems when doing random lookup.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
