### PR TITLE
Skip FSM check in UUID test

### DIFF
--- a/test/test_files/function/uuid.test
+++ b/test/test_files/function/uuid.test
@@ -4,6 +4,7 @@
 
 -CASE UUIDfunctions
 # messing with node group size can change the output order of collect()
+-SKIP_FSM_LEAK_CHECK
 -LOG UUIDOrderByTest
 -STATEMENT CREATE NODE TABLE Person(name STRING, u UUID, PRIMARY KEY(name));
 ---- ok


### PR DESCRIPTION
# Description

Skip FSM Check in UUID test. 

Add this back after #5970 is done.

Associated docs (issue or PR): 
#6002 #5970



