### PR TITLE
Refactor the macro function catalog entry

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -46,6 +46,7 @@ void Catalog::initCatalogSets() {
     functions = std::make_unique<CatalogSet>();
     types = std::make_unique<CatalogSet>();
     indexes = std::make_unique<CatalogSet>();
+    macros = std::make_unique<CatalogSet>();
     internalTables = std::make_unique<CatalogSet>(true /* isInternal */);
     internalSequences = std::make_unique<CatalogSet>(true /* isInternal */);
     internalFunctions = std::make_unique<CatalogSet>(true /* isInternal */);
@@ -428,13 +429,14 @@ void Catalog::dropFunction(Transaction* transaction, const std::string& name) {
 CatalogEntry* Catalog::getFunctionEntry(const Transaction* transaction, const std::string& name,
     bool useInternal) const {
     CatalogEntry* result = nullptr;
-    if (!functions->containsEntry(transaction, name)) {
-        if (!useInternal) {
-            throw CatalogException(getFunctionDoesNotExistMessage(name));
-        }
+    if (functions->containsEntry(transaction, name)) {
+        result = functions->getEntry(transaction, name);
+    } else if (macros->containsEntry(transaction, name)) {
+        result = macros->getEntry(transaction, name);
+    } else if (useInternal) {
         result = internalFunctions->getEntry(transaction, name);
     } else {
-        result = functions->getEntry(transaction, name);
+        throw CatalogException(getFunctionDoesNotExistMessage(name));
     }
     return result;
 }
@@ -449,12 +451,12 @@ std::vector<FunctionCatalogEntry*> Catalog::getFunctionEntries(
 }
 
 bool Catalog::containsMacro(const Transaction* transaction, const std::string& macroName) const {
-    return functions->containsEntry(transaction, macroName);
+    return macros->containsEntry(transaction, macroName);
 }
 
 function::ScalarMacroFunction* Catalog::getScalarMacroFunction(const Transaction* transaction,
     const std::string& name) const {
-    return functions->getEntry(transaction, name)
+    return macros->getEntry(transaction, name)
         ->constCast<ScalarMacroCatalogEntry>()
         .getMacroFunction();
 }
@@ -463,15 +465,14 @@ function::ScalarMacroFunction* Catalog::getScalarMacroFunction(const Transaction
 void Catalog::addScalarMacroFunction(Transaction* transaction, std::string name,
     std::unique_ptr<function::ScalarMacroFunction> macro) {
     auto entry = std::make_unique<ScalarMacroCatalogEntry>(std::move(name), std::move(macro));
-    functions->createEntry(transaction, std::move(entry));
+    macros->createEntry(transaction, std::move(entry));
 }
 
 std::vector<std::string> Catalog::getMacroNames(const Transaction* transaction) const {
     std::vector<std::string> macroNames;
-    for (auto& [_, function] : functions->getEntries(transaction)) {
-        if (function->getType() == CatalogEntryType::SCALAR_MACRO_ENTRY) {
-            macroNames.push_back(function->getName());
-        }
+    for (auto& [_, function] : macros->getEntries(transaction)) {
+        KU_ASSERT(function->getType() == CatalogEntryType::SCALAR_MACRO_ENTRY);
+        macroNames.push_back(function->getName());
     }
     return macroNames;
 }
@@ -547,6 +548,7 @@ void Catalog::serialize(Serializer& ser) const {
     functions->serialize(ser);
     types->serialize(ser);
     indexes->serialize(ser);
+    macros->serialize(ser);
     internalTables->serialize(ser);
     internalSequences->serialize(ser);
     internalFunctions->serialize(ser);
@@ -559,6 +561,7 @@ void Catalog::deserialize(Deserializer& deSer) {
     registerBuiltInFunctions();
     types = CatalogSet::deserialize(deSer);
     indexes = CatalogSet::deserialize(deSer);
+    macros = CatalogSet::deserialize(deSer);
     internalTables = CatalogSet::deserialize(deSer);
     internalSequences = CatalogSet::deserialize(deSer);
     internalFunctions = CatalogSet::deserialize(deSer);

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -225,6 +225,7 @@ private:
     std::unique_ptr<CatalogSet> functions;
     std::unique_ptr<CatalogSet> types;
     std::unique_ptr<CatalogSet> indexes;
+    std::unique_ptr<CatalogSet> macros;
     std::unique_ptr<CatalogSet> internalTables;
     std::unique_ptr<CatalogSet> internalSequences;
     std::unique_ptr<CatalogSet> internalFunctions;

--- a/src/include/function/built_in_function_utils.h
+++ b/src/include/function/built_in_function_utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "aggregate_function.h"
+#include "catalog/catalog_entry/catalog_entry_type.h"
 #include "function.h"
 
 namespace kuzu {
@@ -82,7 +83,7 @@ private:
     static Function* getBestMatch(std::vector<Function*>& functions);
 
     static uint32_t getFunctionCost(const std::vector<common::LogicalType>& inputTypes,
-        Function* function);
+        Function* function, catalog::CatalogEntryType type);
     static uint32_t matchParameters(const std::vector<common::LogicalType>& inputTypes,
         const std::vector<common::LogicalTypeID>& targetTypeIDs);
     static uint32_t matchVarLengthParameters(const std::vector<common::LogicalType>& inputTypes,

--- a/src/include/function/function.h
+++ b/src/include/function/function.h
@@ -61,17 +61,11 @@ using scalar_bind_func =
 struct KUZU_API Function {
     std::string name;
     std::vector<common::LogicalTypeID> parameterTypeIDs;
-    // Currently we only one variable-length function which is list creation. The expectation is
-    // that all parameters must have the same type as parameterTypes[0].
-    // For variable length function. A
-    bool isVarLength = false;
-    bool isListLambda = false;
     bool isReadOnly = true;
 
-    Function() : isVarLength{false}, isListLambda{false}, isReadOnly{true} {};
+    Function() : isReadOnly{true} {};
     Function(std::string name, std::vector<common::LogicalTypeID> parameterTypeIDs)
-        : name{std::move(name)}, parameterTypeIDs{std::move(parameterTypeIDs)}, isVarLength{false},
-          isListLambda{false} {}
+        : name{std::move(name)}, parameterTypeIDs{std::move(parameterTypeIDs)} {}
     Function(const Function&) = default;
 
     virtual ~Function() = default;

--- a/src/include/function/scalar_function.h
+++ b/src/include/function/scalar_function.h
@@ -27,6 +27,8 @@ struct KUZU_API ScalarFunction : public ScalarOrAggregateFunction {
     scalar_func_exec_t execFunc = nullptr;
     scalar_func_select_t selectFunc = nullptr;
     scalar_func_compile_exec_t compileFunc = nullptr;
+    bool isListLambda = false;
+    bool isVarLength = false;
 
     ScalarFunction() = default;
     ScalarFunction(std::string name, std::vector<common::LogicalTypeID> parameterTypeIDs,


### PR DESCRIPTION
This PR:
1. Added a new catalog entry set: macros
2. Moved `isListLambda` and `isVarlen` to the scalarFunction body since they are only used by scalarFunctions.