### PR TITLE
Implement canCheckpointInPlace() for struct columns

### DIFF
--- a/src/include/storage/table/struct_column.h
+++ b/src/include/storage/table/struct_column.h
@@ -37,6 +37,9 @@ protected:
     void lookupInternal(const SegmentState& state, common::offset_t offsetInSegment,
         common::ValueVector* resultVector, uint32_t posInVector) const override;
 
+    bool canCheckpointInPlace(const SegmentState& state,
+        const ColumnCheckpointState& checkpointState) const override;
+
 private:
     std::vector<std::unique_ptr<Column>> childColumns;
 };

--- a/test/test_files/issue/issue.test
+++ b/test/test_files/issue/issue.test
@@ -663,3 +663,17 @@ alice
              MATCH (n)
              DELETE n;
 ---- 0
+
+-CASE 6023
+-STATEMENT CREATE NODE TABLE TestNode (id STRING PRIMARY KEY, grids STRUCT(`type` STRING)[]);
+---- ok
+-STATEMENT CREATE (n:TestNode { `id`: 'test_0_0_0', `grids`: [] });
+---- ok
+-STATEMENT match (t:TestNode) where t.id = 'test_0_0_0' return t.grids
+---- 1
+[]
+-STATEMENT CREATE (n:TestNode { `id`: 'test_0_0_1', `grids`: [{ `type`: "column"}] });
+---- ok
+-STATEMENT match (t:TestNode) where t.id = 'test_0_0_1' return t.grids
+---- 1
+[{type: column}]


### PR DESCRIPTION
# Description

This function is generally not called when checkpointing a struct column directly. However, this is called when the data type for a list column is struct. The default behaviour of `canUpdateInPlace()` is incorrect here if we're using constant compression so we implement a new override.

Fixes #6023

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
