### PR TITLE
Add new targets `test-fast` and `test-slow` 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,12 @@ test-build:
 test: test-build
 	ctest --test-dir build/$(call get-build-path,RelWithDebInfo)/test --output-on-failure -j ${TEST_JOBS}
 
+test-fast: test-build
+	ctest --test-dir build/$(call get-build-path,RelWithDebInfo)/test --output-on-failure -j ${TEST_JOBS} -E ".*_SLOW"
+
+test-slow: test-build
+	ctest --test-dir build/$(call get-build-path,RelWithDebInfo)/test --output-on-failure -j ${TEST_JOBS} -R ".*_SLOW"
+
 lcov:
 	$(call run-cmake-release, -DBUILD_TESTS=TRUE -DBUILD_LCOV=TRUE)
 	ctest --test-dir build/$(call get-build-path,Release)/test --output-on-failure -j ${TEST_JOBS}

--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -166,7 +166,7 @@ void CopyTest::BMExceptionRecoveryTest(BMExceptionRecoveryTestConfig cfg) {
     }
 }
 
-TEST_F(CopyTest, NodeCopyBMExceptionRecoverySameConnection) {
+TEST_F(CopyTest, NodeCopyBMExceptionRecoverySameConnection_SLOW) {
     if (inMemMode) {
         GTEST_SKIP();
     }
@@ -192,7 +192,7 @@ TEST_F(CopyTest, NodeCopyBMExceptionRecoverySameConnection) {
     BMExceptionRecoveryTest(cfg);
 }
 
-TEST_F(CopyTest, NodeCopyBMExceptionRecoverySameConnectionStringKey) {
+TEST_F(CopyTest, NodeCopyBMExceptionRecoverySameConnectionStringKey_SLOW) {
     if (inMemMode) {
         GTEST_SKIP();
     }
@@ -218,7 +218,7 @@ TEST_F(CopyTest, NodeCopyBMExceptionRecoverySameConnectionStringKey) {
     BMExceptionRecoveryTest(cfg);
 }
 
-TEST_F(CopyTest, RelCopyBMExceptionRecoverySameConnection) {
+TEST_F(CopyTest, RelCopyBMExceptionRecoverySameConnection_SLOW) {
     if (inMemMode ||
         common::StorageConfig::NODE_GROUP_SIZE_LOG2 != TestParser::STANDARD_NODE_GROUP_SIZE_LOG_2) {
         GTEST_SKIP();
@@ -267,7 +267,7 @@ TEST_F(CopyTest, RelCopyBMExceptionRecoverySameConnection) {
     BMExceptionRecoveryTest(cfg);
 }
 
-TEST_F(CopyTest, NodeInsertBMExceptionDuringCommitRecovery) {
+TEST_F(CopyTest, NodeInsertBMExceptionDuringCommitRecovery_SLOW) {
     static constexpr uint64_t numValues = 200000;
     BMExceptionRecoveryTestConfig cfg{.canFailDuringExecute = false,
         .canFailDuringCheckpoint = false,
@@ -290,7 +290,7 @@ TEST_F(CopyTest, NodeInsertBMExceptionDuringCommitRecovery) {
     BMExceptionRecoveryTest(cfg);
 }
 
-TEST_F(CopyTest, RelInsertBMExceptionDuringCommitRecovery) {
+TEST_F(CopyTest, RelInsertBMExceptionDuringCommitRecovery_SLOW) {
     static constexpr auto numNodes = 10000;
     BMExceptionRecoveryTestConfig cfg{.canFailDuringExecute = false,
         .canFailDuringCheckpoint = false,
@@ -320,7 +320,7 @@ TEST_F(CopyTest, RelInsertBMExceptionDuringCommitRecovery) {
     BMExceptionRecoveryTest(cfg);
 }
 
-TEST_F(CopyTest, NodeCopyBMExceptionDuringCheckpointRecovery) {
+TEST_F(CopyTest, NodeCopyBMExceptionDuringCheckpointRecovery_SLOW) {
     if (inMemMode || systemConfig->forceCheckpointOnClose == false) {
         GTEST_SKIP();
     }
@@ -352,7 +352,7 @@ TEST_F(CopyTest, NodeCopyBMExceptionDuringCheckpointRecovery) {
     BMExceptionRecoveryTest(cfg);
 }
 
-TEST_F(CopyTest, RelCopyCheckpointBMExceptionRecovery) {
+TEST_F(CopyTest, RelCopyCheckpointBMExceptionRecovery_SLOW) {
     if (inMemMode || systemConfig->forceCheckpointOnClose == false) {
         GTEST_SKIP();
     }

--- a/test/copy/multi_copy_test.cpp
+++ b/test/copy/multi_copy_test.cpp
@@ -96,14 +96,14 @@ private:
     size_t totalTuples = 0;
 };
 
-TEST_F(MultiCopyTest, SingleSerialCopy) {
+TEST_F(MultiCopyTest, SingleSerialCopy_SLOW) {
     copySerial(common::StorageConfig::NODE_GROUP_SIZE * 10.5);
     validate(true /* isSerial */);
 }
 
 // Tests that multiple copies that only add to the existing node group succeed
 // This is also covered by the tinysnb dataset
-TEST_F(MultiCopyTest, OneNodeGroup) {
+TEST_F(MultiCopyTest, OneNodeGroup_SLOW) {
     copy(150);
     copy(175);
     copy(1);
@@ -112,7 +112,7 @@ TEST_F(MultiCopyTest, OneNodeGroup) {
 }
 
 // Tests that a second copy that does not modify any existing node groups succeeds
-TEST_F(MultiCopyTest, FullFirstNodeGroup) {
+TEST_F(MultiCopyTest, FullFirstNodeGroup_SLOW) {
     copy(common::StorageConfig::NODE_GROUP_SIZE);
     copy(common::StorageConfig::NODE_GROUP_SIZE);
     copy(common::StorageConfig::NODE_GROUP_SIZE);
@@ -126,7 +126,7 @@ TEST_F(MultiCopyTest, FullFirstNodeGroup) {
 // on how the work is divided between threads. This assumes that two test threads handle half of the
 // work each, so that each thread finishes with appendIncompleteNodeGroup and the second one fills
 // the shared group.
-TEST_F(MultiCopyTest, PartialGroupSecondCopyWrite) {
+TEST_F(MultiCopyTest, PartialGroupSecondCopyWrite_SLOW) {
     copy(common::StorageConfig::NODE_GROUP_SIZE / 2);
     copy(common::StorageConfig::NODE_GROUP_SIZE);
     validate();
@@ -134,7 +134,7 @@ TEST_F(MultiCopyTest, PartialGroupSecondCopyWrite) {
 
 // Tests that a second copy that modifies the existing node group and copies more than one node
 // group succeeds
-TEST_F(MultiCopyTest, PartialFirstNodeGroup) {
+TEST_F(MultiCopyTest, PartialFirstNodeGroup_SLOW) {
     copy(common::StorageConfig::NODE_GROUP_SIZE / 2);
     copy(common::StorageConfig::NODE_GROUP_SIZE * 2);
     copy(common::StorageConfig::NODE_GROUP_SIZE * 2);
@@ -145,14 +145,14 @@ TEST_F(MultiCopyTest, PartialFirstNodeGroup) {
 // local node group, so the second one to write that to the shared group
 // will need to write twice before it can move its remaining nodes into the shared group
 // See https://github.com/kuzudb/kuzu/issues/3714
-TEST_F(MultiCopyTest, SharedWriteToExistingNodeGroup) {
+TEST_F(MultiCopyTest, SharedWriteToExistingNodeGroup_SLOW) {
     copy(common::StorageConfig::NODE_GROUP_SIZE * 0.75);
     copy(common::StorageConfig::NODE_GROUP_SIZE * systemConfig->maxNumThreads * 0.75);
     validate();
 }
 
 // Tests that a second copy that copies a large number of node groups succeeds
-TEST_F(MultiCopyTest, MultipleNodeGroups) {
+TEST_F(MultiCopyTest, MultipleNodeGroups_SLOW) {
     copy(common::StorageConfig::NODE_GROUP_SIZE * 10.1);
     copy(common::StorageConfig::NODE_GROUP_SIZE * 20.8);
     copy(1);

--- a/test/storage/node_update_test.cpp
+++ b/test/storage/node_update_test.cpp
@@ -27,7 +27,7 @@ TEST_F(NodeUpdateTest, UpdateSameRow) {
     ASSERT_EQ(res->getNext()->getValue(0)->val.int64Val, 300);
 }
 
-TEST_F(NodeUpdateTest, UpdateSameRowRedundantly) {
+TEST_F(NodeUpdateTest, UpdateSameRowRedundantly_SLOW) {
     if (inMemMode || systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }

--- a/test/test_files/agg/hash_ldbc.test
+++ b/test/test_files/agg/hash_ldbc.test
@@ -2,7 +2,7 @@
 -BUFFER_POOL_SIZE 1073741824
 
 --
--CASE AggHash
+-CASE AggHash_SLOW
 -LOG TestAggregateListsWithNulls
 # p.language, p.content and p.imageFile both include nulls
 -STATEMENT MATCH (p:Post) RETURN [p.language], [p.language, p.content], COUNT(p) as n ORDER BY n DESC LIMIT 5;

--- a/test/test_files/copy/copy_node_parquet.test
+++ b/test/test_files/copy/copy_node_parquet.test
@@ -3,7 +3,7 @@
 
 --
 
--CASE CopyNodeTest
+-CASE CopyNodeTest_SLOW
 
 -LOG SubsetTest
 -STATEMENT MATCH (row:tableOfTypes) WHERE row.id >= 20 AND row.id <= 24 RETURN row.*;
@@ -59,7 +59,7 @@
 ---- error
 Binder exception: Copy from Parquet cannot have options other than IGNORE_ERRORS.
 
--CASE IgnoreErrorsTest
+-CASE IgnoreErrorsTest_SLOW
 -STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-test/node/parquet/invalid_pk_col.parquet" (IGNORE_ERRORS=true);
 ---- ok
 -STATEMENT CALL show_warnings() RETURN message

--- a/test/test_files/copy/copy_partial_column.test
+++ b/test/test_files/copy/copy_partial_column.test
@@ -5,7 +5,7 @@
 
 --
 
--CASE RelPartialColumnsTest
+-CASE RelPartialColumnsTest_SLOW
 
 -STATEMENT CREATE NODE TABLE person (ID INt64, fName StRING, gender INT64, isStudent BoOLEAN, isWorker BOOLEAN,
                                 age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP,
@@ -88,7 +88,7 @@ Binder exception: Table knows3 does not contain column dummy.
 ---- 1
 21|15
 
--CASE NodePartialColumnsTest
+-CASE NodePartialColumnsTest_SLOW
 -LOG AllPartialColumns
 -STATEMENT CREATE NODE TABLE tableOfTypes2 (id INT64, int64Column INT64, doubleColumn DOUBLE, booleanColumn BOOLEAN,
                                             dateColumn DATE, timestampColumn TIMESTAMP, stringColumn STRING,

--- a/test/test_files/dml_rel/create/create_ldbc_sf01.test
+++ b/test/test_files/dml_rel/create/create_ldbc_sf01.test
@@ -4,7 +4,7 @@
 
 --
 
--CASE CreateLikeComment
+-CASE CreateLikeComment_SLOW
 -STATEMENT MATCH (n:Person), (m:Comment) WHERE n.id=24189255812290 AND m.id=412317157805 CREATE (n)-[:likes_Comment {creationDate: 202311180116}]->(m);
 ---- ok
 -STATEMENT MATCH (n:Person)-[r:likes_Comment]->(m:Comment) WHERE n.id=24189255812290 AND m.id=412317157805 RETURN r.creationDate;

--- a/test/transaction/checkpoint_test.cpp
+++ b/test/transaction/checkpoint_test.cpp
@@ -62,7 +62,7 @@ public:
     bool checkpointStorage() override { throw RuntimeException("checkpoint failed."); }
 };
 
-TEST_F(FlakyCheckpointerTest, RecoverFromCheckpointStorageFailure) {
+TEST_F(FlakyCheckpointerTest, RecoverFromCheckpointStorageFailure_SLOW) {
     if (inMemMode || systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }
@@ -83,7 +83,7 @@ public:
     }
 };
 
-TEST_F(FlakyCheckpointerTest, RecoverFromCheckpointSerializeFailure) {
+TEST_F(FlakyCheckpointerTest, RecoverFromCheckpointSerializeFailure_SLOW) {
     if (inMemMode || systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }
@@ -104,7 +104,7 @@ public:
     }
 };
 
-TEST_F(FlakyCheckpointerTest, RecoverFromCheckpointWriteHeaderFailure) {
+TEST_F(FlakyCheckpointerTest, RecoverFromCheckpointWriteHeaderFailure_SLOW) {
     if (inMemMode || systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }
@@ -126,7 +126,7 @@ public:
     }
 };
 
-TEST_F(FlakyCheckpointerTest, RecoverFromCheckpointFlushingShadowFailure) {
+TEST_F(FlakyCheckpointerTest, RecoverFromCheckpointFlushingShadowFailure_SLOW) {
     if (inMemMode || systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }
@@ -152,7 +152,7 @@ public:
     }
 };
 
-TEST_F(FlakyCheckpointerTest, RecoverFromCheckpointLoggingCheckpointFailure) {
+TEST_F(FlakyCheckpointerTest, RecoverFromCheckpointLoggingCheckpointFailure_SLOW) {
     if (inMemMode || systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }
@@ -185,7 +185,7 @@ public:
     }
 };
 
-TEST_F(FlakyCheckpointerTest, RecoverFromCheckpointApplyingShadowFailure) {
+TEST_F(FlakyCheckpointerTest, RecoverFromCheckpointApplyingShadowFailure_SLOW) {
     if (inMemMode || systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }
@@ -219,7 +219,7 @@ public:
     }
 };
 
-TEST_F(FlakyCheckpointerTest, RecoverFromCheckpointClearingFilesFailure) {
+TEST_F(FlakyCheckpointerTest, RecoverFromCheckpointClearingFilesFailure_SLOW) {
     if (inMemMode || systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }
@@ -232,7 +232,7 @@ TEST_F(FlakyCheckpointerTest, RecoverFromCheckpointClearingFilesFailure) {
 
 // Simulates a situation where a database attempts to replay a shadow file from an older database
 // with the same path
-TEST_F(FlakyCheckpointerTest, ShadowFileDatabaseIDMismatchExistingDB) {
+TEST_F(FlakyCheckpointerTest, ShadowFileDatabaseIDMismatchExistingDB_SLOW) {
     if (inMemMode || systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }
@@ -270,7 +270,7 @@ TEST_F(FlakyCheckpointerTest, ShadowFileDatabaseIDMismatchExistingDB) {
     EXPECT_THROW(createDBAndConn(), RuntimeException);
 }
 
-TEST_F(FlakyCheckpointerTest, ShadowFileDatabaseIDMismatchNewDB) {
+TEST_F(FlakyCheckpointerTest, ShadowFileDatabaseIDMismatchNewDB_SLOW) {
     if (inMemMode || systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }
@@ -286,7 +286,7 @@ TEST_F(FlakyCheckpointerTest, ShadowFileDatabaseIDMismatchNewDB) {
     EXPECT_THROW(createDBAndConn(), RuntimeException);
 }
 
-TEST_F(FlakyCheckpointerTest, ShadowFileDatabaseIDMismatchCorruptedDB) {
+TEST_F(FlakyCheckpointerTest, ShadowFileDatabaseIDMismatchCorruptedDB_SLOW) {
     if (inMemMode || systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }

--- a/test/transaction/transaction_test.cpp
+++ b/test/transaction/transaction_test.cpp
@@ -144,7 +144,7 @@ static void insertNodes(uint64_t startID, uint64_t num, kuzu::main::Database& da
     }
 }
 
-TEST_F(EmptyDBTransactionTest, ConcurrentNodeInsertions) {
+TEST_F(EmptyDBTransactionTest, ConcurrentNodeInsertions_SLOW) {
     if (systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }
@@ -188,7 +188,7 @@ static void insertNodesWithMixedTypes(uint64_t startID, uint64_t num,
     }
 }
 
-TEST_F(EmptyDBTransactionTest, ConcurrentNodeInsertionsMixedTypes) {
+TEST_F(EmptyDBTransactionTest, ConcurrentNodeInsertionsMixedTypes_SLOW) {
     if (systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }
@@ -234,7 +234,7 @@ static void insertRelationships(uint64_t startID, uint64_t num, kuzu::main::Data
     }
 }
 
-TEST_F(EmptyDBTransactionTest, ConcurrentRelationshipInsertions) {
+TEST_F(EmptyDBTransactionTest, ConcurrentRelationshipInsertions_SLOW) {
     if (systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }
@@ -294,7 +294,7 @@ static void insertComplexRelationships(uint64_t startID, uint64_t num,
     }
 }
 
-TEST_F(EmptyDBTransactionTest, ConcurrentComplexRelationshipInsertions) {
+TEST_F(EmptyDBTransactionTest, ConcurrentComplexRelationshipInsertions_SLOW) {
     if (systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }
@@ -354,7 +354,7 @@ static void updateNodes(uint64_t startID, uint64_t num, kuzu::main::Database& da
     }
 }
 
-TEST_F(EmptyDBTransactionTest, ConcurrentNodeUpdates) {
+TEST_F(EmptyDBTransactionTest, ConcurrentNodeUpdates_SLOW) {
     if (systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }
@@ -412,7 +412,7 @@ static void updateMixedTypeNodes(uint64_t startID, uint64_t num, kuzu::main::Dat
     }
 }
 
-TEST_F(EmptyDBTransactionTest, ConcurrentMixedTypeUpdates) {
+TEST_F(EmptyDBTransactionTest, ConcurrentMixedTypeUpdates_SLOW) {
     if (systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }
@@ -489,7 +489,7 @@ static void updateRelationships(uint64_t startID, uint64_t num, kuzu::main::Data
     }
 }
 
-TEST_F(EmptyDBTransactionTest, ConcurrentRelationshipUpdates) {
+TEST_F(EmptyDBTransactionTest, ConcurrentRelationshipUpdates_SLOW) {
     if (systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }
@@ -564,7 +564,7 @@ static void updateNodesWithMixedTransactions(uint64_t startID, uint64_t num, boo
     }
 }
 
-TEST_F(EmptyDBTransactionTest, ConcurrentNodeUpdatesWithMixedTransactions) {
+TEST_F(EmptyDBTransactionTest, ConcurrentNodeUpdatesWithMixedTransactions_SLOW) {
     if (systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }
@@ -636,7 +636,7 @@ static void updateRelationshipsWithMixedTransactions(uint64_t startID, uint64_t 
     }
 }
 
-TEST_F(EmptyDBTransactionTest, ConcurrentRelationshipUpdatesWithMixedTransactions) {
+TEST_F(EmptyDBTransactionTest, ConcurrentRelationshipUpdatesWithMixedTransactions_SLOW) {
     if (systemConfig->checkpointThreshold == 0) {
         GTEST_SKIP();
     }


### PR DESCRIPTION
# Description

To avoid waiting for some long-running tests locally, this PR starts to add an initial separation of fast and slow tests, which is done by appending a "_SLOW" suffix at the end of test case name.

There can be other more sophisticated mechanisms to separate the fast and slow test cases, but I feel it's unnecessarily complicated vs. simply use the test case suffix, which still allows us to organize tests accordingly to their functionality and is more flexible.