### PR TITLE
Fix potential overflow when writing uncompressed data + fix dictionary offsets when scanning from string column

### DIFF
--- a/src/storage/table/column_chunk_data.cpp
+++ b/src/storage/table/column_chunk_data.cpp
@@ -334,9 +334,11 @@ void ColumnChunkData::setToOnDisk(const ColumnChunkMetadata& otherMetadata) {
 
 ColumnChunkMetadata ColumnChunkData::flushBuffer(PageAllocator& pageAllocator,
     const PageRange& entry, const ColumnChunkMetadata& otherMetadata) const {
-    if (!otherMetadata.compMeta.isConstant() && getBufferSize(numValues) != 0) {
-        return flushBufferFunction(buffer->getBuffer(), pageAllocator.getDataFH(), entry,
-            otherMetadata);
+    const auto bufferSizeToFlush = getBufferSize(numValues);
+    if (!otherMetadata.compMeta.isConstant() && bufferSizeToFlush != 0) {
+        KU_ASSERT(bufferSizeToFlush <= buffer->getBuffer().size_bytes());
+        const auto bufferToFlush = buffer->getBuffer().subspan(0, bufferSizeToFlush);
+        return flushBufferFunction(bufferToFlush, pageAllocator.getDataFH(), entry, otherMetadata);
     }
     KU_ASSERT(otherMetadata.getNumPages() == 0);
     return otherMetadata;

--- a/src/storage/table/compression_flush_buffer.cpp
+++ b/src/storage/table/compression_flush_buffer.cpp
@@ -15,6 +15,7 @@ using namespace transaction;
 ColumnChunkMetadata uncompressedFlushBuffer(std::span<const uint8_t> buffer, FileHandle* dataFH,
     const PageRange& entry, const ColumnChunkMetadata& metadata) {
     KU_ASSERT(dataFH->getNumPages() >= entry.startPageIdx + entry.numPages);
+    KU_ASSERT(buffer.size_bytes() <= entry.startPageIdx * KUZU_PAGE_SIZE);
     dataFH->writePagesToFile(buffer.data(), buffer.size(), entry.startPageIdx);
     return ColumnChunkMetadata(entry.startPageIdx, entry.numPages, metadata.numValues,
         metadata.compMeta);

--- a/test/test_files/dml_rel/create/create_ldbc_sf01.test
+++ b/test/test_files/dml_rel/create/create_ldbc_sf01.test
@@ -10,3 +10,20 @@
 -STATEMENT MATCH (n:Person)-[r:likes_Comment]->(m:Comment) WHERE n.id=24189255812290 AND m.id=412317157805 RETURN r.creationDate;
 ---- 1
 202311180116
+
+-CASE CreateManyRelsSeparateCommit
+-STATEMENT create rel table some_rel_table (FROM Comment TO Comment, str STRING);
+---- ok
+-STATEMENT copy some_rel_table from (
+     match (a:comment), (c:comment) where a.id = 618475290625 and c.id <> a.id return a.id, c.id, c.content)
+---- ok
+-LOOP i 1 10
+-STATEMENT match (a:comment), (c:comment)
+     where a.id = 618475290626 and a.id <> c.id and offset(id(c)) > ${i} * 1000 and offset(id(c)) < (${i} + 1) * 1000
+     create (a)-[:some_rel_table{str: c.content}]->(c)
+---- ok
+-ENDLOOP
+-STATEMENT match (a:comment)-[r:some_rel_table]->(c:comment)
+     where r.str <> c.content and a.id = 618475290626
+     return a.id, c.id, r.str, c.content
+---- 0


### PR DESCRIPTION
# Description

This PR fixes the following issues

1. When writing uncompressed data we copy the entire buffer to disk instead of just copying the correct number of values based on `numValues`. Since the size of the buffer is based on capacity, this can result in writing past the end of the allocated page range and corrupting data.
2. When appending to the dictionary chunk, we used the number of strings in the initial result instead of the number of distinct strings (in other words the size of the dictionary chunk) as the base size.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
