### PR TITLE
Fix QueryResult iterator exhaustion bug in Rust bindings

### DIFF
--- a/src/main/query_result/materialized_query_result.cpp
+++ b/src/main/query_result/materialized_query_result.cpp
@@ -79,8 +79,8 @@ std::string MaterializedQueryResult::toString() const {
     result += "\n";
     auto tuple_ = FlatTuple(this->columnTypes);
     auto iterator_ = FactorizedTableIterator(*table);
-    while (iterator->hasNext()) {
-        iterator->getNext(tuple_);
+    while (iterator_.hasNext()) {
+        iterator_.getNext(tuple_);
         result += tuple_.toString();
     }
     return result;


### PR DESCRIPTION
The toString() method in MaterializedQueryResult was incorrectly using the shared class member 'iterator' instead of the local 'iterator_' variable. This caused the shared iterator to be exhausted whenever toString() was called (e.g., when using Display trait in Rust).

This made the QueryResult unusable for iteration after any display/print operation, causing the iterator to hang or return no results.

Changed:
- iterator->hasNext() to iterator_.hasNext()
- iterator->getNext() to iterator_.getNext()

This ensures toString() uses its own local iterator without affecting the shared iterator used by the Rust bindings.

Fixes the issue where Rust QueryResult iterator would hang after Display.
